### PR TITLE
Fix patch step for OCCT and OpenCV dependencies

### DIFF
--- a/deps/OCCT/OCCT.cmake
+++ b/deps/OCCT/OCCT.cmake
@@ -8,7 +8,7 @@ bambustudio_add_cmake_project(OCCT
     URL https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V7_6_0.zip
     URL_HASH SHA256=28334f0e98f1b1629799783e9b4d21e05349d89e695809d7e6dfa45ea43e1dbc
     #PATCH_COMMAND ${PATCH_CMD} ${CMAKE_CURRENT_LIST_DIR}/0001-OCCT-fix.patch
-    PATCH_COMMAND ${GIT_EXECUTABLE} apply --directory deps/build/dep_OCCT-prefix/src/dep_OCCT --verbose --ignore-space-change --whitespace=fix ${CMAKE_CURRENT_LIST_DIR}/0001-OCCT-fix.patch
+    PATCH_COMMAND ${GIT_EXECUTABLE} apply --verbose --ignore-space-change --whitespace=fix ${CMAKE_CURRENT_LIST_DIR}/0001-OCCT-fix.patch
     #DEPENDS dep_Boost
     #DEPENDS dep_FREETYPE
     CMAKE_ARGS

--- a/deps/OpenCV/OpenCV.cmake
+++ b/deps/OpenCV/OpenCV.cmake
@@ -7,7 +7,7 @@ endif ()
 bambustudio_add_cmake_project(OpenCV
     URL https://github.com/opencv/opencv/archive/refs/tags/4.6.0.tar.gz
     URL_HASH SHA256=1ec1cba65f9f20fe5a41fda1586e01c70ea0c9a6d7b67c9e13edf0cfe2239277
-    PATCH_COMMAND ${GIT_EXECUTABLE} apply --directory deps/build/dep_OpenCV-prefix/src/dep_OpenCV --verbose --ignore-space-change --whitespace=fix ${CMAKE_CURRENT_LIST_DIR}/0001-OpenCV-fix.patch
+    PATCH_COMMAND ${GIT_EXECUTABLE} apply --verbose --ignore-space-change --whitespace=fix ${CMAKE_CURRENT_LIST_DIR}/0001-OpenCV-fix.patch
     CMAKE_ARGS
     -DBUILD_SHARED_LIBS=0
        -DBUILD_PERE_TESTS=OFF


### PR DESCRIPTION
The `PATCH_COMMAND` for OCCT and OpenCV are trying to patch files that don't exist because of the addition of the `--directory` flag. `PATCH_COMMAND` runs in the working directory of the downloaded source files per my own testing. Specifying `--directory` here is causing the patch to try to apply to `dep_OpenCV-prefix/src/OpenCV` from root of the downloaded source rather than from the root of the downloaded source code. This causes `git apply` to try to patch files that don't exist which returns nonzero error codes (I can only reproduce this behavior of `git apply` when the `--directory` flag is present, without it the patch fails silently). I have a comment going into a bit more depth about this [here](https://github.com/bambulab/BambuStudio/issues/4689#issuecomment-2662200508).

This is leading to the build failures and workaround being discussed in #4158, #4689, #5171.

With these changes I'm able to fully cleanbuild on Arch Linux.