### PR TITLE
Added fullscreen support to the camera stream view on macOS

### DIFF
--- a/resources/images/fullscreen.svg
+++ b/resources/images/fullscreen.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="图层_1"
+   data-name="图层 1"
+   viewBox="0 0 16 16"
+   version="1.1"
+   sodipodi:docname="fullscreen.svg"
+   inkscape:version="1.1.2 (b8e25be8, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview13"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="39.0625"
+     inkscape:cx="7.9872"
+     inkscape:cy="8"
+     inkscape:window-width="1695"
+     inkscape:window-height="1225"
+     inkscape:window-x="1520"
+     inkscape:window-y="286"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="图层_1" />
+  <defs
+     id="defs4">
+    <style
+       id="style2">.cls-1{fill:none;}.cls-2,.cls-3{fill:#2b3436;}.cls-2{fill-rule:evenodd;}</style>
+  </defs>
+  <title
+     id="title6">Slice 41</title>
+  <metadata
+     id="metadata830">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title>Slice 41</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path1624"
+     style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 1 1.5 L 6 1.5 L 1 1.5 z M 1.515625 1.515625 L 1.515625 6.515625 L 1.515625 1.515625 z " />
+  <path
+     id="path1624-1"
+     style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 10 1.5 L 15 1.5 L 10 1.5 z M 14.484375 1.515625 L 14.484375 6.515625 L 14.484375 1.515625 z " />
+  <path
+     id="path1624-4"
+     style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 1.515625 9.5 L 1.515625 14.5 L 1.515625 9.5 z M 1 14.515625 L 6 14.515625 L 1 14.515625 z " />
+  <path
+     id="path1624-4-7"
+     style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 14.484375 9.5 L 14.484375 14.5 L 14.484375 9.5 z M 10 14.515625 L 15 14.515625 L 10 14.515625 z " />
+</svg>

--- a/resources/images/fullscreen_selected.svg
+++ b/resources/images/fullscreen_selected.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="图层_1"
+   data-name="图层 1"
+   viewBox="0 0 16 16"
+   version="1.1"
+   sodipodi:docname="fullscreen_selected.svg"
+   inkscape:version="1.1.2 (b8e25be8, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview13"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="39.0625"
+     inkscape:cx="7.9872"
+     inkscape:cy="8"
+     inkscape:window-width="1695"
+     inkscape:window-height="1225"
+     inkscape:window-x="1520"
+     inkscape:window-y="286"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="图层_1" />
+  <defs
+     id="defs4">
+    <style
+       id="style2">.cls-1{fill:none;}.cls-2,.cls-3{fill:#2b3436;}.cls-2{fill-rule:evenodd;}</style>
+  </defs>
+  <title
+     id="title6">Slice 41</title>
+  <metadata
+     id="metadata830">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title>Slice 41</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path1624"
+     style="fill:#ffffff;stroke:#6dda7c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 1 1.5 L 6 1.5 L 1 1.5 z M 1.515625 1.515625 L 1.515625 6.515625 L 1.515625 1.515625 z " />
+  <path
+     id="path1624-1"
+     style="fill:none;stroke:#6dda7c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 10 1.5 L 15 1.5 L 10 1.5 z M 14.484375 1.515625 L 14.484375 6.515625 L 14.484375 1.515625 z " />
+  <path
+     id="path1624-4"
+     style="fill:none;stroke:#6dda7c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 1.515625 9.5 L 1.515625 14.5 L 1.515625 9.5 z M 1 14.515625 L 6 14.515625 L 1 14.515625 z " />
+  <path
+     id="path1624-4-7"
+     style="fill:none;stroke:#6dda7c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 14.484375 9.5 L 14.484375 14.5 L 14.484375 9.5 z M 10 14.515625 L 15 14.515625 L 10 14.515625 z " />
+</svg>

--- a/src/slic3r/GUI/MediaPlayCtrl.cpp
+++ b/src/slic3r/GUI/MediaPlayCtrl.cpp
@@ -853,6 +853,7 @@ bool MediaPlayCtrl::get_stream_url(std::string *url)
 
 void wxMediaCtrl2::DoSetSize(int x, int y, int width, int height, int sizeFlags)
 {
+    // Ignore resize calls while in fullscreen mode
     if (IsFullScreen())
     {
         return;

--- a/src/slic3r/GUI/MediaPlayCtrl.cpp
+++ b/src/slic3r/GUI/MediaPlayCtrl.cpp
@@ -853,6 +853,10 @@ bool MediaPlayCtrl::get_stream_url(std::string *url)
 
 void wxMediaCtrl2::DoSetSize(int x, int y, int width, int height, int sizeFlags)
 {
+    if (IsFullScreen())
+    {
+        return;
+    }
 #ifdef __WXMAC__
     wxWindow::DoSetSize(x, y, width, height, sizeFlags);
 #else

--- a/src/slic3r/GUI/wxMediaCtrl2.h
+++ b/src/slic3r/GUI/wxMediaCtrl2.h
@@ -45,8 +45,11 @@ protected:
     
     void NotifyStopped();
 
+    bool IsFullScreen() const;
+
 private:
     void create_player();
+    void toggle_fullscreen();
     void * m_player = nullptr;
     wxMediaState m_state = wxMEDIASTATE_STOPPED;
     int          m_error  = 0;
@@ -76,6 +79,8 @@ protected:
     wxSize DoGetBestSize() const override;
 
     void DoSetSize(int x, int y, int width, int height, int sizeFlags) override;
+
+    bool IsFullScreen() const { return false; }
 
 #ifdef __WIN32__
     WXLRESULT MSWWindowProc(WXUINT   nMsg,

--- a/src/slic3r/GUI/wxMediaCtrl2.mm
+++ b/src/slic3r/GUI/wxMediaCtrl2.mm
@@ -98,10 +98,6 @@ wxMediaCtrl2::wxMediaCtrl2(wxWindow * parent)
 
 wxMediaCtrl2::~wxMediaCtrl2()
 {
-//    Disconnect(wxID_ANY, wxEVT_KEY_DOWN, wxKeyEventHandler(wxMediaCtrl2::onKeyDown),
-//                              (wxObject*) NULL,
-//                              this);
-
     BambuPlayer * player = (BambuPlayer *) m_player;
     [player dealloc];
 }

--- a/src/slic3r/GUI/wxMediaCtrl2.mm
+++ b/src/slic3r/GUI/wxMediaCtrl2.mm
@@ -16,6 +16,10 @@
 #include <stdlib.h>
 #include <dlfcn.h>
 
+#include <wx/button.h>
+#include <wx/bmpbuttn.h>
+#include "BitmapCache.hpp"
+
 wxDEFINE_EVENT(EVT_MEDIA_CTRL_STAT, wxCommandEvent);
 
 #define BAMBU_DYNAMIC
@@ -56,10 +60,48 @@ wxMediaCtrl2::wxMediaCtrl2(wxWindow * parent)
     CGColorRelease(color);
     imageView.wantsLayer = YES;
     create_player();
+
+    auto key_down = [this](wxKeyEvent& event)
+    {
+        if (event.m_keyCode == WXK_ESCAPE)
+            toggle_fullscreen();
+    };
+    Bind(wxEVT_KEY_DOWN, key_down);
+
+    wxBitmap bmp = *Slic3r::GUI::BitmapCache().load_svg("fullscreen", 0, 0);
+    bmp = bmp.ConvertToImage();
+
+    wxBitmap bmp_selected = *Slic3r::GUI::BitmapCache().load_svg("fullscreen_selected", 0, 0);
+    bmp_selected = bmp_selected.ConvertToImage();
+
+    wxBitmapButton * fullscreen_button = new wxBitmapButton(this, wxID_HIGHEST + 1, bmp,
+                                                wxDefaultPosition,
+                                                wxSize(32, 32),
+                                                wxBORDER_NONE);
+    fullscreen_button->SetBitmapSelected(bmp_selected);
+    auto fullscreen_button_clicked = [this](wxEvent &e) {
+        toggle_fullscreen();
+    };
+    fullscreen_button->Bind(wxEVT_COMMAND_BUTTON_CLICKED, fullscreen_button_clicked);
+
+    wxSizer * hsizer = new wxBoxSizer(wxHORIZONTAL);
+    hsizer->AddStretchSpacer();
+    hsizer->Add(fullscreen_button);
+
+    wxSizer * sizer = new wxBoxSizer(wxVERTICAL);
+    sizer->AddStretchSpacer();
+    sizer->Add(hsizer, 0, wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALL);
+
+    SetSizer(sizer);
+    SetAutoLayout(true);
 }
 
 wxMediaCtrl2::~wxMediaCtrl2()
 {
+//    Disconnect(wxID_ANY, wxEVT_KEY_DOWN, wxKeyEventHandler(wxMediaCtrl2::onKeyDown),
+//                              (wxObject*) NULL,
+//                              this);
+
     BambuPlayer * player = (BambuPlayer *) m_player;
     [player dealloc];
 }
@@ -167,4 +209,25 @@ wxSize wxMediaCtrl2::GetVideoSize() const
     } else {
         return {0, 0};
     }
+}
+
+bool wxMediaCtrl2::IsFullScreen() const
+{
+    NSView * imageView = (NSView *) GetHandle();
+    return (bool) [imageView isInFullScreenMode];
+}
+
+void wxMediaCtrl2::toggle_fullscreen()
+{
+    NSView * imageView = (NSView *) GetHandle();
+    if ([imageView isInFullScreenMode])
+    {
+        [imageView exitFullScreenModeWithOptions:nil];
+    }
+    else
+    {
+        NSDictionary * fullScreenOptions = [NSDictionary dictionaryWithObjectsAndKeys: [NSNumber numberWithBool: NO], NSFullScreenModeAllScreens, nil];
+        [imageView enterFullScreenMode:imageView.window.screen withOptions:fullScreenOptions];
+    }
+    Layout();
 }


### PR DESCRIPTION
Modified wxMediaCtrl2 to use NSView::enterFullScreenMode and exitFullScreenModeWithOptions to toggle fullscreen.
You can enter/exit by clicking on the video and pressing escape. A fullscreen button was also added as an overlay to the video view that can be used to enter/exit fullscreen.

This pull request addresses issue #1192 for macOS.