### PR TITLE
main: Require libx11 1.8

### DIFF
--- a/src/BambuStudio.cpp
+++ b/src/BambuStudio.cpp
@@ -85,10 +85,6 @@ using namespace nlohmann;
 #include "slic3r/GUI/GuiColor.hpp"
 #include <GLFW/glfw3.h>
 
-#ifdef __WXGTK__
-#include <X11/Xlib.h>
-#endif
-
 #ifdef SLIC3R_GUI
     #include "slic3r/GUI/GUI_Init.hpp"
 #endif /* SLIC3R_GUI */
@@ -1361,10 +1357,6 @@ int CLI::run(int argc, char **argv)
     ::setenv("GDK_BACKEND", "x11", /* replace */ true);
 
     ::setenv("WEBKIT_DISABLE_COMPOSITING_MODE", "1", /* replace */ false);
-
-    // Also on Linux, we need to tell Xlib that we will be using threads,
-    // lest we crash when we fire up GStreamer.
-    XInitThreads();
 #endif
 
 	// Switch boost::filesystem to utf8.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,8 @@ if (SLIC3R_GUI)
     endif()
 
     if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        pkg_check_modules(LIBX11 REQUIRED x11>=1.8)
+
         set (wxWidgets_CONFIG_OPTIONS "--toolkit=gtk${SLIC3R_GTK}")
         if (SLIC3R_WX_STABLE)
             find_package(wxWidgets 3.0 REQUIRED COMPONENTS base core adv html gl aui net media webview)


### PR DESCRIPTION
Require a version of libX11 new enough that it will initialise threads support itself, and not require X11 specific code in our startup.

See https://gitlab.freedesktop.org/xorg/lib/libx11/-/commit/afcdb6fb0045c6186aa83d9298f327a7ec1b2cb9