### PR TITLE
Fix "Enable AMS" checkbox font inconsistency

### DIFF
--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -1543,10 +1543,10 @@ wxWindow *SelectMachineDialog::create_ams_checkbox(wxString title, wxWindow *par
     sizer_check->Add(check, 0, wxBOTTOM | wxEXPAND | wxTOP, FromDIP(5));
 
     sizer_checkbox->Add(sizer_check, 0, wxEXPAND, FromDIP(5));
-    sizer_checkbox->Add(0, 0, 0, wxEXPAND | wxLEFT, FromDIP(11));
+    sizer_checkbox->Add(0, 0, 0, wxEXPAND | wxLEFT, FromDIP(7));
 
     auto text = new wxStaticText(checkbox, wxID_ANY, title, wxDefaultPosition, wxDefaultSize, 0);
-    text->SetFont(::Label::Body_13);
+    text->SetFont(::Label::Body_12);
     text->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#323A3C")));
     text->Wrap(-1);
     sizer_checkbox->Add(text, 0, wxALIGN_CENTER, 0);


### PR DESCRIPTION
In the "Print Plate" dialog window, the "Enable AMS" checkbox label uses an inconsistent font size and offset. It differs from the font size and offset of the other checkboxes in the same dialog.  This pull request fixes this issue by equalizing the font properties. On my machine, it also fixes #4461.

## Before
![before](https://github.com/user-attachments/assets/66c2a408-7670-4efa-9272-15715744aeb7)
## After
![After](https://github.com/user-attachments/assets/24032062-fd75-4bbd-9604-67e4b26f7bca)
