### PR TITLE
Fix printing times on same line in GCode file 

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -480,7 +480,7 @@ void GCodeProcessor::TimeProcessor::post_process(const std::string& filename, st
                         //sprintf(buf, "; estimated printing time (%s mode) = %s\n",
                         //    (mode == PrintEstimatedStatistics::ETimeMode::Normal) ? "normal" : "silent",
                         //    get_time_dhms(machine.time).c_str());
-                        sprintf(buf, "; model printing time: %s; total estimated time: %s\n",
+                        sprintf(buf, "; model printing time: %s\n; total estimated time: %s\n",
                                 get_time_dhms(machine.time - machine.prepare_time).c_str(),
                                 get_time_dhms(machine.time).c_str());
                         ret += buf;


### PR DESCRIPTION
Fix the `model printing time` and `total estimated time` statistics being on the same line in the `HEADER_BLOCK` in generated GCode files.

While this may seem simple, it can cause huge headaches when parsing programatically.