### PR TITLE
Bugfix: support spiral lift Z hop without timelapse enabled (fix stringing)

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -527,16 +527,36 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
             toolchange_gcode_str = toolchange_retract_str + toolchange_gcode_str;
             //BBS
             {
-                //BBS: current position and fan_speed is unclear after interting change_filament_gcode
+
                 check_add_eol(toolchange_gcode_str);
+
+                //BBS: gcode writer doesn't know fan speed after inserting tool change gcode
                 toolchange_gcode_str += ";_FORCE_RESUME_FAN_SPEED\n";
-                gcodegen.writer().set_current_position_clear(false);
-                //BBS: check whether custom gcode changes the z position. Update if changed
-                double temp_z_after_tool_change;
-                if (GCodeProcessor::get_last_z_from_gcode(toolchange_gcode_str, temp_z_after_tool_change)) {
-                    Vec3d pos = gcodegen.writer().get_position();
-                    pos(2) = temp_z_after_tool_change;
-                    gcodegen.writer().set_position(pos);
+                
+                //BBS: check whether custom gcode changes the axis positions. Update if changed.
+                bool position_changed = false;
+                Vec3d new_pos = gcodegen.writer().get_position();
+
+                double temp_x_after_toolchange_gcode;
+                if (GCodeProcessor::get_last_pos_from_gcode(toolchange_gcode_str, 0, temp_x_after_toolchange_gcode)) {
+                    new_pos(0) = temp_x_after_toolchange_gcode;
+                    position_changed = true;
+                }
+                
+                double temp_y_after_toolchange_gcode;
+                if (GCodeProcessor::get_last_pos_from_gcode(toolchange_gcode_str, 1, temp_y_after_toolchange_gcode)) {
+                    new_pos(1) = temp_y_after_toolchange_gcode;
+                    position_changed = true;
+                }
+                
+                double temp_z_after_toolchange_gcode;
+                if (GCodeProcessor::get_last_pos_from_gcode(toolchange_gcode_str, 2, temp_z_after_toolchange_gcode)) {
+                    new_pos(2) = temp_z_after_toolchange_gcode;
+                    position_changed = true;
+                }
+                
+                if (position_changed) {
+                    gcodegen.writer().set_position(new_pos);
                 }
             }
 
@@ -3073,16 +3093,37 @@ GCode::LayerResult GCode::process_layer(
     gcode += this->change_layer(print_z);  // this will increase m_layer_index
     m_layer = &layer;
     m_object_layer_over_raft = false;
+
+    // insert timelapse_gcode when traditional mode is not used (smooth mode)
     if (printer_structure == PrinterStructure::psI3 && !need_insert_timelapse_gcode_for_traditional && !m_spiral_vase && print.config().print_sequence == PrintSequence::ByLayer) {
-        std::string timepals_gcode = insert_timelapse_gcode();
-        gcode += timepals_gcode;
-        m_writer.set_current_position_clear(false);
-        //BBS: check whether custom gcode changes the z position. Update if changed
-        double temp_z_after_timepals_gcode;
-        if (GCodeProcessor::get_last_z_from_gcode(timepals_gcode, temp_z_after_timepals_gcode)) {
-            Vec3d pos = m_writer.get_position();
-            pos(2) = temp_z_after_timepals_gcode;
-            m_writer.set_position(pos);
+
+        std::string timelapse_gcode = insert_timelapse_gcode();
+        gcode += timelapse_gcode;
+        
+        //BBS: check whether custom gcode changes the axis positions. Update if changed.
+        bool position_changed = false;
+        Vec3d new_pos = m_writer.get_position();
+        
+        double temp_x_after_timelapse_gcode;
+        if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 0, temp_x_after_timelapse_gcode)) {
+            new_pos(0) = temp_x_after_timelapse_gcode;
+            position_changed = true;
+        }
+        
+        double temp_y_after_timelapse_gcode;
+        if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 1, temp_y_after_timelapse_gcode)) {
+            new_pos(1) = temp_y_after_timelapse_gcode;
+            position_changed = true;
+        }
+        
+        double temp_z_after_timelapse_gcode;
+        if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 2, temp_z_after_timelapse_gcode)) {
+            new_pos(2) = temp_z_after_timelapse_gcode;
+            position_changed = true;
+        }
+        
+        if (position_changed) {
+            m_writer.set_position(new_pos);
         }
     }
     if (! print.config().layer_change_gcode.value.empty()) {
@@ -3421,21 +3462,40 @@ GCode::LayerResult GCode::process_layer(
     // Extrude the skirt, brim, support, perimeters, infill ordered by the extruders.
     for (unsigned int extruder_id : layer_tools.extruders)
     {
+        // insert timelapse_gcode when wipe tower is enabled and traditional mode is used
         if (has_wipe_tower) {
             if (!m_wipe_tower->is_empty_wipe_tower_gcode(*this, extruder_id, extruder_id == layer_tools.extruders.back())) {
                 if (need_insert_timelapse_gcode_for_traditional && !has_insert_timelapse_gcode) {
-                    gcode += this->retract(false, false, LiftType::NormalLift);
+                    gcode += this->retract(false, false, LiftType::SpiralLift);
                     m_writer.add_object_change_labels(gcode);
 
-                    std::string timepals_gcode = insert_timelapse_gcode();
-                    gcode += timepals_gcode;
-                    m_writer.set_current_position_clear(false);
-                    //BBS: check whether custom gcode changes the z position. Update if changed
-                    double temp_z_after_timepals_gcode;
-                    if (GCodeProcessor::get_last_z_from_gcode(timepals_gcode, temp_z_after_timepals_gcode)) {
-                        Vec3d pos = m_writer.get_position();
-                        pos(2) = temp_z_after_timepals_gcode;
-                        m_writer.set_position(pos);
+                    std::string timelapse_gcode = insert_timelapse_gcode();
+                    gcode += timelapse_gcode;
+                    
+                    //BBS: check whether custom gcode changes the axis positions. Update if changed.
+                    bool position_changed = false;
+                    Vec3d new_pos = m_writer.get_position();
+                    
+                    double temp_x_after_timelapse_gcode;
+                    if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 0, temp_x_after_timelapse_gcode)) {
+                        new_pos(0) = temp_x_after_timelapse_gcode;
+                        position_changed = true;
+                    }
+                    
+                    double temp_y_after_timelapse_gcode;
+                    if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 1, temp_y_after_timelapse_gcode)) {
+                        new_pos(1) = temp_y_after_timelapse_gcode;
+                        position_changed = true;
+                    }
+                    
+                    double temp_z_after_timelapse_gcode;
+                    if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 2, temp_z_after_timelapse_gcode)) {
+                        new_pos(2) = temp_z_after_timelapse_gcode;
+                        position_changed = true;
+                    }
+                    
+                    if (position_changed) {
+                        m_writer.set_position(new_pos);
                     }
                     has_insert_timelapse_gcode = true;
                 }
