### PR TITLE
Address Sanitizer stability and correctness cleanups

### DIFF
--- a/src/libslic3r/TreeSupport.cpp
+++ b/src/libslic3r/TreeSupport.cpp
@@ -3305,7 +3305,7 @@ void TreeSupport::generate_contact_points(std::vector<std::vector<TreeSupport::N
     const auto center = bounding_box_middle(bounding_box);
     const auto sin_angle = std::sin(rotate_angle);
     const auto cos_angle = std::cos(rotate_angle);
-    const auto rotated_dims = Point(
+    const Point rotated_dims = Point(
         bounding_box_size(0) * cos_angle + bounding_box_size(1) * sin_angle,
         bounding_box_size(0) * sin_angle + bounding_box_size(1) * cos_angle) / 2;
 

--- a/src/slic3r/GUI/3DScene.hpp
+++ b/src/slic3r/GUI/3DScene.hpp
@@ -286,6 +286,7 @@ public:
 
     GLVolume(float r = 1.f, float g = 1.f, float b = 1.f, float a = 1.f);
     GLVolume(const std::array<float, 4>& rgba) : GLVolume(rgba[0], rgba[1], rgba[2], rgba[3]) {}
+    virtual ~GLVolume() = default;
 
     // BBS
 protected:

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -1706,6 +1706,9 @@ float GLCanvas3D::get_collapse_toolbar_height()
     return collapse_toolbar.is_enabled() ? collapse_toolbar.get_height() : 0;
 }
 
+bool GLCanvas3D::make_current_for_postinit() {
+    return _set_current();
+}
 
 void GLCanvas3D::render(bool only_init)
 {

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -2157,15 +2157,16 @@ void GLCanvas3D::reload_scene(bool refresh_immediately, bool force_full_scene_re
 
     struct GLVolumeState {
         GLVolumeState() :
-            volume_idx(size_t(-1)) {}
+            volume_idx(size_t(-1)), was_wipe_tower(0) {}
         GLVolumeState(const GLVolume* volume, unsigned int volume_idx) :
-            composite_id(volume->composite_id), volume_idx(volume_idx) {}
+            composite_id(volume->composite_id), volume_idx(volume_idx), was_wipe_tower(volume->is_wipe_tower) {}
         GLVolumeState(const GLVolume::CompositeID &composite_id) :
-            composite_id(composite_id), volume_idx(size_t(-1)) {}
+            composite_id(composite_id), volume_idx(size_t(-1)), was_wipe_tower(0) {}
 
         GLVolume::CompositeID       composite_id;
         // Volume index in the old GLVolume vector.
         size_t                      volume_idx;
+        bool                        was_wipe_tower;
     };
 
     // SLA steps to pull the preview meshes for.
@@ -2368,8 +2369,21 @@ void GLCanvas3D::reload_scene(bool refresh_immediately, bool force_full_scene_re
             }
         }
         for (int temp_idx = vol_idx; temp_idx < m_volumes.volumes.size() && !update_object_list; temp_idx++) {
-            if (!m_volumes.volumes[temp_idx]->is_wipe_tower)
+            // Volumes in m_volumes might not exist anymore, so we cannot
+            // directly check if they are is_wipe_towers, for which we do
+            // not want to update the object list.  Instead, we do a kind of
+            // slow thing of seeing if they were in the deleted list, and if
+            // so, if they were a wipe tower.
+            bool was_deleted_wipe_tower = false;
+            for (int del_idx = 0; del_idx < deleted_volumes.size(); del_idx++) {
+                if (deleted_volumes[del_idx].volume_idx == temp_idx && deleted_volumes[del_idx].was_wipe_tower) {
+                    was_deleted_wipe_tower = true;
+                    break;
+                }
+            }
+            if (!was_deleted_wipe_tower) {
                 update_object_list = true;
+            }
         }
         for (int temp_idx = vol_idx; temp_idx < glvolumes_new.size() && !update_object_list; temp_idx++) {
             if (!glvolumes_new[temp_idx]->is_wipe_tower)

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -1041,6 +1041,8 @@ public:
     // If the Z screen space coordinate is not provided, a depth buffer value is substituted.
     Vec3d _mouse_to_3d(const Point& mouse_pos, float* z = nullptr);
 
+    bool make_current_for_postinit();
+
 private:
     bool _is_shown_on_screen() const;
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -39,6 +39,7 @@
 #include <wx/textctrl.h>
 #include <wx/splash.h>
 #include <wx/fontutil.h>
+#include <wx/glcanvas.h>
 
 #include "libslic3r/Utils.hpp"
 #include "libslic3r/Model.hpp"
@@ -1016,6 +1017,16 @@ void GUI_App::post_init()
         mainframe->select_tab(size_t(MainFrame::tp3DEditor));
         plater_->select_view_3D("3D");
         //BBS init the opengl resource here
+#ifdef __linux__
+        if (!plater_->canvas3D()->get_wxglcanvas()->IsShownOnScreen() ||
+            !plater_->canvas3D()->make_current_for_postinit()) {
+            /* The canvas3d didn't actually exist (and therefore, there is
+             * no current EGL context) -- try again later, I guess.
+             */
+            m_post_initialized = false;
+            return;
+        }
+#endif
         Size canvas_size = plater_->canvas3D()->get_canvas_size();
         wxGetApp().imgui()->set_display_size(static_cast<float>(canvas_size.get_width()), static_cast<float>(canvas_size.get_height()));
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ", start to init opengl";

--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -1636,7 +1636,7 @@ static const ImWchar ranges_keyboard_shortcuts[] =
 #endif // __APPLE__
 
 
-std::vector<unsigned char> ImGuiWrapper::load_svg(const std::string& bitmap_name, unsigned target_width, unsigned target_height)
+std::vector<unsigned char> ImGuiWrapper::load_svg(const std::string& bitmap_name, unsigned target_width, unsigned target_height, unsigned *outwidth, unsigned *outheight)
 {
     std::vector<unsigned char> empty_vector;
 
@@ -1666,6 +1666,9 @@ std::vector<unsigned char> ImGuiWrapper::load_svg(const std::string& bitmap_name
     ::nsvgRasterize(rast, image, 0, 0, svg_scale, data.data(), width, height, width * 4);
     ::nsvgDeleteRasterizer(rast);
     ::nsvgDelete(image);
+
+    *outwidth = width;
+    *outheight = height;
 
     return data;
 }
@@ -1951,11 +1954,12 @@ void ImGuiWrapper::init_font(bool compress)
         if (const ImFontAtlas::CustomRect* rect = io.Fonts->GetCustomRectByIndex(rect_id)) {
             assert(rect->Width == icon_sz);
             assert(rect->Height == icon_sz);
-            std::vector<unsigned char> raw_data = load_svg(icon.second, icon_sz, icon_sz);
+            unsigned outwidth, outheight;
+            std::vector<unsigned char> raw_data = load_svg(icon.second, icon_sz, icon_sz, &outwidth, &outheight);
             const ImU32* pIn = (ImU32*)raw_data.data();
-            for (int y = 0; y < icon_sz; y++) {
+            for (unsigned y = 0; y < outheight; y++) {
                 ImU32* pOut = (ImU32*)pixels + (rect->Y + y) * width + (rect->X);
-                for (int x = 0; x < icon_sz; x++)
+                for (unsigned x = 0; x < outwidth; x++)
                     *pOut++ = *pIn++;
             }
         }
@@ -1967,11 +1971,12 @@ void ImGuiWrapper::init_font(bool compress)
         if (const ImFontAtlas::CustomRect* rect = io.Fonts->GetCustomRectByIndex(rect_id)) {
             assert(rect->Width == icon_sz);
             assert(rect->Height == icon_sz);
-            std::vector<unsigned char> raw_data = load_svg(icon.second, icon_sz, icon_sz);
+            unsigned outwidth, outheight;
+            std::vector<unsigned char> raw_data = load_svg(icon.second, icon_sz, icon_sz, &outwidth, &outheight);
             const ImU32* pIn = (ImU32*)raw_data.data();
-            for (int y = 0; y < icon_sz; y++) {
+            for (unsigned y = 0; y < outheight; y++) {
                 ImU32* pOut = (ImU32*)pixels + (rect->Y + y) * width + (rect->X);
-                for (int x = 0; x < icon_sz; x++)
+                for (unsigned x = 0; x < outwidth; x++)
                     *pOut++ = *pIn++;
             }
         }
@@ -1983,11 +1988,12 @@ void ImGuiWrapper::init_font(bool compress)
         if (const ImFontAtlas::CustomRect* rect = io.Fonts->GetCustomRectByIndex(rect_id)) {
             assert(rect->Width == icon_sz);
             assert(rect->Height == icon_sz);
-            std::vector<unsigned char> raw_data = load_svg(icon.second, icon_sz, icon_sz);
+            unsigned outwidth, outheight;
+            std::vector<unsigned char> raw_data = load_svg(icon.second, icon_sz, icon_sz, &outwidth, &outheight);
             const ImU32* pIn = (ImU32*)raw_data.data();
-            for (int y = 0; y < icon_sz; y++) {
+            for (unsigned y = 0; y < outheight; y++) {
                 ImU32* pOut = (ImU32*)pixels + (rect->Y + y) * width + (rect->X);
-                for (int x = 0; x < icon_sz; x++)
+                for (unsigned x = 0; x < outwidth; x++)
                     *pOut++ = *pIn++;
             }
         }

--- a/src/slic3r/GUI/ImGuiWrapper.hpp
+++ b/src/slic3r/GUI/ImGuiWrapper.hpp
@@ -223,7 +223,7 @@ private:
     void render_draw_data(ImDrawData *draw_data);
     bool display_initialized() const;
     void destroy_font();
-    std::vector<unsigned char> load_svg(const std::string& bitmap_name, unsigned target_width, unsigned target_height);
+    std::vector<unsigned char> load_svg(const std::string& bitmap_name, unsigned target_width, unsigned target_height, unsigned *outwidth, unsigned *outheight);
 
     static const char* clipboard_get(void* user_data);
     static void clipboard_set(void* user_data, const char* text);


### PR DESCRIPTION
Some modern compilers, including GCC, Clang, and MSVC, support a mode called "address sanitizer" ("asan"), invoked with `-fsanitize=address`, which adds extra tracking around all memory accesses.  Compiling Bambu Studio with asan turned on revealed a handful of memory usage errors; some of them are not critical, but some of them do seem quite important and could result in stability issues on any platform, not just Linux.

While I was in here, I also tracked down the crash associated with Linux background startup, and I *think* I fixed it.  It's very difficult to reproduce, though, so it's hard to know for sure.