### PR TITLE
Fix .icns File Paths for Directory Structure in macOS

### DIFF
--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -46,7 +46,7 @@
 			<string>STL</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>stl.icns</string>
+			<string>images/stl.icns</string>
 			<key>CFBundleTypeName</key>
 			<string>STL</string>
 			<key>CFBundleTypeRole</key>
@@ -63,7 +63,7 @@
 			<string>OBJ</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>BambuStudio.icns</string>
+			<string>images/BambuStudio.icns</string>
 			<key>CFBundleTypeName</key>
 			<string>STL</string>
 			<key>CFBundleTypeRole</key>
@@ -80,7 +80,7 @@
 			<string>AMF</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>BambuStudio.icns</string>
+			<string>images/BambuStudio.icns</string>
 			<key>CFBundleTypeName</key>
 			<string>AMF</string>
 			<key>CFBundleTypeRole</key>
@@ -97,7 +97,7 @@
 			<string>3MF</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>BambuStudio.icns</string>
+			<string>images/BambuStudio.icns</string>
 			<key>CFBundleTypeName</key>
 			<string>3MF</string>
 			<key>CFBundleTypeRole</key>
@@ -114,7 +114,7 @@
 			<string>GCODE</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>gcode.icns</string>
+			<string>images/gcode.icns</string>
 			<key>CFBundleTypeName</key>
 			<string>GCODE</string>
 			<key>CFBundleTypeRole</key>

--- a/src/platform/osx/Info.plist.in
+++ b/src/platform/osx/Info.plist.in
@@ -7,7 +7,7 @@
   <key>CFBundleGetInfoString</key>
   <string>@SLIC3R_APP_NAME@ Copyright(C) 2021-2023 Lunkuo All Rights Reserved</string>
   <key>CFBundleIconFile</key>
-  <string>BambuStudio.icns</string>
+  <string>images/BambuStudio.icns</string>
   <key>CFBundleName</key>
   <string>@SLIC3R_APP_KEY@</string>
   <key>CFBundleShortVersionString</key>
@@ -42,7 +42,7 @@
         <string>STL</string>
       </array>
       <key>CFBundleTypeIconFile</key>
-      <string>stl.icns</string>
+      <string>images/stl.icns</string>
       <key>CFBundleTypeName</key>
       <string>STL</string>
       <key>CFBundleTypeRole</key>
@@ -59,7 +59,7 @@
         <string>OBJ</string>
       </array>
       <key>CFBundleTypeIconFile</key>
-      <string>BambuStudio.icns</string>
+      <string>images/BambuStudio.icns</string>
       <key>CFBundleTypeName</key>
       <string>STL</string>
       <key>CFBundleTypeRole</key>
@@ -76,7 +76,7 @@
         <string>AMF</string>
       </array>
       <key>CFBundleTypeIconFile</key>
-      <string>BambuStudio.icns</string>
+      <string>images/BambuStudio.icns</string>
       <key>CFBundleTypeName</key>
       <string>AMF</string>
       <key>CFBundleTypeRole</key>
@@ -93,7 +93,7 @@
         <string>3MF</string>
       </array>
       <key>CFBundleTypeIconFile</key>
-      <string>BambuStudio.icns</string>
+      <string>images/BambuStudio.icns</string>
       <key>CFBundleTypeName</key>
       <string>3MF</string>
       <key>CFBundleTypeRole</key>
@@ -110,7 +110,7 @@
         <string>GCODE</string>
       </array>
       <key>CFBundleTypeIconFile</key>
-      <string>gcode.icns</string>
+      <string>images/gcode.icns</string>
       <key>CFBundleTypeName</key>
       <string>GCODE</string>
       <key>CFBundleTypeRole</key>


### PR DESCRIPTION
### Description of Changes

<img width="565" alt="Screenshot 2023-12-15 at 01 39 13" src="https://github.com/bambulab/BambuStudio/assets/2759749/3a62a75d-5493-43ed-a318-104920c4aa45">
<img width="521" alt="Screenshot 2023-12-15 at 01 39 00" src="https://github.com/bambulab/BambuStudio/assets/2759749/74d166cd-d3f7-475a-b557-113a9308a388">


This pull request introduces updates to the paths of `.icns` files in our macOS application. These changes are necessary to accommodate a new directory structure, where icons will now be stored in the `images` subfolder within the `Resources` directory.

### Affected Files

- The changes affect two key files:
  1. src/platform/osx/Info.plist.in
  2. cmake/modules/MacOSXBundleInfo.plist.in

### Details of Changes

- In all lines where the path to `.icns` icon files was used, the path has been updated to reflect the new directory structure.
- For example, lines like `<string>BambuStudio.icns</string>` have been changed to `<string>images/BambuStudio.icns</string>` in `Info.plist`.
- These modifications apply to all references to `.icns` files in the specified files.

### Reason for Changes

- Icons didn’t work with associated files in MacOS

### Impact on Build and Deployment

- Following the acceptance of these changes, a rebuild of the project will be necessary to ensure the icons are displayed correctly.
- A comprehensive testing of the application is recommended to ensure there are no issues related to the loading of icons.

Thank you for your attention to this request.