@@ -3644,10 +3704,11 @@ GCode::LayerResult GCode::process_layer(
                     };
 
                     //BBS: for first layer, we always print wall firstly to get better bed adhesive force
-                    //This behaviour is same with cura
+
+                    // insert timelapse_gcode when no wipe tower, has infill and not first layer
                     if (is_infill_first && !first_layer) {
                         if (!has_wipe_tower && need_insert_timelapse_gcode_for_traditional && !has_insert_timelapse_gcode && has_infill(by_region_specific)) {
-                            gcode += this->retract(false, false, LiftType::NormalLift);
+                            gcode += this->retract(false, false, LiftType::SpiralLift);
                             if (!temp_start_str.empty() && m_writer.empty_object_start_str()) {
                                 std::string end_str = std::string("; stop printing object, unique label id: ") + std::to_string(instance_to_print.label_object_id) + "\n";
                                 if (print.is_BBL_Printer())
@@ -3655,15 +3716,33 @@ GCode::LayerResult GCode::process_layer(
                                 gcode += end_str;
                             }
 
-                            std::string timepals_gcode = insert_timelapse_gcode();
-                            gcode += timepals_gcode;
-                            m_writer.set_current_position_clear(false);
-                            //BBS: check whether custom gcode changes the z position. Update if changed
-                            double temp_z_after_timepals_gcode;
-                            if (GCodeProcessor::get_last_z_from_gcode(timepals_gcode, temp_z_after_timepals_gcode)) {
-                                Vec3d pos = m_writer.get_position();
-                                pos(2) = temp_z_after_timepals_gcode;
-                                m_writer.set_position(pos);
+                            std::string timelapse_gcode = insert_timelapse_gcode();
+                            gcode += timelapse_gcode;
+
+                            //BBS: check whether custom gcode changes the axis positions. Update if changed.
+                            bool position_changed = false;
+                            Vec3d new_pos = m_writer.get_position();
+                            
+                            double temp_x_after_timelapse_gcode;
+                            if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 0, temp_x_after_timelapse_gcode)) {
+                                new_pos(0) = temp_x_after_timelapse_gcode;
+                                position_changed = true;
+                            }
+                            
+                            double temp_y_after_timelapse_gcode;
+                            if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 1, temp_y_after_timelapse_gcode)) {
+                                new_pos(1) = temp_y_after_timelapse_gcode;
+                                position_changed = true;
+                            }
+                            
+                            double temp_z_after_timelapse_gcode;
+                            if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 2, temp_z_after_timelapse_gcode)) {
+                                new_pos(2) = temp_z_after_timelapse_gcode;
+                                position_changed = true;
+                            }
+                            
+                            if (position_changed) {
+                                m_writer.set_position(new_pos);
                             }
 
                             if (!temp_start_str.empty() && m_writer.empty_object_start_str())
