### PR TITLE
FIX: Fix unreadable overlay elements in 3D view on XWayland/Intel

### DIFF
--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -2641,6 +2641,13 @@ void ImGuiWrapper::init_font(bool compress)
     builder.BuildRanges(&ranges); // Build the final result (ordered ranges with all the unique characters submitted)
 
     io.Fonts->Flags |= ImFontAtlasFlags_NoPowerOfTwoHeight;
+
+#ifdef __linux__
+    // Limit texture height to avoid exceeding GL_MAX_TEXTURE_SIZE
+    // Make the atlas wider to keep it shorter (height limit might be 16384 on XWayland)
+    io.Fonts->TexDesiredWidth = 8192;
+#endif
+
     ImFontConfig cfg = ImFontConfig();
     cfg.OversampleH = cfg.OversampleV = 1;
     //FIXME replace with io.Fonts->AddFontFromMemoryTTF(buf_decompressed_data, (int)buf_decompressed_size, m_font_size, nullptr, ranges.Data);


### PR DESCRIPTION
Backported from:
https://github.com/OrcaSlicer/OrcaSlicer/pull/11557

Tested in:
https://github.com/flathub/com.bambulab.BambuStudio/pull/90