### PR TITLE
FIX: CURL: don't build curl.exe

### DIFF
--- a/deps/CURL/CURL.cmake
+++ b/deps/CURL/CURL.cmake
@@ -66,6 +66,7 @@ bambustudio_add_cmake_project(CURL
   #                     ${GIT_EXECUTABLE} apply --whitespace=fix ${CMAKE_CURRENT_LIST_DIR}/curl-mods.patch
   CMAKE_ARGS
     -DBUILD_TESTING:BOOL=OFF
+    -DBUILD_CURL_EXE:BOOL=OFF
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     -DCURL_STATICLIB=${_curl_static}
     ${_curl_platform_flags}


### PR DESCRIPTION
on ubuntu 20.04, link curl.exe will cause an error

Change-Id: Ic854abdf020d36148394552eccc76dd7be19208f