### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ ARG USER=root
 ARG UID=0
 ARG GID=0
 RUN [[ "$UID" != "0" ]] \
-  && groupadd -g $GID $USER \
+  && groupadd -f -g $GID $USER \
   && useradd -u $UID -g $GID $USER
 
 # Using an entrypoint instead of CMD because the binary


### PR DESCRIPTION
add -f option to groupadd command (line 89). This fixed an issue for me where the group in $GID already existed, preventing me from completing DockerBuild.sh on Linux Mint 19.

This may not be the best way to fix this. I'm not sure how the value in $GID is determined but on my machine it resolved to a value that already existed. This caused the DockerBuild.sh script to fail. 

Looking into it deeper it seems like somehow I am not a member of the group with the same name as my user which seems to be what the Dockerfile expects. With the -f option I am able to use DockerRun.sh, BambuStudio runs and everything still works fine under my user when opening/saving files.



