### PR TITLE
Support independent external perimeter fan speed

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -703,7 +703,7 @@ static std::vector<std::string> s_Preset_filament_options {
     // Profile compatibility
     "filament_vendor", "compatible_prints", "compatible_prints_condition", "compatible_printers", "compatible_printers_condition", "inherits",
     //BBS
-    "filament_wipe_distance", "additional_cooling_fan_speed",
+    "filament_wipe_distance", "additional_cooling_fan_speed", "external_perimeter_fan", "external_perimeter_fan_speed",
     "bed_temperature_difference", "nozzle_temperature_range_low", "nozzle_temperature_range_high"
 };
 

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -62,6 +62,8 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
     static std::unordered_set<std::string> steps_gcode = {
         //BBS
         "additional_cooling_fan_speed",
+        "external_perimeter_fan",
+        "external_perimeter_fan_speed",
         "reduce_crossing_wall",
         "max_travel_detour_distance",
         "printable_area",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1294,6 +1294,23 @@ void PrintConfigDef::init_fff_params()
     def->mode = comSimple;
     def->set_default_value(new ConfigOptionBool(true));
 
+    def = this->add("external_perimeter_fan", coBools);
+    def->label = L("External perimeter fan");
+    def->tooltip = L("Use a seperate fan speed for external perimeters (visible ones). "
+                     "External perimeters can benefit from higher fan speed to improve surface finish, "
+                     "while internal perimeters, infill, etc. benefit from lower fan speed to improve layer adhesion.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBools{ false });
+
+    def = this->add("external_perimeter_fan_speed", coInts);
+    def->label = L("External perimeter fan speed");
+    def->tooltip = L("Fan speed for external perimeters.");
+    def->sidetext = L("%");
+    def->min = 0;
+    def->max = 100;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionInts{ 20 });
+
     def = this->add("gcode_flavor", coEnum);
     def->label = L("G-code flavor");
     def->tooltip = L("What kind of gcode the printer is compatible with");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -799,6 +799,8 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionBools,              enable_overhang_bridge_fan))
     ((ConfigOptionInts,               overhang_fan_speed))
     ((ConfigOptionEnumsGeneric,       overhang_fan_threshold))
+    ((ConfigOptionBools,              external_perimeter_fan))
+    ((ConfigOptionInts,               external_perimeter_fan_speed))
     ((ConfigOptionEnum<PrintSequence>,print_sequence))
     ((ConfigOptionBools,              slow_down_for_layer_cooling))
     ((ConfigOptionFloat,              default_acceleration))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2537,6 +2537,8 @@ void TabFilament::build()
         line.append_option(optgroup->get_option("fan_max_speed"));
         line.append_option(optgroup->get_option("slow_down_layer_time"));
         optgroup->append_line(line);
+        optgroup->append_single_option_line("external_perimeter_fan");
+        optgroup->append_single_option_line("external_perimeter_fan_speed");
         optgroup->append_single_option_line("reduce_fan_stop_start_freq");
         optgroup->append_single_option_line("slow_down_for_layer_cooling", "auto-cooling");
         optgroup->append_single_option_line("slow_down_min_speed");
@@ -2648,6 +2650,9 @@ void TabFilament::toggle_options()
         bool has_enable_overhang_bridge_fan = m_config->opt_bool("enable_overhang_bridge_fan", 0);
         for (auto el : { "overhang_fan_speed", "overhang_fan_threshold" })
             toggle_option(el, has_enable_overhang_bridge_fan);
+
+        bool has_external_perimeter_fan = m_config->opt_bool("external_perimeter_fan", 0);
+        toggle_option("external_perimeter_fan_speed", has_external_perimeter_fan);
     }
 
     if (m_active_page->title() == "Setting Overrides")


### PR DESCRIPTION
This adds a new filament setting that is most useful for improving the surface finish of higher temperature filaments (e.g. PETG, PC, and ABS) while simultaneously using lower fan speeds (or no fan) for interior perimeters and infill (for better layer adhesion and part strength).

This is a port of [PrusaSlicer PR 2921](https://github.com/prusa3d/PrusaSlicer/pull/2921) that I've been using longterm with very good results.