### PR TITLE
fix: Upgrade dependencies and code to work on new macOS SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,6 +338,9 @@ if(SLIC3R_STATIC)
     set(Boost_USE_STATIC_LIBS ON)
     # Use boost libraries linked statically to the C++ runtime.
     # set(Boost_USE_STATIC_RUNTIME ON)
+
+    # Enable deprecated timer header (XXX replace header)
+    add_definitions(-DBOOST_TIMER_ENABLE_DEPRECATED)
 endif()
 #set(Boost_DEBUG ON)
 # set(Boost_COMPILER "-mgw81")

--- a/deps/Boost/Boost.cmake
+++ b/deps/Boost/Boost.cmake
@@ -128,12 +128,11 @@ list(APPEND _patch_command COMMAND git init && ${PATCH_CMD} ${CMAKE_CURRENT_LIST
 
 ExternalProject_Add(
     dep_Boost
-    #URL "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.zip"
-    URL "https://github.com/bambulab/boost/releases/download/1.78.0/boost_1_78_0.zip"
-    URL_HASH SHA256=f22143b5528e081123c3c5ed437e92f648fe69748e95fa6e2bd41484e2986cc3
+    URL "https://boostorg.jfrog.io/artifactory/main/release/1.85.0/source/boost_1_85_0.zip"
+    URL_HASH SHA256=e712fe7eb1b9ec37ac25102525412fb4d74e638996443944025791f48f29408a
     DOWNLOAD_DIR ${DEP_DOWNLOAD_DIR}/Boost
     CONFIGURE_COMMAND "${_bootstrap_cmd}"
-    PATCH_COMMAND ${_patch_command}
+    # PATCH_COMMAND ${_patch_command}
     BUILD_COMMAND "${_build_cmd}"
     BUILD_IN_SOURCE    ON
     INSTALL_COMMAND "${_install_cmd}"

--- a/deps/CGAL/CGAL.cmake
+++ b/deps/CGAL/CGAL.cmake
@@ -3,8 +3,8 @@ bambustudio_add_cmake_project(
     # GIT_REPOSITORY https://github.com/CGAL/cgal.git
     # GIT_TAG        caacd806dc55c61cc68adaad99f2240f00493b29 # releases/CGAL-5.3
     # For whatever reason, this keeps downloading forever (repeats downloads if finished)
-    URL      https://github.com/CGAL/cgal/archive/refs/tags/v5.4.zip
-    URL_HASH SHA256=d7605e0a5a5ca17da7547592f6f6e4a59430a0bc861948974254d0de43eab4c0
+    URL      https://github.com/CGAL/cgal/archive/refs/tags/v5.6.1.zip
+    URL_HASH SHA256=a968cc77b9a2c6cbe5b1680ceee8d8cd8c5369aedb9daced9e5c90b4442dc574
     DEPENDS dep_Boost dep_GMP dep_MPFR
 )
 

--- a/src/libslic3r/Format/bbs_3mf.cpp
+++ b/src/libslic3r/Format/bbs_3mf.cpp
@@ -23,7 +23,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/string_file.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/nowide/fstream.hpp>
 #include <boost/nowide/cstdio.hpp>
@@ -1237,12 +1236,19 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
             m_backup_path = filename.substr(0, filename.size() - 5);
             model.set_backup_path(m_backup_path);
             try {
-                if (boost::filesystem::exists(model.get_backup_path() + "/origin.txt"))
-                    boost::filesystem::load_string_file(model.get_backup_path() + "/origin.txt", m_origin_file);
+                std::string filepath = model.get_backup_path() + "/origin.txt";
+                if (boost::filesystem::exists(filepath)) {
+                    boost::filesystem::ifstream originfile(filepath);
+                    m_origin_file.assign(
+                        (std::istreambuf_iterator<char>(originfile)),
+                        (std::istreambuf_iterator<char>())
+                    );
+                    originfile.close();
+                }
             } catch (...) {}
-            boost::filesystem::save_string_file(
-                model.get_backup_path() + "/lock.txt",
-                boost::lexical_cast<std::string>(get_current_pid()));
+            boost::filesystem::ofstream lockfile(model.get_backup_path() + "/lock.txt");
+            lockfile << boost::lexical_cast<std::string>(get_current_pid());
+            lockfile.close();
         }
         else {
             m_backup_path = model.get_backup_path();
@@ -1253,7 +1259,9 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
             file_version = *m_bambuslicer_generator_version;
         // save for restore
         if (result && m_load_aux && !m_load_restore) {
-            boost::filesystem::save_string_file(model.get_backup_path() + "/origin.txt", filename);
+            boost::filesystem::ofstream originfile(model.get_backup_path() + "/origin.txt");
+            originfile << filename;
+            originfile.close();
         }
         if (m_load_restore && !result) // not clear failed backup data for later analyze
             model.set_backup_path("detach");
@@ -5355,6 +5363,7 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
         boost::system::error_code ec;
         std::string filename = std::string(store_params.path);
         boost::filesystem::remove(filename + ".tmp", ec);
+        boost::filesystem::ofstream outputfile;
 
         bool result = _save_model_to_file(filename + ".tmp", *store_params.model, store_params.plate_data_list, store_params.project_presets, store_params.config,
             store_params.thumbnail_data, store_params.top_thumbnail_data, store_params.pick_thumbnail_data, store_params.proFn,
@@ -5367,7 +5376,9 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
                 return false;
             }
             if (!(store_params.strategy & SaveStrategy::Silence))
-                boost::filesystem::save_string_file(store_params.model->get_backup_path() + "/origin.txt", filename);
+                outputfile.open(store_params.model->get_backup_path() + "/origin.txt");
+                outputfile << filename;
+                outputfile.close();
         }
         return result;
     }
@@ -8164,9 +8175,14 @@ bool has_restore_data(std::string & path, std::string& origin)
         origin = "<lock>";
         return false;
     }
