### PR TITLE
feat(url handler): add User Preference for 3rd party model sites

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -366,6 +366,11 @@ void AppConfig::set_defaults()
         set_bool("staff_pick_switch", true);
     }
 
+    if (get("allow_external_model_sites").empty()) {
+        set_bool("allow_external_model_sites", false);
+    }
+
+
     if (get("sync_system_preset").empty()) {
         set_bool("sync_system_preset", true);
     }

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -1096,11 +1096,12 @@ void GUI_App::post_init()
 
             std::string download_params_url = url_decode(this->init_params->input_files.front());
             auto input_str_arr = split_str(download_params_url, "file=");
-
-
+            // -1 not set, wxNO not open, wxYES open
+            short ext_url_open_state = -1;
             std::string download_url;
-#if BBL_RELEASE_TO_PUBLIC
-			short ext_url_open_state = -1; // -1 not set, wxNO not open, wxYES open
+            if (app_config->get("allow_external_model_sites") == "true") {
+                ext_url_open_state = wxYES
+            }
             for (auto input_str : input_str_arr) {
                 if (boost::starts_with(input_str, "http://makerworld") ||
                     boost::starts_with(input_str, "https://makerworld") ||
@@ -1120,11 +1121,6 @@ void GUI_App::post_init()
                     }
                 }
             }
-#else
-            for (auto input_str : input_str_arr) {
-                download_url = input_str;
-            }
-#endif
             try
             {
                 //filter relative directories

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1244,6 +1244,8 @@ wxWindow* PreferencesDialog::create_general_page()
     auto item_modelmall = create_item_checkbox(_L("Show online staff-picked models on the home page"), page, _L("Show online staff-picked models on the home page"), 50, "staff_pick_switch");
 
     auto item_show_history = create_item_checkbox(_L("Show history on the home page"), page, _L("Show history on the home page"), 50, "show_print_history");
+    auto item_allow_external_model_sites = create_item_checkbox(_L("Open modeles from 3rd party without confirm"), page, _L("Open modeles from 3rd party without confirm"), 50, "allow_external_model_sites");
+
     auto title_project = create_item_title(_L("Project"), page, "");
     auto item_max_recent_count = create_item_input(_L("Maximum recent projects"), "", page, _L("Maximum count of recent projects"), "max_recent_count", [](wxString value) {
         long max = 0;
@@ -1322,6 +1324,7 @@ wxWindow* PreferencesDialog::create_general_page()
     auto item_title_modelmall   = sizer_page->Add(title_modelmall, 0, wxTOP | wxEXPAND, FromDIP(20));
     auto item_item_modelmall    = sizer_page->Add(item_modelmall, 0, wxTOP, FromDIP(3));
     auto item_item_show_history = sizer_page->Add(item_show_history, 0, wxTOP, FromDIP(3));
+    auto item_item_allow_external_model_sites = sizer_page->Add(item_allow_external_model_sites, 0, wxTOP, FromDIP(3));
 
     auto update_modelmall = [this, item_title_modelmall, item_item_modelmall, item_item_show_history](wxEvent &e) {
         bool has_model_mall = wxGetApp().has_model_mall();


### PR DESCRIPTION
This PR is a direct follow up of #6856.

- Introducing a User Preference to allow the import of 3d models from 3rd party websites.
- Unified the behavior between the BBL_RELEASE_TO_PUBLIC and self-compiled versions.


The changes are minimal and aims to improve the user consistency between the different variants of BBS.