### PR TITLE
Fix macOS scroll bounce issue

### DIFF
--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -460,9 +460,15 @@ bool ImGuiWrapper::update_mouse_data(wxMouseEvent& evt)
     io.MouseDown[0] = evt.LeftIsDown();
     io.MouseDown[1] = evt.RightIsDown();
     io.MouseDown[2] = evt.MiddleIsDown();
-    float wheel_delta = static_cast<float>(evt.GetWheelDelta());
-    if (wheel_delta != 0.0f) {
-        io.MouseWheel = evt.GetWheelRotation() > 0 ? 1.f : -1.f;
+    int wheel_delta = evt.GetWheelDelta();
+    if (wheel_delta != 0) {
+        int wheel_rotation = evt.GetWheelRotation();
+        if (wheel_rotation > 0)
+            io.MouseWheel = 1.f;
+        else if (wheel_rotation < 0)
+            io.MouseWheel = -1.f;
+        else
+            io.MouseWheel = 0.0f;
     }
     unsigned buttons = (evt.LeftIsDown() ? 1 : 0) | (evt.RightIsDown() ? 2 : 0) | (evt.MiddleIsDown() ? 4 : 0);
     m_mouse_buttons = buttons;


### PR DESCRIPTION
This is a fix for a mouse wheel event issue on macOS where scrolling on some screens causes an annoying bounce back in the wrong direction. For example, go to the Slicing Result window, select Filament (or something to cause a long, tall view that requires scrolling), and then scroll up and down (I tested on macOS with a trackpad). 

It bounces back unnecessarily, making it very difficult to reach the top of the window. 

The issue is that scroll events with wheelRotation=0 were incorrectly interpreted as reverse scrolls. Now properly ignoring zero rotation events. 