### PR TITLE
Add Docker flag to remove containers after finishing

### DIFF
--- a/DockerRun.sh
+++ b/DockerRun.sh
@@ -20,6 +20,8 @@ docker run \
   --privileged=true \
   `# Attach tty for running bambu with command line things` \
   -ti \
+  `# Remove container when it is finished` \
+  --rm \
   `# Pass all parameters from this script to the bambu ENTRYPOINT binary` \
   bambustudio $* 
   


### PR DESCRIPTION
When using `DockerRun.sh` stale containers were left over after closing the application. These containers would also not be re-used.

Add the `--rm` flag to make Docker delete the containers after running the application, since they are re-created for each run anyways.