### PR TITLE
Update Helio Additive optimization UI (#1)

### DIFF
--- a/src/slic3r/GUI/HelioReleaseNote.hpp
+++ b/src/slic3r/GUI/HelioReleaseNote.hpp
@@ -137,6 +137,7 @@ private:
     wxPanel* panel_simulation{nullptr};
     wxPanel* panel_pay_optimization{nullptr};
     wxPanel* panel_optimization{nullptr};
+    wxPanel* panel_velocity_volumetric{nullptr};
 
     wxPanel* advanced_settings_link{nullptr};
     LinkLabel* buy_now_link{nullptr};
@@ -166,7 +167,7 @@ public:
 private:
     wxBoxSizer* create_input_item(wxWindow* parent, std::string key, wxString name, wxString unit,
                                   const std::vector<std::shared_ptr<TextInputValChecker>>& checkers);
-    wxBoxSizer* create_combo_item(wxWindow* parent, std::string key,  wxString name, std::map<int, wxString> combolist, int def);
+    wxBoxSizer* create_combo_item(wxWindow* parent, std::string key,  wxString name, std::map<int, wxString> combolist, int def, int width = 120);
     wxBoxSizer* create_input_optimize_layers(wxWindow* parent, int layer_count);
 
     void on_selected_simulation(wxMouseEvent& e) { update_action(0); }


### PR DESCRIPTION
## UI/UX Changes

### Simplified Optimization Settings Layout
- Removed "Advanced Settings" collapsible section in favor of a cleaner, more intuitive layout
- Promoted "Layers to Optimize" to top-level, always-visible field for better accessibility
- Added new "Limits" dropdown with two options:
  - "Helio default (recommended)": Uses backend optimization values (default)
  - "Slicer default": Shows manual input fields for velocity and volumetric speed

### Conditional Field Visibility
- Velocity and volumetric speed fields now hidden by default when "Helio default" is selected
- Fields become visible when user selects "Slicer default" option
- Maintains same functionality as previous advanced settings behavior

### Forced Mode Behavior (Restored)
- Automatically forces "Slicer default" mode when:
  - Nozzle diameter = 0.2mm, OR
  - Layer height < 0.2mm
- Disables Limits dropdown when forced to prevent user override
- These edge cases require manual tuning and cannot use Helio defaults

### UI Polish
- Updated "Buy Now" link text to "Buy Now / Manage Account"
- Increased Limits dropdown width from 120px to 350px to prevent clipping of  "Helio default (recommended)" text
- Maintains consistent dark mode theming

## Code Quality Improvements

### Maintainability
- Replaced magic numbers with named constants:
  - `LIMITS_HELIO_DEFAULT = 0`
  - `LIMITS_SLICER_DEFAULT = 1`
  - `LIMITS_DROPDOWN_WIDTH = 350`
- Improved code readability and reduced risk of errors

## Technical Details

### Modified Files
- `src/slic3r/GUI/HelioReleaseNote.cpp`: Primary UI restructuring and logic
- `src/slic3r/GUI/HelioReleaseNote.hpp`: Added `panel_velocity_volumetric` member, updated `create_combo_item` signature to support custom width

### Backward Compatibility
- Maintains all existing functionality
- No API changes to public interfaces
- Dialog lifecycle handles state reset (no persistent state issues)

## Testing
- Verified UI layout changes across light and dark modes
- Confirmed forced mode behavior for 0.2mm nozzle and layer height < 0.2
- Tested dropdown selection toggling field visibility
- Validated local builds on macOS (Debug and Release configurations)