### PR TITLE
Update MacOS compile guide

### DIFF
--- a/doc/How to build - Mac OS.md
+++ b/doc/How to build - Mac OS.md
@@ -12,6 +12,11 @@ Cmake, git, gettext can be installed from brew(brew install cmake git gettext)
 
 ## building the deps
 You need to build the dependence of BambuStudio first. (Only needs for the first time)  
+Next, for arm64 architecture:
+```shell
+cmake ../ -DDESTDIR="/Users/username/work/projects/BambuStudio_dep" -DOPENSSL_ARCH="darwin64-arm64-cc"
+make
+```
 
 Suppose you download the codes into /Users/_username_/work/projects/BambuStudio  
 create a directory to store the dependence built: /Users/_username_/work/projects/BambuStudio_dep  
@@ -20,8 +25,6 @@ create a directory to store the dependence built: /Users/_username_/work/project
 `cd BambuStudio/deps`  
 `mkdir build;cd build`  
 
-for arm64 architecture  
-`cmake ../ -DDESTDIR="/Users/username/work/projects/BambuStudio_dep" -DOPENSSL_ARCH="darwin64-arm64-cc"`  
 for x86 architeccture  
 `cmake ../ -DDESTDIR="/Users/username/work/projects/BambuStudio_dep" -DOPENSSL_ARCH="darwin64-x86_64-cc"`  
 `make -jN`  (N can be a number between 1 and the max cpu number)  

--- a/doc/How to build - Mac OS.md
+++ b/doc/How to build - Mac OS.md
@@ -1,44 +1,67 @@
 
-# Building Bambu Studio on Mac OS
+# Building Bambu Studio on MacOS
 
 ## Enviroment setup
-Install Following tools:  
-- Xcode from app store  
-- Cmake  
-- git  
-- gettext  
+
+Install Following tools:
+
+- Xcode from app store
+- Cmake
+- git
+- gettext
 
 Cmake, git, gettext can be installed from brew(brew install cmake git gettext)
 
-## building the deps
-You need to build the dependence of BambuStudio first. (Only needs for the first time)  
+## Building the dependencies
+
+You need to build the dependencies of BambuStudio first. (Only needs for the first time)
+
+Suppose you download the codes into `/Users/_username_/work/projects/BambuStudio`.
+
+Create a directory to store the built dependencies: `/Users/_username_/work/projects/BambuStudio_dep`.
+**(Please make sure to replace the username with the one on your computer)**
+
+Then:
+
+```shell
+cd BambuStudio/deps
+mkdir build
+cd build
+```
+
 Next, for arm64 architecture:
 ```shell
 cmake ../ -DDESTDIR="/Users/username/work/projects/BambuStudio_dep" -DOPENSSL_ARCH="darwin64-arm64-cc"
 make
 ```
 
-Suppose you download the codes into /Users/_username_/work/projects/BambuStudio  
-create a directory to store the dependence built: /Users/_username_/work/projects/BambuStudio_dep  
-**(Please make sure to replace the username with the one on your computer)**  
+Or, for x86 architeccture:
+```shell
+cmake ../ -DDESTDIR="/Users/username/work/projects/BambuStudio_dep" -DOPENSSL_ARCH="darwin64-x86_64-cc"
+make -jN
+```
+(N can be a number between 1 and the max cpu number)  
 
-`cd BambuStudio/deps`  
-`mkdir build;cd build`  
+## Building Bambu Studio
 
-for x86 architeccture  
-`cmake ../ -DDESTDIR="/Users/username/work/projects/BambuStudio_dep" -DOPENSSL_ARCH="darwin64-x86_64-cc"`  
-`make -jN`  (N can be a number between 1 and the max cpu number)  
+Create a directory to store the installed files at `/Users/username/work/projects/BambuStudio/install_dir`:
 
-## building the Bambu Studio
-create a directory to store the installed files at /Users/username/work/projects/BambuStudio/install_dir  
-`cd BambuStudio`  
-`mkdir install_dir`  
-`mkdir build;cd build`  
+```shell
+cd BambuStudio
+mkdir install_dir
+mkdir build
+cd build
+```
 
-building it use cmake  
-`cmake ..  -DBBL_RELEASE_TO_PUBLIC=1 -DCMAKE_PREFIX_PATH="/Users/username/work/projects/BambuStudio_dep/usr/local" -DCMAKE_INSTALL_PREFIX="../install_dir" -DCMAKE_BUILD_TYPE=Release -DCMAKE_MACOSX_RPATH=ON -DCMAKE_INSTALL_RPATH="/Users/username/work/projects/BambuStudio_dep/usr/local" -DCMAKE_MACOSX_BUNDLE=on`  
-`cmake --build . --target install --config Release -jN`  
+To build using CMake:
 
-building it use xcode  
-`cmake .. -GXcode -DBBL_RELEASE_TO_PUBLIC=1 -DCMAKE_PREFIX_PATH="/Users/username/work/projects/BambuStudio_dep/usr/local" -DCMAKE_INSTALL_PREFIX="../install_dir" -DCMAKE_BUILD_TYPE=Release -DCMAKE_MACOSX_RPATH=ON -DCMAKE_INSTALL_RPATH="/Users/username/work/projects/BambuStudio_dep/usr/local" -DCMAKE_MACOSX_BUNDLE=on`  
-then building it using Xcode
+```shell
+cmake ..  -DBBL_RELEASE_TO_PUBLIC=1 -DCMAKE_PREFIX_PATH="/Users/username/work/projects/BambuStudio_dep/usr/local" -DCMAKE_INSTALL_PREFIX="../install_dir" -DCMAKE_BUILD_TYPE=Release -DCMAKE_MACOSX_RPATH=ON -DCMAKE_INSTALL_RPATH="/Users/username/work/projects/BambuStudio_dep/usr/local" -DCMAKE_MACOSX_BUNDLE=on
+cmake --build . --target install --config Release -jN
+```
+
+To build for use with XCode:
+
+```shell
+cmake .. -GXcode -DBBL_RELEASE_TO_PUBLIC=1 -DCMAKE_PREFIX_PATH="/Users/username/work/projects/BambuStudio_dep/usr/local" -DCMAKE_INSTALL_PREFIX="../install_dir" -DCMAKE_BUILD_TYPE=Release -DCMAKE_MACOSX_RPATH=ON -DCMAKE_INSTALL_RPATH="/Users/username/work/projects/BambuStudio_dep/usr/local" -DCMAKE_MACOSX_BUNDLE=on
+```


### PR DESCRIPTION
While trying to compile on my Macbook Pro running Ventura 13.4.1 using AppleClang 14.0.3.14030022, I ran into an error related to bad syntax `&& && git init` and was unable to finish compiling.

I was able to determine that the changes made in #1097 caused this issue. With the fix in this PR, I was able to successfully finish compiling.

I also noticed that the compile guide was missing a `make` command for arm64 architecture and have added that.

Lastly, I made some adjustments to the formatting in the Mac Compile Guide to try and improve readability.