### PR TITLE
Docker Run Fix for MIT-SHM BadAccess X socket permissions

### DIFF
--- a/DockerRun.sh
+++ b/DockerRun.sh
@@ -8,6 +8,8 @@ set -x
 docker run \
   `# Use the hosts networking.  Printer wifi and also dbus communication` \
   --net=host \
+  `# Some X installs will not have permissions to talk to sockets for shared memory` \
+  --ipc host \
   `# Run as your workstations username to keep permissions the same` \
   -u $USER \
   `# Bind mount your home directory into the container for loading/saving files` \


### PR DESCRIPTION
In some X installations using the MIT shared memory extension for rendering window elements, Bambu
Studio needs direct access to a UNIX socket
for fast rendering.

This fix passes `--ipc host` with docker run
to allow the container to just have direct access
to the host's IPC system.

The error message that this solves is:

```
(bambu-studio:1): Gdk-ERROR **: 00:02:37.498: The program 'bambu-studio' received an X Window System error.
This probably reflects a bug in the program.
The error was 'BadAccess (attempt to access private resource denied)'.
  (Details: serial 316 error_code 10 request_code 130 (MIT-SHM) minor_code 1)
  (Note to programmers: normally, X errors are reported asynchronously;
   that is, you will receive the error a while after causing it.
   To debug your program, run it with the GDK_SYNCHRONIZE environment
   variable to change this behavior. You can then get a meaningful
   backtrace from your debugger if you break on the gdk_x_error() function.)
```

Here are some extra links for more information:

https://github.com/osrf/docker_images/issues/21
http://wiki.ros.org/docker/Tutorials/GUI
https://en.wikipedia.org/wiki/MIT-SHM