### PR TITLE
Add ability to disable Power Loss Recovery on BBL machines

### DIFF
--- a/bbl/i18n/BambuStudio.pot
+++ b/bbl/i18n/BambuStudio.pot
@@ -11095,6 +11095,12 @@ msgstr ""
 msgid "Enable this to enable the camera on printer to check the quality of first layer"
 msgstr ""
 
+msgid "Disable Power Loss Recovery"
+msgstr ""
+
+msgid "Enable this to disable power loss recovery commands in generated G-code"
+msgstr ""
+
 msgid "Enable clumping detection"
 msgstr ""
 

--- a/bbl/i18n/en/BambuStudio_en.po
+++ b/bbl/i18n/en/BambuStudio_en.po
@@ -11249,6 +11249,12 @@ msgstr "Scan first layer"
 msgid "Enable this to enable the camera on printer to check the quality of first layer"
 msgstr "Enable this to allow the camera on the printer to check the quality of the first layer."
 
+msgid "Disable Power Loss Recovery"
+msgstr "Disable Power Loss Recovery"
+
+msgid "Enable this to disable power loss recovery commands in generated G-code"
+msgstr "Enable this to disable power loss recovery commands in generated G-code"
+
 msgid "Enable clumping detection"
 msgstr "Enable clumping detection by probing"
 

--- a/resources/profiles/BBL/machine/fdm_machine_common.json
+++ b/resources/profiles/BBL/machine/fdm_machine_common.json
@@ -143,6 +143,7 @@
         "60"
     ],
     "scan_first_layer": "0",
+    "disable_power_loss_recovery": "0",
     "silent_mode": "0",
     "single_extruder_multi_material": "1",
     "support_air_filtration": "0",

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2834,7 +2834,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
 
                 // BBS: close powerlost recovery
                 {
-                    if (m_second_layer_things_done && print.is_BBL_Printer()) {
+                    if (m_second_layer_things_done && print.is_BBL_Printer() && print.config().disable_power_loss_recovery.value != true) {
                         file.write("; close powerlost recovery\n");
                         file.write("M1003 S0\n");
                     }
@@ -2922,7 +2922,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
 
             // BBS: close powerlost recovery
             {
-                if (m_second_layer_things_done && print.is_BBL_Printer()) {
+                if (m_second_layer_things_done && print.is_BBL_Printer() && print.config().disable_power_loss_recovery.value != true) {
                     file.write("; close powerlost recovery\n");
                     file.write("M1003 S0\n");
                 }
@@ -3994,7 +3994,7 @@ GCode::LayerResult GCode::process_layer(
     if (!first_layer && !m_second_layer_things_done) {
         //BBS: open powerlost recovery
         {
-            if (print.is_BBL_Printer()) {
+            if (print.is_BBL_Printer() && print.config().disable_power_loss_recovery.value != true) {
                 gcode += "; open powerlost recovery\n";
                 gcode += "M1003 S1\n";
             }

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1036,7 +1036,7 @@ static std::vector<std::string> s_Preset_printer_options {
     "default_print_profile", "inherits",
     "silent_mode",
     // BBS
-    "scan_first_layer", "wrapping_detection_layers", "wrapping_exclude_area", "machine_load_filament_time", "machine_unload_filament_time", "machine_pause_gcode", "template_custom_gcode","machine_hotend_change_time",
+    "scan_first_layer", "disable_power_loss_recovery", "wrapping_detection_layers", "wrapping_exclude_area", "machine_load_filament_time", "machine_unload_filament_time", "machine_pause_gcode", "template_custom_gcode","machine_hotend_change_time",
     "nozzle_type","auxiliary_fan", "fan_direction", "nozzle_volume","upward_compatible_machine", "z_hop_types","support_chamber_temp_control","support_air_filtration","support_cooling_filter","cooling_filter_enabled","auto_disable_filter_on_overheat","printer_structure","thumbnail_size",
     "best_object_pos", "head_wrap_detect_zone","printer_notes",
     "enable_long_retraction_when_cut","long_retractions_when_cut","retraction_distances_when_cut",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2779,6 +2779,13 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionBool(false));
 
     // BBS
+    def = this->add("disable_power_loss_recovery", coBool);
+    def->label = L("Disable Power Loss Recovery");
+    def->tooltip = L("Enable this to disable power loss recovery commands in generated G-code");
+    def->mode = comDevelop;
+    def->set_default_value(new ConfigOptionBool(false));
+
+    // BBS
     def          = this->add("enable_wrapping_detection", coBool);
     def->label   = L("Enable clumping detection");
     def->tooltip = L("Enable clumping detection");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1119,7 +1119,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionIntsNullable,        filament_flush_temp))
     // BBS
     ((ConfigOptionBool,                scan_first_layer))
-    ((ConfigOptionsBool,               disable_power_loss_recovery))
+    ((ConfigOptionBool,                disable_power_loss_recovery))
     ((ConfigOptionBool,                enable_wrapping_detection))
     ((ConfigOptionInt,                 wrapping_detection_layers))
     ((ConfigOptionPoints,              wrapping_exclude_area))

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1119,6 +1119,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionIntsNullable,        filament_flush_temp))
     // BBS
     ((ConfigOptionBool,                scan_first_layer))
+    ((ConfigOptionsBool,               disable_power_loss_recovery))
     ((ConfigOptionBool,                enable_wrapping_detection))
     ((ConfigOptionInt,                 wrapping_detection_layers))
     ((ConfigOptionPoints,              wrapping_exclude_area))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -4345,6 +4345,7 @@ void TabPrinter::build_fff()
         optgroup->append_single_option_line(option);
 
         optgroup->append_single_option_line("scan_first_layer");
+        optgroup->append_single_option_line("disable_power_loss_recovery");
         //option  = optgroup->get_option("wrapping_exclude_area");
         //option.opt.full_width = true;
         //optgroup->append_single_option_line(option);


### PR DESCRIPTION
# Description

This PR adds the ability to disable [Power Loss Recovery](https://wiki.bambulab.com/en/knowledge-sharing/power-loss-recovery) on Bambu Lab machines.

There is chatter online that the feature causes excessive wear on Micro SD storage, while the feature sounds great, I personally would rather disable it and reduce any additional wear on the storage.

I have added a tick box/toggle to the machine section, will require develop mode to be enabled and is an opt in to disable, so it shouldn't impact any existing logic unless specifically toggled to disable the feature.

I haven't yet been able to get the toolchain setup and compiling locally, but given the minor nature of the changes, I'll be more than happy to test it via the compiled version from GitHub action (once finished) and update the PR with screenshots.
