### PR TITLE
FIX: Fix focus stealing from app when filament changes

### DIFF
--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1110,10 +1110,10 @@ void MainFrame::init_tabpanel()
             m_topbar->DisableUndoRedoItems();
         }
 #endif
-
+#ifndef __WXGTK__
         if (panel)
             panel->SetFocus();
-
+#endif
         /*switch (sel) {
         case TabPosition::tpHome:
             show_option(false);

--- a/src/slic3r/GUI/StatusPanel.cpp
+++ b/src/slic3r/GUI/StatusPanel.cpp
@@ -4255,7 +4255,9 @@ void StatusPanel::set_default()
     m_ams_control_box->Hide();
     m_ams_control->Reset();
     error_info_reset();
+#ifndef __WXGTK__
     SetFocus();
+#endif
 }
 
 void StatusPanel::show_status(int status)


### PR DESCRIPTION
At every filament related event, the old code would try to set the keyboard focus to the "Device" tab, leading to a number of, either, focus stealing events, or notifications if the desktop has focus stealing prevention (like GNOME).

Disable the focus setting on Linux to prevent that focus stealing.

Closes: https://github.com/bambulab/BambuStudio/issues/3046