### PR TITLE
deps/wxWidgets: avoid patching too many times

### DIFF
--- a/deps/wxWidgets/wxWidgets.cmake
+++ b/deps/wxWidgets/wxWidgets.cmake
@@ -18,10 +18,16 @@ else ()
     set(_wx_edge "-DwxUSE_WEBVIEW_EDGE=OFF")
 endif ()
 
+if (MSVC)
+    set(_patch_cmd ${PATCH_CMD} ${CMAKE_CURRENT_LIST_DIR}/0001-wxWidget-fix.patch)
+else ()
+    set(_patch_cmd test -f WXWIDGETS_PATCHED || ${PATCH_CMD} ${CMAKE_CURRENT_LIST_DIR}/0001-wxWidget-fix.patch && touch WXWIDGETS_PATCHED)
+endif ()
+
 bambustudio_add_cmake_project(wxWidgets
     GIT_REPOSITORY "https://github.com/wxWidgets/wxWidgets"
     GIT_TAG ${_wx_git_tag}
-    PATCH_COMMAND ${PATCH_CMD} ${CMAKE_CURRENT_LIST_DIR}/0001-wxWidget-fix.patch
+    PATCH_COMMAND ${_patch_cmd}
     DEPENDS ${PNG_PKG} ${ZLIB_PKG} ${EXPAT_PKG} dep_TIFF dep_JPEG
     CMAKE_ARGS
         -DwxBUILD_PRECOMP=ON


### PR DESCRIPTION
Each time the dependency build was run, previously, the build system attempted to patch wxWidgets after checking it out from Git.  The problem, of course, is that if this happened once, it would not succeed a second time, so the only workaround was to blow away the wxWidgets source tree.

The real solution to this is to create a BBL fork of wxWidgets (or to upstream the changes...).  But for now, we add a file to determine whether the patch has taken place already, and if it's there, we don't apply the patch again.  This will mean that all kinds of exciting things happen if you change Git revisions of wxWidgets or the patch changes (in those cases, you'll have to blow away the build), but at least this makes it possible to build twice in the same repository in the best case.

To update an existing checkout, run:

```
$ touch deps/build/dep_wxWidgets-prefix/src/dep_wxWidgets/WXWIDGETS_PATCHED
```