### PR TITLE
Fixes Helio optmization reloading bug. Issue #8907

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10049,7 +10049,6 @@ void Plater::priv::on_helio_input_dlg(SimpleEvent &a)
 void Plater::priv::on_action_slice_all(SimpleEvent&)
 {
     if (q != nullptr) {
-        helio_background_process.reset();
         BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << ":received slice project event\n" ;
         //BBS update extruder params and speed table before slicing
         const Slic3r::DynamicPrintConfig& config = wxGetApp().preset_bundle->full_config();


### PR DESCRIPTION
Fix for the mentioned issue https://github.com/bambulab/BambuStudio/issues/8907

### Bambu Studio Version

2.4.0.70

### Where is the application from?

Bambu Lab github releases, Bambu Lab Official website

### OS version

Windows 11

### Additional system information

Intel 12700k
32 GiB RAM

### Printer

Bambu Lab P1S

### Printer Firmware Version

N/A

### How to reproduce

1. Right click the plate -> Create Primitive -> Cylinder
2. Slice plate
3. Click the Helio Button
4. Start Simulation
5. Wait for it to finish
6. Move the object on the build plate or create a new object
7. Slice all (Important to Slice all and not Slice plate)
8. Start Helio Simulation

### Actual results

Old simulation result is loaded no matter how many times you make changes and click "Slice all"

<img width="1638" height="1324" alt="Image" src="https://github.com/user-attachments/assets/ab4dc582-b6bf-4956-9b15-06092720f701" />

https://github.com/user-attachments/assets/3ce00734-6f53-42a1-99a4-4befc849ec73

### Expected results

New simulation result should be loaded

### Project file & Debug log uploads

[project and logs.zip](https://github.com/user-attachments/files/23727518/project.and.logs.zip)