### PR TITLE
Fixed issue on macOS where app drops all mouse events and becomes non responsive (#7250)

### DIFF
--- a/src/slic3r/GUI/Widgets/SideButton.cpp
+++ b/src/slic3r/GUI/Widgets/SideButton.cpp
@@ -329,9 +329,15 @@ void SideButton::mouseDown(wxMouseEvent& event)
 void SideButton::mouseReleased(wxMouseEvent& event)
 {
     event.Skip();
+
+    if (HasCapture())
+    {
+        // Release mouse capture regardless of pressedDown state, to avoid cases where capture may be stuck permanently
+        ReleaseMouse();
+    }
+
     if (pressedDown) {
         pressedDown = false;
-        ReleaseMouse();
         if (wxRect({0, 0}, GetSize()).Contains(event.GetPosition()))
             sendButtonEvent();
     }


### PR DESCRIPTION
When slicing for H2D/H2C, the filament-saver popup (FilamentGroupPopup) causes a mouse capture issue that occasionally renders the app non-responsive. The issue is with the "Slice Plate" SideButton object.

Because on macOS it doesn't always receive clean pairs of mouseDown and mouseReleased, it can get into a state where the mouse capture is stuck on that button, which means the button now eats up all mouse events for the app.

The fix (which should be VERY safe for all platforms) is to ensure that whenever we receive a mouseReleased, we always check if the button currently has a mouse capture, and then release it if it does (without checking the pressedDown state). I considered limiting the change to just macOS, but I really don't think it is necessary.