### PR TITLE
unix: Fix "Open in BambuStudio" button on MakerWorld

### DIFF
--- a/src/platform/unix/BambuStudio.desktop
+++ b/src/platform/unix/BambuStudio.desktop
@@ -2,10 +2,10 @@
 Name=BambuStudio
 GenericName=3D Printing Software
 Icon=BambuStudio
-Exec=bambu-studio %F
+Exec=bambu-studio %U
 Terminal=false
 Type=Application
-MimeType=model/stl;model/3mf;application/vnd.ms-3mfdocument;application/prs.wavefront-obj;application/x-amf;
+MimeType=model/stl;model/3mf;application/vnd.ms-3mfdocument;application/prs.wavefront-obj;application/x-amf;x-scheme-handler/bambustudio;
 Categories=Graphics;3DGraphics;Engineering;
 Keywords=3D;Printing;Slicer;slice;3D;printer;convert;gcode;stl;obj;amf;SLA
 StartupNotify=false


### PR DESCRIPTION
Make the "Open in BambuStudio" button on MakerWorld works by informing the system that BambuStudio is the application to handle URLs with the bambustudio scheme, and that it can handle URLs, not just local files.

This fixes this error message visible in Firefox' console when clicking the button on the website:
```
Prevented navigation to “bambustudio://open?file=https%3A%2F%2Fmakerworld.bblmw.com[...]bambu_scraper_grip_ams.3mf” due to an unknown protocol.
```