@@ -3675,8 +3754,10 @@ GCode::LayerResult GCode::process_layer(
                         gcode += this->extrude_perimeters(print, by_region_specific);
                     } else {
                         gcode += this->extrude_perimeters(print, by_region_specific);
+
+                        // insert timelapse_gcode when no wipe tower, no infill and is first layer
                         if (!has_wipe_tower && need_insert_timelapse_gcode_for_traditional && !has_insert_timelapse_gcode && has_infill(by_region_specific)) {
-                            gcode += this->retract(false, false, LiftType::NormalLift);
+                            gcode += this->retract(false, false, LiftType::SpiralLift);
                             if (!temp_start_str.empty() && m_writer.empty_object_start_str()) {
                                 std::string end_str = std::string("; stop printing object, unique label id: ") + std::to_string(instance_to_print.label_object_id) + "\n";
                                 if (print.is_BBL_Printer())
@@ -3684,15 +3765,33 @@ GCode::LayerResult GCode::process_layer(
                                 gcode += end_str;
                             }
 
-                            std::string timepals_gcode = insert_timelapse_gcode();
-                            gcode += timepals_gcode;
-                            m_writer.set_current_position_clear(false);
-                            //BBS: check whether custom gcode changes the z position. Update if changed
-                            double temp_z_after_timepals_gcode;
-                            if (GCodeProcessor::get_last_z_from_gcode(timepals_gcode, temp_z_after_timepals_gcode)) {
-                                Vec3d pos = m_writer.get_position();
-                                pos(2) = temp_z_after_timepals_gcode;
-                                m_writer.set_position(pos);
+                            std::string timelapse_gcode = insert_timelapse_gcode();
+                            gcode += timelapse_gcode;
+
+                            //BBS: check whether custom gcode changes the axis positions. Update if changed.
+                            bool position_changed = false;
+                            Vec3d new_pos = m_writer.get_position();
+                            
+                            double temp_x_after_timelapse_gcode;
+                            if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 0, temp_x_after_timelapse_gcode)) {
+                                new_pos(0) = temp_x_after_timelapse_gcode;
+                                position_changed = true;
+                            }
+                            
+                            double temp_y_after_timelapse_gcode;
+                            if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 1, temp_y_after_timelapse_gcode)) {
+                                new_pos(1) = temp_y_after_timelapse_gcode;
+                                position_changed = true;
+                            }
+                            
+                            double temp_z_after_timelapse_gcode;
+                            if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 2, temp_z_after_timelapse_gcode)) {
+                                new_pos(2) = temp_z_after_timelapse_gcode;
+                                position_changed = true;
+                            }
+                            
+                            if (position_changed) {
+                                m_writer.set_position(new_pos);
                             }
 
                             if (!temp_start_str.empty() && m_writer.empty_object_start_str())
