### PR TITLE
Linux: add support for "go live"

### DIFF
--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -226,7 +226,7 @@ then
         
         # make Slic3r
         echo "[8/9] Building Slic3r..."
-        make -j$NCORES BambuStudio # Slic3r
+        make -j$NCORES BambuStudio bambu_source # Slic3r
 
         # make .mo
         # make gettext_po_to_mo # FIXME: DeftDawg: complains about msgfmt not existing even in SuperSlicer, did this ever work?

--- a/resources/cameratools/ffmpeg.cfg
+++ b/resources/cameratools/ffmpeg.cfg
@@ -1,0 +1,17 @@
+-fflags
+nobuffer
+-flags
+low_delay
+-analyzeduration
+10
+-probesize
+3200
+-f
+h264
+-i
+pipe:
+-vcodec
+copy
+-f
+rtp
+rtp://127.0.0.1:1234

--- a/resources/cameratools/ffmpeg.sdp
+++ b/resources/cameratools/ffmpeg.sdp
@@ -1,0 +1,9 @@
+v=0
+o=- 0 0 IN IP4 127.0.0.1
+s=No Name
+c=IN IP4 127.0.0.1
+t=0 0
+a=tool:libavformat LIBAVFORMAT_VERSION
+m=video 1234 RTP/AVP 96
+a=rtpmap:96 H264/90000
+a=fmtp:96 packetization-mode=1; sprop-parameter-sets=Z0LAH42NUCSC2TZAAAADAEAAAA8jwiEagA==,aM4xsgA=; profile-level-id=42C01F

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -270,3 +270,8 @@ if (WIN32)
 else ()
     install(TARGETS BambuStudio RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif ()
+
+if (UNIX)
+    add_executable(bambu_source bambu_source.c)
+    install(TARGETS bambu_source RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()

--- a/src/bambu_source.c
+++ b/src/bambu_source.c
@@ -1,0 +1,108 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <dlfcn.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <signal.h>
+#define BAMBU_DYNAMIC
+#include "slic3r/GUI/Printer/BambuTunnel.h"
+
+struct BambuLib lib;
+
+static void _log(void *ctx, int lvl, const char* msg) {
+	fprintf(stderr, "bambu: log lvl %d: %s\n", lvl, msg);
+	lib.Bambu_FreeLogMsg(msg);
+}
+
+Bambu_Tunnel tnl = NULL;
+
+static void _cleanup_shm() {
+	if (tnl) {
+		lib.Bambu_Close(tnl);
+		lib.Bambu_Destroy(tnl);
+		tnl = NULL;
+	}
+}
+
+static void _sigint(int sig) {
+	fprintf(stderr, "received signal %d, gracefully shutting down\n", sig);
+	exit(0);
+}
+
+int main(int argc, char **argv) {
+	const char *path;
+	void *bambusource;
+	
+	signal(SIGINT, _sigint);
+	signal(SIGTERM, _sigint);
+	
+	bambusource = dlopen("libBambuSource.so", RTLD_NOW);
+	if (!bambusource) {
+		fprintf(stderr, "dlopen(\"libBambuSource.so\"): %s\n", dlerror());
+		return 1;
+	}
+#define LOAD(func) \
+	lib.func = dlsym(bambusource, #func); \
+	if (!lib.func) { \
+		fprintf(stderr, "dlsym(..., " #func "): symbol missing\n"); \
+		return 1; \
+	}
+	LOAD(Bambu_Create);
+	LOAD(Bambu_SetLogger);
+	LOAD(Bambu_FreeLogMsg);
+	LOAD(Bambu_Open);
+	LOAD(Bambu_StartStream);
+	LOAD(Bambu_Close);
+	LOAD(Bambu_Destroy);
+	LOAD(Bambu_ReadSample);	
+
+	if (argc == 2) {
+		path = argv[1];
+	} else {
+		path = "";
+	}
+	
+	if (lib.Bambu_Create(&tnl, path) != Bambu_success) {
+		fprintf(stderr, "failed to bambu_create\n");
+		return 1;
+	}
+	
+	lib.Bambu_SetLogger(tnl, _log, 0);
+	if (lib.Bambu_Open(tnl) != Bambu_success) {
+		fprintf(stderr, "failed to bambu_open path\n");
+	}
+	atexit(_cleanup_shm);
+
+	int rv;
+	while ((rv = lib.Bambu_StartStream(tnl, 1 /* video */)) == Bambu_would_block) {
+		usleep(100000);
+	}
+	if (rv != Bambu_success) {
+		fprintf(stderr, "failed to start stream\n");
+		lib.Bambu_Close(tnl);
+		lib.Bambu_Destroy(tnl);
+		tnl = NULL;
+		return 3;
+	}
+	
+	while (1) {
+		struct Bambu_Sample sample;
+		while ((rv = lib.Bambu_ReadSample(tnl, &sample)) == Bambu_success) {
+			if (write(1, sample.buffer, sample.size) < sample.size) {
+				rv = -1;
+				break;
+			}
+		}
+		if (rv != Bambu_would_block) {
+			break;
+		}
+		usleep(100000);
+	}
+	
+	fprintf(stderr, "bambu exited with rv %d\n", rv);
+	lib.Bambu_Close(tnl);
+	lib.Bambu_Destroy(tnl);
+	tnl = NULL;
+	return 0;
+}

--- a/src/platform/unix/BuildLinuxImage.sh.in
+++ b/src/platform/unix/BuildLinuxImage.sh.in
@@ -30,6 +30,7 @@ echo -n "[9/9] Generating Linux app..."
     # copy Resources
     cp -Rf ../resources package/resources
     cp -f src/@SLIC3R_APP_CMD@ package/bin/@SLIC3R_APP_CMD@
+    cp -f src/bambu_source package/bin/bambu_source
     # remove unneeded po from resources
     ## find package/resources/localization -name "*.po" -type f -delete ## FIXME: DD - do we need this?
 


### PR DESCRIPTION
Add a bambu_source binary (analogous to that from the cameratools package), and then use the system ffmpeg to actually do the rtp streaming.

Fixes #1155.