### PR TITLE
Update appimagetool link

### DIFF
--- a/src/platform/unix/build_appimage.sh.in
+++ b/src/platform/unix/build_appimage.sh.in
@@ -1,5 +1,5 @@
 #!/bin/sh
-APPIMAGETOOLURL="https://github.com/AppImage/AppImageKit/releases/latest/download/appimagetool-x86_64.AppImage"
+APPIMAGETOOLURL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
 
 
 APP_IMAGE="@SLIC3R_APP_KEY@_ubu64.AppImage"


### PR DESCRIPTION
It helps to build AppImage for any linux include musl-based
This pr also raises the question of the need for additional builds for ubuntu, ubuntu-latest and fedora