### PR TITLE
Fixes #7211 where the CreateFilamentPresetDialog fails to resize

### DIFF
--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -556,7 +556,7 @@ static void adjust_dialog_in_screen(DPIDialog* dialog) {
 }
 
 CreateFilamentPresetDialog::CreateFilamentPresetDialog(wxWindow *parent)
-	: DPIDialog(parent ? parent : nullptr, wxID_ANY, _L("Create Filament"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX | wxCENTRE)
+	: DPIDialog(parent ? parent : nullptr, wxID_ANY, _L("Create Filament"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX | wxCENTRE | wxRESIZE_BORDER)
 {
     m_create_type.base_filament = _L("Create Based on Current Filament");
     m_create_type.base_filament_preset = _L("Copy Current Filament Preset ");


### PR DESCRIPTION
**Issue**
The CreateFilamentPresetDialog fails to resize properly to show the printer list in the bottom of the dialog window.  This precludes selection of printer(s) which prevents the successful creation of the filament profile.  

**Fix**
This "fix" simple adds the wxRESIZE_BORDER flag on window creation so the dialog can be resized to reveal the printer list.  In my opinion, this is really just a workaround. Ideally the printer list is contained within scrollable control or the is resized window properly when the printer list is populated.

Fixes #7211 