### PR TITLE
Fix: Failed processing of the filename_format template for Creality Ender 3 Printer

### DIFF
--- a/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3.json
@@ -51,7 +51,7 @@
     "ironing_type": "no ironing",
     "layer_height": "0.2",
     "reduce_infill_retraction": "1",
-    "filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
+    "filename_format": "{input_filename_base}_{filament_type[0]}_{print_time}.gcode",
     "detect_overhang_wall": "1",
     "overhang_1_4_speed": "0",
     "overhang_2_4_speed": "50",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3KE.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3KE.json
@@ -46,7 +46,7 @@
 	"ironing_speed": "44%",
 	"ironing_type": "no ironing",
 	"reduce_infill_retraction": "1",
-	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
+	"filename_format": "{input_filename_base}_{filament_type[0]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",
 	"overhang_2_4_speed": "50",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3Plus.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3Plus.json
@@ -51,7 +51,7 @@
     "ironing_type": "no ironing",
     "layer_height": "0.2",
     "reduce_infill_retraction": "1",
-    "filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
+    "filename_format": "{input_filename_base}_{filament_type[0]}_{print_time}.gcode",
     "detect_overhang_wall": "1",
     "overhang_1_4_speed": "0",
     "overhang_2_4_speed": "50",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1C.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1C.json
@@ -51,7 +51,7 @@
   "ironing_type": "no ironing",
   "layer_height": "0.2",
   "reduce_infill_retraction": "1",
-  "filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
+  "filename_format": "{input_filename_base}_{filament_type[0]}_{print_time}.gcode",
   "detect_overhang_wall": "1",
   "overhang_1_4_speed": "0",
   "overhang_2_4_speed": "50",


### PR DESCRIPTION
Fix Failed processing of the filename_format template for Creality Ender 3 Printers 
Ender 3 V3 
Ender 3 V3 KE
Ender 3 V3 Plus
Ender K1C
![2025-01-09_214342](https://github.com/user-attachments/assets/8a2ec405-800c-4870-aea0-af558271639a)
https://github.com/bambulab/BambuStudio/issues/5614
https://github.com/bambulab/BambuStudio/issues/5291