@@ -3761,22 +3860,41 @@ GCode::LayerResult GCode::process_layer(
     BOOST_LOG_TRIVIAL(trace) << "Exported layer " << layer.id() << " print_z " << print_z <<
     log_memory_info();
 
+    // insert timelapse_gcode when no wipe tower and no infill
     if (!has_wipe_tower && need_insert_timelapse_gcode_for_traditional && !has_insert_timelapse_gcode) {
         if (m_support_traditional_timelapse)
             m_support_traditional_timelapse = false;
 
-        gcode += this->retract(false, false, LiftType::NormalLift);
+        gcode += this->retract(false, false, LiftType::SpiralLift);
         m_writer.add_object_change_labels(gcode);
 
-        std::string timepals_gcode = insert_timelapse_gcode();
-        gcode += timepals_gcode;
-        m_writer.set_current_position_clear(false);
-        //BBS: check whether custom gcode changes the z position. Update if changed
-        double temp_z_after_timepals_gcode;
-        if (GCodeProcessor::get_last_z_from_gcode(timepals_gcode, temp_z_after_timepals_gcode)) {
-            Vec3d pos = m_writer.get_position();
-            pos(2) = temp_z_after_timepals_gcode;
-            m_writer.set_position(pos);
+        std::string timelapse_gcode = insert_timelapse_gcode();
+        gcode += timelapse_gcode;
+
+        //BBS: check whether custom gcode changes the axis positions. Update if changed.
+        bool position_changed = false;
+        Vec3d new_pos = m_writer.get_position();
+        
+        double temp_x_after_timelapse_gcode;
+        if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 0, temp_x_after_timelapse_gcode)) {
+            new_pos(0) = temp_x_after_timelapse_gcode;
+            position_changed = true;
+        }
+        
+        double temp_y_after_timelapse_gcode;
+        if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 1, temp_y_after_timelapse_gcode)) {
+            new_pos(1) = temp_y_after_timelapse_gcode;
+            position_changed = true;
+        }
+        
+        double temp_z_after_timelapse_gcode;
+        if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 2, temp_z_after_timelapse_gcode)) {
+            new_pos(2) = temp_z_after_timelapse_gcode;
+            position_changed = true;
+        }
+        
+        if (position_changed) {
+            m_writer.set_position(new_pos);
         }
     }
 
