### PR TITLE
Fix spanish translation for "Ludicrous"

### DIFF
--- a/bbl/i18n/es/BambuStudio_es.po
+++ b/bbl/i18n/es/BambuStudio_es.po
@@ -5213,16 +5213,16 @@ msgid "This only takes effect during printing"
 msgstr "Esto solo tiene efecto durante la impresión"
 
 msgid "Silent"
-msgstr "Silencio"
+msgstr "Silenciosa"
 
 msgid "Standard"
 msgstr "Estándar"
 
 msgid "Sport"
-msgstr "Deportivo"
+msgstr "Deportiva"
 
 msgid "Ludicrous"
-msgstr "Lúdico"
+msgstr "Absurda"
 
 msgid "Turning off the lights during the task will cause the failure of AI monitoring, like spaghetti dectection. Please choose carefully."
 msgstr ""


### PR DESCRIPTION
The Spanish .po file translates "Ludicrous" as "Lúdico", which is absolutely erroneous. The correct translation is "Absurda", as it was done when Spaceballs was dubbed both in Spain and Latin American ("Ludicrous speed" -> "Velocidad absurda").

Of course, since, in Spanish, words have gender, all the other speeds must be swapped from masculine to feminine to keep the gender matching.