### PR TITLE
fix: update base image to Ubuntu 24.04 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/ubuntu:24.10
+FROM docker.io/ubuntu:24.04
 
 # Disable interactive package configuration
 RUN apt-get update && \


### PR DESCRIPTION
fix docker build image bug described here:
https://github.com/bambulab/BambuStudio/issues/9431