@@ -5215,16 +5333,33 @@ std::string GCode::set_extruder(unsigned int extruder_id, double print_z, bool b
 
         //BBS
         {
-            //BBS: gcode writer doesn't know where the extruder is and whether fan speed is changed after inserting tool change gcode
-            //Set this flag so that normal lift will be used the first time after tool change.
+            //BBS: gcode writer doesn't know fan speed after inserting tool change gcode
             gcode += ";_FORCE_RESUME_FAN_SPEED\n";
-            m_writer.set_current_position_clear(false);
-            //BBS: check whether custom gcode changes the z position. Update if changed
-            double temp_z_after_tool_change;
-            if (GCodeProcessor::get_last_z_from_gcode(toolchange_gcode_parsed, temp_z_after_tool_change)) {
-                Vec3d pos = m_writer.get_position();
-                pos(2) = temp_z_after_tool_change;
-                m_writer.set_position(pos);
+
+            //BBS: check whether custom gcode changes the axis positions. Update if changed.
+            bool position_changed = false;
+            Vec3d new_pos = m_writer.get_position();
+            
+            double temp_x_after_toolchange_gcode;
+            if (GCodeProcessor::get_last_pos_from_gcode(toolchange_gcode_parsed, 0, temp_x_after_toolchange_gcode)) {
+                new_pos(0) = temp_x_after_toolchange_gcode;
+                position_changed = true;
+            }
+            
+            double temp_y_after_toolchange_gcode;
+            if (GCodeProcessor::get_last_pos_from_gcode(toolchange_gcode_parsed, 1, temp_y_after_toolchange_gcode)) {
+                new_pos(1) = temp_y_after_toolchange_gcode;
+                position_changed = true;
+            }
+            
+            double temp_z_after_toolchange_gcode;
+            if (GCodeProcessor::get_last_pos_from_gcode(toolchange_gcode_parsed, 2, temp_z_after_toolchange_gcode)) {
+                new_pos(2) = temp_z_after_toolchange_gcode;
+                position_changed = true;
+            }
+            
+            if (position_changed) {
+                m_writer.set_position(new_pos);
             }
         }
     }

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -2068,13 +2068,14 @@ int GCodeProcessor::get_gcode_last_filament(const std::string& gcode_str)
     return out_filament;
 }
 
