### PR TITLE
Add expand/collapse all for plate context menu

### DIFF
--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -1501,6 +1501,27 @@ void MenuFactory::create_plate_menu()
             return !plater()->get_partplate_list().get_selected_plate()->get_objects().empty() && !plater()->is_background_process_slicing();
         }, m_parent);
 
+    auto get_plate_idx = []() {
+        int plate_idx = plater()->GetPlateIndexByRightMenuInLeftUI();
+        if (plate_idx < 0)
+            plate_idx = plater()->get_partplate_list().get_curr_plate_index();
+        return plate_idx;
+    };
+
+    append_menu_item(
+        menu, wxID_ANY, _L("Expand all"), _L("Expand all objects on this plate"),
+        [get_plate_idx](wxCommandEvent&) {
+            obj_list()->expand_collapse_plate(get_plate_idx(), true);
+        },
+        "", nullptr, []() { return true; }, m_parent);
+
+    append_menu_item(
+        menu, wxID_ANY, _L("Collapse all"), _L("Collapse all objects on this plate"),
+        [get_plate_idx](wxCommandEvent&) {
+            obj_list()->expand_collapse_plate(get_plate_idx(), false);
+        },
+        "", nullptr, []() { return true; }, m_parent);
+
     // delete current plate
 #ifdef __WINDOWS__
     append_menu_item(menu, wxID_ANY, _L("Delete Plate"), _L("Remove the selected plate"),

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -5293,6 +5293,34 @@ void ObjectList::select_all()
     selection_changed();
 }
 
+void ObjectList::expand_collapse_plate(int plate_idx, bool expand)
+{
+    if (m_objects_model == nullptr)
+        return;
+
+    wxDataViewItem plate_item = m_objects_model->GetItemByPlateId(plate_idx);
+    if (!plate_item.IsOk())
+        return;
+
+    auto walk = [this, expand](const auto& self, const wxDataViewItem& item) -> void {
+        if (!item.IsOk())
+            return;
+
+        if (expand)
+            Expand(item);
+
+        wxDataViewItemArray children;
+        m_objects_model->GetChildren(item, children);
+        for (const auto& child : children)
+            self(self, child);
+
+        if (!expand)
+            Collapse(item);
+    };
+
+    walk(walk, plate_item);
+}
+
 void ObjectList::select_item_all_children()
 {
     if (wxGetApp().plater()  && !wxGetApp().plater()->canvas3D()->get_gizmos_manager().is_allow_select_all()) {

--- a/src/slic3r/GUI/GUI_ObjectList.hpp
+++ b/src/slic3r/GUI/GUI_ObjectList.hpp
@@ -406,6 +406,7 @@ public:
     void select_item(const ObjectVolumeID& ov_id);
     void select_items(const std::vector<ObjectVolumeID>& ov_ids);
     void select_all();
+    void expand_collapse_plate(int plate_idx, bool expand);
     void select_item_all_children();
     void update_selection_mode();
     bool check_last_selection(wxString& msg_str);


### PR DESCRIPTION
Another useful feature. Right-click the plate name or the bed plate to expand or collapse items in the object list. 

<img width="914" height="1008" alt="SCR-20251209-rmo-2" src="https://github.com/user-attachments/assets/35940d49-27d0-46bb-aa86-6b4981c0fe66" />

Thanks