### PR TITLE
Fix filament sorting by vendor and type in AMSMaterialsSetting

### DIFF
--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -858,7 +858,7 @@ static void _collect_filament_info(const wxString& shown_name,
                                    unordered_map<wxString, wxString>& query_filament_types)
 {
     query_filament_vendors[shown_name] = filament.config.get_filament_vendor();
-    query_filament_vendors[shown_name] = filament.config.get_filament_type();
+    query_filament_types[shown_name] = filament.config.get_filament_type();
 }
 
 void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_min, wxString temp_max, wxString k, wxString n)


### PR DESCRIPTION
`_collect_filament_info()` in `AMSMaterialsSetting.cpp` was assigning both filament vendor and type to `query_filament_vendors` map so that the filament was only being sorted by type which led to a case where Bambu options where shown before and after other vendors' options.

Old incorrectly sorted

<img width="860" height="865" alt="image" src="https://github.com/user-attachments/assets/b676b97f-5cf0-465a-901c-92a7e7f26bf8" />


Corrected sorting screenshot - it's not entirely alphabetically because Bambu has promoted certain vendor+type combinations to the top

<img width="870" height="865" alt="image" src="https://github.com/user-attachments/assets/5d628e62-11fe-4b92-85a8-2adff11d82ba" />
