### PR TITLE
libslic3r: Fix BOOST_LOG_TRIVIAL declaration

### DIFF
--- a/src/libslic3r/Support/SupportParameters.hpp
+++ b/src/libslic3r/Support/SupportParameters.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <boost/log/trivial.hpp>
 #include "../libslic3r.h"
 #include "../Flow.hpp"
 #include "../PrintConfig.hpp"


### PR DESCRIPTION
```
/run/build/BambuStudio/src/libslic3r/Support/SupportParameters.hpp: In constructor ‘Slic3r::SupportParameters::SupportParameters(const Slic3r::PrintObject&)’: /run/build/BambuStudio/src/libslic3r/Support/SupportParameters.hpp:172:39: error: ‘warning’ was not declared in this scope
  172 |                     BOOST_LOG_TRIVIAL(warning) << "tree support default to organic support";
      |                                       ^~~~~~~
/run/build/BambuStudio/src/libslic3r/Support/SupportParameters.hpp:172:21: error: ‘BOOST_LOG_TRIVIAL’ was not declared in this scope
  172 |                     BOOST_LOG_TRIVIAL(warning) << "tree support default to organic support";
      |                     ^~~~~~~~~~~~~~~~~
/run/build/BambuStudio/src/libslic3r/Support/SupportParameters.hpp:175:39: error: ‘warning’ was not declared in this scope
  175 |                     BOOST_LOG_TRIVIAL(warning) << "tree support default to hybrid tree due to adaptive layer height";
      |                                       ^~~~~~~
/run/build/BambuStudio/src/libslic3r/Support/SupportParameters.hpp:175:21: error: ‘BOOST_LOG_TRIVIAL’ was not declared in this scope
  175 |                     BOOST_LOG_TRIVIAL(warning) << "tree support default to hybrid tree due to adaptive layer height";
      |                     ^~~~~~~~~~~~~~~~~
```