### PR TITLE
Bambu GUI: be much more careful about calling Layout() and Refresh()

### DIFF
--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -2326,38 +2326,45 @@ int MachineObject::parse_json(std::string payload)
                     }
 
                     if (jj.contains("mc_remaining_time")) {
+                        display_dirty_subtask = 1;
                         if (jj["mc_remaining_time"].is_string())
                             mc_left_time = stoi(j["print"]["mc_remaining_time"].get<std::string>()) * 60;
                         else if (jj["mc_remaining_time"].is_number_integer())
                             mc_left_time = j["print"]["mc_remaining_time"].get<int>() * 60;
                     }
                     if (jj.contains("mc_percent")) {
+                        display_dirty_subtask = 1;
                         if (jj["mc_percent"].is_string())
                             mc_print_percent = stoi(j["print"]["mc_percent"].get<std::string>());
                         else if (jj["mc_percent"].is_number_integer())
                             mc_print_percent = j["print"]["mc_percent"].get<int>();
                     }
                     if (jj.contains("mc_print_sub_stage")) {
+                        display_dirty_subtask = 1;
                         if (jj["mc_print_sub_stage"].is_number_integer())
                             mc_print_sub_stage = j["print"]["mc_print_sub_stage"].get<int>();
                     }
                     /* printing */
                     if (jj.contains("mc_print_stage")) {
+                        display_dirty_subtask = 1;
                         if (jj["mc_print_stage"].is_string())
                             mc_print_stage = atoi(jj["mc_print_stage"].get<std::string>().c_str());
                         if (jj["mc_print_stage"].is_number())
                             mc_print_stage = jj["mc_print_stage"].get<int>();
                     }
                     if (jj.contains("mc_print_error_code")) {
+                        display_dirty_subtask = 1;
                         if (jj["mc_print_error_code"].is_number())
                             mc_print_error_code = jj["mc_print_error_code"].get<int>();
 
                     }
                     if (jj.contains("mc_print_line_number")) {
+                        display_dirty_subtask = 1;
                         if (jj["mc_print_line_number"].is_string() && !jj["mc_print_line_number"].is_null())
                             mc_print_line_number = atoi(jj["mc_print_line_number"].get<std::string>().c_str());
                     }
                     if (jj.contains("print_error")) {
+                        display_dirty_print_error = 1;
                         if (jj["print_error"].is_number())
                             print_error = jj["print_error"].get<int>();
                     }
