### PR TITLE
add  -std=gnu89 to GMP, needed to build on Fedora 43

### DIFF
--- a/deps/GMP/GMP.cmake
+++ b/deps/GMP/GMP.cmake
@@ -3,8 +3,8 @@ set(_srcdir ${CMAKE_CURRENT_LIST_DIR}/gmp)
 set(_dstdir ${DESTDIR}/usr/local)
 
 if (MSVC)
-    set(_output  ${_dstdir}/include/gmp.h 
-                 ${_dstdir}/lib/libgmp-10.lib 
+    set(_output  ${_dstdir}/include/gmp.h
+                 ${_dstdir}/lib/libgmp-10.lib
                  ${_dstdir}/bin/libgmp-10.dll)
 
     add_custom_command(
@@ -13,11 +13,11 @@ if (MSVC)
         COMMAND ${CMAKE_COMMAND} -E copy ${_srcdir}/lib/win${DEPS_BITS}/libgmp-10.lib ${_dstdir}/lib/
         COMMAND ${CMAKE_COMMAND} -E copy ${_srcdir}/lib/win${DEPS_BITS}/libgmp-10.dll ${_dstdir}/bin/
     )
-    
+
     add_custom_target(dep_GMP SOURCES ${_output})
 
 else ()
-    set(_gmp_ccflags "-O2 -DNDEBUG -fPIC -DPIC -Wall -Wmissing-prototypes -Wpointer-arith -pedantic -fomit-frame-pointer -fno-common")
+    set(_gmp_ccflags "-O2 -DNDEBUG -fPIC -DPIC -Wall -Wmissing-prototypes -Wpointer-arith -pedantic -fomit-frame-pointer -fno-common -std=gnu89")
     set(_gmp_build_tgt "${CMAKE_SYSTEM_PROCESSOR}")
 
     if (APPLE)
@@ -60,7 +60,7 @@ else ()
         URL https://github.com/bambulab/gmp/archive/refs/tags/6.2.1.tar.gz
         URL_HASH SHA256=705ae57ee2014b2c6fc0f572c85ee43276b99b6b256ee16c1a9d3a8c4e3609d5
         DOWNLOAD_DIR ${DEP_DOWNLOAD_DIR}/GMP
-        BUILD_IN_SOURCE ON 
+        BUILD_IN_SOURCE ON
         CONFIGURE_COMMAND  env "CFLAGS=${_gmp_ccflags}" "CXXFLAGS=${_gmp_ccflags}" ./configure ${_cross_compile_arg} --enable-shared=no --enable-cxx=yes --enable-static=yes "--prefix=${DESTDIR}/usr/local" ${_gmp_build_tgt}
         BUILD_COMMAND     make -j
         INSTALL_COMMAND   make install


### PR DESCRIPTION
> GMP needs -std=gnu89 as a compiler flag, or it will not compile on modern gcc 


# GMP Build Failure with GCC 15 on Fedora 43

## Problem
BambuStudio's dependency build fails when compiling GMP 6.2.1 with GCC 15.2.1 on Fedora 43. The configure script's "long long reliability test 1" fails because GCC 15 treats function calls with incorrect argument counts as errors rather than warnings.

## Error
```
configure: error: could not find a working compiler, see config.log for details
```

The specific failure is in a test program where a function `g()` with 0 parameters is called with 6 arguments, which GCC 15 rejects.

## Root Cause
GCC 15 has stricter error checking and enforces `-Werror=implicit-function-declaration` and related flags by default. GMP 6.2.1 (released 2020) predates these stricter compiler standards.

## Solution
Add `-std=gnu89` to the GMP compiler flags to use the older, more permissive C standard during GMP's configure tests.

**File to modify:** `deps/GMP/GMP.cmake`

**Change:**
```cmake
# Before:
set(_gmp_ccflags "-O2 -DNDEBUG -fPIC -DPIC -Wall -Wmissing-prototypes -Wpointer-arith -pedantic -fomit-frame-pointer -fno-common")

# After:
set(_gmp_ccflags "-O2 -DNDEBUG -fPIC -DPIC -Wall -Wmissing-prototypes -Wpointer-arith -pedantic -fomit-frame-pointer -fno-common -std=gnu89")
```

Similarly for `_gmp_cxxflags`, add `-std=gnu++98`.

## Alternative Solutions
1. Update to a newer GMP version (6.3.0+) that handles modern compilers better
2. Allow users to use system GMP instead of bundled version on modern Linux distros

## Affected Systems
- Fedora 43 (GCC 15.2.1)
- Any Linux distribution with GCC 15+
- Likely future Ubuntu/Debian releases as they update to GCC 15

## Workaround
Users can manually edit `deps/GMP/GMP.cmake` and add `-std=gnu89` to compiler flags before running `./BuildLinux.sh -d`.
EOF
cat /tmp/bambu_gcc15_issue.md

Output
# GMP Build Failure with GCC 15 on Fedora 43

## Problem
BambuStudio's dependency build fails when compiling GMP 6.2.1 with GCC 15.2.1 on Fedora 43. The configure script's "long long reliability test 1" fails because GCC 15 treats function calls with incorrect argument counts as errors rather than warnings.

## Error
```
configure: error: could not find a working compiler, see config.log for details
```

The specific failure is in a test program where a function `g()` with 0 parameters is called with 6 arguments, which GCC 15 rejects.

## Root Cause
GCC 15 has stricter error checking and enforces `-Werror=implicit-function-declaration` and related flags by default. GMP 6.2.1 (released 2020) predates these stricter compiler standards.

## Solution
Add `-std=gnu89` to the GMP compiler flags to use the older, more permissive C standard during GMP's configure tests.

**File to modify:** `deps/GMP/GMP.cmake`

**Change:**
```cmake
# Before:
set(_gmp_ccflags "-O2 -DNDEBUG -fPIC -DPIC -Wall -Wmissing-prototypes -Wpointer-arith -pedantic -fomit-frame-pointer -fno-common")

# After:
set(_gmp_ccflags "-O2 -DNDEBUG -fPIC -DPIC -Wall -Wmissing-prototypes -Wpointer-arith -pedantic -fomit-frame-pointer -fno-common -std=gnu89")
```

Similarly for `_gmp_cxxflags`, add `-std=gnu++98`.

## Alternative Solutions
1. Update to a newer GMP version (6.3.0+) that handles modern compilers better
2. Allow users to use system GMP instead of bundled version on modern Linux distros

## Affected Systems
- Fedora 43 (GCC 15.2.1)
- Any Linux distribution with GCC 15+
- Likely future Ubuntu/Debian releases as they update to GCC 15

## Workaround
Users can manually edit `deps/GMP/GMP.cmake` and add `-std=gnu89` to compiler flags before running `./BuildLinux.sh -d`.