### PR TITLE
feat: Enable 'seam_gap' setting with 'Advanced Mode'

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3520,7 +3520,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("In order to reduce the visibility of the seam in a closed loop extrusion, the loop is interrupted and shortened by a specified amount.\n" "This amount as a percentage of the current extruder diameter. The default value for this parameter is 15");
     def->sidetext = "%";
     def->min = 0;
-    def->mode = comDevelop;
+    def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionPercent(15));
 
     def          = this->add("seam_slope_conditional", coBool);


### PR DESCRIPTION
Fixes https://github.com/bambulab/BambuStudio/issues/6064

I could've sworn that the setting "Seam Gap" was available even without developer mode, but turns out that's not true! This should make it available under "Advanced Mode". I don't know why the setting was under Dev Mode before.