@@ -2369,6 +2376,7 @@ int MachineObject::parse_json(std::string payload)
                     try {
                         if (jj.contains("online")) {
                             if (jj["online"].contains("ahb")) {
+                                display_dirty_ams = true;
                                 if (jj["online"]["ahb"].get<bool>()) {
                                     online_ahb = true;
                                 } else {
@@ -2376,6 +2384,7 @@ int MachineObject::parse_json(std::string payload)
                                 }
                             }
                             if (jj["online"].contains("rfid")) {
+                                display_dirty_ams = true;
                                 if (jj["online"]["rfid"].get<bool>()) {
                                     online_rfid = true;
                                 } else {
@@ -2399,16 +2408,20 @@ int MachineObject::parse_json(std::string payload)
 
 #pragma region print_task
                     if (jj.contains("printer_type")) {
+                        display_dirty_printer = true;
                         printer_type = parse_printer_type(jj["printer_type"].get<std::string>());
                     }
 
                     if (jj.contains("subtask_name")) {
+                        display_dirty_subtask = true;
                         subtask_name = jj["subtask_name"].get<std::string>();
                     }
                     if (jj.contains("layer_num")) {
+                        display_dirty_subtask = true;
                         curr_layer = jj["layer_num"].get<int>();
                     }
                     if (jj.contains("total_layer_num")) {
+                        display_dirty_subtask = true;
                         total_layers = jj["total_layer_num"].get<int>();
                         if (total_layers == 0)
                             is_support_layer_num = false;
@@ -2419,16 +2432,21 @@ int MachineObject::parse_json(std::string payload)
                     }
 
                     if (jj.contains("gcode_state")) {
+                        display_dirty_subtask = true;
                         this->set_print_state(jj["gcode_state"].get<std::string>());
                     }
 
                     if (jj.contains("task_id")) {
+                        display_dirty_subtask = true;
                         this->task_id_ = jj["task_id"].get<std::string>();
                     }
 
-                    if (jj.contains("gcode_file"))
+                    if (jj.contains("gcode_file")) {
+                        display_dirty_subtask = true;
                         this->m_gcode_file = jj["gcode_file"].get<std::string>();
+                    }
                     if (jj.contains("gcode_file_prepare_percent")) {
+                        display_dirty_subtask = true;
                         std::string percent_str = jj["gcode_file_prepare_percent"].get<std::string>();
                         if (!percent_str.empty()) {
                             try{
@@ -2440,6 +2458,7 @@ int MachineObject::parse_json(std::string payload)
                         && jj.contains("profile_id")
                         && jj.contains("subtask_id")
                         ){
+                        display_dirty_subtask = true;
                         obj_subtask_id = jj["subtask_id"].get<std::string>();
 
                         int plate_index = -1;
@@ -2476,44 +2495,57 @@ int MachineObject::parse_json(std::string payload)
                     /* temperature */
                     if (jj.contains("bed_temper")) {
                         if (jj["bed_temper"].is_number()) {
+                            display_dirty_temp = true;
                             bed_temp = jj["bed_temper"].get<float>();
                         }
                     }
                     if (jj.contains("bed_target_temper")) {
                         if (jj["bed_target_temper"].is_number()) {
+                            display_dirty_temp = true;
                             bed_temp_target = jj["bed_target_temper"].get<float>();
                         }
                     }
                     if (jj.contains("frame_temper")) {
                         if (jj["frame_temper"].is_number()) {
+                            display_dirty_temp = true;
                             frame_temp = jj["frame_temper"].get<float>();
                         }
                     }
                     if (jj.contains("nozzle_temper")) {
                         if (jj["nozzle_temper"].is_number()) {
+                            display_dirty_temp = true;
                             nozzle_temp = jj["nozzle_temper"].get<float>();
                         }
                     }
                     if (jj.contains("nozzle_target_temper")) {
                         if (jj["nozzle_target_temper"].is_number()) {
+                            display_dirty_temp = true;
                             nozzle_temp_target = jj["nozzle_target_temper"].get<float>();
                         }
                     }
                     if (jj.contains("chamber_temper")) {
                         if (jj["chamber_temper"].is_number()) {
+                            display_dirty_temp = true;
                             chamber_temp = jj["chamber_temper"].get<float>();
                         }
                     }
                     /* signals */
-                    if (jj.contains("link_th_state"))
+                    if (jj.contains("link_th_state")) {
+                        display_dirty_signal = true;
                         link_th = jj["link_th_state"].get<std::string>();
-                    if (jj.contains("link_ams_state"))
+                    }
+                    if (jj.contains("link_ams_state")) {
+                        display_dirty_signal = true;
                         link_ams = jj["link_ams_state"].get<std::string>();
-                    if (jj.contains("wifi_signal"))
+                    }
+                    if (jj.contains("wifi_signal")) {
+                        display_dirty_signal = true;
                         wifi_signal = jj["wifi_signal"].get<std::string>();
+                    }
 
                     /* cooling */
                     if (jj.contains("fan_gear")) {
+                        display_dirty_fan = true;
                         fan_gear = jj["fan_gear"].get<std::uint32_t>();
                         big_fan2_speed = (int)((fan_gear & 0x00FF0000) >> 16);
                         big_fan1_speed = (int)((fan_gear & 0x0000FF00) >> 8);
@@ -2521,6 +2553,7 @@ int MachineObject::parse_json(std::string payload)
                     }
                     else {
                         if (jj.contains("cooling_fan_speed")) {
+                            display_dirty_fan = true;
                             cooling_fan_speed = stoi(jj["cooling_fan_speed"].get<std::string>());
                             cooling_fan_speed = round( floor(cooling_fan_speed / float(1.5)) * float(25.5) );
                         }
@@ -2529,6 +2562,7 @@ int MachineObject::parse_json(std::string payload)
                         }
 
                         if (jj.contains("big_fan1_speed")) {
+                            display_dirty_fan = true;
                             big_fan1_speed = stoi(jj["big_fan1_speed"].get<std::string>());
                             big_fan1_speed = round( floor(big_fan1_speed / float(1.5)) * float(25.5) );
                         }
@@ -2537,6 +2571,7 @@ int MachineObject::parse_json(std::string payload)
                         }
 
                         if (jj.contains("big_fan2_speed")) {
+                            display_dirty_fan = true;
                             big_fan2_speed = stoi(jj["big_fan2_speed"].get<std::string>());
                             big_fan2_speed = round( floor(big_fan2_speed / float(1.5)) * float(25.5) );
                         }
@@ -2546,15 +2581,18 @@ int MachineObject::parse_json(std::string payload)
                     }
 
                     if (jj.contains("heatbreak_fan_speed")) {
+                        display_dirty_fan = true;
                         heatbreak_fan_speed = stoi(jj["heatbreak_fan_speed"].get<std::string>());
                     }
                     
                     /* parse speed */
                     try {
                         if (jj.contains("spd_lvl")) {
+                            display_dirty_speed = true;
                             printing_speed_lvl = (PrintingSpeedLevel)jj["spd_lvl"].get<int>();
                         }
                         if (jj.contains("spd_mag")) {
+                            display_dirty_speed = true;
                             printing_speed_mag = jj["spd_mag"].get<int>();
                         }
                     }
@@ -2564,6 +2602,7 @@ int MachineObject::parse_json(std::string payload)
 
                     try {
                         if (jj.contains("stg")) {
+                            display_dirty_stage = true;
                             stage_list_info.clear();
                             if (jj["stg"].is_array()) {
                                 for (auto it = jj["stg"].begin(); it != jj["stg"].end(); it++) {
@@ -2574,6 +2613,7 @@ int MachineObject::parse_json(std::string payload)
                             }
                         }
                         if (jj.contains("stg_cur")) {
+                            display_dirty_stage = true;
                             stage_curr = jj["stg_cur"].get<int>();
                         }
                     }
@@ -2597,6 +2637,7 @@ int MachineObject::parse_json(std::string payload)
                     try {
                         if (jj.contains("lights_report") && jj["lights_report"].is_array()) {
                             for (auto it = jj["lights_report"].begin(); it != jj["lights_report"].end(); it++) {
+                                display_dirty_light = true;
                                 if ((*it)["node"].get<std::string>().compare("chamber_light") == 0)
                                     chamber_light = light_effect_parse((*it)["mode"].get<std::string>());
                                 if ((*it)["node"].get<std::string>().compare("work_light") == 0)
@@ -2627,6 +2668,7 @@ int MachineObject::parse_json(std::string payload)
 #pragma region upgrade
                     try {
                         if (jj.contains("upgrade_state")) {
+                            display_dirty_upgrade = true;
                             if (jj["upgrade_state"].contains("status"))
                                 upgrade_status = jj["upgrade_state"]["status"].get<std::string>();
                             if (jj["upgrade_state"].contains("progress")) {
@@ -2722,6 +2764,7 @@ int MachineObject::parse_json(std::string payload)
                                 if (camera_recording_hold_count > 0)
                                     camera_recording_hold_count--;
                                 else {
+                                    display_dirty_ipcam = true;
                                     if (jj["ipcam"]["ipcam_record"].get<std::string>() == "enable") {
                                         camera_recording_when_printing = true;
                                     }
@@ -2734,6 +2777,7 @@ int MachineObject::parse_json(std::string payload)
                                 if (camera_timelapse_hold_count > 0)
                                     camera_timelapse_hold_count--;
                                 else {
+                                    display_dirty_ipcam = true;
                                     if (jj["ipcam"]["timelapse"].get<std::string>() == "enable") {
                                         camera_timelapse = true;
                                     }
@@ -2743,6 +2787,7 @@ int MachineObject::parse_json(std::string payload)
                                 }
                             }
                             if (jj["ipcam"].contains("ipcam_dev")) {
+                                display_dirty_ipcam = true;
                                 if (jj["ipcam"]["ipcam_dev"].get<std::string>() == "1") {
                                     has_ipcam = true;
                                 } else {
@@ -2753,6 +2798,7 @@ int MachineObject::parse_json(std::string payload)
                                 if (camera_resolution_hold_count > 0)
                                     camera_resolution_hold_count--;
                                 else {
+                                    display_dirty_ipcam = true;
                                     camera_resolution = jj["ipcam"]["resolution"].get<std::string>();
                                 }
                             }
@@ -2767,6 +2813,7 @@ int MachineObject::parse_json(std::string payload)
                             if (xcam_ai_monitoring_hold_count > 0)
                                 xcam_ai_monitoring_hold_count--;
                             else {
+                                display_dirty_xcam = true;
                                 if (jj["xcam"].contains("printing_monitor")) {
                                     // new protocol
                                     xcam_ai_monitoring = jj["xcam"]["printing_monitor"].get<bool>();
@@ -2788,6 +2835,7 @@ int MachineObject::parse_json(std::string payload)
                             if (xcam_first_layer_hold_count > 0)
                                 xcam_first_layer_hold_count--;
                             else {
+                                display_dirty_xcam = true;
                                 if (jj["xcam"].contains("first_layer_inspector")) {
                                     xcam_first_layer_inspector = jj["xcam"]["first_layer_inspector"].get<bool>();
                                 }
@@ -2796,6 +2844,7 @@ int MachineObject::parse_json(std::string payload)
                             if (xcam_buildplate_marker_hold_count > 0)
                                 xcam_buildplate_marker_hold_count--;
                             else {
+                                display_dirty_xcam = true;
                                 if (jj["xcam"].contains("buildplate_marker_detector")) {
                                     xcam_buildplate_marker_detector = jj["xcam"]["buildplate_marker_detector"].get<bool>();
                                     is_xcam_buildplate_supported = true;
@@ -2813,8 +2862,9 @@ int MachineObject::parse_json(std::string payload)
 #pragma region hms
                     // parse hms msg
                     try {
-                        hms_list.clear();
                         if (jj.contains("hms")) {
+                            display_dirty_hms_list = true;
+                            hms_list.clear();
                             if (jj["hms"].is_array()) {
                                 for (auto it = jj["hms"].begin(); it != jj["hms"].end(); it++) {
                                     HMSItem item;
@@ -2838,6 +2888,7 @@ int MachineObject::parse_json(std::string payload)
                     /* ams status */
                     try {
                         if (jj.contains("ams_status")) {
+                            display_dirty_ams = true;
                             int ams_status = jj["ams_status"].get<int>();
                             this->_parse_ams_status(ams_status);
                         }
@@ -2847,6 +2898,7 @@ int MachineObject::parse_json(std::string payload)
                     }
 
                     if (jj.contains("ams")) {
+                        display_dirty_ams = true;
                         if (jj["ams"].contains("ams")) {
                             long int last_ams_exist_bits = ams_exist_bits;
                             long int last_tray_exist_bits = tray_exist_bits;
@@ -3118,6 +3170,7 @@ int MachineObject::parse_json(std::string payload)
                     /* vitrual tray*/
                     try {
                         if (jj.contains("vt_tray")) {
+                            display_dirty_ams = true;
                             if (jj["vt_tray"].contains("id"))
                                 vt_tray.id = jj["vt_tray"]["id"].get<std::string>();
                             auto curr_time = std::chrono::system_clock::now();
@@ -3158,6 +3211,7 @@ int MachineObject::parse_json(std::string payload)
                     ams_version = -1;
 
                     if (jj["ams_id"].is_number()) {
+                        display_dirty_ams = true;
                         int ams_id = jj["ams_id"].get<int>();
                         auto ams_it = amsList.find(std::to_string(ams_id));
                         if (ams_it != amsList.end()) {
@@ -3444,6 +3498,7 @@ void MachineObject::update_slice_info(std::string project_id, std::string profil
                     } catch(...) {
                         ;
                     }
+                    this->display_dirty_subtask = true;
                 }
             });
     }

--- a/src/slic3r/GUI/DeviceManager.hpp
+++ b/src/slic3r/GUI/DeviceManager.hpp
@@ -493,13 +493,17 @@ public:
     bool is_mapping_exceed_filament(std::vector<FilamentInfo>& result, int &exceed_index);
     void reset_mapping_result(std::vector<FilamentInfo>& result);
 
+    bool   display_dirty_printer = true;
+
     /*online*/
+    bool   display_dirty_ams = true;
     bool   online_rfid;
     bool   online_ahb;
     int    online_version = -1;
     int    last_online_version = -1;
 
     /* temperature */
+    bool   display_dirty_temp = true;
     float  nozzle_temp;
     float  nozzle_temp_target;
     float  bed_temp;
@@ -508,6 +512,7 @@ public:
     float  frame_temp;
 
     /* cooling */
+    bool    display_dirty_fan = true;
     int     heatbreak_fan_speed = 0;
     int     cooling_fan_speed = 0;
     int     big_fan1_speed = 0;
@@ -515,17 +520,20 @@ public:
     uint32_t fan_gear       = 0;
 
     /* signals */
+    bool display_dirty_signal = true;
     std::string wifi_signal;
     std::string link_th;
     std::string link_ams;
 
     /* lights */
+    bool display_dirty_light = true;
     LIGHT_EFFECT chamber_light;
     LIGHT_EFFECT work_light;
     std::string light_effect_str(LIGHT_EFFECT effect);
     LIGHT_EFFECT light_effect_parse(std::string effect_str);
 
     /* upgrade */
+    bool display_dirty_upgrade = true;
     bool upgrade_force_upgrade { false };
     bool upgrade_new_version { false };
     bool upgrade_consistency_request { false };
@@ -561,6 +569,7 @@ public:
     float   nozzle { 0.0f };        // default is 0.0f as initial value
     bool    is_220V_voltage { false };
 
+    bool    display_dirty_subtask = 1;
     int     mc_print_stage;
     int     mc_print_sub_stage;
     int     mc_print_error_code;
@@ -571,11 +580,14 @@ public:
     int     home_flag;
     int     hw_switch_state;
     bool    is_system_printing();
+    
+    bool    display_dirty_print_error = true;
     int     print_error;
     int     curr_layer = 0;
     int     total_layers = 0;
     bool    is_support_layer_num { false };
 
+    bool display_dirty_stage = true;
     std::vector<int> stage_list_info;
     int stage_curr = 0;
     int m_push_count = 0;
@@ -598,12 +610,14 @@ public:
     /* printing status */
     std::string print_status;      /* enum string: FINISH, RUNNING, PAUSE, INIT, FAILED */
     std::string iot_print_status;  /* iot */
+    bool display_dirty_speed = true;
     PrintingSpeedLevel printing_speed_lvl;
     int                printing_speed_mag = 100;
     PrintingSpeedLevel _parse_printing_speed_lvl(int lvl);
     int get_bed_temperature_limit();
 
     /* camera */
+    bool display_dirty_ipcam = true;
     bool has_ipcam { false };
     bool camera_recording { false };
     bool camera_recording_when_printing { false };
@@ -615,6 +629,7 @@ public:
     bool xcam_first_layer_inspector { false };
     int  xcam_first_layer_hold_count = 0;
 
+    bool display_dirty_xcam = true;
     bool xcam_ai_monitoring{ false };
     int  xcam_ai_monitoring_hold_count = 0;
     std::string xcam_ai_monitoring_sensitivity;
@@ -637,6 +652,7 @@ public:
     bool is_support_send_to_sdcard { true };
 
     /* HMS */
+    bool display_dirty_hms_list = true;
     std::vector<HMSItem>    hms_list;
 
     /* machine mqtt apis */

--- a/src/slic3r/GUI/StatusPanel.cpp
+++ b/src/slic3r/GUI/StatusPanel.cpp
@@ -1075,6 +1075,8 @@ void StatusBasePanel::show_ams_group(bool show, bool support_virtual_tray)
 void StatusPanel::update_camera_state(MachineObject* obj)
 {
     if (!obj) return;
+    
+    bool did_change = false;
 
     //m_bitmap_sdcard_abnormal_img->SetToolTip(_L("SD Card Abnormal"));
     //sdcard
@@ -1093,6 +1095,7 @@ void StatusPanel::update_camera_state(MachineObject* obj)
             m_bitmap_sdcard_img->SetToolTip(_L("SD Card"));
         }
         m_last_sdcard = (int)obj->get_sdcard_state();
+        did_change = true;
     }
 
     //recording
@@ -1104,12 +1107,17 @@ void StatusPanel::update_camera_state(MachineObject* obj)
                 m_bitmap_recording_img->SetBitmap(m_bitmap_recording_off.bmp());
             }
             m_last_recording = obj->is_recording() ? 1 : 0;
+            did_change = true;
         }
-        if (!m_bitmap_recording_img->IsShown())
+        if (!m_bitmap_recording_img->IsShown()) {
             m_bitmap_recording_img->Show();
+            did_change = true;
+        }
     } else {
-        if (m_bitmap_recording_img->IsShown())
+        if (m_bitmap_recording_img->IsShown()) {
             m_bitmap_recording_img->Hide();
+            did_change = true;
+        }
     }
     
     //timelapse
@@ -1121,12 +1129,17 @@ void StatusPanel::update_camera_state(MachineObject* obj)
                 m_bitmap_timelapse_img->SetBitmap(m_bitmap_timelapse_off.bmp());
             }
             m_last_timelapse = obj->is_timelapse() ? 1 : 0;
+            did_change = true;
         }
-        if (!m_bitmap_timelapse_img->IsShown())
+        if (!m_bitmap_timelapse_img->IsShown()) {
             m_bitmap_timelapse_img->Show();
+            did_change = true;
+        }
     } else {
-        if (m_bitmap_timelapse_img->IsShown())
+        if (m_bitmap_timelapse_img->IsShown()) {
             m_bitmap_timelapse_img->Hide();
+            did_change = true;
+        }
     }
     
     //vcamera
@@ -1138,12 +1151,17 @@ void StatusPanel::update_camera_state(MachineObject* obj)
                 m_bitmap_vcamera_img->SetBitmap(m_bitmap_vcamera_off.bmp());
             }
             m_last_vcamera = m_media_play_ctrl->IsStreaming() ? 1 : 0;
+            did_change = true;
         }
-        if (!m_bitmap_vcamera_img->IsShown())
+        if (!m_bitmap_vcamera_img->IsShown()) {
             m_bitmap_vcamera_img->Show();
+            did_change = true;
+        }
     } else {
-        if (m_bitmap_vcamera_img->IsShown())
+        if (m_bitmap_vcamera_img->IsShown()) {
             m_bitmap_vcamera_img->Hide();
+            did_change = true;
+        }
     }
 
     //camera setting
@@ -1152,7 +1170,9 @@ void StatusPanel::update_camera_state(MachineObject* obj)
         m_camera_popup->update(show_vcamera);
     }
 
-    m_panel_monitoring_title->Layout();
+    if (did_change) {
+        m_panel_monitoring_title->Layout();
+    }
 }
 
 StatusPanel::StatusPanel(wxWindow *parent, wxWindowID id, const wxPoint &pos, const wxSize &size, long style, const wxString &name)
@@ -1449,10 +1469,11 @@ void StatusPanel::update(MachineObject *obj)
 {
     if (!obj) return;
 
-    m_project_task_panel->Freeze();
-    update_subtask(obj);
-    m_project_task_panel->Thaw();
-
+    if (obj->display_dirty_subtask) {
+        m_project_task_panel->Freeze();
+        update_subtask(obj);
+        m_project_task_panel->Thaw();
+    }
 
     m_machine_ctrl_panel->Freeze();
 
@@ -1461,12 +1482,16 @@ void StatusPanel::update(MachineObject *obj)
     else
         show_printing_status();
 
-    update_temp_ctrl(obj);
+    if (obj->display_dirty_temp) {
+        update_temp_ctrl(obj);
+    }
     update_misc_ctrl(obj);
 
     // BBS hide tasklist info
     // update_tasklist(obj);
-    update_ams(obj);
+    if (obj->display_dirty_ams) {
+        update_ams(obj);
+    }
 
     update_cali(obj);
 
@@ -1540,7 +1565,9 @@ void StatusPanel::update(MachineObject *obj)
              m_print_connect_types[obj->dev_id] = obj->dev_connection_type;
         }
        
-        update_error_message();
+        if (obj->display_dirty_print_error || obj->display_dirty_hms_list) {
+            update_error_message();
+        }
     }
 
     update_camera_state(obj);

--- a/src/slic3r/GUI/Widgets/AMSControl.cpp
+++ b/src/slic3r/GUI/Widgets/AMSControl.cpp
@@ -178,7 +178,7 @@ void AMSrefresh::on_timer(wxTimerEvent &event)
     //} else {
     //    m_rotation_angle++;
     //}
-    Refresh();
+    //Refresh();
 }
 
 void AMSrefresh::PlayLoading()
@@ -306,12 +306,16 @@ Description:AMSextruder
 **************************************************/
 void AMSextruderImage::TurnOn(wxColour col) 
 {
+    if (m_colour == col)
+        return;
     m_colour  = col;
     Refresh();
 }
 
 void AMSextruderImage::TurnOff() 
 {
+    if (m_colour == AMS_EXTRUDER_DEF_COLOUR)
+        return;
     m_colour = AMS_EXTRUDER_DEF_COLOUR;
     Refresh();
 }
@@ -762,6 +766,10 @@ void AMSLib::doRender(wxDC &dc)
 
 void AMSLib::Update(Caninfo info, bool refresh)
 {
+    if (m_info.material_colour == info.material_colour &&
+        m_info.material_remain == info.material_remain &&
+        m_info.material_state == info.material_state)
+        return;
     m_info = info;
     Layout();
     if (refresh) Refresh();
@@ -847,6 +855,10 @@ void AMSRoad::create(wxWindow *parent, wxWindowID id, const wxPoint &pos, const 
 
 void AMSRoad::Update(AMSinfo amsinfo, Caninfo info, int canindex, int maxcan)
 {
+    /* for now, all that the road renders is humidity, so we don't have to
+     * implement equality on AMSinfo or Caninfo...  */
+    if (m_amsinfo.ams_humidity == amsinfo.ams_humidity && m_canindex == canindex)
+        return;
     m_amsinfo = amsinfo;
     m_info     = info;
     m_canindex = canindex;

--- a/src/slic3r/GUI/Widgets/Button.cpp
+++ b/src/slic3r/GUI/Widgets/Button.cpp
@@ -60,6 +60,8 @@ bool Button::Create(wxWindow* parent, wxString text, wxString icon, long style, 
 
 void Button::SetLabel(const wxString& label)
 {
+    if (GetLabel() == label)
+        return;
     wxWindow::SetLabel(label);
     messureSize();
     Refresh();
@@ -68,11 +70,15 @@ void Button::SetLabel(const wxString& label)
 void Button::SetIcon(const wxString& icon)
 {
     if (!icon.IsEmpty()) {
+        if (this->active_icon.name() == icon.ToStdString())
+            return;
         //BBS set button icon default size to 20
         this->active_icon = ScalableBitmap(this, icon.ToStdString(), this->active_icon.px_cnt());
     }
     else
     {
+        if (this->inactive_icon.name() == "")
+            return;
         this->active_icon = ScalableBitmap();
     }
     Refresh();
@@ -81,9 +87,13 @@ void Button::SetIcon(const wxString& icon)
 void Button::SetInactiveIcon(const wxString &icon)
 {
     if (!icon.IsEmpty()) {
+        if (this->inactive_icon.name() == icon.ToStdString())
+            return;
         // BBS set button icon default size to 20
         this->inactive_icon = ScalableBitmap(this, icon.ToStdString(), this->active_icon.px_cnt());
     } else {
+        if (this->inactive_icon.name() == "")
+            return;
         this->inactive_icon = ScalableBitmap();
     }
     Refresh();

--- a/src/slic3r/GUI/Widgets/ComboBox.cpp
+++ b/src/slic3r/GUI/Widgets/ComboBox.cpp
@@ -67,9 +67,10 @@ int ComboBox::GetSelection() const { return drop.GetSelection(); }
 
 void ComboBox::SetSelection(int n)
 {
+    int oldselection = drop.selection;
     drop.SetSelection(n);
     SetLabel(drop.GetValue());
-    if (drop.selection >= 0)
+    if (drop.selection >= 0 && drop.selection != oldselection)
         SetIcon(icons[drop.selection]);
 }
 

--- a/src/slic3r/GUI/Widgets/ImageSwitchButton.cpp
+++ b/src/slic3r/GUI/Widgets/ImageSwitchButton.cpp
@@ -48,8 +48,10 @@ ImageSwitchButton::ImageSwitchButton(wxWindow *parent, ScalableBitmap &img_on, S
 
 void ImageSwitchButton::SetLabels(wxString const &lbl_on, wxString const &lbl_off)
 {
-	labels[0] = lbl_on;
-	labels[1] = lbl_off;
+    if (labels[0] == lbl_on && labels[1] == lbl_off)
+        return;
+    labels[0] = lbl_on;
+    labels[1] = lbl_off;
     auto fina_txt = GetValue() ? labels[0] : labels[1];
     SetToolTip(fina_txt);
     messureSize();
@@ -74,6 +76,8 @@ void ImageSwitchButton::SetTextColor(StateColor const &color)
 
 void ImageSwitchButton::SetValue(bool value)
 {
+    if (m_on_off == value)
+        return;
     m_on_off = value;
     messureSize();
     Refresh();
@@ -234,6 +238,8 @@ void FanSwitchButton::SetTextColor(StateColor const& color)
 
 void FanSwitchButton::SetValue(bool value)
 {
+    if (m_on_off == value)
+        return;
     m_on_off = value;
     messureSize();
     Refresh();
@@ -323,6 +329,8 @@ void FanSwitchButton::Rescale()
 
 void FanSwitchButton::setFanValue(int val)
 {
+    if (m_speed == val)
+        return;
     m_speed = val;
     Refresh();
 }

--- a/src/slic3r/GUI/Widgets/ProgressBar.cpp
+++ b/src/slic3r/GUI/Widgets/ProgressBar.cpp
@@ -101,8 +101,11 @@ void ProgressBar::Disable(wxString text)
 
 void ProgressBar::SetValue(int step) 
 { 
+    bool was_disable = m_disable;
     m_disable = false;
     SetProgress(step);
+    if (was_disable)
+        Refresh();
 }
 
 void ProgressBar::Reset() 
@@ -113,9 +116,10 @@ void ProgressBar::Reset()
 
 void ProgressBar::SetProgress(int step)
 { 
+    bool was_disable = m_disable;
     m_disable = false;
     if (step < 0) return;
-    //if (step == m_step) return;
+    if (step == m_step && !was_disable) return;
     m_step = step;
     Refresh();
 }

--- a/src/slic3r/GUI/Widgets/SideTools.cpp
+++ b/src/slic3r/GUI/Widgets/SideTools.cpp
@@ -51,8 +51,11 @@ void SideTools::on_timer(wxTimerEvent &event)
 
 void SideTools::set_current_printer_name(std::string dev_name) 
 {
+     wxString wxdev_name = from_u8(dev_name);
+     if (!m_none_printer && m_dev_name == wxdev_name)
+         return;
      m_none_printer = false;
-     m_dev_name     = from_u8(dev_name);
+     m_dev_name     = wxdev_name;
      Refresh();
 }
 

--- a/src/slic3r/GUI/Widgets/StepCtrl.cpp
+++ b/src/slic3r/GUI/Widgets/StepCtrl.cpp
@@ -48,6 +48,8 @@ void StepCtrlBase::SelectItem(int item)
 
 void StepCtrlBase::Idle() 
 { 
+    if (step == -1)
+        return;
     step = -1; 
     sendStepCtrlEvent();
     Refresh();

--- a/src/slic3r/GUI/Widgets/TempInput.cpp
+++ b/src/slic3r/GUI/Widgets/TempInput.cpp
@@ -161,13 +161,13 @@ wxString TempInput::erasePending(wxString &str)
 
 void TempInput::SetTagTemp(int temp)
 {
-    text_ctrl->SetValue(wxString::Format("%d", temp));
-    messureSize();
-    Refresh();
+    SetTagTemp(wxString::Format("%d", temp));
 }
 
 void TempInput::SetTagTemp(wxString temp) 
 { 
+    if (text_ctrl->GetValue() == temp)
+        return;
     text_ctrl->SetValue(temp);
     messureSize();
     Refresh();
@@ -175,11 +175,13 @@ void TempInput::SetTagTemp(wxString temp)
 
 void TempInput::SetCurrTemp(int temp) 
 { 
-    SetLabel(wxString::Format("%d", temp)); 
+    SetCurrTemp(wxString::Format("%d", temp)); 
 }
 
 void TempInput::SetCurrTemp(wxString temp) 
 {
+    if (temp == GetLabel())
+        return;
     SetLabel(temp);
 }
 
@@ -244,12 +246,16 @@ void TempInput::Warning(bool warn, WarningType type)
 
 void TempInput::SetIconActive()
 {
+    if (actice)
+        return;
     actice = true;
     Refresh();
 }
 
 void TempInput::SetIconNormal()
 {
+    if (!actice)
+        return;
     actice = false;
     Refresh();
 }

--- a/src/slic3r/GUI/Widgets/TextInput.cpp
+++ b/src/slic3r/GUI/Widgets/TextInput.cpp
@@ -88,6 +88,8 @@ void TextInput::SetCornerRadius(double radius)
 
 void TextInput::SetLabel(const wxString& label)
 {
+    if (label == GetLabel())
+        return;
     wxWindow::SetLabel(label);
     messureSize();
     Refresh();

--- a/src/slic3r/GUI/wxExtensions.cpp
+++ b/src/slic3r/GUI/wxExtensions.cpp
@@ -952,6 +952,9 @@ void ScalableButton::SetBitmap_(const ScalableBitmap& bmp)
 
 bool ScalableButton::SetBitmap_(const std::string& bmp_name)
 {
+    if (m_current_icon_name == bmp_name)
+        return true;
+
     m_current_icon_name = bmp_name;
     if (m_current_icon_name.empty())
         return false;


### PR DESCRIPTION
Repainting the screen is expensive and causes lots of idle CPU usage when the printer is continuously sending updates over the network (or a timer is simply firing); in some cases, it can even cause a SVG to continuously be rerendered to a bitmap.  In general, we should avoid causing widgets to repaint if they don't change; we add some checks to see if anything has actually changed inside of a widget before we actually commit to repainting.

This is a first step towards taking much finer-grained control over when these operations are called, rather than unconditionally calling them at 1Hz.  In the future, we should remove the 1Hz timer entirely -- and only call Layout on things that need their layout updated -- but in the mean time, this change substantially reduces the amount of CPU time (and battery!) that Bambu Studio consumes in the background when nothing is happening (particularly important for laptop users!).

This also reduces the annoying flickering in the video playback on Linux, but it probably will not entirely solve it.

Roughly, there are two major types of changes in here:
* `MachineObject` gets a set of `display_dirty_` variables, which are used to represent whether machine state has changed that needs to be updated.
* Individual widgets try to remember their previous state, and if they have been asked to change but their contents would remain the same, they do nothing.
