### PR TITLE
Fixed tooltip for cool plate initial layer temp.

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -650,7 +650,7 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Initial layer");
     def->full_label = L("Initial layer bed temperature");
     def->tooltip = L("Bed temperature of the initial layer. "
-        "Value 0 means the filament does not support to print on the Bambu Cool Plate SuperTack");
+        "Value 0 means the filament does not support to print on the Cool Plate");
     def->sidetext = "°C";
     def->min = 0;
     def->max = 120;


### PR DESCRIPTION
See below screenshot. When hover cursor on the Cool Plate (not supertack)'s initial layer print temp setting, the tooltip is showing "Bambo Cool Plate Supertack" which is incorrect.

This PR fixes this tooltip verbiage.

<img width="750" alt="bambu-bug" src="https://github.com/user-attachments/assets/21569119-ba7f-4af5-99c5-5a649d0a120e">
