### PR TITLE
Fix missing build dependency (bc) in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,8 @@ RUN apt-get update && apt-get install  -y \
     pkgconf \
     sudo \
     wayland-protocols \
-    wget 
+    wget \
+    bc
 
 # Change your locale here if you want.  See the output
 # of `locale -a` to pick the correct string formatting.


### PR DESCRIPTION
The build was canceled due to missing bc. This PR adds the `bc` package to the build environment.

```
> [ 9/12] RUN ./BuildLinux.sh -d:
0.383 FOUND_GTK3=ii  libgtk-3-0:amd64    3.24.33-1ubuntu2.2 amd64        GTK graphical user interface library
0.383 ii  libgtk-3-bin        3.24.33-1ubuntu2.2 amd64        programs for the GTK graphical user interface library
0.383 ii  libgtk-3-common     3.24.33-1ubuntu2.2 all          common files for the GTK graphical user interface library
0.383 ii  libgtk-3-dev:amd64  3.24.33-1ubuntu2.2 amd64        development files for the GTK library
0.383 un  libgtk-3-doc        <none>             <none>       (no description available)
0.383 Changing date in version...
0.385 done
0.393 ./BuildLinux.sh: line 122: bc: command not found
------

3 warnings found (use --debug to expand):
- LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format (line 2)
- WorkdirRelativePath: Relative workdir "BambuStudio" can have unexpected results if the base image changes (line 63)
- LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 76)
Dockerfile:70
--------------------
68 |
69 |     # Build dependencies in ./deps
70 | >>> RUN ./BuildLinux.sh -d
71 |
72 |     # Build slic3r
--------------------
ERROR: failed to solve: process "/bin/sh -c ./BuildLinux.sh -d" did not complete successfully: exit code: 127
```

The build is successful when `bc` is available.