### PR TITLE
FIX: Thumbnail generation in CLI mode segfaults when no valid opengl context exists

### DIFF
--- a/src/BambuStudio.cpp
+++ b/src/BambuStudio.cpp
@@ -6161,7 +6161,7 @@ int CLI::run(int argc, char **argv)
                                     else {
                                         if (!opengl_valid)
                                             opengl_valid = init_opengl_and_colors(model, colors);
-                                        outfile = print_fff->export_gcode(outfile, gcode_result, cli_generate_thumbnails);
+                                        outfile = opengl_valid ? print_fff->export_gcode(outfile, gcode_result, cli_generate_thumbnails) : print_fff->export_gcode(outfile, gcode_result, nullptr);
                                     }
                                     slice_time[TIME_USING_CACHE] = slice_time[TIME_USING_CACHE] + ((long long)Slic3r::Utils::get_current_milliseconds_time_utc() - temp_time);
                                     BOOST_LOG_TRIVIAL(info) << "export_gcode finished: time_using_cache update to " << slice_time[TIME_USING_CACHE] << " secs.";


### PR DESCRIPTION
A small edge case in the way the glfw/opengl context is handled causes slices performed in environments without opengl, for a multitude of reasons, e.i. wayland, headless etc. to segfault.

The underlying trigger is the fact `shader` is null which causes  `p_opengl_mgr->bind_shader` to crash. I am not too familiar with the overall code architecture, my immediate thought was that in such an environment trying to generate a thumbnail is not really intended, so disabling it entirely would make the most sense. It is also possible to handle the crash more granularity by conditionally calling `bind_shader` based on the current `p_opengl_mgr` and `shader` state.  

In the end this is the smallest change that solves the specific use case we have, gracefully not generating thumbnails while still outputting the project file.

Files for simple reproducable with Creality CR 10 V2: [repo.zip](https://github.com/user-attachments/files/21112864/repo.zip) to trigger the crash, running with `xvfb-run` or wayland should be enough to do the trick in terms of replicating. 

A quick repo:

```
mkdir -p /tmp/repo
cd /tmp/repo
wget https://github.com/user-attachments/files/21112864/repo.zip
unzip repo.zip
./BambuStudio_ubu64.AppImage --debug 3 --export-3mf output.3mf --slice 0 --arrange 0 --load-settings='process.json;machine.json' --load-filaments=filament.json model.stl
```
