### PR TITLE
Linux: MediaPlayCtrl: make playback more reliable with wxUSE_GSTREAMER_PLAYER for systems that have that

### DIFF
--- a/src/slic3r/GUI/MediaPlayCtrl.cpp
+++ b/src/slic3r/GUI/MediaPlayCtrl.cpp
@@ -31,6 +31,9 @@ MediaPlayCtrl::MediaPlayCtrl(wxWindow *parent, wxMediaCtrl2 *media_ctrl, const w
 {
     SetBackgroundColour(*wxWHITE);
     m_media_ctrl->Bind(wxEVT_MEDIA_STATECHANGED, &MediaPlayCtrl::onStateChanged, this);
+#if wxUSE_GSTREAMER_PLAYER
+    m_media_ctrl->Bind(wxEVT_MEDIA_LOADED, &MediaPlayCtrl::onStateChanged, this);
+#endif
 
     m_button_play = new Button(this, "", "media_play", wxBORDER_NONE);
     m_button_play->SetCanFocus(false);
@@ -354,11 +357,11 @@ void MediaPlayCtrl::onStateChanged(wxMediaEvent &event)
         Stop();
         return;
     }
-    if (last_state == MEDIASTATE_LOADING && state == wxMEDIASTATE_STOPPED) {
+    if (last_state == MEDIASTATE_LOADING && (state == wxMEDIASTATE_STOPPED || state == wxMEDIASTATE_PAUSED || event.GetEventType() == wxEVT_MEDIA_LOADED)) {
         wxSize size = m_media_ctrl->GetVideoSize();
         BOOST_LOG_TRIVIAL(info) << "MediaPlayCtrl::onStateChanged: size: " << size.x << "x" << size.y;
         m_failed_code = m_media_ctrl->GetLastError();
-        if (size.GetWidth() > 1000) {
+        if (size.GetWidth() > 1000 || (event.GetEventType() == wxEVT_MEDIA_LOADED)) {
             m_last_state = state;
             SetStatus(_L("Playing..."), false);
             m_failed_retry = 0;


### PR DESCRIPTION
On Linux, there are actually two ways to build a wxWidgets video player -- Gstreamer, and gstreamer-player.  (I have no idea why they did not just pick one.)  The gstreamer-player path is a little different, and did not reliably start the stream previously.  (The symptom is that when built on a system that has the `libgstreamer-plugins-bad1.0-dev` package installed, the video player would stay black and would say "Loading..." forever, but if you right-clicked on the play button, it would in fact start playing.)  This collection of hacks gets gstreamer-player working.