### PR TITLE
Include stdint.h for uint32_t definition

### DIFF
--- a/src/mcut/source/math.cpp
+++ b/src/mcut/source/math.cpp
@@ -24,7 +24,7 @@
 #include <algorithm> // std::sort
 #include <cstdlib>
 #include <tuple> // std::make_tuple std::get<>
-
+#include <stdint.h>  // uint32_t definition
 
     double square_root(const double& number)
     {


### PR DESCRIPTION
Fixes compilation failure on Linux (tested with gcc-14) due to missing uint32_t definition.