### PR TITLE
Fix Brim paint gizmo memory leaking

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
@@ -113,7 +113,7 @@ bool GLGizmoBrimEars::is_use_point(const BrimPoint &point) const
 void GLGizmoBrimEars::render_points(const Selection &selection, bool picking) const
 {
     auto editing_cache = m_editing_cache;
-    if (render_hover_point != nullptr) { editing_cache.push_back(*render_hover_point); }
+    if (render_hover_point) { editing_cache.push_back(*render_hover_point); }
 
     size_t cache_size = editing_cache.size();
 
@@ -308,10 +308,9 @@ bool GLGizmoBrimEars::gizmo_event(SLAGizmoEventType action, const Vec2d &mouse_p
         Transform3d             inverse_trsf = volume->get_instance_transformation().get_matrix(true).inverse();
         std::pair<Vec3f, Vec3f> pos_and_normal;
         if (unproject_on_mesh2(mouse_position, pos_and_normal)) {
-            render_hover_point = new CacheEntry(BrimPoint(pos_and_normal.first, m_new_point_head_diameter / 2.f), false, (inverse_trsf * m_world_normal).cast<float>(), true);
+            render_hover_point = CacheEntry(BrimPoint(pos_and_normal.first, m_new_point_head_diameter / 2.f), false, (inverse_trsf * m_world_normal).cast<float>(), true);
         } else {
-            delete render_hover_point;
-            render_hover_point = nullptr;
+            render_hover_point.reset();
         }
     } else if (action == SLAGizmoEventType::LeftDown && (shift_down || alt_down || control_down)) {
         // left down with shift - show the selection rectangle:

--- a/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.hpp
@@ -107,7 +107,7 @@ private:
     const Vec3d m_world_normal = {0, 0, 1};
     std::map<GLVolume*, std::shared_ptr<PickRaycaster>>   m_mesh_raycaster_map;
     GLVolume* m_last_hit_volume;
-    CacheEntry* render_hover_point = nullptr;
+    std::optional<CacheEntry> render_hover_point;
 
     bool m_link_text_hover = false;
 


### PR DESCRIPTION
Fix `render_hover_point` memory leaking by using `std::optional`