### PR TITLE
Fix Italian translation: "Orario di completamento"

### DIFF
--- a/bbl/i18n/it/BambuStudio_it.po
+++ b/bbl/i18n/it/BambuStudio_it.po
@@ -5736,7 +5736,7 @@ msgid "Click to view thermal preconditioning explanation"
 msgstr "Fai clic per visualizzare la spiegazione del preriscaldamento termico"
 
 msgid "Estimated finish time: "
-msgstr "Tempo di completamento stimato: "
+msgstr "Orario di completamento stimato: "
 
 msgid ""
 "The estimated printing time for \n"


### PR DESCRIPTION
EN: Improved Italian translation for clarity. Line 5739 now uses “Orario di completamento”.

IT: Migliorata la traduzione italiana per un uso più corretto e naturale. La riga 5739 ora utilizza “Orario di completamento”.
