### PR TITLE
Enable Reload from disk in multi-selection menu

### DIFF
--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -1702,6 +1702,7 @@ wxMenu* MenuFactory::multi_selection_menu()
         append_menu_items_convert_unit(menu);
         //BBS
         append_menu_item_change_filament(menu);
+        append_menu_item_reload_from_disk(menu);
         menu->AppendSeparator();
         append_menu_item_export_stl(menu, true);
     }
@@ -1718,6 +1719,7 @@ wxMenu* MenuFactory::multi_selection_menu()
         append_menu_item_delete(menu);
         append_menu_items_convert_unit(menu);
         append_menu_item_change_filament(menu);
+        append_menu_item_reload_from_disk(menu);
         wxMenu* split_menu = new wxMenu();
         if (split_menu) {
             append_menu_item(split_menu, wxID_ANY, _L("To objects"), _L("Split the selected object into multiple objects"),


### PR DESCRIPTION
As mentioned in the title, we can now reload from disk with multi-selection. 

Tested on Mac only (I don't have Windows) with multiple steps and STL. Works like a charm, extremely useful!

<img width="862" height="1118" alt="SCR-20251209-qsn-2" src="https://github.com/user-attachments/assets/0bc02a07-4681-4095-9476-4587a7c415c6" />

