### PR TITLE
Allow line width of nozzle diameter * 2.5

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1165,7 +1165,7 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
         	} else if (extrusion_width_min <= layer_height) {
                 err_msg = L("Too small line width");
 				return false;
-			} else if (extrusion_width_max >= max_nozzle_diameter * 2.5) {
+			} else if (extrusion_width_max > max_nozzle_diameter * 2.5) {
                 err_msg = L("Too large line width");
 				return false;
 			}


### PR DESCRIPTION
As it were, 1 mm would be disallowed but 0.99 would be allowed for 0.4 nozzle.  1 mm is the sane maximum and 0.99 is unnecessary tedious to write.

OrcaSlicer already has this as `>` (it also allows 5x nozzle size but I personally see no use for that considering the nozzle flat size of Bambu hotends).