### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build_bambu.yml
+++ b/.github/workflows/build_bambu.yml
@@ -195,7 +195,7 @@ jobs:
 
       # - name: Deploy Ubuntu release
       #   if: ${{ ! env.ACT && github.ref == 'refs/heads/main' && inputs.os == 'ubuntu-22.04' }}
-      #   uses: WebFreak001/deploy-nightly@v3.1.0
+      #   uses: WebFreak001/deploy-nightly@v3.2.0
       #   with:
       #     upload_url: https://uploads.github.com/repos/SoftFever/OrcaSlicer/releases/137995723/assets{?name,label}
       #     release_id: 137995723
@@ -206,7 +206,7 @@ jobs:
 
       # - name: Deploy orca_custom_preset_tests
       #   if: ${{ ! env.ACT && github.ref == 'refs/heads/main' && inputs.os == 'ubuntu-22.04' }}
-      #   uses: WebFreak001/deploy-nightly@v3.1.0
+      #   uses: WebFreak001/deploy-nightly@v3.2.0
       #   with:
       #     upload_url: https://uploads.github.com/repos/SoftFever/OrcaSlicer/releases/137995723/assets{?name,label}
       #     release_id: 137995723


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `WebFreak001/deploy-nightly` | [`v3.1.0`](https://github.com/WebFreak001/deploy-nightly/releases/tag/v3.1.0) | [`v3.2.0`](https://github.com/WebFreak001/deploy-nightly/releases/tag/v3.2.0) | [Release](https://github.com/WebFreak001/deploy-nightly/releases/tag/v3) | build_bambu.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
