### PR TITLE
Precise outer wall is applying to all wall sequences

### DIFF
--- a/bbl/i18n/en/BambuStudio_en.po
+++ b/bbl/i18n/en/BambuStudio_en.po
@@ -11220,7 +11220,7 @@ msgid "Precise wall"
 msgstr ""
 
 msgid "Improve shell precision by adjusting outer wall spacing. This also improves layer consistency."
-msgstr ""
+msgstr "Improve shell precision by adjusting outer wall spacing. This also improves layer consistency. NOTE: This option will be ignored unless the order of walls is set to inner/outer"
 
 msgid "Speed of gap infill. Gap usually has irregular line width and should be printed more slowly"
 msgstr "This is the speed for gap infill. Gaps usually have irregular line width and should be printed more slowly."

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -850,7 +850,7 @@ void PerimeterGenerator::process_classic()
     coord_t ext_perimeter_spacing   = this->ext_perimeter_flow.scaled_spacing();
     coord_t ext_perimeter_spacing2;
     // Orca: ignore precise_outer_wall if wall_sequence is not InnerOuter
-    if (config->precise_outer_wall)
+    if (config->precise_outer_wall && config->wall_sequence == WallSequence::InnerOuter)
         ext_perimeter_spacing2 = scaled<coord_t>(0.5f * (this->ext_perimeter_flow.width() + this->perimeter_flow.width()));
     else
         ext_perimeter_spacing2 = scaled<coord_t>(0.5f * (this->ext_perimeter_flow.spacing() + this->perimeter_flow.spacing()));
@@ -1489,7 +1489,7 @@ void PerimeterGenerator::process_arachne()
     // we need to process each island separately because we might have different
     // extra perimeters for each one
 
-    bool apply_precise_outer_wall = config->precise_outer_wall;
+	bool apply_precise_outer_wall = config->precise_outer_wall && config->wall_sequence == WallSequence::InnerOuter;
     for (const Surface& surface : this->slices->surfaces) {
         // detect how many perimeters must be generated for this island
         int loop_number = this->config->wall_loops + surface.extra_perimeters - 1; // 0-indexed loops

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1535,6 +1535,13 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
                 return except;
             }
         }
+
+		// check wall sequence and precise outer wall
+		if (m_default_region_config.precise_outer_wall && m_default_region_config.wall_sequence != WallSequence::InnerOuter)
+		{
+			warning->string = L("Precise outer wall will be ignored unless the order of walls is set to inner/outer");
+			warning->opt_key = "precise_outer_wall";
+		}
     }
 
     return {};


### PR DESCRIPTION
Precise wall was not checking for the wall sequence to be Inner/Outer, as a result having Precise wall enabled on Outer/Inner or Inner/Outer/Inner would incorrectly try to compensate the outer wall width, checking I noticed the code comment which suggested that the logic originally came from Orca Slicer.

However it looks like it wasn't completely implemented here in Bambu Studio, I found the following commits on OrcaSlicer and have approximated the changes needed to check that the wall sequence is set correctly.

- https://github.com/OrcaSlicer/OrcaSlicer/commit/d2eb007d5711bc1ffa061952faa0fde2f672dc59
- https://github.com/OrcaSlicer/OrcaSlicer/commit/2f2018f9ee93b4c79fca42bfd51c04f35ab28ed7