### PR TITLE
Add 'Direct Drive High Flow' to common extruder variants

### DIFF
--- a/resources/profiles/BBL/filament/fdm_filament_common.json
+++ b/resources/profiles/BBL/filament/fdm_filament_common.json
@@ -169,7 +169,8 @@
         "0"
     ],
     "filament_extruder_variant": [
-        "Direct Drive Standard"
+        "Direct Drive Standard",
+        "Direct Drive High Flow"
     ],
     "filament_scarf_seam_type": [
         "none"


### PR DESCRIPTION
Adds `Direct Drive High Flow` to `fdm_filament_common.json` in `resources/profiles/BBL/filament` so that Filament profiles created via the Custom Filaments GUI, will be able to toggle between Standard and High Flow.

<img width="585" height="72" alt="image" src="https://github.com/user-attachments/assets/3f2c59b8-6f11-4b39-bffe-879e20efbf05" />
