### PR TITLE
All printers: Change printable height to 256 mm

### DIFF
--- a/resources/profiles/BBL/machine/fdm_machine_common.json
+++ b/resources/profiles/BBL/machine/fdm_machine_common.json
@@ -74,7 +74,7 @@
     "min_layer_height": [
         "0.08"
     ],
-    "printable_height": "250",
+    "printable_height": "256",
     "extruder_clearance_radius": "65",
     "extruder_clearance_height_to_rod": "36",
     "extruder_clearance_height_to_lid": "140",


### PR DESCRIPTION
The Z-hop problem was already taken care of so this limitation is obsolete.