### PR TITLE
Get "other layers" bed temperature from filaments used on the first layer

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4031,7 +4031,9 @@ GCode::LayerResult GCode::process_layer(
         // BBS
         int bed_temp = 0;
         if (m_config.bed_temperature_formula == BedTempFormula::btfHighestTemp)
-            bed_temp = get_highest_bed_temperature(false,print);
+            // Keep using the hottest requirement from the first layer so later filaments that never touch the bed
+            // don't raise the bed temperature unnecessarily.
+            bed_temp = get_highest_bed_temperature(true, print);
         else
             bed_temp = get_bed_temperature(first_extruder_id, false, m_config.curr_bed_type);
         gcode += m_writer.set_bed_temperature(bed_temp);

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3481,9 +3481,15 @@ int GCode::get_bed_temperature(const int extruder_id, const bool is_first_layer,
 
 int GCode::get_highest_bed_temperature(const bool is_first_layer, const Print& print) const
 {
+    return get_highest_bed_temperature(is_first_layer, print, is_first_layer);
+}
+
+int GCode::get_highest_bed_temperature(const bool is_first_layer, const Print& print, const bool use_first_layer_filaments) const
+{
     auto bed_type = m_config.curr_bed_type;
     int bed_temp = 0;
-    for (auto fidx : print.get_slice_used_filaments(is_first_layer)) {
+    const auto filaments = print.get_slice_used_filaments(use_first_layer_filaments);
+    for (auto fidx : filaments) {
         bed_temp = std::max(bed_temp, get_bed_temperature(fidx, is_first_layer, bed_type));
     }
     return bed_temp;
@@ -4031,9 +4037,9 @@ GCode::LayerResult GCode::process_layer(
         // BBS
         int bed_temp = 0;
         if (m_config.bed_temperature_formula == BedTempFormula::btfHighestTemp)
-            // Keep using the hottest requirement from the first layer so later filaments that never touch the bed
-            // don't raise the bed temperature unnecessarily.
-            bed_temp = get_highest_bed_temperature(true, print);
+            // Using the hottest "other layers" temperature from filaments that touched the bed - so
+            // filaments not on the bed don't raise the temperature unnecessarily.
+            bed_temp = get_highest_bed_temperature(false, print, true);
         else
             bed_temp = get_bed_temperature(first_extruder_id, false, m_config.curr_bed_type);
         gcode += m_writer.set_bed_temperature(bed_temp);

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -592,6 +592,7 @@ private:
     // BBS
     int get_bed_temperature(const int extruder_id, const bool is_first_layer, const BedType bed_type) const;
     int get_highest_bed_temperature(const bool is_first_layer,const Print &print) const;
+    int get_highest_bed_temperature(const bool is_first_layer, const Print &print, const bool use_first_layer_filaments) const;
 
     double      calc_max_volumetric_speed(const double layer_height, const double line_width, const std::string co_str);
     std::string _extrude(const ExtrusionPath &path, std::string description = "", double speed = -1, bool set_holes_and_compensation_speed = false, bool is_first_slope = false);


### PR DESCRIPTION
Fixes #6790 

After several multimaterial prints, I realized that the bed temperature was going far higher than I expected after the first layer. The materials on the first layer did not need such a high temperature.
This happens because a higher bed temperature material was used later - the bed temp rose to the hottest "other layers" temperature even though that material was not touching the bed. The goal here is to make sure that the bed temperature never goes above the highest "other layers" temperature of ONLY the materials that are on the first layer.