### PR TITLE
Set default texture for bed shape panel

### DIFF
--- a/src/slic3r/GUI/BedShapeDialog.cpp
+++ b/src/slic3r/GUI/BedShapeDialog.cpp
@@ -275,6 +275,7 @@ void BedShapePanel::activate_options_page(ConfigOptionsGroupShp options_group)
 
 wxPanel *BedShapePanel::init_texture_panel()
 {
+    init_texture_panel_with_default();
     wxPanel *panel = new wxPanel(this);
     wxGetApp().UpdateDarkUI(panel, true);
     ConfigOptionsGroupShp optgroup = std::make_shared<ConfigOptionsGroup>(panel, _L("Texture"));


### PR DESCRIPTION
Changes Made

• Added a default PNG file to define the texture for the bed shape panel.

• Updated relevant configurations to ensure the default texture is applied seamlessly.

Purpose

The purpose of this change is to:

1. Provide a consistent and professional visual texture for the bed shape panel.

2. Improve the user experience by ensuring the build plate is always textured by default.

Testing

• Verified that the default texture is applied to the bed shape panel.

• Tested compatibility with existing configurations and ensured no conflicts arise.