-    if (boost::filesystem::exists(path + "/lock.txt")) {
-        std::string pid;
-        boost::filesystem::load_string_file(path + "/lock.txt", pid);
+    const std::string lockfile_path = path + "/lock.txt";
+    if (boost::filesystem::exists(lockfile_path)) {
+        boost::filesystem::ifstream lockfile(lockfile_path);
+        std::string pid(
+            (std::istreambuf_iterator<char>(lockfile)),
+            (std::istreambuf_iterator<char>())
+        );
+        lockfile.close();
         try {
             if (get_process_name(boost::lexical_cast<int>(pid)) ==
                 get_process_name(0)) {
@@ -8182,8 +8198,14 @@ bool has_restore_data(std::string & path, std::string& origin)
     if (!boost::filesystem::exists(file3mf))
         return false;
     try {
-        if (boost::filesystem::exists(path + "/origin.txt"))
-            boost::filesystem::load_string_file(path + "/origin.txt", origin);
+        if (boost::filesystem::exists(path + "/origin.txt")) {
+            boost::filesystem::ifstream originfile(path + "/origin.txt");
+            origin.assign(
+                (std::istreambuf_iterator<char>(originfile)),
+                (std::istreambuf_iterator<char>())
+            );
+            originfile.close();
+        }
     }
     catch (...) {
     }

--- a/src/libslic3r/MeshBoolean.cpp
+++ b/src/libslic3r/MeshBoolean.cpp
@@ -200,12 +200,12 @@ indexed_triangle_set cgal_to_indexed_triangle_set(const _Mesh &cgalmesh)
     const auto &vertices = cgalmesh.vertices();
     int vsize = int(vertices.size());
 
-    for (auto &vi : vertices) {
+    for (const auto &vi : vertices) {
         auto &v = cgalmesh.point(vi); // Don't ask...
         its.vertices.emplace_back(to_vec3f(v));
     }
 
-    for (auto &face : faces) {
+    for (const auto &face : faces) {
         auto vtc = cgalmesh.vertices_around_face(cgalmesh.halfedge(face));
 
         int i = 0;

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -23,7 +23,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/filesystem/string_file.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/nowide/iostream.hpp>
@@ -906,8 +905,9 @@ std::string Model::get_backup_path()
             BOOST_LOG_TRIVIAL(info) << "create /Metadata in " << temp_path;
             boost::filesystem::create_directories(backup_path + "/Metadata");
             BOOST_LOG_TRIVIAL(info) << "create /lock.txt in " << temp_path;
-            boost::filesystem::save_string_file(backup_path + "/lock.txt",
-                boost::lexical_cast<std::string>(get_current_pid()));
+            boost::filesystem::ofstream lockfile(backup_path + "/lock.txt");
+            lockfile << boost::lexical_cast<std::string>(get_current_pid());
+            lockfile.close();
         }
     } catch (std::exception &ex) {
         BOOST_LOG_TRIVIAL(error) << "Failed to create backup path" << temp_path << ": " << ex.what();

--- a/src/libslic3r/PrintBase.cpp
+++ b/src/libslic3r/PrintBase.cpp
@@ -80,7 +80,7 @@ std::string PrintBase::output_filename(const std::string &format, const std::str
 			cfg.opt_string("input_filename_base") + default_ext :
 			this->placeholder_parser().process(format, 0, &cfg);
         if (filename.extension().empty())
-            filename = boost::filesystem::change_extension(filename, default_ext);
+            filename.replace_extension(default_ext);
         return filename.string();
     } catch (std::runtime_error &err) {
         throw Slic3r::PlaceholderParserError(L("Failed processing of the filename_format template.") + "\n" + err.what());

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -830,7 +830,7 @@ CopyFileResult copy_file_inner(const std::string& from, const std::string& to, s
 	// That may happen when copying on some exotic file system, for example Linux on Chrome.
 	copy_file_linux(source, target, ec);
 #else // __linux__
-	boost::filesystem::copy_file(source, target, boost::filesystem::copy_option::overwrite_if_exists, ec);
+	boost::filesystem::copy_file(source, target, boost::filesystem::copy_options::overwrite_existing, ec);
 #endif // __linux__
 	if (ec) {
 		error_message = ec.message();

--- a/src/slic3r/GUI/Auxiliary.cpp
+++ b/src/slic3r/GUI/Auxiliary.cpp
@@ -346,7 +346,7 @@ void AuFile::on_input_enter(wxCommandEvent &evt)
     }
 
     auto     existing  = false;
-    auto     dir       = m_file_path.branch_path();
+    auto     dir       = m_file_path.parent_path();
     auto     new_fullname = new_file_name + m_file_path.extension().string();
 
     
@@ -462,8 +462,8 @@ void AuFile::on_set_cover()
     wxGetApp().plater()->model().model_info->cover_file = path.string();
     //wxGetApp().plater()->model().model_info->cover_file = m_file_name.ToStdString();
 
-    auto full_path          = m_file_path.branch_path();
-    auto full_root_path         = full_path.branch_path();
+    auto full_path          = m_file_path.parent_path();
+    auto full_root_path         = full_path.parent_path();
     auto full_root_path_str = encode_path(full_root_path.string().c_str());
     auto dir       = wxString::Format("%s/.thumbnails", full_root_path_str);
 
@@ -507,8 +507,8 @@ void AuFile::on_set_delete()
     auto     is_fine = fs::remove(bfs_path);
 
     if (m_cover) {
-        auto full_path          = m_file_path.branch_path();
-        auto full_root_path     = full_path.branch_path();
+        auto full_path          = m_file_path.parent_path();
+        auto full_root_path     = full_path.parent_path();
         auto full_root_path_str = encode_path(full_root_path.string().c_str());
         auto dir                = wxString::Format("%s/.thumbnails", full_root_path_str);
         fs::path dir_path(dir.c_str());
@@ -949,7 +949,7 @@ void AuxiliaryPanel::on_import_file(wxCommandEvent &event)
            
 
             boost::system::error_code ec;
-            if (!fs::copy_file(src_bfs_path, fs::path(dir_path.ToStdWstring()), fs::copy_option::overwrite_if_exists, ec)) continue;
+            if (!fs::copy_file(src_bfs_path, fs::path(dir_path.ToStdWstring()), fs::copy_options::overwrite_existing, ec)) continue;
             Slic3r::put_other_changes();
 
             // add in file list

--- a/src/slic3r/GUI/MediaPlayCtrl.cpp
+++ b/src/slic3r/GUI/MediaPlayCtrl.cpp
@@ -8,7 +8,6 @@
 #include "MsgDialog.hpp"
 #include "DownloadProgressDialog.hpp"
 
-#include <boost/filesystem/string_file.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/nowide/cstdio.hpp>
@@ -777,8 +776,12 @@ bool MediaPlayCtrl::start_stream_service(bool *need_install)
     file_url2.Replace("\\", "/");
     file_url2 = wxURI(file_url2).BuildURI();
     try {
-        std::string configs;
-        boost::filesystem::load_string_file(file_ff_cfg, configs);
+        boost::filesystem::ifstream configfile(file_ff_cfg);
+        std::string configs(
+            (std::istreambuf_iterator<char>(configfile)),
+            (std::istreambuf_iterator<char>())
+        );
+        configfile.close();
         std::vector<std::string> configss;
         boost::algorithm::split(configss, configs, boost::algorithm::is_any_of("\r\n"));
         configss.erase(std::remove(configss.begin(), configss.end(), std::string()), configss.end());

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -9,7 +9,6 @@
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/filesystem/string_file.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/log/trivial.hpp>
@@ -877,10 +876,24 @@ void PresetUpdater::priv::sync_tooltip(std::string http_url, std::string languag
         std::string language_version = "00.00.00.00";
         fs::path cache_root = fs::path(data_dir()) / "resources/tooltip";
         try {
-            auto vf = cache_root / "common" / "version";
-            if (fs::exists(vf)) fs::load_string_file(vf, common_version);
+            fs::path vf = cache_root / "common" / "version";
+            if (fs::exists(vf)) {
+            	boost::filesystem::ifstream versionfile(vf);
+		        common_version.assign(
+		            (std::istreambuf_iterator<char>(versionfile)),
+		            (std::istreambuf_iterator<char>())
+		        );
+		        versionfile.close();
+	        }
             vf = cache_root / language / "version";
-            if (fs::exists(vf)) fs::load_string_file(vf, language_version);
+            if (fs::exists(vf)) {
+            	boost::filesystem::ifstream versionfile(vf);
+		        language_version.assign(
+		            (std::istreambuf_iterator<char>(versionfile)),
+		            (std::istreambuf_iterator<char>())
+		        );
+		        versionfile.close();
+            }
         } catch (...) {}
         std::map<std::string, Resource> resources
         {
@@ -1086,13 +1099,23 @@ void PresetUpdater::priv::sync_printer_config(std::string http_url)
 
     try {
         if (fs::exists(config_folder / "version.txt")) {
-            fs::load_string_file(config_folder / "version.txt", curr_version);
+        	boost::filesystem::ifstream filedata(config_folder / "version.txt");
+	        curr_version.assign(
+	            (std::istreambuf_iterator<char>(filedata)),
+	            (std::istreambuf_iterator<char>())
+	        );
+	        filedata.close();
             boost::algorithm::trim(curr_version);
         }
     } catch (...) {}
     try {
         if (fs::exists(cache_folder / "version.txt")) {
-            fs::load_string_file(cache_folder / "version.txt", cached_version);
+            boost::filesystem::ifstream filedata(cache_folder / "version.txt");
+	        cached_version.assign(
+	            (std::istreambuf_iterator<char>(filedata)),
+	            (std::istreambuf_iterator<char>())
+	        );
+	        filedata.close();
             boost::algorithm::trim(cached_version);
         }
     } catch (...) {}
@@ -1128,7 +1151,12 @@ void PresetUpdater::priv::sync_printer_config(std::string http_url)
     bool result = false;
     try {
         if (fs::exists(cache_folder / "version.txt")) {
-            fs::load_string_file(cache_folder / "version.txt", cached_version);
+        	boost::filesystem::ifstream filedata(cache_folder / "version.txt");
+	        cached_version.assign(
+	            (std::istreambuf_iterator<char>(filedata)),
+	            (std::istreambuf_iterator<char>())
+	        );
+	        filedata.close();
             boost::algorithm::trim(cached_version);
             result = true;
         }
@@ -1233,13 +1261,23 @@ Updates PresetUpdater::priv::get_printer_config_updates(bool update) const
     std::string             resc_version;
     try {
         if (fs::exists(resc_folder / "version.txt")) {
-            fs::load_string_file(resc_folder / "version.txt", resc_version);
+        	boost::filesystem::ifstream filedata(resc_folder / "version.txt");
+	        resc_version.assign(
+	            (std::istreambuf_iterator<char>(filedata)),
+	            (std::istreambuf_iterator<char>())
+	        );
+	        filedata.close();
             boost::algorithm::trim(resc_version);
         }
     } catch (...) {}
     try {
         if (fs::exists(config_folder / "version.txt")) {
-            fs::load_string_file(config_folder / "version.txt", curr_version);
+        	boost::filesystem::ifstream filedata(config_folder / "version.txt");
+	        curr_version.assign(
+	            (std::istreambuf_iterator<char>(filedata)),
+	            (std::istreambuf_iterator<char>())
+	        );
+	        filedata.close();
             boost::algorithm::trim(curr_version);
         }
     } catch (...) {}


### PR DESCRIPTION
This PR performs a number of updates to make Bambu Studio compile on the latest macOS SDK (14.4 at the time of writing).

The particular changes made are the following:

- Bump CGAL to v5.6.1
- Bump Boost to v1.85.0
  - A frozen copy of Boost will no longer need to be maintained!
  - The `filesystem/string_file.hpp` header was deprecated and had been removed entirely in v1.83.0, so code utilizing it has been replaced
  - Various other methods were deprecated in Boost and have been removed, so they have been replaced according to Boost's suggestions
