### PR TITLE
slic3r: Fix wxDir declaration

### DIFF
--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -17,6 +17,7 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <wx/dir.h>
 #include "fast_float/fast_float.h"
 
 #define CALI_DEBUG


### PR DESCRIPTION
```
/run/build/BambuStudio/src/slic3r/GUI/DeviceManager.cpp: In static member function ‘static boost::bimaps::bimap<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > Slic3r::DeviceManager::get_all_model_id_with_name()’: /run/build/BambuStudio/src/slic3r/GUI/DeviceManager.cpp:6076:5: error: ‘wxDir’ was not declared in this scope; did you mean ‘wxDIR’?
 6076 |     wxDir dir(Slic3r::resources_dir() + "/printers/");
      |     ^~~~~
      |     wxDIR
```