### PR TITLE
Fix window drag lag on Windows

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -689,7 +689,7 @@ target_link_libraries(libslic3r_gui libslic3r cereal imgui imguizmo minilzo GLEW
 #target_link_libraries(libslic3r_gui libslic3r cereal imgui imguizmo minilzo GLEW::GLEW OpenGL::GL hidapi libcurl OpenSSL::SSL OpenSSL::Crypto ${wxWidgets_LIBRARIES} glfw)
 
 if (MSVC)
-    target_link_libraries(libslic3r_gui Setupapi.lib)
+    target_link_libraries(libslic3r_gui Setupapi.lib dwmapi.lib)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     FIND_LIBRARY(WAYLAND_SERVER_LIBRARIES NAMES wayland-server)
     FIND_LIBRARY(WAYLAND_EGL_LIBRARIES    NAMES wayland-egl)

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -69,6 +69,7 @@
 #include <dbt.h>
 #include <shlobj.h>
 #include <shellapi.h>
+#include <dwmapi.h>
 #endif // _WIN32
 #include <slic3r/GUI/CreatePresetsDialog.hpp>
 
@@ -183,6 +184,14 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
 {
 #ifdef __WXOSX__
     set_miniaturizable(GetHandle());
+#endif
+
+#ifdef _WIN32
+    // Enable DWM hardware-accelerated compositing for this borderless window.
+    // Without this, dragging the window by the title bar causes lag because
+    // DWM can't efficiently composite a frameless window during drag.
+    MARGINS margins = {0, 0, 0, 1};
+    DwmExtendFrameIntoClientArea((HWND)GetHandle(), &margins);
 #endif
 
     if (!wxGetApp().app_config->has("user_mode")) {
@@ -348,14 +357,16 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
             }
 #endif
 #ifdef _WIN32
-        if (!m_is_in_move_or_resize) {
-#endif
-            Refresh();
-            Layout();
-            wxQueueEvent(wxGetApp().plater(), new SimpleEvent(EVT_NOTICE_CHILDE_SIZE_CHANGED));
-#ifdef _WIN32
+        if (m_is_in_move_or_resize) {
+            ULONGLONG now = GetTickCount64();
+            if (now - m_last_resize_layout_ms < 33)
+                return;
+            m_last_resize_layout_ms = now;
         }
 #endif
+        Refresh();
+        Layout();
+        wxQueueEvent(wxGetApp().plater(), new SimpleEvent(EVT_NOTICE_CHILDE_SIZE_CHANGED));
         });
 
     //BBS
@@ -821,7 +832,8 @@ WXLRESULT MainFrame::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam
             AdjustWorkingAreaForAutoHide(hWnd, mmi);
             return 0;
         }
-      }
+        break;
+    }
     case WM_ENTERSIZEMOVE:
         m_is_in_move_or_resize = true;
         break;
@@ -829,6 +841,7 @@ WXLRESULT MainFrame::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam
         m_is_in_move_or_resize = false;
         Refresh();
         Layout();
+        wxQueueEvent(wxGetApp().plater(), new SimpleEvent(EVT_NOTICE_CHILDE_SIZE_CHANGED));
         break;
     }
     return wxFrame::MSWWindowProc(nMsg, wParam, lParam);

--- a/src/slic3r/GUI/MainFrame.hpp
+++ b/src/slic3r/GUI/MainFrame.hpp
@@ -429,6 +429,7 @@ public:
     uint32_t  			m_ulSHChangeNotifyRegister { 0 };
 	static constexpr int WM_USER_MEDIACHANGED { 0x7FFF }; // WM_USER from 0x0400 to 0x7FFF, picking the last one to not interfere with wxWidgets allocation
     bool                m_is_in_move_or_resize { false };
+    ULONGLONG           m_last_resize_layout_ms { 0 };
 #endif // _WIN32
 };
 


### PR DESCRIPTION
 - Suppress expensive Refresh() / Layout() / GL re-render during interactive window drag and resize on Windows
  - Use WM_ENTERSIZEMOVE / WM_EXITSIZEMOVE messages to detect the operation, then do a single refresh when it ends

  Problem

  Dragging the window by the title bar causes multi-second lag and pegs one CPU core at 100%. The custom titlebar handling fires WM_NCCALCSIZE hundreds of times
   per second during drag, each triggering wxEVT_SIZE → Refresh() → full OpenGL render with no throttling.

  Fixes #934

  Changes

  - MainFrame.hpp: Add m_is_in_move_or_resize flag (#ifdef _WIN32)
  - MainFrame.cpp: Handle WM_ENTERSIZEMOVE / WM_EXITSIZEMOVE in MSWWindowProc()
  - MainFrame.cpp: Guard Refresh() / Layout() / wxQueueEvent() in wxEVT_SIZE handler
