### PR TITLE
Added bc to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN echo deb-src http://archive.ubuntu.com/ubuntu \
 
 RUN apt-get update && apt-get install  -y \
     autoconf \
+    bc \
     build-essential \
     cmake \
     curl \


### PR DESCRIPTION
This PR adds bc to the Dockerfile for BambuStudio to ensure the build process completes without errors. The BuildLinux.sh script requires bc for numerical operations, and missing this package causes the Docker build to fail, including bc guarantees successful builds in environments where bc isn't preinstalled.

Installing bc inside the Docker container enhances the reliability of the build process and avoids the need for manual fixes in future builds.