### PR TITLE
Allow URL handler to open files from untrusted sites with confirm

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -1100,6 +1100,7 @@ void GUI_App::post_init()
 
             std::string download_url;
 #if BBL_RELEASE_TO_PUBLIC
+			USHORT ext_url_open_state = -1; // -1 not set, wxNO not open, wxYES open
             for (auto input_str : input_str_arr) {
                 if (boost::starts_with(input_str, "http://makerworld") ||
                     boost::starts_with(input_str, "https://makerworld") ||
@@ -1108,6 +1109,15 @@ void GUI_App::post_init()
                     boost::algorithm::contains(input_str, "amazonaws.com") ||
                     boost::algorithm::contains(input_str, "aliyuncs.com")) {
                     download_url = input_str;
+                }
+                else {
+                    if (ext_url_open_state == -1) {
+                        wxString askMsg = wxString::Format(_L("This file is not from a trusted site, do you want to open it anyway?"));
+                        ext_url_open_state = wxMessageBox(askMsg, "Bambu Studio", wxYES_NO | wxICON_EXCLAMATION);
+                    }
+                    if (ext_url_open_state == wxYES) {
+                        download_url = input_str;
+                    }
                 }
             }
 #else

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -1100,7 +1100,7 @@ void GUI_App::post_init()
 
             std::string download_url;
 #if BBL_RELEASE_TO_PUBLIC
-			USHORT ext_url_open_state = -1; // -1 not set, wxNO not open, wxYES open
+			short ext_url_open_state = -1; // -1 not set, wxNO not open, wxYES open
             for (auto input_str : input_str_arr) {
                 if (boost::starts_with(input_str, "http://makerworld") ||
                     boost::starts_with(input_str, "https://makerworld") ||


### PR DESCRIPTION
Essentially this PR is a follow up of #5347. It addresses #5347 #6120 #3798

I am not going to talk about the vague "security" approach currently deployed for the URL handler, improve that is out of scope of this PR.

The changes directly implements the decision made by @lanewei120 

> keep the original url judge logic currently, let it go on as before(we will refine more these address check later)
and popup a warning dialog when the url doesn't meet the above
and if user clicks ok, bambu studio will go on to load it


I am currently having issue building on my PC due to strange deps error (W11, every requirement installed, clean clone of repository), so I am using this PR as a github-action build check.

The changes are minimal. 