### PR TITLE
Add Fiberon presets for H2D

### DIFF
--- a/resources/profiles/BBL.json
+++ b/resources/profiles/BBL.json
@@ -1567,35 +1567,51 @@
         },
         {
             "name": "Fiberon PA12-CF @base",
-            "sub_path": "filament/Fiberon PA12-CF @base.json"
+            "sub_path": "filament/Polymaker/Fiberon PA12-CF @base.json"
         },
         {
             "name": "Fiberon PA12-CF @BBL X1C",
-            "sub_path": "filament/Fiberon PA12-CF @BBL X1C.json"
+            "sub_path": "filament/Polymaker/Fiberon PA12-CF @BBL X1C.json"
+        },
+        {
+            "name": "Fiberon PA12-CF @BBL H2D",
+            "sub_path": "filament/Polymaker/Fiberon PA12-CF @BBL H2D.json"
         },
         {
             "name": "Fiberon PA6-CF @base",
-            "sub_path": "filament/Fiberon PA6-CF @base.json"
+            "sub_path": "filament/Polymaker/Fiberon PA6-CF @base.json"
         },
         {
             "name": "Fiberon PA6-CF @BBL X1C",
-            "sub_path": "filament/Fiberon PA6-CF @BBL X1C.json"
+            "sub_path": "filament/Polymaker/Fiberon PA6-CF @BBL X1C.json"
+        },
+        {
+            "name": "Fiberon PA6-CF @BBL H2D",
+            "sub_path": "filament/Polymaker/Fiberon PA6-CF @BBL H2D.json"
         },
         {
             "name": "Fiberon PA6-GF @base",
-            "sub_path": "filament/Fiberon PA6-GF @base.json"
+            "sub_path": "filament/Polymaker/Fiberon PA6-GF @base.json"
         },
         {
             "name": "Fiberon PA6-GF @BBL X1C",
-            "sub_path": "filament/Fiberon PA6-GF @BBL X1C.json"
+            "sub_path": "filament/Polymaker/Fiberon PA6-GF @BBL X1C.json"
+        },
+        {
+            "name": "Fiberon PA6-GF @BBL H2D",
+            "sub_path": "filament/Polymaker/Fiberon PA6-GF @BBL H2D.json"
         },
         {
             "name": "Fiberon PA612-CF @base",
-            "sub_path": "filament/Fiberon PA612-CF @base.json"
+            "sub_path": "filament/Polymaker/Fiberon PA612-CF @base.json"
         },
         {
             "name": "Fiberon PA612-CF @BBL X1C",
-            "sub_path": "filament/Fiberon PA612-CF @BBL X1C.json"
+            "sub_path": "filament/Polymaker/Fiberon PA612-CF @BBL X1C.json"
+        },
+        {
+            "name": "Fiberon PA612-CF @BBL H2D",
+            "sub_path": "filament/Polymaker/Fiberon PA612-CF @BBL H2D.json"
         },
         {
             "name": "Generic PA @base",
@@ -2275,27 +2291,39 @@
         },
         {
             "name": "Fiberon PET-CF @base",
-            "sub_path": "filament/Fiberon PET-CF @base.json"
+            "sub_path": "filament/Polymaker/Fiberon PET-CF @base.json"
         },
         {
             "name": "Fiberon PET-CF @BBL X1C",
-            "sub_path": "filament/Fiberon PET-CF @BBL X1C.json"
+            "sub_path": "filament/Polymaker/Fiberon PET-CF @BBL X1C.json"
+        },
+        {
+            "name": "Fiberon PET-CF @BBL H2D",
+            "sub_path": "filament/Polymaker/Fiberon PET-CF @BBL H2D.json"
         },
         {
             "name": "Fiberon PETG-ESD @base",
-            "sub_path": "filament/Fiberon PETG-ESD @base.json"
+            "sub_path": "filament/Polymaker/Fiberon PETG-ESD @base.json"
         },
         {
             "name": "Fiberon PETG-ESD @BBL X1C",
-            "sub_path": "filament/Fiberon PETG-ESD @BBL X1C.json"
+            "sub_path": "filament/Polymaker/Fiberon PETG-ESD @BBL X1C.json"
+        },
+        {
+            "name": "Fiberon PETG-ESD @BBL H2D",
+            "sub_path": "filament/Polymaker/Fiberon PETG-ESD @BBL H2D.json"
         },
         {
             "name": "Fiberon PETG-rCF @base",
-            "sub_path": "filament/Fiberon PETG-rCF @base.json"
+            "sub_path": "filament/Polymaker/Fiberon PETG-rCF @base.json"
         },
         {
             "name": "Fiberon PETG-rCF @BBL X1C",
-            "sub_path": "filament/Fiberon PETG-rCF @BBL X1C.json"
+            "sub_path": "filament/Polymaker/Fiberon PETG-rCF @BBL X1C.json"
+        },
+        {
+            "name": "Fiberon PETG-rCF @BBL H2D",
+            "sub_path": "filament/Polymaker/Fiberon PETG-rCF @BBL H2D.json"
         },
         {
             "name": "Generic PETG @base",

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PA12-CF @BBL H2D.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PA12-CF @BBL H2D.json
@@ -1,0 +1,148 @@
+{
+    "type": "filament",
+    "name": "Fiberon PA12-CF @BBL H2D",
+    "inherits": "Fiberon PA12-CF @base",
+    "from": "system",
+    "filament_id": "GFL52",
+    "setting_id": "GFL52_10",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle",
+        "Bambu Lab H2D 0.6 nozzle",
+        "Bambu Lab H2D 0.8 nozzle"
+    ],
+    "eng_plate_temp": [
+        "40"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "40"
+    ],
+    "fan_cooling_layer_time": [
+        "15"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "filament_cost": [
+        "99.99"
+    ],
+    "filament_density": [
+        "1.06"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "nil"
+    ],
+    "filament_extruder_variant": [
+        "Direct Drive Standard",
+        "Direct Drive High Flow"
+    ],
+    "filament_flow_ratio": [
+        "0.95",
+        "0.95"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "14",
+        "14"
+    ],
+    "filament_pre_cooling_temperature": [
+        "0",
+        "0"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_ramming_volumetric_speed": [
+        "-1",
+        "-1"
+    ],
+    "filament_retract_before_wipe": [
+        "nil",
+        "nil"
+    ],
+    "filament_retract_restart_extra": [
+        "nil",
+        "nil"
+    ],
+    "filament_retract_when_changing_layer": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_minimum_travel": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "nil"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "filament_wipe": [
+        "nil",
+        "nil"
+    ],
+    "filament_wipe_distance": [
+        "nil",
+        "nil"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "nil"
+    ],
+    "filament_z_hop_types": [
+        "nil",
+        "nil"
+    ],
+    "hot_plate_temp": [
+        "40"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "40"
+    ],
+    "nozzle_temperature": [
+        "300",
+        "300"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "300",
+        "300"
+    ],
+    "nozzle_temperature_range_high": [
+        "300",
+        "300"
+    ],
+    "nozzle_temperature_range_low": [
+        "260",
+        "260"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ],
+    "temperature_vitrification": [
+        "131"
+    ],
+    "textured_plate_temp": [
+        "40"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "40"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PA12-CF @BBL X1C.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PA12-CF @BBL X1C.json
@@ -1,0 +1,16 @@
+{
+    "type": "filament",
+    "name": "Fiberon PA12-CF @BBL X1C",
+    "inherits": "Fiberon PA12-CF @base",
+    "from": "system",
+    "setting_id": "GFSL52_00",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PA12-CF @base.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PA12-CF @base.json
@@ -1,0 +1,71 @@
+{
+    "type": "filament",
+    "name": "Fiberon PA12-CF @base",
+    "inherits": "fdm_filament_pa",
+    "from": "system",
+    "filament_id": "GFL52",
+    "instantiation": "false",
+    "eng_plate_temp": [
+        "40"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "40"
+    ],
+    "fan_cooling_layer_time": [
+        "15"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "filament_cost": [
+        "99.99"
+    ],
+    "filament_density": [
+        "1.06"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "14"
+    ],
+    "filament_type": [
+        "PA-CF"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "full_fan_speed_layer": [
+        "2"
+    ],
+    "hot_plate_temp": [
+        "40"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "40"
+    ],
+    "nozzle_temperature": [
+        "300"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "300"
+    ],
+    "nozzle_temperature_range_low": [
+        "260"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "temperature_vitrification": [
+        "131"
+    ],
+    "textured_plate_temp": [
+        "40"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "40"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PA6-CF @BBL H2D.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PA6-CF @BBL H2D.json
@@ -1,0 +1,148 @@
+{
+    "type": "filament",
+    "name": "Fiberon PA6-CF @BBL H2D",
+    "inherits": "Fiberon PA6-CF @base",
+    "from": "system",
+    "filament_id": "GFL50",
+    "setting_id": "GFL50_10",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle",
+        "Bambu Lab H2D 0.6 nozzle",
+        "Bambu Lab H2D 0.8 nozzle"
+    ],
+    "eng_plate_temp": [
+        "40"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "40"
+    ],
+    "fan_cooling_layer_time": [
+        "15"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "filament_cost": [
+        "83.99"
+    ],
+    "filament_density": [
+        "1.17"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "nil"
+    ],
+    "filament_extruder_variant": [
+        "Direct Drive Standard",
+        "Direct Drive High Flow"
+    ],
+    "filament_flow_ratio": [
+        "0.95",
+        "0.95"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "14",
+        "14"
+    ],
+    "filament_pre_cooling_temperature": [
+        "0",
+        "0"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_ramming_volumetric_speed": [
+        "-1",
+        "-1"
+    ],
+    "filament_retract_before_wipe": [
+        "nil",
+        "nil"
+    ],
+    "filament_retract_restart_extra": [
+        "nil",
+        "nil"
+    ],
+    "filament_retract_when_changing_layer": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_minimum_travel": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "nil"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "filament_wipe": [
+        "nil",
+        "nil"
+    ],
+    "filament_wipe_distance": [
+        "nil",
+        "nil"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "nil"
+    ],
+    "filament_z_hop_types": [
+        "nil",
+        "nil"
+    ],
+    "hot_plate_temp": [
+        "40"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "40"
+    ],
+    "nozzle_temperature": [
+        "300",
+        "300"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "300",
+        "300"
+    ],
+    "nozzle_temperature_range_high": [
+        "300",
+        "300"
+    ],
+    "nozzle_temperature_range_low": [
+        "280",
+        "280"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ],
+    "temperature_vitrification": [
+        "215"
+    ],
+    "textured_plate_temp": [
+        "40"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "40"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PA6-CF @BBL X1C.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PA6-CF @BBL X1C.json
@@ -1,0 +1,16 @@
+{
+    "type": "filament",
+    "name": "Fiberon PA6-CF @BBL X1C",
+    "inherits": "Fiberon PA6-CF @base",
+    "from": "system",
+    "setting_id": "GFSL50_00",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PA6-CF @base.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PA6-CF @base.json
@@ -1,0 +1,68 @@
+{
+    "type": "filament",
+    "name": "Fiberon PA6-CF @base",
+    "inherits": "fdm_filament_pa",
+    "from": "system",
+    "filament_id": "GFL50",
+    "instantiation": "false",
+    "eng_plate_temp": [
+        "40"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "40"
+    ],
+    "fan_cooling_layer_time": [
+        "15"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "filament_cost": [
+        "83.99"
+    ],
+    "filament_density": [
+        "1.17"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "14"
+    ],
+    "filament_type": [
+        "PA6-CF"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "hot_plate_temp": [
+        "40"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "40"
+    ],
+    "nozzle_temperature": [
+        "300"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "300"
+    ],
+    "nozzle_temperature_range_low": [
+        "280"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "temperature_vitrification": [
+        "215"
+    ],
+    "textured_plate_temp": [
+        "40"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "40"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PA6-GF @BBL H2D.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PA6-GF @BBL H2D.json
@@ -1,0 +1,148 @@
+{
+    "type": "filament",
+    "name": "Fiberon PA6-GF @BBL H2D",
+    "inherits": "Fiberon PA6-GF @base",
+    "from": "system",
+    "filament_id": "GFL51",
+    "setting_id": "GFL51_10",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle",
+        "Bambu Lab H2D 0.6 nozzle",
+        "Bambu Lab H2D 0.8 nozzle"
+    ],
+    "eng_plate_temp": [
+        "40"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "40"
+    ],
+    "fan_cooling_layer_time": [
+        "12"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "filament_cost": [
+        "63.99"
+    ],
+    "filament_density": [
+        "1.2"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "nil"
+    ],
+    "filament_extruder_variant": [
+        "Direct Drive Standard",
+        "Direct Drive High Flow"
+    ],
+    "filament_flow_ratio": [
+        "0.95",
+        "0.95"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "12",
+        "12"
+    ],
+    "filament_pre_cooling_temperature": [
+        "0",
+        "0"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_ramming_volumetric_speed": [
+        "-1",
+        "-1"
+    ],
+    "filament_retract_before_wipe": [
+        "nil",
+        "nil"
+    ],
+    "filament_retract_restart_extra": [
+        "nil",
+        "nil"
+    ],
+    "filament_retract_when_changing_layer": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_minimum_travel": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "nil"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "filament_wipe": [
+        "nil",
+        "nil"
+    ],
+    "filament_wipe_distance": [
+        "nil",
+        "nil"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "nil"
+    ],
+    "filament_z_hop_types": [
+        "nil",
+        "nil"
+    ],
+    "hot_plate_temp": [
+        "40"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "40"
+    ],
+    "nozzle_temperature": [
+        "300",
+        "300"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "300",
+        "300"
+    ],
+    "nozzle_temperature_range_high": [
+        "300",
+        "300"
+    ],
+    "nozzle_temperature_range_low": [
+        "280",
+        "280"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ],
+    "temperature_vitrification": [
+        "191"
+    ],
+    "textured_plate_temp": [
+        "40"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "40"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PA6-GF @BBL X1C.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PA6-GF @BBL X1C.json
@@ -1,0 +1,19 @@
+{
+    "type": "filament",
+    "name": "Fiberon PA6-GF @BBL X1C",
+    "inherits": "Fiberon PA6-GF @base",
+    "from": "system",
+    "setting_id": "GFSL51_00",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab X1 0.6 nozzle",
+        "Bambu Lab X1 0.8 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PA6-GF @base.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PA6-GF @base.json
@@ -1,0 +1,71 @@
+{
+    "type": "filament",
+    "name": "Fiberon PA6-GF @base",
+    "inherits": "fdm_filament_pa",
+    "from": "system",
+    "filament_id": "GFL51",
+    "instantiation": "false",
+    "eng_plate_temp": [
+        "40"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "40"
+    ],
+    "fan_cooling_layer_time": [
+        "15"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "filament_cost": [
+        "63.99"
+    ],
+    "filament_density": [
+        "1.2"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_type": [
+        "PA-GF"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "full_fan_speed_layer": [
+        "2"
+    ],
+    "hot_plate_temp": [
+        "40"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "40"
+    ],
+    "nozzle_temperature": [
+        "300"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "300"
+    ],
+    "nozzle_temperature_range_low": [
+        "280"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "temperature_vitrification": [
+        "191"
+    ],
+    "textured_plate_temp": [
+        "40"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "40"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PA612-CF @BBL H2D.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PA612-CF @BBL H2D.json
@@ -1,0 +1,148 @@
+{
+    "type": "filament",
+    "name": "Fiberon PA612-CF @BBL H2D",
+    "inherits": "Fiberon PA612-CF @base",
+    "from": "system",
+    "filament_id": "GFL53",
+    "setting_id": "GFL53_10",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle",
+        "Bambu Lab H2D 0.6 nozzle",
+        "Bambu Lab H2D 0.8 nozzle"
+    ],
+    "eng_plate_temp": [
+        "100"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "100"
+    ],
+    "fan_cooling_layer_time": [
+        "5"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_cost": [
+        "94.99"
+    ],
+    "filament_density": [
+        "1.06"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "nil"
+    ],
+    "filament_extruder_variant": [
+        "Direct Drive Standard",
+        "Direct Drive High Flow"
+    ],
+    "filament_flow_ratio": [
+        "0.95",
+        "0.95"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "8",
+        "8"
+    ],
+    "filament_pre_cooling_temperature": [
+        "0",
+        "0"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_ramming_volumetric_speed": [
+        "-1",
+        "-1"
+    ],
+    "filament_retract_before_wipe": [
+        "nil",
+        "nil"
+    ],
+    "filament_retract_restart_extra": [
+        "nil",
+        "nil"
+    ],
+    "filament_retract_when_changing_layer": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_minimum_travel": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "nil"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "filament_wipe": [
+        "nil",
+        "nil"
+    ],
+    "filament_wipe_distance": [
+        "nil",
+        "nil"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "nil"
+    ],
+    "filament_z_hop_types": [
+        "nil",
+        "nil"
+    ],
+    "hot_plate_temp": [
+        "100"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "100"
+    ],
+    "nozzle_temperature": [
+        "290",
+        "290"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "290",
+        "290"
+    ],
+    "nozzle_temperature_range_high": [
+        "300",
+        "300"
+    ],
+    "nozzle_temperature_range_low": [
+        "260",
+        "260"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ],
+    "temperature_vitrification": [
+        "180"
+    ],
+    "textured_plate_temp": [
+        "100"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "100"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PA612-CF @BBL X1C.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PA612-CF @BBL X1C.json
@@ -1,0 +1,16 @@
+{
+    "type": "filament",
+    "name": "Fiberon PA612-CF @BBL X1C",
+    "inherits": "Fiberon PA612-CF @base",
+    "from": "system",
+    "setting_id": "GFSL53_00",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PA612-CF @base.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PA612-CF @base.json
@@ -1,0 +1,41 @@
+{
+    "type": "filament",
+    "name": "Fiberon PA612-CF @base",
+    "inherits": "fdm_filament_pa",
+    "from": "system",
+    "filament_id": "GFL53",
+    "instantiation": "false",
+    "fan_cooling_layer_time": [
+        "5"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_cost": [
+        "94.99"
+    ],
+    "filament_density": [
+        "1.06"
+    ],
+    "filament_flow_ratio": [
+        "0.96"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "full_fan_speed_layer": [
+        "2"
+    ],
+    "overhang_fan_speed": [
+        "40"
+    ],
+    "overhang_fan_threshold": [
+        "0%"
+    ],
+    "temperature_vitrification": [
+        "180"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PET-CF @BBL H2D.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PET-CF @BBL H2D.json
@@ -1,0 +1,153 @@
+{
+    "type": "filament",
+    "name": "Fiberon PET-CF @BBL H2D",
+    "inherits": "Fiberon PET-CF @base",
+    "from": "system",
+    "filament_id": "GFL54",
+    "setting_id": "GFL54_10",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle",
+        "Bambu Lab H2D 0.6 nozzle",
+        "Bambu Lab H2D 0.8 nozzle"
+    ],
+    "cool_plate_temp": [
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "70"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "70"
+    ],
+    "fan_cooling_layer_time": [
+        "242"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "filament_cost": [
+        "89.99"
+    ],
+    "filament_density": [
+        "1.34"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "nil"
+    ],
+    "filament_extruder_variant": [
+        "Direct Drive Standard",
+        "Direct Drive High Flow"
+    ],
+    "filament_flow_ratio": [
+        "0.95",
+        "0.95"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_pre_cooling_temperature": [
+        "0",
+        "0"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_ramming_volumetric_speed": [
+        "-1",
+        "-1"
+    ],
+    "filament_retract_before_wipe": [
+        "nil",
+        "nil"
+    ],
+    "filament_retract_restart_extra": [
+        "nil",
+        "nil"
+    ],
+    "filament_retract_when_changing_layer": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_minimum_travel": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "nil"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "filament_wipe": [
+        "nil",
+        "nil"
+    ],
+    "filament_wipe_distance": [
+        "nil",
+        "nil"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "nil"
+    ],
+    "filament_z_hop_types": [
+        "nil",
+        "nil"
+    ],
+    "hot_plate_temp": [
+        "70"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "70"
+    ],
+    "nozzle_temperature": [
+        "300",
+        "300"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "300",
+        "300"
+    ],
+    "nozzle_temperature_range_high": [
+        "300",
+        "300"
+    ],
+    "nozzle_temperature_range_low": [
+        "270",
+        "270"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ],
+    "temperature_vitrification": [
+        "70"
+    ],
+    "textured_plate_temp": [
+        "70"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "70"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PET-CF @BBL X1C.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PET-CF @BBL X1C.json
@@ -1,0 +1,16 @@
+{
+    "type": "filament",
+    "name": "Fiberon PET-CF @BBL X1C",
+    "inherits": "Fiberon PET-CF @base",
+    "from": "system",
+    "setting_id": "GFSL54_00",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PET-CF @base.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PET-CF @base.json
@@ -1,0 +1,92 @@
+{
+    "type": "filament",
+    "name": "Fiberon PET-CF @base",
+    "inherits": "fdm_filament_pet",
+    "from": "system",
+    "filament_id": "GFL54",
+    "instantiation": "false",
+    "cool_plate_temp": [
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "70"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "70"
+    ],
+    "fan_cooling_layer_time": [
+        "242"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "filament_cost": [
+        "89.99"
+    ],
+    "filament_density": [
+        "1.34"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_type": [
+        "PET-CF"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "hot_plate_temp": [
+        "70"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "70"
+    ],
+    "nozzle_temperature_range_low": [
+        "270"
+    ],
+    "nozzle_temperature_range_high": [
+        "300"
+    ],
+    "nozzle_temperature": [
+        "300"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "300"
+    ],
+    "required_nozzle_HRC": [
+        "40"
+    ],
+    "supertack_plate_temp": [
+        "80"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "80"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
+    "temperature_vitrification": [
+        "147"
+    ],
+    "textured_plate_temp": [
+        "70"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "70"
+    ],
+    "filament_adhesiveness_category": [
+        "800"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PETG-ESD @BBL H2D.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PETG-ESD @BBL H2D.json
@@ -1,0 +1,153 @@
+{
+    "type": "filament",
+    "name": "Fiberon PETG-ESD @BBL H2D",
+    "inherits": "Fiberon PETG-ESD @base",
+    "from": "system",
+    "filament_id": "GFL06",
+    "setting_id": "GFL06_10",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle",
+        "Bambu Lab H2D 0.6 nozzle",
+        "Bambu Lab H2D 0.8 nozzle"
+    ],
+    "cool_plate_temp": [
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "60"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "60"
+    ],
+    "fan_cooling_layer_time": [
+        "15"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "filament_cost": [
+        "29.99"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "nil"
+    ],
+    "filament_extruder_variant": [
+        "Direct Drive Standard",
+        "Direct Drive High Flow"
+    ],
+    "filament_flow_ratio": [
+        "0.95",
+        "0.95"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "20"
+    ],
+    "filament_pre_cooling_temperature": [
+        "0",
+        "0"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_ramming_volumetric_speed": [
+        "-1",
+        "-1"
+    ],
+    "filament_retract_before_wipe": [
+        "nil",
+        "nil"
+    ],
+    "filament_retract_restart_extra": [
+        "nil",
+        "nil"
+    ],
+    "filament_retract_when_changing_layer": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_minimum_travel": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "nil"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "filament_wipe": [
+        "nil",
+        "nil"
+    ],
+    "filament_wipe_distance": [
+        "nil",
+        "nil"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "nil"
+    ],
+    "filament_z_hop_types": [
+        "nil",
+        "nil"
+    ],
+    "hot_plate_temp": [
+        "60"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "60"
+    ],
+    "nozzle_temperature": [
+        "290",
+        "290"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "290",
+        "290"
+    ],
+    "nozzle_temperature_range_high": [
+        "290",
+        "290"
+    ],
+    "nozzle_temperature_range_low": [
+        "250",
+        "250"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ],
+    "temperature_vitrification": [
+        "76"
+    ],
+    "textured_plate_temp": [
+        "60"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "60"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PETG-ESD @BBL X1C.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PETG-ESD @BBL X1C.json
@@ -1,0 +1,19 @@
+{
+    "type": "filament",
+    "name": "Fiberon PETG-ESD @BBL X1C",
+    "inherits": "Fiberon PETG-ESD @base",
+    "from": "system",
+    "setting_id": "GFSL06_00",
+    "instantiation": "true",
+    "filament_cost": [
+        "29.99"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PETG-ESD @base.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PETG-ESD @base.json
@@ -1,0 +1,77 @@
+{
+    "type": "filament",
+    "name": "Fiberon PETG-ESD @base",
+    "inherits": "fdm_filament_pet",
+    "from": "system",
+    "filament_id": "GFL06",
+    "instantiation": "false",
+    "cool_plate_temp": [
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "60"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "60"
+    ],
+    "fan_cooling_layer_time": [
+        "15"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "filament_cost": [
+        "0"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "20"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "hot_plate_temp": [
+        "60"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "60"
+    ],
+    "nozzle_temperature": [
+        "290"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "290"
+    ],
+    "nozzle_temperature_range_high": [
+        "290"
+    ],
+    "nozzle_temperature_range_low": [
+        "250"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
+    "temperature_vitrification": [
+        "76"
+    ],
+    "textured_plate_temp": [
+        "60"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "60"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PETG-rCF @BBL H2D.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PETG-rCF @BBL H2D.json
@@ -1,0 +1,153 @@
+{
+    "type": "filament",
+    "name": "Fiberon PETG-rCF @BBL H2D",
+    "inherits": "Fiberon PETG-rCF @base",
+    "from": "system",
+    "filament_id": "GFL55",
+    "setting_id": "GFL55_10",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle",
+        "Bambu Lab H2D 0.6 nozzle",
+        "Bambu Lab H2D 0.8 nozzle"
+    ],
+    "cool_plate_temp": [
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "70"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "70"
+    ],
+    "fan_cooling_layer_time": [
+        "15"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "filament_cost": [
+        "29.99"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "nil"
+    ],
+    "filament_extruder_variant": [
+        "Direct Drive Standard",
+        "Direct Drive High Flow"
+    ],
+    "filament_flow_ratio": [
+        "0.95",
+        "0.95"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_pre_cooling_temperature": [
+        "0",
+        "0"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_ramming_volumetric_speed": [
+        "-1",
+        "-1"
+    ],
+    "filament_retract_before_wipe": [
+        "nil",
+        "nil"
+    ],
+    "filament_retract_restart_extra": [
+        "nil",
+        "nil"
+    ],
+    "filament_retract_when_changing_layer": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_minimum_travel": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "nil"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "filament_wipe": [
+        "nil",
+        "nil"
+    ],
+    "filament_wipe_distance": [
+        "nil",
+        "nil"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "nil"
+    ],
+    "filament_z_hop_types": [
+        "nil",
+        "nil"
+    ],
+    "hot_plate_temp": [
+        "70"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "70"
+    ],
+    "nozzle_temperature": [
+        "270",
+        "270"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "270",
+        "270"
+    ],
+    "nozzle_temperature_range_high": [
+        "270",
+        "270"
+    ],
+    "nozzle_temperature_range_low": [
+        "240",
+        "240"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ],
+    "temperature_vitrification": [
+        "70"
+    ],
+    "textured_plate_temp": [
+        "70"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "70"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PETG-rCF @BBL X1C.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PETG-rCF @BBL X1C.json
@@ -1,0 +1,16 @@
+{
+    "type": "filament",
+    "name": "Fiberon PETG-rCF @BBL X1C",
+    "inherits": "Fiberon PETG-rCF @base",
+    "from": "system",
+    "setting_id": "GFSL55_00",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/Polymaker/Fiberon PETG-rCF @base.json
+++ b/resources/profiles/BBL/filament/Polymaker/Fiberon PETG-rCF @base.json
@@ -1,0 +1,80 @@
+{
+    "type": "filament",
+    "name": "Fiberon PETG-rCF @base",
+    "inherits": "fdm_filament_pet",
+    "from": "system",
+    "filament_id": "GFL55",
+    "instantiation": "false",
+    "cool_plate_temp": [
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "70"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "70"
+    ],
+    "fan_cooling_layer_time": [
+        "12"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "filament_cost": [
+        "39.99"
+    ],
+    "filament_density": [
+        "1.3"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_type": [
+        "PETG-CF"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "hot_plate_temp": [
+        "70"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "70"
+    ],
+    "nozzle_temperature": [
+        "270"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "270"
+    ],
+    "nozzle_temperature_range_high": [
+        "270"
+    ],
+    "nozzle_temperature_range_low": [
+        "240"
+    ],
+    "required_nozzle_HRC": [
+        "40"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
+    "textured_plate_temp": [
+        "70"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "70"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ]
+}


### PR DESCRIPTION
# Summary
- What issue does this PR address or fix?
1. Add more Polymaker filaments for Bambu Lab printers.
2. Change the location of Polymaker's filament presets within BBL to a separate folder.
- What new features or enhancements does this PR introduce?
None
- Are there any breaking changes or dependencies that need to be considered?
No