### PR TITLE
Small error in message (file download)

### DIFF
--- a/bbl/i18n/BambuStudio.pot
+++ b/bbl/i18n/BambuStudio.pot
@@ -4797,7 +4797,7 @@ msgstr ""
 msgid "File renaming failed, please try again."
 msgstr ""
 
-msgid "File upload failed, please try again."
+msgid "File download failed, please try again."
 msgstr ""
 
 #, possible-c-format, possible-boost-format


### PR DESCRIPTION
When it fails to download a file, the msgbox says "file upload failed" instead of "file download"