### PR TITLE
Add CLI option to disable safety parameter clamping (cli_safe_params)

### DIFF
--- a/src/BambuStudio.cpp
+++ b/src/BambuStudio.cpp
@@ -2836,7 +2836,7 @@ int CLI::run(int argc, char **argv)
         else {
             ret = update_full_config(m_print_config, load_machine_config, different_keys_set, true);
             BOOST_LOG_TRIVIAL(info) << boost::format("load a new printer, update all the keys, different_settings: %1%")%different_settings[filament_count+1];
-            if (new_printer_name != current_printer_name)
+            if (new_printer_name != current_printer_name && cli_safe_params)
             {
                 //printer safe check
                 BOOST_LOG_TRIVIAL(info) << boost::format("check printer cli safe params, current_printer_name %1%, new_printer_name %2%, printer_model %3%")%current_printer_name %new_printer_name %printer_model;
@@ -5320,7 +5320,7 @@ int CLI::run(int argc, char **argv)
     }
 
     // loop through action options
-    bool export_to_3mf = false, load_slicedata = false, export_slicedata = false, export_slicedata_error = false;
+    bool export_to_3mf = false, load_slicedata = false, export_slicedata = false, export_slicedata_error = false, cli_safe_params = true;
     bool no_check = false;
     std::string export_3mf_file, load_slice_data_dir, export_slice_data_dir, export_stls_dir;
     std::vector<ThumbnailData*> calibration_thumbnails;
@@ -5550,6 +5550,8 @@ int CLI::run(int argc, char **argv)
                 record_exit_reson(outfile_dir, CLI_INVALID_PARAMS, 0, cli_errors[CLI_INVALID_PARAMS], sliced_info);
                 flush_and_exit(CLI_INVALID_PARAMS);
             }
+	}else if(opt_key=="cli_safe_params"){
+            cli_safe_params = m_config.opt_bool(opt_key);
         } else if (opt_key == "slice") {
             //BBS: slice 0 means all plates, i means plate i;
             plate_to_slice = m_config.option<ConfigOptionInt>("slice")->value;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -7485,6 +7485,11 @@ CLIActionsConfigDef::CLIActionsConfigDef()
     def->cli = "gcodeviewer";
     def->set_default_value(new ConfigOptionBool(false));*/
 
+    def = this->add("cli_safe_params", coBool);
+    def->label = "Enable CLI Safety Checks";
+    def->tooltip = "When enabled, parameters exceeding the printer's safety limits (e.g., acceleration) will be clamped to safe defaults. Disable at your own risk.";
+    def->set_default_value(new ConfigOptionBool(true));
+
     def = this->add("slice", coInt);
     def->label = "Slice";
     def->tooltip = "Slice the plates: 0-all plates, i-plate i, others-invalid";


### PR DESCRIPTION
This PR introduces a new configuration option cli_safe_params (default: true) which controls whether the CLI applies built-in safety limits to machine parameters such as acceleration.

**Motivation:**
Power users may want to apply custom values beyond the default safety limits (e.g., machine_max_acceleration_x = 12000) for experimental or performance-driven use cases.
Until now, the CLI forcibly clamped such values (e.g., to 6000) even if they were explicitly set in machine.json.

**What this adds:**
	•	New config entry cli_safe_params (type: bool)
	•	When set to false, the CLI will skip the safety check and use the values defined in config files as-is.
	•	Default behavior remains unchanged to protect less experienced users.
	
Example usage:
`BambuStudio --cli_safe_params=false --load machine.json --load process.json --export_gcode`
	