### PR TITLE
Explicitly specify C++17 in libslic3r and libslic3r_cgal cmake, fixing build on Fedora 40

### DIFF
--- a/src/clipper2/CMakeLists.txt
+++ b/src/clipper2/CMakeLists.txt
@@ -37,7 +37,7 @@ target_include_directories(Clipper2
 if (WIN32)
   target_compile_options(Clipper2 PRIVATE /W4 /WX)
 else()
-  target_compile_options(Clipper2 PRIVATE -Wall -Wextra -Wpedantic -Werror)
+  target_compile_options(Clipper2 PRIVATE -Wall -Wextra -Wpedantic -Werror -Wno-error=template-id-cdtor)
   target_link_libraries(Clipper2 PUBLIC -lm)
 
 endif()

--- a/src/clipper2/CMakeLists.txt
+++ b/src/clipper2/CMakeLists.txt
@@ -37,9 +37,11 @@ target_include_directories(Clipper2
 if (WIN32)
   target_compile_options(Clipper2 PRIVATE /W4 /WX)
 else()
-  target_compile_options(Clipper2 PRIVATE -Wall -Wextra -Wpedantic -Werror -Wno-error=template-id-cdtor)
+  target_compile_options(Clipper2 PRIVATE -Wall -Wextra -Wpedantic -Werror)
   target_link_libraries(Clipper2 PUBLIC -lm)
-
+  if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 14.1)
+    target_compile_options(Clipper2 PRIVATE -Wno-error=template-id-cdtor)
+  endif()
 endif()
 
 set_target_properties(Clipper2 PROPERTIES FOLDER Libraries

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -456,6 +456,11 @@ if (_opts)
     target_compile_options(libslic3r_cgal PRIVATE "${_opts_bad}")
 endif()
 
+set_property(TARGET libslic3r PROPERTY CXX_STANDARD 17)
+set_property(TARGET libslic3r PROPERTY CXX_EXTENSIONS OFF)
+set_property(TARGET libslic3r_cgal PROPERTY CXX_STANDARD 17)
+set_property(TARGET libslic3r_cgal PROPERTY CXX_EXTENSIONS OFF)
+
 target_link_libraries(libslic3r_cgal PRIVATE ${_cgal_tgt} libigl mcut)
 
 if (MSVC AND "${CMAKE_SIZEOF_VOID_P}" STREQUAL "4") # 32 bit MSVC workaround

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -456,10 +456,12 @@ if (_opts)
     target_compile_options(libslic3r_cgal PRIVATE "${_opts_bad}")
 endif()
 
-set_property(TARGET libslic3r PROPERTY CXX_STANDARD 17)
-set_property(TARGET libslic3r PROPERTY CXX_EXTENSIONS OFF)
-set_property(TARGET libslic3r_cgal PROPERTY CXX_STANDARD 17)
-set_property(TARGET libslic3r_cgal PROPERTY CXX_EXTENSIONS OFF)
+if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 14.1)
+    set_property(TARGET libslic3r PROPERTY CXX_STANDARD 17)
+    set_property(TARGET libslic3r PROPERTY CXX_EXTENSIONS OFF)
+    set_property(TARGET libslic3r_cgal PROPERTY CXX_STANDARD 17)
+    set_property(TARGET libslic3r_cgal PROPERTY CXX_EXTENSIONS OFF)
+endif()
 
 target_link_libraries(libslic3r_cgal PRIVATE ${_cgal_tgt} libigl mcut)
 


### PR DESCRIPTION
Bambu studio currently fails to build on Fedora 40. This is because the CMake configuration of `libslic3r` and `libslic3r_cgal` currently does not explicitly specify the C++ standard, but it seems like the `libslic3r` and `libslic3r_cgal` code assumes C++17. Without explicit specification, the compiler uses C++20.

Also added `-Wno-error=template-id-cdtor` to the compiler flags for `Clipper2`, preventing this warning from being thrown as an error. The `template-id-cdtor` warning being thrown as an error is a [c++20 addition in gcc](https://gcc.gnu.org/onlinedocs/gcc-14.1.0/gcc/C_002b_002b-Dialect-Options.html#index-Wno-template-id-cdtor).

This fixes #4018.