### PR TITLE
libslic3r: Fix BOOST_LOG_TRIVIAL declaration

### DIFF
--- a/src/libslic3r/CSGMesh/PerformCSGMeshBooleans.hpp
+++ b/src/libslic3r/CSGMesh/PerformCSGMeshBooleans.hpp
@@ -4,6 +4,8 @@
 #include <stack>
 #include <vector>
 
+#include <boost/log/trivial.hpp>
+
 #include "CSGMesh.hpp"
 
 #include "libslic3r/Execution/ExecutionTBB.hpp"


### PR DESCRIPTION
```
In file included from /run/build/BambuStudio/src/slic3r/GUI/Gizmos/GLGizmoMeshBoolean.cpp:5: /run/build/BambuStudio/src/libslic3r/CSGMesh/PerformCSGMeshBooleans.hpp: In lambda function: /run/build/BambuStudio/src/libslic3r/CSGMesh/PerformCSGMeshBooleans.hpp:281:35: error: ‘info’ was not declared in this scope; did you mean ‘tbb::v1::info’?
  281 |                 BOOST_LOG_TRIVIAL(info) << "check_csgmesh_booleans fails! mesh " << i << "/" << csgrange.size() << " is empty, cannot do boolean!";
      |                                   ^~~~
      |                                   tbb::v1::info
/run/build/BambuStudio/src/libslic3r/CSGMesh/PerformCSGMeshBooleans.hpp:295:35: error: ‘info’ was not declared in this scope; did you mean ‘tbb::v1::info’?
  295 |                 BOOST_LOG_TRIVIAL(info) << "check_csgmesh_booleans fails! mesh " << i << "/" << csgrange.size() << " does_self_intersect is true, cannot do boolean!";
      |                                   ^~~~
      |                                   tbb::v1::info
```