### PR TITLE
Update Bambu Lab A1 mini 0.4 nozzle.json

### DIFF
--- a/resources/profiles/BBL/machine/Bambu Lab A1 mini 0.4 nozzle.json
+++ b/resources/profiles/BBL/machine/Bambu Lab A1 mini 0.4 nozzle.json
@@ -12,7 +12,7 @@
     "printer_variant": "0.4",
     "auxiliary_fan": "0",
     "bed_exclude_area": [],
-    "best_object_pos": "0.7x0.5",
+    "best_object_pos": "0.5x0.7",
     "default_filament_profile": [
         "Bambu PLA Basic @BBL A1M"
     ],


### PR DESCRIPTION
the value was in incorrect order, default print is on the middle right hand side of the bed instead of the middle back.