### PR TITLE
Fix "Beta Version" appearing as "Internal Version"

### DIFF
--- a/version.inc
+++ b/version.inc
@@ -7,6 +7,8 @@ set(SLIC3R_APP_KEY "BambuStudio")
 if(NOT DEFINED BBL_RELEASE_TO_PUBLIC)
 set(BBL_RELEASE_TO_PUBLIC "0")
 endif()
+# Note that defining BBL_INTERNAL_TESTING will create a beta version
+# not an "internal testing" version (the default)
 if(NOT DEFINED BBL_INTERNAL_TESTING)
 set(BBL_INTERNAL_TESTING "1")
 endif()


### PR DESCRIPTION
The value of BBL_INTERNAL_TESTING is reversed and should be set to 1 when requested instead of 1 when not requested.

Fixes: 79480405a022 ("ENH: update version to 1.3.0")

Note: pretty sure I got this right, in my testing, without `-DBBL_RELEASE_TO_PUBLIC=1` in the build flags, it would default to an "internal testing" version instead of a "beta version".