### PR TITLE
Fix illegible color in 'unsaved changes dialog' on Linux

### DIFF
--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -1539,7 +1539,6 @@ void UnsavedChangesDialog::update_list()
                      text_left->SetFont(::Label::Head_13);
                      text_left->Wrap(-1);
                      text_left->SetForegroundColour(GREY700);
-                     text_left->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_INFOTEXT));
 
                      sizer_left_v->Add(text_left, 0, wxLEFT, 37);
 
@@ -1568,7 +1567,6 @@ void UnsavedChangesDialog::update_list()
                 text_left->SetFont(::Label::Body_13);
                 text_left->Wrap(-1);
                 text_left->SetForegroundColour(GREY700);
-                text_left->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_INFOTEXT));
 
                 sizer_left_v->Add(text_left, 0, wxLEFT, 51 );
 


### PR DESCRIPTION
Some fonts are illegible in light theme on Linux:
![image](https://github.com/user-attachments/assets/4791a37c-6653-4f8c-a4cf-3ea3531484fd)

The foreground color `wxSystemSettings::GetColour(wxSYS_COLOUR_INFOTEXT)` varies on different platform while the background color is hard coded, which causes the problem. Just hard code the foreground color to fix it.

After the fix:
![image](https://github.com/user-attachments/assets/c6e5ac65-2ce7-4fd4-9cc8-5e8d89a30e61)
![image](https://github.com/user-attachments/assets/42035a64-546a-4c7a-9528-e7395a9924c7)
