### PR TITLE
Update SelectMachine.cpp

### DIFF
--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -2222,7 +2222,7 @@ wxString SelectMachineDialog::format_steel_name(NozzleType type)
         return _L("Tungsten Carbide");
     }
 
-    return _L("Unknown");
+    return wxString::Format(_L("Unknown nozzle type: '%s'"), name);
 }
 
 void SelectMachineDialog::EnableEditing(bool enable)


### PR DESCRIPTION
Rather than returning just 'unknown', we can pass the string of the nozzle type. At a minimum this helps the end user just as much as 'unknown'. At best it helps everyone involved figure out what kind of nozzle is causing issues when future nozzles are introduced.