-//BBS: get last z position from gcode
-bool GCodeProcessor::get_last_z_from_gcode(const std::string& gcode_str, double& z)
+//BBS: get last position from gcode for specified axis
+//axis index is the same as Vec3d (X=0, Y=1, Z=2)
+bool GCodeProcessor::get_last_pos_from_gcode(const std::string& gcode_str, int axis, double& pos)
 {
     int str_size = gcode_str.size();
     int start_index = 0;
     int end_index = 0;
-    bool is_z_changed = false;
+    bool is_axis_changed = false;
     while (end_index < str_size) {
         //find a full line
         if (gcode_str[end_index] != '\n') {
@@ -2094,24 +2095,32 @@ bool GCodeProcessor::get_last_z_from_gcode(const std::string& gcode_str, double&
                                        || line_str.find("G2 ") == 0
                                        || line_str.find("G3 ") == 0))
             {
-                auto z_pos = line_str.find(" Z");
-                double temp_z = 0;
-                if (z_pos != line_str.npos
-                    && z_pos + 2 < line_str.size()) {
+                std::string axis_str;
+                if (axis == 0) {
+                    axis_str = "X";
+                } else if (axis == 1) {
+                    axis_str = "Y";
+                } else if (axis == 2) {
+                    axis_str = "Z";
+                }
+                auto axis_pos = line_str.find(" " + axis_str);
+                double temp_axis_pos = 0;
+                if (axis_pos != line_str.npos
+                    && axis_pos + 2 < line_str.size()) {
                     // Try to parse the numeric value.
-                    std::string z_sub = line_str.substr(z_pos + 2);
-                    char* c = &z_sub[0];
-                    char* end = c + sizeof(z_sub.c_str());
+                    std::string axis_substr = line_str.substr(axis_pos + 2);
+                    char* start_ptr = &axis_substr[0];
+                    char* end_ptr = start_ptr + sizeof(axis_substr.c_str());
 
                     auto is_end_of_word = [](char c) {
                         return c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == 0 || c == ';';
                     };
 
-                    auto [pend, ec] = fast_float::from_chars(c, end, temp_z);
-                    if (pend != c && is_end_of_word(*pend)) {
+                    auto [parsed_ptr, error_code] = fast_float::from_chars(start_ptr, end_ptr, temp_axis_pos);
+                    if (parsed_ptr != start_ptr && is_end_of_word(*parsed_ptr)) {
                         // The axis value has been parsed correctly.
-                        z = temp_z;
-                        is_z_changed = true;
+                        pos = temp_axis_pos;
+                        is_axis_changed = true;
                     }
                 }
             }
@@ -2120,7 +2129,7 @@ bool GCodeProcessor::get_last_z_from_gcode(const std::string& gcode_str, double&
         start_index = end_index + 1;
         end_index = start_index;
     }
-    return is_z_changed;
+    return is_axis_changed;
 }
 
 void GCodeProcessor::process_tags(const std::string_view comment, bool producers_enabled)

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -295,7 +295,7 @@ namespace Slic3r {
         static bool contains_reserved_tags(const std::string& gcode, unsigned int max_count, std::vector<std::string>& found_tag);
 
         static int get_gcode_last_filament(const std::string &gcode_str);
-        static bool get_last_z_from_gcode(const std::string& gcode_str, double& z);
+        static bool get_last_pos_from_gcode(const std::string& gcode_str, int axis, double& pos);
 
         static const float Wipe_Width;
         static const float Wipe_Height;


### PR DESCRIPTION
This is the successor of https://github.com/bambulab/BambuStudio/pull/4611, which was just another workaround after detailed analysis.

## Problem
As outlined in the original PR, BambuStudio will not use a spiral Z hop for layer changes when timelapse is disabled and there is no infill. Actually, it will not use a spiral Z hop in other scenarios too (whenever timelapse gcode is injected), but they don't matter as much as the layer changes.

- Find a slow-motion video here: [imgur](https://imgur.com/a/1P2z3HZ)
- Find a .3mf / gcode file here: [missing_spiral_z.zip](https://github.com/user-attachments/files/16603440/missing_spiral_z.zip)

**Screenshot show the model's missing spiral Z hop:**

![grafik](https://github.com/user-attachments/assets/4de8aed6-c4ab-4e12-b68c-058363091ada)

**Screenshot after successful fixing of the bug (see "Solution/PR Content"):**

![grafik](https://github.com/user-attachments/assets/9212277e-faa7-4b82-9f12-3e94f03d4e5d)


## Cause

Timelapse gcode is injected into the model and Bambu Studio is technically not aware what it does - the user can change it individually. That means the position is changed without the gcode processor in Bambu Studio knowing or causing it. 

It's quite important for Bambu Studio to know the position of all axes. Most importantly to: 
1. prevent the collisions, e.g nozzle scratching when moving to next position because assumed position is wrong
2. do safety checks, e.g. if a spiral Z hop would move an axis out of its physical limits

For the Z position (2.), BambuStudio already extracts the last position from the `timelapse_gcode` and writes it to its internal state (`get_last_z_from_gcode`). But for  X and Y, it is not implemented. We don't know why and there actually was comment suggesting to do it ("TODO") in a previous commit, but it seems it was forgotten.

**Instead, a flag was implemented that marks the position as unknown/unsafe after importing `timelapse_gcode` and additionally set the Z hop type to normal. This definitely prevents collisions but ultimately causes stringing.**

## Solution/PR Content

**To make layer changes use spiral Z hop, we need to do two things:**

1. Change lift mode to spiral (the easy part)
2. Flag the position as safe, so import the axis positions after `timelapse_gcode` execution (the hard part)

So this PR does the following:

- Extent the `GCodeProcessor::get_last_z_from_gcode` method to support X and Y coordinates
- Change the usage of this method in timelapse handling to retrieve X and Y position too
- Remove the flag `m_writer.set_current_position_clear(false);` that sets the position as unknown/unsafe
- Use the optimized method/approach for other gcode injection too (`change_filament_gcode`)
