### PR TITLE
Set default sparse infill to crosshatch

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1623,7 +1623,7 @@ void PrintConfigDef::init_fff_params()
     def->enum_labels.push_back(L("Support Cubic"));
     def->enum_labels.push_back(L("Lightning"));
     def->enum_labels.push_back(L("Cross Hatch"));
-    def->set_default_value(new ConfigOptionEnum<InfillPattern>(ipCubic));
+    def->set_default_value(new ConfigOptionEnum<InfillPattern>(ipCrossHatch));
 
     def = this->add("top_surface_acceleration", coFloat);
     def->label = L("Top surface");


### PR DESCRIPTION
Inspired by [this thread on reddit](https://www.reddit.com/r/BambuLab/comments/1e7voun/petition_to_remove_grid_infill_as_default/), this PR updates the default Sparse infill option to `CrossHatch`, rather than `Grid`.

Why this change?

> The grid infill, while simple and fast, has a notable drawback: material accumulates at the crossing points, which can cause annoying noise or even print failures due to the nozzle going over these material accumulations. The crosshatch infill mitigates this issue by distributing material more evenly, reducing the risk of these complications. 

[source: Prusa Blog](https://blog.prusa3d.com/everything-you-need-to-know-about-infills_43579/)

I had many prints fail as a result of awkwardly overlapping grid infill - it seems like an odd choice for the default option.