### PR TITLE
Fix typo during flow rate calibration failure

### DIFF
--- a/bbl/i18n/BambuStudio.pot
+++ b/bbl/i18n/BambuStudio.pot
@@ -8734,7 +8734,7 @@ msgstr ""
 msgid "Connecting to printer..."
 msgstr ""
 
-msgid "The failed test result has been droped."
+msgid "The failed test result has been dropped."
 msgstr ""
 
 msgid "Flow Dynamics Calibration result has been saved to the printer"
@@ -8862,7 +8862,7 @@ msgstr ""
 
 msgid ""
 "Part of the calibration failed! You may clean the plate and retry. The "
-"failed test result would be droped."
+"failed test result would be dropped."
 msgstr ""
 
 msgid ""

--- a/bbl/i18n/de/BambuStudio_de.po
+++ b/bbl/i18n/de/BambuStudio_de.po
@@ -9773,7 +9773,7 @@ msgstr ""
 msgid "Connecting to printer..."
 msgstr ""
 
-msgid "The failed test result has been droped."
+msgid "The failed test result has been dropped."
 msgstr ""
 
 msgid "Flow Dynamics Calibration result has been saved to the printer"
@@ -9901,7 +9901,7 @@ msgstr ""
 
 msgid ""
 "Part of the calibration failed! You may clean the plate and retry. The "
-"failed test result would be droped."
+"failed test result would be dropped."
 msgstr ""
 
 msgid ""

--- a/bbl/i18n/en/BambuStudio_en.po
+++ b/bbl/i18n/en/BambuStudio_en.po
@@ -9517,7 +9517,7 @@ msgstr ""
 msgid "Connecting to printer..."
 msgstr ""
 
-msgid "The failed test result has been droped."
+msgid "The failed test result has been dropped."
 msgstr ""
 
 msgid "Flow Dynamics Calibration result has been saved to the printer"
@@ -9645,7 +9645,7 @@ msgstr ""
 
 msgid ""
 "Part of the calibration failed! You may clean the plate and retry. The "
-"failed test result would be droped."
+"failed test result would be dropped."
 msgstr ""
 
 msgid ""

--- a/bbl/i18n/es/BambuStudio_es.po
+++ b/bbl/i18n/es/BambuStudio_es.po
@@ -9705,7 +9705,7 @@ msgstr ""
 msgid "Connecting to printer..."
 msgstr ""
 
-msgid "The failed test result has been droped."
+msgid "The failed test result has been dropped."
 msgstr ""
 
 msgid "Flow Dynamics Calibration result has been saved to the printer"
@@ -9833,7 +9833,7 @@ msgstr ""
 
 msgid ""
 "Part of the calibration failed! You may clean the plate and retry. The "
-"failed test result would be droped."
+"failed test result would be dropped."
 msgstr ""
 
 msgid ""

--- a/bbl/i18n/fr/BambuStudio_fr.po
+++ b/bbl/i18n/fr/BambuStudio_fr.po
@@ -9781,7 +9781,7 @@ msgstr ""
 msgid "Connecting to printer..."
 msgstr ""
 
-msgid "The failed test result has been droped."
+msgid "The failed test result has been dropped."
 msgstr ""
 
 msgid "Flow Dynamics Calibration result has been saved to the printer"
@@ -9909,7 +9909,7 @@ msgstr ""
 
 msgid ""
 "Part of the calibration failed! You may clean the plate and retry. The "
-"failed test result would be droped."
+"failed test result would be dropped."
 msgstr ""
 
 msgid ""

--- a/bbl/i18n/hu/BambuStudio_hu.po
+++ b/bbl/i18n/hu/BambuStudio_hu.po
@@ -9634,7 +9634,7 @@ msgstr ""
 msgid "Connecting to printer..."
 msgstr ""
 
-msgid "The failed test result has been droped."
+msgid "The failed test result has been dropped."
 msgstr ""
 
 msgid "Flow Dynamics Calibration result has been saved to the printer"
