### PR TITLE
Remove redundant CMakeLists code for Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,11 +207,6 @@ endif ()
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     find_package(PkgConfig REQUIRED)
 
-    if (CMAKE_VERSION VERSION_LESS "3.1")
-        # Workaround for an old CMake, which does not understand CMAKE_CXX_STANDARD.
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    endif()
-
     # Boost on Raspberry-Pi does not link to pthreads.
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)


### PR DESCRIPTION
This PR removes some redundant code in the CMakeLists for Linux compilation.  The code removed implements a workaround for older versions of CMake that did not support `CMAKE_CXX_STANDARD`; however, the very first line in the CMakeLists requires a version of CMake newer than the version that implemented the worked-around feature.  Therefore, the `if` clause will never be true!
