### PR TITLE
Rename "Allow Prompt Sound" to "Enable notification sounds" for clarity

### DIFF
--- a/src/slic3r/GUI/PrintOptionsDialog.cpp
+++ b/src/slic3r/GUI/PrintOptionsDialog.cpp
@@ -995,10 +995,10 @@ wxBoxSizer* PrintOptionsDialog::create_settings_group(wxWindow* parent)
     sizer->Add(text_save_remote_print_file_to_storage_explain, 0, wxLEFT, FromDIP(58));
     line_sizer->Add(FromDIP(5), 0, 0, 0);
     sizer->Add(0, 0, 0, wxTOP, FromDIP(15));
-    //Allow prompt sound
+    //Enable notification sounds
     line_sizer = new wxBoxSizer(wxHORIZONTAL);
     m_cb_sup_sound = new CheckBox(parent);
-    text_sup_sound = new Label(parent, _L("Allow Prompt Sound"));
+    text_sup_sound = new Label(parent, _L("Enable notification sounds"));
     text_sup_sound->SetFont(Label::Body_14);
     line_sizer->Add(FromDIP(5), 0, 0, 0);
     line_sizer->Add(m_cb_sup_sound, 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(5));


### PR DESCRIPTION
## Summary

I find the option label "Allow Prompt Sound" kind of confusing. I think "Enable notification sounds" is more clear.

## Changes

- **Source code**: Updated UI label in `PrintOptionsDialog.cpp:1001`
- **Translations**: Updated msgid in template and all 17 language translations
- **Compiled translations**: Regenerated all `.mo` files using `msgfmt`

### Translation improvements

- **Czech**: Fixed verb from "allow" to proper "enable" (Povolit → Zapnout)
- **French**: Reordered to natural French structure (sons de notification → notifications sonores)
- **Spanish**: Changed to more common verb (Habilitar → Activar)
- **Italian**: Updated to more natural phrasing (Abilita → Attiva)
- **Chinese**: Made more concise (启用通知声音 → 启用通知音)

(NOTE: this was done by LLM, I can't attest to its accuracy.)


## Files Modified

- 1 source file (`src/slic3r/GUI/PrintOptionsDialog.cpp`)
- 18 localization files (`.pot` + 17 `.po` files)
- 17 compiled translation files (`.mo` files)

## Testing

- Built locally and verified msgfmt compilation succeeds
- Verified translation formatting (no line breaks, proper punctuation)
- All 17 languages have updated translations with culturally appropriate phrasing
