### PR TITLE
fix: incorrect translation for updating

### DIFF
--- a/bbl/i18n/de/BambuStudio_de.po
+++ b/bbl/i18n/de/BambuStudio_de.po
@@ -8407,7 +8407,7 @@ msgid "Latest version"
 msgstr "Neueste Version"
 
 msgid "Updating"
-msgstr "Aktualiseren"
+msgstr "Aktualisieren"
 
 msgid "Updating failed"
 msgstr "Aktualisierung fehlgeschlagen"


### PR DESCRIPTION
added the missing "i" in "Aktualisieren"