### PR TITLE
Fix crash when retrieving timelapse list 

### DIFF
--- a/deps/OpenCV/OpenCV.cmake
+++ b/deps/OpenCV/OpenCV.cmake
@@ -53,6 +53,7 @@ bambustudio_add_cmake_project(OpenCV
        -DWITH_OPENJPEG=OFF
        -DWITH_QUIRC=OFF
        -DWITH_VTK=OFF
+       -DWITH_JPEG=OFF
        -DWITH_WEBP=OFF
        -DENABLE_PRECOMPILED_HEADERS=OFF
        -DINSTALL_TESTS=OFF


### PR DESCRIPTION
Fixes #8079. When a thumbnail is loaded, the call to `wxImage` segfaults. In my debug builds the message "Wrong JPEG library version: library is 62, caller expects 80" got printed before the segfault. So it seems that wxImage called jpeg functions from the jpeg package that opencv built (which is always libjpeg version 6.2), and not from the jpeg dependency.
I've changed the cmake file to disable the jpeg usage in opencv.