### PR TITLE
deps/wxWidgets: Disable EGL for wxGLCanvas

### DIFF
--- a/deps/wxWidgets/wxWidgets.cmake
+++ b/deps/wxWidgets/wxWidgets.cmake
@@ -49,6 +49,7 @@ bambustudio_add_cmake_project(wxWidgets
         -DwxUSE_LIBJPEG=sys
         -DwxUSE_LIBTIFF=sys
         -DwxUSE_EXPAT=sys
+        -DwxUSE_GLCANVAS_EGL=OFF
 )
 
 if (MSVC)


### PR DESCRIPTION
This works around https://github.com/supermerill/SuperSlicer/issues/1093 which causes the build plate to not be visible in some setups.

It's the same workaround used by Nixpkgs for its PrusaSlicer and SuperSlicer packages until it switched to Prusa's wxWidgets 3.1.4.

Ref: #12