### PR TITLE
Add Klipper/Moonraker compatible metadata and thumbnails to GCode for Non-Bambu Printers

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -57,7 +57,8 @@ const std::vector<std::string> GCodeProcessor::Reserved_Tags = {
     "_GP_FIRST_LINE_M73_PLACEHOLDER",
     "_GP_LAST_LINE_M73_PLACEHOLDER",
     "_GP_ESTIMATED_PRINTING_TIME_PLACEHOLDER",
-    "_GP_TOTAL_LAYER_NUMBER_PLACEHOLDER"
+    "_GP_TOTAL_LAYER_NUMBER_PLACEHOLDER",
+    "_GP_ESTIMATED_PRINTING_TIME_MOONRAKER_COMPATIBLE_PLACEHOLDER"
 };
 
 const std::string GCodeProcessor::Flush_Start_Tag = " FLUSH_START";
@@ -476,6 +477,18 @@ void GCodeProcessor::TimeProcessor::post_process(const std::string& filename, st
                         sprintf(buf, "; model printing time: %s; total estimated time: %s\n",
                                 get_time_dhms(machine.time - machine.prepare_time).c_str(),
                                 get_time_dhms(machine.time).c_str());
+                        ret += buf;
+                    }
+                }
+            }
+            //SL: add moonraker compat estimated time tag 
+            else if (line == reserved_tag(ETags::Estimated_Printing_Time_Moonraker_Compatible_Placeholder)) {
+                for (size_t i = 0; i < static_cast<size_t>(PrintEstimatedStatistics::ETimeMode::Count); ++i) {
+                    const TimeMachine& machine = machines[i];
+                    PrintEstimatedStatistics::ETimeMode mode = static_cast<PrintEstimatedStatistics::ETimeMode>(i);
+                    if (mode == PrintEstimatedStatistics::ETimeMode::Normal || machine.enabled) {
+                        char buf[128];
+                        sprintf(buf, "; estimated printing time (normal mode) = %s\n", get_time_dhms(machine.time).c_str());
                         ret += buf;
                     }
                 }

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -253,7 +253,8 @@ namespace Slic3r {
             First_Line_M73_Placeholder,
             Last_Line_M73_Placeholder,
             Estimated_Printing_Time_Placeholder,
-            Total_Layer_Number_Placeholder
+            Total_Layer_Number_Placeholder,
+            Estimated_Printing_Time_Moonraker_Compatible_Placeholder // SL
         };
 
         static const std::string& reserved_tag(ETags tag) { return Reserved_Tags[static_cast<unsigned char>(tag)]; }

--- a/src/libslic3r/GCode/ThumbnailData.hpp
+++ b/src/libslic3r/GCode/ThumbnailData.hpp
@@ -8,7 +8,7 @@
 namespace Slic3r {
 
 //BBS: thumbnail_size in gcode file
-static std::vector<Vec2d> THUMBNAIL_SIZE = { Vec2d(50, 50) };
+static std::vector<Vec2d> THUMBNAIL_SIZE = { Vec2d(300, 300) }; // SL change image size
 
 struct ThumbnailData
 {


### PR DESCRIPTION
This is the biggest thing that I'm missing from using Bambu Studio for all of my printers.

Uncommented the Thumbnail generation block and conditionalized for only non-Bambu printers, and increased the thumbnail size from 50x50 to 300x300.

Added Moonraker compatible stats/config to the bottom of the GCode export, only for non-Bambu printers.   Moonraker searches the "footer" (last read-size block) for most of the values - and has particular pattern expressions.   I also considered patching Moonraker, but found that several of the settings (such as filament used stats) were not available anywhere in the GCode output, so a change was required here anyway.

Please adjust or expand as you see fit.  

Thanks!