### PR TITLE
additional appimage job for ubuntu 20.04

### DIFF
--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -42,3 +42,28 @@ jobs:
         with:
           name: BambuStudio_Linux
           path: './build/BambuStudio_ubu64.AppImage'
+
+  appimage-builder-u2004:
+    name: Linux AppImage Build Ubuntu 20.04
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install podman
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
+      - name: Build
+        shell: bash
+        run: |
+          rm -rf build
+          podman buildx build -t bambu-studio-builder:latest .
+          podman run -d -it --name bambu-studio-builder bambu-studio-builder:latest /bin/bash -c 'tail -f /dev/null'
+          podman cp bambu-studio-builder:/BambuStudio/build/BambuStudio_ubu64.AppImage ./
+          podman stop bambu-studio-builder
+          podman rm bambu-studio-builder
+      - uses: actions/upload-artifact@v3
+        with:
+          name: BambuStudio_Linux
+          path: './BambuStudio_ubu64.AppImage'

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -58,7 +58,7 @@ jobs:
         shell: bash
         run: |
           rm -rf build
-          podman buildx build -t bambu-studio-builder:latest .
+          podman buildx build --build-arg BUILD_LINUX_EXTRA_ARGS=-r -t bambu-studio-builder:latest .
           podman run -d -it --name bambu-studio-builder bambu-studio-builder:latest /bin/bash -c 'tail -f /dev/null'
           podman cp bambu-studio-builder:/BambuStudio/build/BambuStudio_ubu64.AppImage ./
           podman stop bambu-studio-builder

--- a/Containerfile
+++ b/Containerfile
@@ -20,6 +20,7 @@
 
 FROM docker.io/ubuntu:20.04
 LABEL maintainer "DeftDawg <DeftDawg@gmail.com>"
+ARG BUILD_LINUX_EXTRA_ARGS=""
 
 # Disable interactive package configuration
 RUN apt-get update && \
@@ -58,14 +59,14 @@ WORKDIR BambuStudio
 
 # These can run together, but we run them seperate for podman caching
 # Update System dependencies
-RUN ./BuildLinux.sh -u
+RUN ./BuildLinux.sh -u ${BUILD_LINUX_EXTRA_ARGS}
 
 # Build dependencies in ./deps
-RUN ./BuildLinux.sh -d
+RUN ./BuildLinux.sh -d ${BUILD_LINUX_EXTRA_ARGS}
 
 # Build slic3r
-RUN ./BuildLinux.sh -s
+RUN ./BuildLinux.sh -s ${BUILD_LINUX_EXTRA_ARGS}
 
 # Build AppImage
 ENV container podman
-RUN ./BuildLinux.sh -i
+RUN ./BuildLinux.sh -i ${BUILD_LINUX_EXTRA_ARGS}


### PR DESCRIPTION
added a copy of the job to build with ubuntu 20.04 builder image to define correct glib versions. Also see discussion in https://github.com/bambulab/BambuStudio/issues/1667