### PR TITLE
FIX: Correct copyright year info of MacOS etc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -252,7 +252,7 @@ else ()
         set(MACOSX_BUNDLE_ICON_FILE Icon.icns)
         set(MACOSX_BUNDLE_BUNDLE_NAME "Bambu Studio")
         set(MACOSX_BUNDLE_SHORT_VERSION_STRING ${SLIC3R_VERSION})
-        set(MACOSX_BUNDLE_COPYRIGHT "Copyright(C) 2021-2023 Lunkuo All Rights Reserved")
+        set(MACOSX_BUNDLE_COPYRIGHT "Copyright(C) 2021-2025 Lunkuo All Rights Reserved")
     endif()
     add_custom_command(TARGET BambuStudio POST_BUILD
         COMMAND ln -sfn "${SLIC3R_RESOURCES_DIR}" "${BIN_RESOURCES_DIR}"

--- a/src/platform/msw/BambuStudio-gcodeviewer.rc.in
+++ b/src/platform/msw/BambuStudio-gcodeviewer.rc.in
@@ -12,7 +12,7 @@ PRODUCTVERSION @SLIC3R_VERSION@
    VALUE "ProductName", "@SLIC3R_APP_NAME@ G-code Viewer"
    VALUE "ProductVersion", "@SLIC3R_BUILD_ID@"
    VALUE "InternalName", "@SLIC3R_APP_NAME@ G-code Viewer"
-   VALUE "LegalCopyright", "Copyright(C) 2021-2023 Lunkuo All Rights Reserved"
+   VALUE "LegalCopyright", "Copyright(C) 2021-2025 Lunkuo All Rights Reserved"
    VALUE "OriginalFilename", "bambu-gcodeviewer.exe"
   }
  }

--- a/src/platform/msw/BambuStudio.rc.in
+++ b/src/platform/msw/BambuStudio.rc.in
@@ -12,7 +12,7 @@ PRODUCTVERSION @SLIC3R_COMMA_SEPARATED_VERSION@
    VALUE "ProductName", "@SLIC3R_APP_NAME@"
    VALUE "ProductVersion", "@SLIC3R_BUILD_ID@"
    VALUE "InternalName", "@SLIC3R_APP_NAME@"
-   VALUE "LegalCopyright", "Copyright(C) 2021-2023 Lunkuo All Rights Reserved"
+   VALUE "LegalCopyright", "Copyright(C) 2021-2025 Lunkuo All Rights Reserved"
    VALUE "OriginalFilename", "bambu-studio.exe"
   }
  }

--- a/src/platform/osx/Info.plist.in
+++ b/src/platform/osx/Info.plist.in
@@ -5,7 +5,7 @@
   <key>CFBundleExecutable</key>
   <string>@SLIC3R_APP_KEY@</string>
   <key>CFBundleGetInfoString</key>
-  <string>@SLIC3R_APP_NAME@ Copyright(C) 2021-2023 Lunkuo All Rights Reserved</string>
+  <string>@SLIC3R_APP_NAME@ Copyright(C) 2021-2025 Lunkuo All Rights Reserved</string>
   <key>CFBundleIconFile</key>
   <string>images/BambuStudio.icns</string>
   <key>CFBundleName</key>


### PR DESCRIPTION
Correct copyright year info of MacOS etc. Github Issue:https://github.com/bambulab/BambuStudio/issues/8849

The CMakeList file year is currently 2021-2023 like the github link shows.
<img width="592" height="968" alt="image" src="https://github.com/user-attachments/assets/cad8997a-66d6-4962-85b0-6a1e088289a9" />

@MackBambu Maybe 2021-2026 is better?

