### PR TITLE
FIX: Fix build error with wxWidgets 3.2.4

### DIFF
--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -329,7 +329,7 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
     // Always fill in the "printhost_port" combo box from the config and select it.
     {
         Choice* choice = dynamic_cast<Choice*>(m_optgroup->get_field("printhost_port"));
-        choice->set_values({ m_config->opt_string("printhost_port") });
+        choice->set_values(std::vector<std::string>({ m_config->opt_string("printhost_port") }));
         choice->set_selection();
     }
 


### PR DESCRIPTION
Make initializers explicit to avoid ambiguous wxArrayString overloads.

```
src/slic3r/GUI/PhysicalPrinterDialog.cpp: In member function ‘void Slic3r::GUI::PhysicalPrinterDialog::build_printhost_settings(Slic3r::GUI::ConfigOptionsGroup*)’: src/slic3r/GUI/PhysicalPrinterDialog.cpp:332: error: call of overloaded ‘set_values(<brace-enclosed initializer list>)’ is ambiguous
  332 |         choice->set_values({ m_config->opt_string("printhost_port") });
      |
```

See https://github.com/prusa3d/PrusaSlicer/pull/11769