### PR TITLE
slic3r: Fix std::regex declaration

### DIFF
--- a/src/slic3r/GUI/Jobs/PrintJob.cpp
+++ b/src/slic3r/GUI/Jobs/PrintJob.cpp
@@ -1,4 +1,5 @@
 #include "PrintJob.hpp"
+#include <regex>
 #include "libslic3r/MTUtils.hpp"
 #include "libslic3r/Model.hpp"
 #include "libslic3r/PresetBundle.hpp"


### PR DESCRIPTION
```
/run/build/BambuStudio/src/slic3r/GUI/Jobs/PrintJob.cpp: In member function ‘virtual void Slic3r::GUI::PrintJob::process()’: /run/build/BambuStudio/src/slic3r/GUI/Jobs/PrintJob.cpp:291:22: error: ‘regex’ is not a member of ‘std’; did you mean ‘boost::regex’?
  291 |                 std::regex pattern("_+");
      |                      ^~~~~
```