### PR TITLE
Fixes #740

### DIFF
--- a/src/BambuStudio_app_msvc.cpp
+++ b/src/BambuStudio_app_msvc.cpp
@@ -250,9 +250,6 @@ int wmain(int argc, wchar_t **argv)
     bool load_mesa =
         // Forced from the command line.
         force_mesa ||
-        // Running over a rempote desktop, and the RemoteFX is not enabled, therefore Windows will only provide SW OpenGL 1.1 context.
-        // In that case, use Mesa.
-        ::GetSystemMetrics(SM_REMOTESESSION) ||
         // Try to load the default OpenGL driver and test its context version.
         ! opengl_version_check.load_opengl_dll() || ! opengl_version_check.is_version_greater_or_equal_to(2, 0);
 #endif /* SLIC3R_GUI */


### PR DESCRIPTION
Removing check for local or Remote FX virtualized RDP session. The checks below this line already verify if proper OpenGL support is present.