### PR TITLE
fix: use generator expression for Xcode post-build resource symlink

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -243,7 +243,8 @@ else ()
     if (XCODE)
         # Because of Debug/Release/etc. configurations (similar to MSVC) the slic3r binary is located in an extra level
         set(BIN_RESOURCES_DIR "${CMAKE_CURRENT_BINARY_DIR}/resources")
-        set(BIN_CONF_DIR "Debug")
+        # Use generator expression for Xcode multi-config builds
+        set(BIN_CONF_DIR "$<CONFIG>")
     else ()
         set(BIN_RESOURCES_DIR "${CMAKE_CURRENT_BINARY_DIR}/../resources")
     endif ()


### PR DESCRIPTION
## Summary

- Fixes macOS Xcode build failure when building non-Debug configurations (Release, RelWithDebInfo, MinSizeRel)

## Problem

The post-build script that creates the Resources symlink was hardcoded to use the `Debug` configuration path regardless of the actual build configuration:

```cmake
set(BIN_CONF_DIR "Debug")  # Always Debug, even for Release builds
```

This caused builds to fail with:
```
ln: .../src/Debug/BambuStudio.app/Contents/Resources: No such file or directory
Command PhaseScriptExecution failed with a nonzero exit code
```

## Solution

Replace the hardcoded `"Debug"` with CMake's `$<CONFIG>` generator expression, which correctly resolves to the actual build configuration (Release, Debug, etc.) at build time.

## Testing

- Tested on macOS with Xcode generator using `./BuildMac.sh` (Release configuration)
- Build now completes successfully