@@ -9762,7 +9762,7 @@ msgstr ""
 
 msgid ""
 "Part of the calibration failed! You may clean the plate and retry. The "
-"failed test result would be droped."
+"failed test result would be dropped."
 msgstr ""
 
 msgid ""

--- a/bbl/i18n/it/BambuStudio_it.po
+++ b/bbl/i18n/it/BambuStudio_it.po
@@ -9706,7 +9706,7 @@ msgstr ""
 msgid "Connecting to printer..."
 msgstr ""
 
-msgid "The failed test result has been droped."
+msgid "The failed test result has been dropped."
 msgstr ""
 
 msgid "Flow Dynamics Calibration result has been saved to the printer"
@@ -9834,7 +9834,7 @@ msgstr ""
 
 msgid ""
 "Part of the calibration failed! You may clean the plate and retry. The "
-"failed test result would be droped."
+"failed test result would be dropped."
 msgstr ""
 
 msgid ""

--- a/bbl/i18n/ja/BambuStudio_ja.po
+++ b/bbl/i18n/ja/BambuStudio_ja.po
@@ -9218,7 +9218,7 @@ msgstr ""
 msgid "Connecting to printer..."
 msgstr ""
 
-msgid "The failed test result has been droped."
+msgid "The failed test result has been dropped."
 msgstr ""
 
 msgid "Flow Dynamics Calibration result has been saved to the printer"
@@ -9346,7 +9346,7 @@ msgstr ""
 
 msgid ""
 "Part of the calibration failed! You may clean the plate and retry. The "
-"failed test result would be droped."
+"failed test result would be dropped."
 msgstr ""
 
 msgid ""

--- a/bbl/i18n/ko/BambuStudio_ko.po
+++ b/bbl/i18n/ko/BambuStudio_ko.po
@@ -9360,7 +9360,7 @@ msgstr ""
 msgid "Connecting to printer..."
 msgstr ""
 
-msgid "The failed test result has been droped."
+msgid "The failed test result has been dropped."
 msgstr ""
 
 msgid "Flow Dynamics Calibration result has been saved to the printer"
@@ -9488,7 +9488,7 @@ msgstr ""
 
 msgid ""
 "Part of the calibration failed! You may clean the plate and retry. The "
-"failed test result would be droped."
+"failed test result would be dropped."
 msgstr ""
 
 msgid ""

--- a/bbl/i18n/nl/BambuStudio_nl.po
+++ b/bbl/i18n/nl/BambuStudio_nl.po
@@ -9727,7 +9727,7 @@ msgstr ""
 msgid "Connecting to printer..."
 msgstr ""
 
-msgid "The failed test result has been droped."
+msgid "The failed test result has been dropped."
 msgstr ""
 
 msgid "Flow Dynamics Calibration result has been saved to the printer"
@@ -9855,7 +9855,7 @@ msgstr ""
 
 msgid ""
 "Part of the calibration failed! You may clean the plate and retry. The "
-"failed test result would be droped."
+"failed test result would be dropped."
 msgstr ""
 
 msgid ""

--- a/bbl/i18n/sv/BambuStudio_sv.po
+++ b/bbl/i18n/sv/BambuStudio_sv.po
@@ -9541,7 +9541,7 @@ msgstr ""
 msgid "Connecting to printer..."
 msgstr ""
 
-msgid "The failed test result has been droped."
+msgid "The failed test result has been dropped."
 msgstr ""
 
 msgid "Flow Dynamics Calibration result has been saved to the printer"
@@ -9669,7 +9669,7 @@ msgstr ""
 
 msgid ""
 "Part of the calibration failed! You may clean the plate and retry. The "
-"failed test result would be droped."
+"failed test result would be dropped."
 msgstr ""
 
 msgid ""

