### PR TITLE
Fix PopupWindow dropdown menus do not display #4201 

### DIFF
--- a/src/slic3r/GUI/Widgets/PopupWindow.cpp
+++ b/src/slic3r/GUI/Widgets/PopupWindow.cpp
@@ -16,7 +16,7 @@ bool PopupWindow::Create(wxWindow *parent, int style)
     if (!wxPopupTransientWindow::Create(parent, style))
         return false;
 #ifdef __WXGTK__
-    GetTopParent(parent)->Bind(wxEVT_ACTIVATE, &PopupWindow::topWindowActiavate, this);
+    GetTopParent(parent)->Bind(wxEVT_ACTIVATE, &PopupWindow::topWindowActivate, this);
 #endif
     return true;
 }
@@ -24,12 +24,12 @@ bool PopupWindow::Create(wxWindow *parent, int style)
 PopupWindow::~PopupWindow()
 {
 #ifdef __WXGTK__
-    GetTopParent(this)->Unbind(wxEVT_ACTIVATE, &PopupWindow::topWindowActiavate, this);
+    GetTopParent(this)->Unbind(wxEVT_ACTIVATE, &PopupWindow::topWindowActivate, this);
 #endif
 }
 
 #ifdef __WXGTK__
-void PopupWindow::topWindowActiavate(wxActivateEvent &event)
+void PopupWindow::topWindowActivate(wxActivateEvent &event)
 {
     event.Skip();
     if (!event.GetActive() && IsShown()) DismissAndNotify();

--- a/src/slic3r/GUI/Widgets/PopupWindow.cpp
+++ b/src/slic3r/GUI/Widgets/PopupWindow.cpp
@@ -32,6 +32,5 @@ PopupWindow::~PopupWindow()
 void PopupWindow::topWindowActivate(wxActivateEvent &event)
 {
     event.Skip();
-    if (!event.GetActive() && IsShown()) DismissAndNotify();
 }
 #endif

--- a/src/slic3r/GUI/Widgets/PopupWindow.hpp
+++ b/src/slic3r/GUI/Widgets/PopupWindow.hpp
@@ -17,7 +17,7 @@ public:
 
 private:
 #ifdef __WXGTK__
-    void topWindowActiavate(wxActivateEvent &event);
+    void topWindowActivate(wxActivateEvent &event);
 #endif
 };
 


### PR DESCRIPTION
Fixes https://github.com/bambulab/BambuStudio/issues/4201 that makes Bambu Studio unusable under some window managers, but reintroduces inconvenience of PopupWindow remaining in front after alt+tab.