### PR TITLE
Update fdm_filament_pla.json

### DIFF
--- a/resources/profiles/BBL/filament/fdm_filament_pla.json
+++ b/resources/profiles/BBL/filament/fdm_filament_pla.json
@@ -74,7 +74,7 @@
         "4"
     ],
     "additional_cooling_fan_speed": [
-        "70"
+        "50"
     ],
     "filament_start_gcode": [
         "; filament start gcode\n{if  (bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S255\n{elsif(bed_temperature[current_extruder] >35)||(bed_temperature_initial_layer[current_extruder] >35)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"


### PR DESCRIPTION
When ever there is an object on the side of the plate nearest the aux fan, it always curls when the cooling fan is at 70%.  50% has worked just as well on other parts being printed and the parts near the edge of the bed don't warp.