### PR TITLE
Add all Neptune 4 printers as supported by Elegoo generic filaments

### DIFF
--- a/resources/profiles/Elegoo/filament/Generic ABS @Elegoo.json
+++ b/resources/profiles/Elegoo/filament/Generic ABS @Elegoo.json
@@ -26,6 +26,9 @@
         "Elegoo Neptune 3 Pro 0.4 nozzle",
         "Elegoo Neptune 3 Plus 0.4 nozzle",
         "Elegoo Neptune 3 Max 0.4 nozzle",
-        "Elegoo Neptune 4 0.4 nozzle"
+        "Elegoo Neptune 4 0.4 nozzle",
+        "Elegoo Neptune 4 Pro 0.4 nozzle",
+        "Elegoo Neptune 4 Plus 0.4 nozzle",
+        "Elegoo Neptune 4 Max 0.4 nozzle"
     ]
 }

--- a/resources/profiles/Elegoo/filament/Generic PETG @Elegoo.json
+++ b/resources/profiles/Elegoo/filament/Generic PETG @Elegoo.json
@@ -32,6 +32,9 @@
         "Elegoo Neptune 3 Pro 0.4 nozzle",
         "Elegoo Neptune 3 Plus 0.4 nozzle",
         "Elegoo Neptune 3 Max 0.4 nozzle",
-        "Elegoo Neptune 4 0.4 nozzle"
+        "Elegoo Neptune 4 0.4 nozzle",
+        "Elegoo Neptune 4 Pro 0.4 nozzle",
+        "Elegoo Neptune 4 Plus 0.4 nozzle",
+        "Elegoo Neptune 4 Max 0.4 nozzle"
     ]
 }

--- a/resources/profiles/Elegoo/filament/Generic PLA @Elegoo.json
+++ b/resources/profiles/Elegoo/filament/Generic PLA @Elegoo.json
@@ -22,6 +22,9 @@
         "Elegoo Neptune 3 Pro 0.4 nozzle",
         "Elegoo Neptune 3 Plus 0.4 nozzle",
         "Elegoo Neptune 3 Max 0.4 nozzle",
-        "Elegoo Neptune 4 0.4 nozzle"
+        "Elegoo Neptune 4 0.4 nozzle",
+        "Elegoo Neptune 4 Pro 0.4 nozzle",
+        "Elegoo Neptune 4 Plus 0.4 nozzle",
+        "Elegoo Neptune 4 Max 0.4 nozzle"
     ]
 }


### PR DESCRIPTION
When using the Neptune 4 Plus on the 1.10 beta all the Elegoo filaments are missing and we are left with a generic filament. This PR adds all the Neptune 4 family of printers as supported by the generic Elegoo filaments.