--- a/bbl/i18n/zh_cn/BambuStudio_zh_CN.po
+++ b/bbl/i18n/zh_cn/BambuStudio_zh_CN.po
@@ -9067,7 +9067,7 @@ msgstr "请选择要校准的耗材丝。"
 msgid "Connecting to printer..."
 msgstr "正在连接打印机..."
 
-msgid "The failed test result has been droped."
+msgid "The failed test result has been dropped."
 msgstr "测试失败的结果已被删除。"
 
 msgid "Flow Dynamics Calibration result has been saved to the printer"
@@ -9227,7 +9227,7 @@ msgstr ""
 
 msgid ""
 "Part of the calibration failed! You may clean the plate and retry. The "
-"failed test result would be droped."
+"failed test result would be dropped."
 msgstr ""
 
 msgid ""

--- a/src/slic3r/GUI/CalibrationWizard.cpp
+++ b/src/slic3r/GUI/CalibrationWizard.cpp
@@ -587,7 +587,7 @@ void PressureAdvanceWizard::on_cali_save()
                     return;
                 }
                 if (save_page->is_all_failed()) {
-                    MessageDialog msg_dlg(nullptr, _L("The failed test result has been droped."), wxEmptyString, wxOK);
+                    MessageDialog msg_dlg(nullptr, _L("The failed test result has been dropped."), wxEmptyString, wxOK);
                     msg_dlg.ShowModal();
                     show_step(start_step);
                     return;
@@ -945,7 +945,7 @@ void FlowRateWizard::on_cali_save()
                 return;
             }
             if (save_page->is_all_failed()) {
-                MessageDialog msg_dlg(nullptr, _L("The failed test result has been droped."), wxEmptyString, wxOK);
+                MessageDialog msg_dlg(nullptr, _L("The failed test result has been dropped."), wxEmptyString, wxOK);
                 msg_dlg.ShowModal();
                 show_step(start_step);
                 return;

--- a/src/slic3r/GUI/CalibrationWizardSavePage.cpp
+++ b/src/slic3r/GUI/CalibrationWizardSavePage.cpp
@@ -146,7 +146,7 @@ void CaliPASaveAutoPanel::create_panel(wxWindow* parent)
     wxBoxSizer* part_failed_sizer = new wxBoxSizer(wxVERTICAL);
     m_part_failed_panel->SetSizer(part_failed_sizer);
     part_failed_sizer->AddSpacer(FromDIP(10));
-    auto part_failed_text = new Label(m_part_failed_panel, _L("Part of the calibration failed! You may clean the plate and retry. The failed test result would be droped."));
+    auto part_failed_text = new Label(m_part_failed_panel, _L("Part of the calibration failed! You may clean the plate and retry. The failed test result would be dropped."));
     part_failed_text->SetFont(Label::Body_14);
     part_failed_sizer->Add(part_failed_text, 0, wxLEFT | wxRIGHT, FromDIP(20));
     part_failed_sizer->AddSpacer(FromDIP(10));
@@ -900,7 +900,7 @@ void CalibrationFlowX1SavePage::create_page(wxWindow* parent)
     wxBoxSizer* part_failed_sizer = new wxBoxSizer(wxVERTICAL);
     m_part_failed_panel->SetSizer(part_failed_sizer);
     part_failed_sizer->AddSpacer(FromDIP(10));
-    auto part_failed_text = new Label(m_part_failed_panel, _L("Part of the calibration failed! You may clean the plate and retry. The failed test result would be droped."));
+    auto part_failed_text = new Label(m_part_failed_panel, _L("Part of the calibration failed! You may clean the plate and retry. The failed test result would be dropped."));
     part_failed_text->SetFont(Label::Body_14);
     part_failed_sizer->Add(part_failed_text, 0, wxLEFT | wxRIGHT, FromDIP(20));
     part_failed_sizer->AddSpacer(FromDIP(10));


### PR DESCRIPTION
Change "droped" to dropped for flow rate calibration fail.

Discovered this typo during my flow rate calibration for my X1C