### PR TITLE
Prevent Cmd-Shift-M from minimizing on  EXCEPT on "Home" sub-screen, thus preventing 3DConnexion prefs dialog from working

### DIFF
--- a/src/slic3r/GUI/KBShortcutsDialog.cpp
+++ b/src/slic3r/GUI/KBShortcutsDialog.cpp
@@ -195,8 +195,13 @@ void KBShortcutsDialog::fill_shortcuts()
             #else
                 { ctrl + "P", L("Preferences") },
             #endif
-            //3D control
+            //3D control, for Apple, use Cmd-Shift-M instead of Ctrl/Cmd-M due
+            #ifndef __APPLE__
+            { ctrl + "Shift+M", L("Show/Hide 3Dconnexion devices settings dialog") },
+            #else
             { ctrl + "M", L("Show/Hide 3Dconnexion devices settings dialog") },
+            #endif
+
             // Switch table page
             #ifndef __APPLE__
                 { ctrl + "Tab", L("Switch tab page")},

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -611,7 +611,7 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
         if (evt.CmdDown() && (evt.GetKeyCode() == 'H')) {
             //call parent_menu hide behavior
             return;}
-        if (evt.CmdDown() && (evt.GetKeyCode() == 'M')) {
+        if (evt.CmdDown() && !evt.ShiftDown() && (evt.GetKeyCode() == 'M')) {
             this->Iconize();
             return;
         }


### PR DESCRIPTION
This is for issue #4055.

The problem is that hitting "Cmd-Shift-M" on mac always minimizes the app, even though it should only minimize on "Cmd-M", and not on "Cmd-Shift-M".  This means that on the "Prepare" and "Preview" screens on a Mac, it is impossible to get the 3DConnexion preferences dialog to appear.

The code that minimizes (using the WXWidgets "Iconize()" call) happens in MainFrame.cpp keyboard event loop.  The code that's checking, looks for "Cmd-M" but does not check for any other keyboard modifiers, so I added a check to ignore the event if Shift is pressed along with "Cmd-M".

There's a secondary issue that isn't really relevant to this bug in that the app will still minimize when pressing "Cmd-Shift-M", but ONLY on the "Home" sub-screen. (all other sub-screens work as they should).

I'm not sure why, but when the "Home" sub-screen is selected, the keyboard event loop (MainFrame.cpp, line 609), is called TWICE when "Cmd-Shift-<any key>" is pressed:

* Once where the event's wxKeyModifier (retrieved via `evt.GetModifiers()` is set to `wxMOD_CONTROL`  AND `wxMOD_SHIFT`.  (this is correct)
* Once where the event's wxKeyModifier  is **ONLY** set to `wxMOD_CONTROL` (this is wrong).

Again, this double-event (with the wrong modifiers) only happens when the user is on the "Home" sub-screen.  For the context of this bug the 3DConnexion preferences dialog isn't needed on the "Home" sub-screen so this secondary bug doesn't matter.  But it does make the UX odd where Cmd-Shift-M will minimize the app when the user is viewing the "Home" sub-screen, but not minimize the app when the user is viewing any other sub-screen.
