### PR TITLE
FIX: recognition with correct ID: SUNLU PETG @BBL A1M.json

### DIFF
--- a/resources/profiles/BBL/filament/SUNLU/SUNLU PETG @BBL A1M.json
+++ b/resources/profiles/BBL/filament/SUNLU/SUNLU PETG @BBL A1M.json
@@ -1,21 +1,15 @@
 {
     "type": "filament",
     "name": "SUNLU PETG @BBL A1M 0.4 nozzle",
-    "inherits": "SUNLU PETG @BBL X1C",
+    "inherits": "SUNLU PETG @base",
     "from": "system",
     "setting_id": "GFSNLS08_05",
     "instantiation": "true",
     "filament_flow_ratio": [
         "0.94"
     ],
-    "filament_long_retractions_when_cut": [
-        "nil"
-    ],
     "filament_max_volumetric_speed": [
         "9"
-    ],
-    "filament_retraction_distances_when_cut": [
-        "nil"
     ],
     "compatible_printers": [
         "Bambu Lab A1 mini 0.4 nozzle"


### PR DESCRIPTION
Changed inherits from X1C to regular SUNLU PETG base and adapted the A1 preset 1 to 1, works now in Bambu Studio!