### PR TITLE
Disable use of system eigen3 for OpenCV.cmake

### DIFF
--- a/deps/OpenCV/OpenCV.cmake
+++ b/deps/OpenCV/OpenCV.cmake
@@ -26,7 +26,7 @@ bambustudio_add_cmake_project(OpenCV
        -DBUILD_ZLIB=OFF
        -DWITH_1394=OFF
        -DWITH_CUDA=OFF
-       -DWITH_EIGEN=ON
+       -DWITH_EIGEN=OFF
        ${_use_IPP}
        -DWITH_ITT=OFF
        -DWITH_FFMPEG=OFF


### PR DESCRIPTION
This is a port of https://github.com/SoftFever/OrcaSlicer/pull/5311 which is a fix for https://github.com/SoftFever/OrcaSlicer/issues/5194 which happens to apply to Bambu Studio as well