### PR TITLE
UX: Convert 'Change type' to submenu with checkmarks

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectList.hpp
+++ b/src/slic3r/GUI/GUI_ObjectList.hpp
@@ -418,6 +418,8 @@ public:
 
     ModelVolume* get_selected_model_volume();
     void change_part_type();
+    void set_volume_type(ModelVolumeType new_type);
+    ModelVolumeType get_selected_volume_type();
 
     void last_volume_is_deleted(const int obj_idx);
     void update_and_show_object_settings_item();


### PR DESCRIPTION
## Summary

This PR improves the "Change type" context menu for parts/volumes by converting it from a dialog-based selection to an inline submenu with checkmarks.

**Before:** Clicking "Change type" opens a separate dialog popup requiring an extra click to select the type.

**After:** "Change type" shows a submenu (like "Change Filament") with all options visible and checkmarks indicating the current type(s).

## Changes

- Added `set_volume_type(ModelVolumeType)` function to `ObjectList` for direct type assignment
- Added `get_selected_volume_type()` helper function
- Modified `append_menu_item_change_type()` in `GUI_Factories.cpp` to create a submenu
- Checkmarks update dynamically based on selection
- Multi-selection support: when selecting multiple items of different types, all applicable types show checkmarks

## Benefits

- **Fewer clicks**: Change type directly from submenu without extra dialog
- **Visual feedback**: See current type at a glance via checkmark
- **Consistency**: Matches UX pattern of "Change Filament" submenu
- **Multi-select aware**: Shows all types present in current selection

<img width="1086" height="1252" alt="SCR-20260130-wb4" src="https://github.com/user-attachments/assets/1991785d-6bc8-4a8c-8671-405e1b1b81b1" />


## Test plan

- [x] Right-click on a part → "Change type" shows submenu with checkmark on current type
- [x] Select type from submenu → part type changes correctly
- [x] Select multiple parts of same type → single checkmark shown
- [x] Select multiple parts of different types → multiple checkmarks shown
- [x] Verify all type options work: Part, Negative Part, Modifier, Support Blocker, Support Enforcer