### PR TITLE
Add Traditional Chinese (zh_TW) translation

### DIFF
--- a/bbl/i18n/zh_TW/BambuStudio_zh_TW.po
+++ b/bbl/i18n/zh_TW/BambuStudio_zh_TW.po
@@ -1,0 +1,23954 @@
+# Copyright (C) 2019 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Traditional Chinese (zh_TW) translation converted from zh_CN.
+# FIRST Translator Jiang Yue <maze1024@gmail.com>, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Slic3rPE\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-02-05 19:18+0800\n"
+"PO-Revision-Date: 2025-02-20 20:32+0800\n"
+"Last-Translator: Jiang Yue <maze1024@gmail.com>\n"
+"Language-Team: \n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.5\n"
+
+msgid "The filament may not be compatible with the current machine settings. Generic filament presets will be used."
+msgstr "該材料與當前機器設定不相容，將使用通用的材料預設。"
+
+msgid "The filament model is unknown. Still using the previous filament preset."
+msgstr "未知的材料型號，將使用之前的材料預設。"
+
+msgid "The filament model is unknown. Generic filament presets will be used."
+msgstr "未知的耗材型別。將使用通用耗材預設。"
+
+msgid "The filament may not be compatible with the current machine settings. A random filament preset will be used."
+msgstr "該材料與當前機器設定不相容，將使用隨機的材料預設。"
+
+msgid "The filament model is unknown. A random filament preset will be used."
+msgstr "未知的材料型號，將使用隨機的材料預設。"
+
+msgid "right"
+msgstr "右"
+
+msgid "left"
+msgstr "左"
+
+msgid "right extruder"
+msgstr "右側擠出機"
+
+msgid "left extruder"
+msgstr "左擠出機"
+
+msgid "extruder"
+msgstr "擠出機"
+
+msgid "TPU is not supported by AMS."
+msgstr "AMS不支援TPU。"
+
+msgid "AMS does not support 'Bambu Lab PET-CF'."
+msgstr "AMS 不支援 'Bambu Lab PET-CF'。"
+
+msgid "The current filament doesn't support the E3D high-flow nozzle and can't be used."
+msgstr "當前耗材不支援 E3D 大流量噴嘴，無法使用。"
+
+#, c-format, boost-format
+msgid "When using %s on the right extruder, it can only be used as support material."
+msgstr "%s在右擠出機列印時，只能作為支撐耗材。"
+
+msgid "The current filament doesn't support the TPU high-flow nozzle and can't be used."
+msgstr "當前耗材不支援 TPU 大流量噴嘴，無法使用。"
+
+msgid "Auto dynamic flow calibration is not supported for TPU filament."
+msgstr "TPU線材不支援自動動態流量校準。"
+
+msgid "Dynamic flow calibration is not supported for TPU 85A filament."
+msgstr "TPU 85A耗材不支援動態流量校準。"
+
+msgid "How to feed TPU filament."
+msgstr "TPU進料方式。"
+
+msgid "Using non-bambu filament may have printing quality issues."
+msgstr "使用非拓竹耗材可能會存在列印質量問題。"
+
+msgid "Please cold pull before printing TPU to avoid clogging. You may use cold pull maintenance on the printer."
+msgstr "為了避免堵塞，列印TPU前請冷拔。您可使用印表機上的冷拔維護功能。"
+
+msgid "Damp PVA will become flexible and get stuck inside AMS,please take care to dry it before use."
+msgstr "潮溼的PVA會變得柔軟並粘在AMS內，請在使用前注意乾燥。"
+
+msgid "Damp PVA is flexible and may get stuck in extruder. Dry it before use."
+msgstr "受潮的PVA會變柔，可能會卡在擠出機中。使用前請先烘乾。"
+
+msgid "PPS-CF is brittle and could break in bended PTFE tube above Toolhead."
+msgstr "PPS-CF較脆, 容易斷在工具頭上方的彎折鐵氟龍管裡。"
+
+msgid "PPA-CF is brittle and could break in bended PTFE tube above Toolhead."
+msgstr "PPA-CF較脆, 容易斷在工具頭上方的彎折鐵氟龍管裡。"
+
+msgid "PLA Glow may wear the AMS first stage feeder. Use an external spool instead."
+msgstr "夜光耗材可能磨損 AMS 進料口，建議使用外掛料盤列印。"
+
+msgid "Default settings may affect print quality. Adjust as needed for best results."
+msgstr "使用預設引數列印可能影響列印質量，請根據實際效果調整引數以獲得最佳結果。"
+
+#, c-format, boost-format
+msgid "%s has a risk of nozzle clogging when using 0.4mm high-flow nozzles. Use with caution."
+msgstr "%s在使用0.4mm高流量噴嘴時會有堵頭風險，請謹慎使用。"
+
+#, c-format, boost-format
+msgid "%s filaments are hard and brittle and could break in AMS, and there is also a risk of nozzle clogging when using 0.4mm high-flow nozzles. Use with caution."
+msgstr "%s較脆，容易斷在AMS裡。同時使用 0.4mm高流量噴嘴也會帶來堵頭風險，請謹慎使用。"
+
+#, c-format, boost-format
+msgid "%s has a risk of nozzle clogging when using 0.4, 0.6, 0.8mm high-flow nozzles. Use with caution."
+msgstr "%s在使用 0.4，0.6，0.8mm 高流量噴嘴時會有堵頭風險，請謹慎使用。"
+
+#, c-format, boost-format
+msgid "%s is not supported by %s extruder."
+msgstr "%s 不支援在 %s 擠出機列印。"
+
+msgid "The toolhead and hotend rack may move. Please keep your hands away from the chamber."
+msgstr "工具頭和熱端架可能會運動，請勿將手伸入機箱。"
+
+msgid "Warning"
+msgstr "警告"
+
+msgid "Hotend information may be inaccurate. Would you like to re-read the hotend? (Hotend information may change during power-off)."
+msgstr "熱端資訊可能不準確。是否重新讀取熱端？（斷電期間熱端資訊可能會發生變化）。"
+
+msgid "I confirm all"
+msgstr "確認無誤"
+
+msgid "Re-read all"
+msgstr "重新讀取全部"
+
+msgid "Reading the hotends, please wait."
+msgstr "正在讀取熱端資訊，請稍候。"
+
+msgid "During the hotend upgrade, the toolhead will move. Don't reach into the chamber."
+msgstr "在熱端升級過程中，工具頭會移動。請勿將手伸入機箱內。"
+
+msgid "Update"
+msgstr "韌體更新"
+
+msgid "High Flow"
+msgstr "高流量"
+
+msgid "Standard"
+msgstr "標準"
+
+msgid "TPU High Flow"
+msgstr "TPU高流量"
+
+msgid "Unknown"
+msgstr "未知"
+
+msgid "Hybrid"
+msgstr "混合"
+
+msgid "Hardened Steel"
+msgstr "硬化鋼"
+
+msgid "Stainless Steel"
+msgstr "不鏽鋼"
+
+msgid "Tungsten Carbide"
+msgstr "碳化鎢"
+
+msgid "Update successful."
+msgstr "更新成功。"
+
+msgid "Downloading failed."
+msgstr "下載失敗。"
+
+msgid "Verification failed."
+msgstr "驗證失敗。"
+
+msgid "Update failed."
+msgstr "更新失敗。"
+
+msgid "Current AMS humidity"
+msgstr "艙內乾燥程度"
+
+msgid "Humidity"
+msgstr "溼度"
+
+msgid "Temperature"
+msgstr "溫度"
+
+msgid "Left Time"
+msgstr "剩餘時間"
+
+msgid "Drying"
+msgstr "烘乾"
+
+msgid "Idle"
+msgstr "空閒"
+
+#, c-format, boost-format
+msgid "%d ℃"
+msgstr ""
+
+msgid "Model:"
+msgstr "型號："
+
+msgid "Serial:"
+msgstr "序列號："
+
+msgid "Version:"
+msgstr "版本："
+
+msgid "Latest version"
+msgstr "最新版本"
+
+msgid "Row A"
+msgstr "A排"
+
+msgid "Row B"
+msgstr "B排"
+
+msgid "Toolhead"
+msgstr "工具頭"
+
+msgid "Empty"
+msgstr "空"
+
+msgid "Error"
+msgstr "錯誤"
+
+msgid "Induction Hotend Rack"
+msgstr "感應熱端架"
+
+msgid "Hotends Info"
+msgstr "熱端資訊"
+
+msgid "Read All"
+msgstr "讀取全部"
+
+msgid "Reading "
+msgstr "讀取中 "
+
+msgid "Please wait"
+msgstr "請稍候"
+
+msgid "Reading"
+msgstr "讀取中"
+
+msgid "Running..."
+msgstr "執行中..."
+
+msgid "Raised"
+msgstr "已升起"
+
+msgid "The hotend is in an abnormal state and currently unavailable. Please go to 'Device -> Upgrade' to upgrade firmware."
+msgstr "熱端狀態異常，當前不可用。請前往“裝置 -> 升級”升級韌體。"
+
+msgid "Abnormal Hotend"
+msgstr "熱端異常"
+
+msgid "Cancel"
+msgstr "取消"
+
+msgid "Jump to the upgrade page"
+msgstr "跳轉至升級頁面"
+
+msgid "SN"
+msgstr "序列號"
+
+msgid "Version"
+msgstr "版本"
+
+msgid "Hotend Rack"
+msgstr "熱端掛架"
+
+msgid "ToolHead"
+msgstr "工具頭"
+
+msgid "Nozzle information needs to be read"
+msgstr "需要讀取噴嘴資訊"
+
+msgid "Supports Painting"
+msgstr "支撐繪製"
+
+msgid "Please select single object."
+msgstr "請選中單個物件。"
+
+msgid "Mouse wheel"
+msgstr "滑鼠滾輪"
+
+msgid "Section view"
+msgstr "剖面檢視"
+
+msgid "Reset direction"
+msgstr "重置方向"
+
+msgid "Ctrl + Mouse wheel"
+msgstr "Ctrl + 滑鼠滾輪"
+
+msgid "Pen size"
+msgstr "畫筆尺寸"
+
+msgid "Left mouse button"
+msgstr "滑鼠左鍵"
+
+msgid "Enforce supports"
+msgstr "強制支撐"
+
+msgid "Right mouse button"
+msgstr "滑鼠右鍵"
+
+msgid "Block supports"
+msgstr "遮蔽支撐"
+
+msgid "Shift + Left mouse button"
+msgstr "Shift + 滑鼠左鍵"
+
+msgid "Erase"
+msgstr "擦除"
+
+msgid "Erase all painting"
+msgstr "擦除所有繪製"
+
+msgid "Highlight overhang areas"
+msgstr "高亮懸空區域"
+
+msgid "Gap fill"
+msgstr "縫隙填充"
+
+msgid "Perform"
+msgstr "執行"
+
+msgid "Gap area"
+msgstr "間隙面積"
+
+msgid "Tool type"
+msgstr "工具型別"
+
+msgid "Smart fill angle"
+msgstr "智慧填充角度"
+
+msgid "On overhangs only"
+msgstr "僅對懸空區生效"
+
+msgid "Auto support threshold angle: "
+msgstr "自動支撐角度閾值："
+
+msgid "Circle"
+msgstr "圓"
+
+msgid "Sphere"
+msgstr "球"
+
+msgid "Fill"
+msgstr "填充"
+
+msgid "Gap Fill"
+msgstr "縫隙填充"
+
+#, boost-format
+msgid "Allows painting only on facets selected by: \"%1%\""
+msgstr "繪製僅對由%1%選中的面片生效"
+
+msgid "Highlight faces according to overhang angle."
+msgstr "根據當前設定的懸空角度來高亮片面。"
+
+msgid "No auto support"
+msgstr "無自動支撐"
+
+msgid "Painting below the build plate is not allowed."
+msgstr "不允許在熱床下方塗色。"
+
+msgid "The white outline indicates the position of the build plate at Z = 0."
+msgstr "白色輪廓表示熱床在Z=0處的位置。"
+
+msgid "Support Generated"
+msgstr "已生成支撐"
+
+msgid "Mode"
+msgstr "模式"
+
+msgid "Convex hull"
+msgstr "凸包"
+
+msgid "Triangular facet"
+msgstr "三角面片"
+
+msgid "Warning: All triangle areas are too small,The current function is not working."
+msgstr "警告：所有的三角形面積過小，當前功能不能工作。"
+
+msgid "Lay on face"
+msgstr "選擇底面"
+
+#, boost-format
+msgid "Filament count exceeds the maximum number that painting tool supports. only the first %1% filaments will be available in painting tool."
+msgstr "耗材絲數量超過塗色工具支援的最大值，僅前%1%個耗材絲可在塗色工具中使用。"
+
+msgid "Color Painting"
+msgstr "塗色"
+
+msgid "Pen shape"
+msgstr "畫筆形狀"
+
+msgid "Paint"
+msgstr "繪製"
+
+msgid "Key 1~9"
+msgstr "按鍵 1~9"
+
+msgid "Choose filament"
+msgstr "選擇耗材絲"
+
+msgid "Connected same color"
+msgstr "連線相同顏色"
+
+msgid "Edge detection"
+msgstr "邊沿檢測"
+
+msgid "Triangles"
+msgstr "三角形"
+
+msgid "Filaments"
+msgstr "耗材絲"
+
+msgid "Brush"
+msgstr "畫刷"
+
+msgid "Smart fill"
+msgstr "智慧填充"
+
+msgid "Bucket fill"
+msgstr "批次填充"
+
+msgid "Height range"
+msgstr "高度範圍"
+
+msgid "Shift + Enter"
+msgstr "Shift + 回車"
+
+msgid "Toggle Wireframe"
+msgstr "顯示/隱藏線框"
+
+msgid "Shift + L"
+msgstr ""
+
+msgid "Toggle non-manifold edges"
+msgstr "切換非流行邊"
+
+msgid "Rotate horizontally"
+msgstr "水平旋轉"
+
+msgid "hit face"
+msgstr "選中面片"
+
+msgid "Shortcut Key "
+msgstr "快捷鍵 "
+
+msgid "Triangle"
+msgstr "三角形"
+
+msgid "Height Range"
+msgstr "高度範圍"
+
+msgid "Place input box of bottom near mouse"
+msgstr "起點輸入框置於滑鼠附近"
+
+msgid "Vertical"
+msgstr "垂直"
+
+msgid "Horizontal"
+msgstr "水平"
+
+msgid "View: keep horizontal"
+msgstr "檢視：保持水平"
+
+msgid "Remove painted color"
+msgstr "移除已繪製的顏色"
+
+#, boost-format
+msgid "Painted using: Filament %1%"
+msgstr "繪製使用：耗材絲%1%"
+
+msgid "Fuzzy skin Painting"
+msgstr "絨毛表面繪製"
+
+msgid "Add fuzzy skin"
+msgstr "新增絨毛表面"
+
+msgid "Remove fuzzy skin"
+msgstr "刪除絨毛表面"
+
+msgid "Move"
+msgstr "移動"
+
+msgid "Please select at least one object."
+msgstr "請至少選中一個物件。"
+
+msgid "Rotate"
+msgstr "旋轉"
+
+msgid "Optimize orientation"
+msgstr "最佳化朝向"
+
+msgid "Apply"
+msgstr "應用"
+
+msgid "Scale"
+msgstr "縮放"
+
+msgid "Error: Please close all toolbar menus first"
+msgstr "錯誤：請先關閉所有工具欄選單"
+
+msgid "Tool-Move"
+msgstr "工具-移動"
+
+msgid "Tool-Scale"
+msgstr "工具-縮放"
+
+msgid "Tool-Rotate"
+msgstr "工具-旋轉"
+
+msgid "Tool-Lay on Face"
+msgstr "工具-選擇底面"
+
+msgid "Bottom:"
+msgstr "底邊:"
+
+msgid "in"
+msgstr "英寸"
+
+msgid "mm"
+msgstr "mm"
+
+msgid "Part selection"
+msgstr "零件選擇"
+
+msgid "Fixed step drag"
+msgstr "固定步長拖動"
+
+msgid "Keep holding down Ctrl"
+msgstr "持續按住Ctrl鍵"
+
+msgid "Select multiple objects"
+msgstr "選擇多個物件"
+
+msgid "Keep holding down Alt"
+msgstr "持續按住Alt鍵"
+
+msgid "Select multiple parts"
+msgstr "選擇多個零件"
+
+msgid "Single sided scaling"
+msgstr "單邊縮放"
+
+msgid "Position"
+msgstr "位置"
+
+msgid "Rotate (relative)"
+msgstr "旋轉 (相對)"
+
+msgid "Scale ratios"
+msgstr "縮放比例"
+
+msgid "Object Operations"
+msgstr "物件操作"
+
+msgid "Volume Operations"
+msgstr "零件操作"
+
+msgid "Translate"
+msgstr "平移"
+
+msgid "Group Operations"
+msgstr "組操作"
+
+msgid "Set Orientation"
+msgstr "設定方向"
+
+msgid "Set Scale"
+msgstr "設定縮放"
+
+msgid "Reset Position"
+msgstr "重置位置"
+
+msgid "Reset Rotation"
+msgstr "重置旋轉"
+
+msgid "Object coordinates"
+msgstr "物體座標"
+
+msgid "World coordinates"
+msgstr "世界座標"
+
+msgid "Align selected"
+msgstr "對齊所選的"
+
+msgid "Translate(Relative)"
+msgstr "平移(相對)"
+
+msgid "Align Object"
+msgstr "對齊物件"
+
+msgid "Align Plate"
+msgstr "對齊盤"
+
+msgid "Align top-bottom center"
+msgstr "上下居中"
+
+msgid "Holded down Ctrl key continuously and click by left mouse button can select multiple objects, or holded down Alt key continuously and click by left mouse button can select multiple parts"
+msgstr "持續按住Ctrl鍵並單擊滑鼠左鍵可以選擇多個物件，或者持續按住Alt鍵並單擊小鼠左鍵可以選中多個部分"
+
+msgid "Align"
+msgstr "對齊"
+
+msgid "Distribute"
+msgstr "分佈"
+
+msgid "Align left"
+msgstr "左側對齊"
+
+msgid "Align left-right center"
+msgstr "左右居中"
+
+msgid "Align right"
+msgstr "右側對齊"
+
+msgid "Distribute left-right"
+msgstr "左右均勻分佈"
+
+msgid "Please select at least 3 parts or objects"
+msgstr "請至少選擇 3 個零件或物件"
+
+msgid "Align front"
+msgstr "前方對齊"
+
+msgid "Align front-back center"
+msgstr "前後居中"
+
+msgid "Align back"
+msgstr "後方對齊"
+
+msgid "Distribute front-back"
+msgstr "前後均勻分佈"
+
+msgid "Align bottom"
+msgstr "底部對齊"
+
+msgid "Align top"
+msgstr "頂部對齊"
+
+msgid "Distribute top-bottom"
+msgstr "上下均勻分佈"
+
+msgid "°"
+msgstr "°"
+
+msgid "Reset current rotation to the value when open the rotation tool."
+msgstr "將當前旋轉重置為開啟旋轉工具時的值。"
+
+msgid "Rotate (absolute)"
+msgstr "旋轉 (絕對)"
+
+msgid "Reset current rotation to real zeros."
+msgstr "將當前旋轉重置為實數零。"
+
+msgid "Part coordinates"
+msgstr "零件座標"
+
+msgid "%"
+msgstr "%"
+
+#. TRN - Input label. Be short as possible
+#. Height of one text line - Font Ascent
+#. TRN - Input label. Be short as possible
+msgid "Size"
+msgstr "大小"
+
+msgid "uniform scale"
+msgstr "等比例縮放"
+
+msgid "Part"
+msgstr "零件"
+
+msgid "Object"
+msgstr "物件"
+
+msgid "Drag to move the cut plane"
+msgstr "拖動切割平面可移動"
+
+msgid ""
+"Drag to move the cut plane\n"
+"Right-click a part to assign it to the other side"
+msgstr "拖動切割平面可移動；在零件上單擊滑鼠右鍵以將其指定給另一側"
+
+msgid "Left click"
+msgstr "左擊"
+
+msgid "Add connector"
+msgstr "新增連線件"
+
+msgid "Right click"
+msgstr "右擊"
+
+msgid "Remove connector"
+msgstr "刪除連線件"
+
+msgid "Drag"
+msgstr "拖動"
+
+msgid "Move connector"
+msgstr "移動連線件"
+
+msgid "Add connector to selection"
+msgstr "選擇連線件"
+
+msgid "Remove connector from selection"
+msgstr "取消選擇連線件"
+
+msgid "Select all connectors"
+msgstr "選擇所有連線件"
+
+msgid "Left drag"
+msgstr "左鍵拖動"
+
+msgid "Plot cut plane"
+msgstr "繪製切割平面"
+
+msgid "right click"
+msgstr "單擊右鍵"
+
+msgid "Assign the part to the other side"
+msgstr "將零件指定給另一側"
+
+msgid "Cut"
+msgstr "剪下"
+
+msgid "non-manifold edges be caused by cut tool, do you want to fix it now?"
+msgstr "因切割產生了非流形邊，您是否想現在修復？"
+
+msgid "Repairing model object"
+msgstr "修復模型物件"
+
+msgid "Connector"
+msgstr "連線件"
+
+msgid "Flip cut plane"
+msgstr "翻轉剖切面"
+
+msgid "Planar"
+msgstr "平面"
+
+msgid "Dovetail"
+msgstr "燕尾榫"
+
+msgid "Movement:"
+msgstr "移動："
+
+msgid "Groove Angle"
+msgstr "凹槽角"
+
+#. TRN - Input label. Be short as possible
+#. Angle between Y axis and text line direction.
+#. TRN - Input label. Be short as possible
+msgid "Rotation"
+msgstr "旋轉"
+
+msgid "Movement"
+msgstr "移動"
+
+msgid "Height"
+msgstr "高度"
+
+msgid "Edit connectors"
+msgstr "編輯連線件"
+
+msgid "Add connectors"
+msgstr "新增連線件"
+
+msgid "Groove"
+msgstr "凹槽"
+
+#. TRN - Input label. Be short as possible
+#. Size in emboss direction
+#. TRN - Input label. Be short as possible
+msgid "Depth"
+msgstr "深度"
+
+msgid "Width"
+msgstr "寬度"
+
+msgid "Flap Angle"
+msgstr "翼偏角"
+
+msgid "Keep orientation"
+msgstr "保持方向"
+
+msgid "Place on cut"
+msgstr "切割面放置到熱床"
+
+msgid "Flip"
+msgstr "翻轉"
+
+msgid "After cut"
+msgstr "切割後"
+
+msgid "Cut to parts"
+msgstr "切割為零件"
+
+msgid "Auto Segment"
+msgstr "自動分割"
+
+msgid "Perform cut"
+msgstr "執行切割"
+
+msgid "Reset"
+msgstr "重置"
+
+msgid "Connectors"
+msgstr "連線件"
+
+msgid "Type"
+msgstr "型別"
+
+msgid "Style"
+msgstr "樣式"
+
+msgid "Shape"
+msgstr "形狀"
+
+msgid "Depth ratio"
+msgstr "深度"
+
+msgid "Remove connectors"
+msgstr "刪除所有連線件"
+
+msgid "Prizm"
+msgstr "稜柱"
+
+msgid "Frustum"
+msgstr "錐體"
+
+msgid "Square"
+msgstr "正方形"
+
+msgid "Hexagon"
+msgstr "六邊形"
+
+msgid "Snap global parameters"
+msgstr "按扣全域性引數"
+
+msgid "Bulge"
+msgstr "凸度"
+
+msgid "Gap"
+msgstr "間隙"
+
+msgid "Confirm connectors"
+msgstr "確認"
+
+msgid "Invalid connectors detected"
+msgstr "檢測到無效連線件"
+
+msgid "connector is out of cut contour"
+msgstr "個連線件超出了切割面範圍"
+
+msgid "connectors are out of cut contour"
+msgstr "個連線件超出了切割面範圍"
+
+msgid "connector is out of object"
+msgstr "個連線件穿透了模型"
+
+msgid "connectors is out of object"
+msgstr "個連線件穿透了模型"
+
+msgid "Some connectors are overlapped"
+msgstr "存在連線件相互重疊"
+
+msgid ""
+"Invalid state. \n"
+"No one part is selected to keep after cut"
+msgstr ""
+"無效狀態。\n"
+"切割後沒有選中要保留的部分"
+
+msgid "Plug"
+msgstr "插銷"
+
+msgid "Dowel"
+msgstr "銷釘"
+
+msgid "Snap"
+msgstr "按扣"
+
+msgid "Tolerance"
+msgstr "容差"
+
+msgid "Mesh name"
+msgstr "Mesh名"
+
+msgid "Detail level"
+msgstr "細節等級"
+
+msgid "Decimate ratio"
+msgstr "簡化率"
+
+#, boost-format
+msgid "Processing model '%1%' with more than 1M triangles could be slow. It is highly recommended to simplify the model."
+msgstr "處理超出1M個三角形面片的模型“%1%”可能會很慢。強烈建議簡化模型。"
+
+msgid "Simplify model"
+msgstr "簡化模型"
+
+msgid "Simplify"
+msgstr "簡化"
+
+msgid "Simplification is currently only allowed when a single part is selected"
+msgstr "僅支援對單個零件做簡化"
+
+msgid "Extra high"
+msgstr "非常高"
+
+msgid "High"
+msgstr "高"
+
+msgid "Medium"
+msgstr "中"
+
+msgid "Low"
+msgstr "低"
+
+msgid "Extra low"
+msgstr "非常低"
+
+#, c-format, boost-format
+msgid "%d triangles"
+msgstr "%d 個三角形"
+
+msgid "Show wireframe"
+msgstr "顯示線框"
+
+#, boost-format
+msgid "%1%"
+msgstr "%1%"
+
+msgid "Can't apply when process preview."
+msgstr "處理預覽的過程中無法應用。"
+
+msgid "Operation already cancelling. Please wait few seconds."
+msgstr "操作已在取消中，請等待片刻。"
+
+msgid "Face recognition"
+msgstr "外觀面檢測"
+
+msgid "Perform Recognition"
+msgstr "執行檢測"
+
+msgid "Vertex"
+msgstr "點"
+
+msgid "Edge"
+msgstr "線"
+
+msgid "Plane"
+msgstr "面"
+
+msgid "Point on edge"
+msgstr "線上點"
+
+msgid "Point on circle"
+msgstr "圓上點"
+
+msgid "Point on plane"
+msgstr "平面點"
+
+msgid "Center of edge"
+msgstr "線中心"
+
+msgid "Center of circle"
+msgstr "圓心"
+
+msgid "Select feature"
+msgstr "選擇特徵"
+
+msgid "Select point"
+msgstr "選擇點"
+
+msgid "Delete"
+msgstr "刪除"
+
+msgid "Restart selection"
+msgstr "重新選擇"
+
+msgid "Esc"
+msgstr "Esc"
+
+msgid "Cancel a feature until exit"
+msgstr "取消一個特徵直到退出"
+
+msgid "Measure"
+msgstr "測量"
+
+msgid "Please confirm explosion ratio = 1,and please select at least one object"
+msgstr "請確保爆炸比例為1，且至少選擇一個物件"
+
+msgid "Edit to scale"
+msgstr "編輯縮放"
+
+msgctxt "Verb"
+msgid "Scale all"
+msgstr "縮放全部"
+
+msgid "None"
+msgstr "無"
+
+msgid "Diameter"
+msgstr "直徑"
+
+msgid "Length"
+msgstr "長度"
+
+msgid "Selection"
+msgstr "選擇"
+
+msgid " (Moving)"
+msgstr "(活動的)"
+
+msgid ""
+"Select 2 faces on objects and \n"
+" make objects assemble together."
+msgstr ""
+"在兩個物體上選擇兩個面 \n"
+"並將物體組合在一起。"
+
+msgid ""
+"Select 2 points or circles on objects and \n"
+" specify distance between them."
+msgstr ""
+"在兩個物體上選擇兩個點或圓 \n"
+"並指定它們之間的距離。"
+
+msgid "Face"
+msgstr "面"
+
+msgid " (Fixed)"
+msgstr "(固定的)"
+
+msgid "Point"
+msgstr "點"
+
+msgid ""
+"Feature 1 has been reset, \n"
+"feature 2 has been feature 1"
+msgstr "特徵1已經被重置，特徵2變成特徵1"
+
+msgid "Warning:please select Plane's feature."
+msgstr "警告:請選擇面特徵。"
+
+msgid "Warning:please select Point's or Circle's feature."
+msgstr "警告:請選擇點或圓特徵。"
+
+msgid "Warning:please select two different mesh."
+msgstr "警告:請選擇兩個不同的網格。"
+
+msgid "Copy to clipboard"
+msgstr "複製到剪貼簿"
+
+msgid "Angle"
+msgstr "角度"
+
+msgid "Perpendicular distance"
+msgstr "平行距離"
+
+msgid "Distance"
+msgstr "距離"
+
+msgid "Direct distance"
+msgstr "直線距離"
+
+msgid "Distance XYZ"
+msgstr "XYZ距離"
+
+msgid "Parallel"
+msgstr "平行"
+
+msgid "Center coincidence"
+msgstr "中心重合"
+
+msgid "Featue 1"
+msgstr "特徵1"
+
+msgid "Reverse rotation"
+msgstr "反轉方向"
+
+msgid "Rotate around center:"
+msgstr "繞中心旋轉:"
+
+msgid "Parallel_distance:"
+msgstr "平行距離:"
+
+msgid "Flip by Face 2"
+msgstr "透過面2翻轉"
+
+msgid "Assemble"
+msgstr "裝配"
+
+msgid "Please confirm explosion ratio = 1 and select at least two volumes."
+msgstr "請確保爆炸比例為1且至少選擇兩個網格。"
+
+msgid "Please select at least two volumes."
+msgstr "請至少選擇兩個網格。"
+
+msgid "(Moving)"
+msgstr "(活動的)"
+
+msgid "Point and point assembly"
+msgstr "點和點裝配"
+
+msgid ""
+"It is recommended to assemble the objects first,\n"
+"because the objects is restriced to bed \n"
+"and only parts can be lifted."
+msgstr "建議先組裝零件，因為零件受到熱床的限制，只有部件可以抬起。"
+
+msgid "Face and face assembly"
+msgstr "面和麵裝配"
+
+msgid "Brush size"
+msgstr "畫刷尺寸"
+
+msgid "Brush shape"
+msgstr "畫刷形狀"
+
+msgid "Enforce seam"
+msgstr "新增Z縫"
+
+msgid "Block seam"
+msgstr "遮蔽Z縫"
+
+msgid "Seam painting"
+msgstr "Z縫繪製"
+
+msgid "Remove selection"
+msgstr "移除繪製"
+
+msgid "Recommend"
+msgstr ""
+
+msgid "Old version"
+msgstr "舊版本"
+
+msgid "First font"
+msgstr "第一個字型"
+
+msgid "Default font"
+msgstr "預設字型"
+
+msgid "Save the parameters of the current text tool as a style for easy subsequent use."
+msgstr "將當前文字工具的引數儲存為樣式，以便後續輕鬆使用。"
+
+#, boost-format
+msgid "Modified style \"%1%\""
+msgstr "修改樣式”%1% “"
+
+#, boost-format
+msgid "Current style is \"%1%\""
+msgstr "當前樣式是\"%1%\""
+
+#, boost-format
+msgid ""
+"Changing style to \"%1%\" will discard current style modification.\n"
+"\n"
+"Would you like to continue anyway?"
+msgstr ""
+"將樣式更改為 “%1%” 將丟棄當前樣式修改。\n"
+"\n"
+"無論如何您想繼續嗎？"
+
+msgid "Not valid style."
+msgstr "樣式無效。"
+
+#, boost-format
+msgid "Style \"%1%\" can't be used and will be removed from a list."
+msgstr "樣式\"%1%\"無法使用，將從列表中刪除。"
+
+msgid "First Add style to list."
+msgstr "首先將樣式新增到列表中。"
+
+#, boost-format
+msgid "Save %1% style"
+msgstr "儲存%1%樣式"
+
+msgid "New name of style"
+msgstr "樣式的新名稱"
+
+msgid "Name can't be empty."
+msgstr "名稱不能為空。"
+
+msgid "Name has to be unique."
+msgstr "名稱必須是唯一的。"
+
+msgid "OK"
+msgstr "確認"
+
+msgid "Save as new style"
+msgstr "另存為新樣式"
+
+msgid "The current style has been modified but not saved. Do you want to save it?"
+msgstr "當前樣式已被修改但未儲存。您想要儲存嗎？"
+
+msgid "Save current style"
+msgstr ""
+
+msgid "Add new style"
+msgstr "新增新樣式"
+
+msgid "Only valid font can be added to style"
+msgstr "有效字型才能新增到樣式中"
+
+msgid "Add style to my list"
+msgstr ""
+
+msgid "Remove style"
+msgstr "刪除樣式"
+
+msgid "Can't remove the last existing style."
+msgstr "無法刪除最後一個現有樣式。"
+
+#, boost-format
+msgid "Are you sure you want to permanently remove the \"%1%\" style?"
+msgstr "您確定要永久刪除\"%1%\"樣式嗎？"
+
+#, boost-format
+msgid "Delete \"%1%\" style."
+msgstr "刪除\"%1%\"樣式。"
+
+#, boost-format
+msgid "Can't delete \"%1%\". It is last style."
+msgstr "無法刪除\"%1%\"。這是最後一種樣式。"
+
+#, boost-format
+msgid "Can't delete temporary style \"%1%\"."
+msgstr "無法刪除臨時樣式 “%1%”。"
+
+msgid "Operation"
+msgstr "操作"
+
+msgid "Click to change text into object part."
+msgstr "單擊可將文字更改為物件部分。"
+
+msgid "You can't change a type of the last solid part of the object."
+msgstr "不能更改物件的最後一個實體部分的型別。"
+
+msgctxt "EmbossOperation"
+msgid "Cut"
+msgstr "負零件"
+
+msgid "Click to change part type into negative volume."
+msgstr "單擊可將零件型別更改為負零件。"
+
+msgid "Modifier"
+msgstr "修改器"
+
+msgid "Click to change part type into modifier."
+msgstr "單擊以將零件型別更改為修改器"
+
+msgid "Surround projection by character"
+msgstr "按字元環繞投影"
+
+msgid "Not surround"
+msgstr "未環繞"
+
+msgid "Surround surface"
+msgstr "環繞表面"
+
+msgid "Surround"
+msgstr "環繞"
+
+msgid "Reset rotation"
+msgstr "重置旋轉"
+
+msgid "Rotate the text counterclockwise."
+msgstr "逆時針旋轉文字。"
+
+msgid "Text shape"
+msgstr "文字形狀"
+
+#. TRN - Input label. Be short as possible
+#. Select look of letter shape
+msgid "Font"
+msgstr "字型"
+
+msgid "Thickness"
+msgstr "厚度"
+
+msgid "Input text"
+msgstr "輸入文字"
+
+msgid "Advanced"
+msgstr "高階"
+
+msgid "Embedded depth"
+msgstr "內嵌深度"
+
+msgid "Text Gap"
+msgstr "文字間距"
+
+msgid "Warning:There is a mirror in the text matrix, and dragging it will completely regenerate it."
+msgstr "警告：文字矩陣中有一個映象，拖動它將完全重新生成它。"
+
+msgid "Warning:Due to font upgrades,previous font may not necessarily be replaced successfully, and recommend you to modify the font."
+msgstr "警告：由於字型升級，以前的字型不一定能替換成功，建議您修改字型。"
+
+msgid "Warning:create text fail."
+msgstr "警告：建立文字失敗。"
+
+msgid "Warning:text normal is error."
+msgstr "警告：文字法向量錯誤"
+
+msgid "Warning:text normal has been reset."
+msgstr "警告:文字法向量已經被重置。"
+
+msgid "Warning:current text spacing is not very reasonable. If you continue editing, a more reasonable text spacing will be generated."
+msgstr "警告：當前文字間距不夠合理。如果繼續編輯，將生成更合理的文字間距。"
+
+msgid "Warning:old matrix has at least two parameters: mirroring, scaling, and rotation. If you continue editing, it may not be correct. Please dragging text or cancel using current pose, save and reedit again."
+msgstr "警告：舊矩陣至少有兩個引數：映象、縮放和旋轉。如果繼續編輯，則可能不正確。請拖動文字或取消使用當前姿勢，儲存並重新編輯。"
+
+msgid "Error:Detecting an incorrect mesh id or an unknown error, regenerating text may result in incorrect outcomes.Please drag text,save it then reedit it again."
+msgstr "錯誤：檢測到不正確的網格id或未知錯誤，重新生成文字可能會導致不正確的結果。請拖動文字，儲存，然後重新編輯。"
+
+msgid "Warning:Due to functional upgrade, rotation information cannot be restored. Please drag or modify text,save it and reedit it will ok."
+msgstr ""
+
+msgid "Detected that text did not adhere to mesh surface. Please manually drag yellow square to mesh surface that needs to be adhered."
+msgstr "檢測到文字未貼合在網格表面。請手動將黃色方塊拖動到需要貼合的網格表面。"
+
+msgid "The text cannot be written using the selected font. Please try choosing a different font."
+msgstr "無法使用所選字型書寫文字。請嘗試選擇其他字型。"
+
+msgid "Embossed text cannot contain only white spaces."
+msgstr "浮雕文字不能只包含空白。"
+
+msgid "Unsupported characters automatically switched to fallback font."
+msgstr "不支援的字元已自動切換到備用字型。"
+
+msgid "Text doesn't show current horizontal alignment."
+msgstr "文字不顯示當前的水平對齊方式。"
+
+#, boost-format
+msgid "Font \"%1%\" can't be selected."
+msgstr "無法選擇字型 \"%1%\"。"
+
+msgid "Revert text size."
+msgstr "重置文字大小"
+
+msgid ""
+"Advanced options cannot be changed for the selected font.\n"
+"Select another font."
+msgstr ""
+"無法更改所選字型的高階選項。\n"
+"請選擇另一種字型。"
+
+#. TRN - Input label. Be short as possible
+msgid "Boldness"
+msgstr "粗細"
+
+msgid "Skew"
+msgstr "偏斜"
+
+msgid "No symbol"
+msgstr "沒有符號"
+
+msgid "Loading"
+msgstr "載入中"
+
+msgid "In queue"
+msgstr "在佇列中"
+
+#. TRN - Input label. Be short as possible
+#. Copy surface of model on surface of the embossed text
+#. TRN - Input label. Be short as possible
+msgid "Use surface"
+msgstr "使用表面"
+
+#. TRN - Input label. Be short as possible
+#. Option to change projection on curved surface
+#. for each character(glyph) in text separately
+msgid "Per glyph"
+msgstr "按字元"
+
+#. TRN - Input label. Be short as possible
+#. Align Top|Middle|Bottom and Left|Center|Right
+msgid "Alignment"
+msgstr "對齊"
+
+#. TRN - Input label. Be short as possible
+msgid "Text gap"
+msgstr ""
+
+#. TRN - Input label. Be short as possible
+msgid "Line gap"
+msgstr "行間距"
+
+#. TRN - Input label. Be short as possible
+#. Like Font italic
+msgid "Skew ratio"
+msgstr "偏斜率"
+
+#. TRN - Input label. Be short as possible
+#. Distance from model surface to be able
+#. move text as part fully into not flat surface
+#. move text as modifier fully out of not flat surface
+#. TRN - Input label. Be short as possible
+msgid "From surface"
+msgstr "距表面"
+
+msgid "Style name"
+msgstr "樣式名稱"
+
+msgid "There is already a text style with the same name."
+msgstr "已經存在同名的文字樣式。"
+
+msgid "There are spaces or illegal characters present."
+msgstr ""
+
+msgid "Head diameter"
+msgstr "Brim 直徑"
+
+msgid "Max angle"
+msgstr "最大角度"
+
+msgid "Detection radius"
+msgstr "檢測半徑"
+
+msgid "Remove selected points"
+msgstr "刪除已選擇的點"
+
+msgid "Remove all"
+msgstr "刪除所有點"
+
+msgid "Auto-generate points"
+msgstr "自動生成點"
+
+msgid "Add a brim ear"
+msgstr "加入一個耳狀Brim"
+
+msgid "Delete a brim ear"
+msgstr "刪除一個耳狀Brim"
+
+msgid "Ctrl+Mouse wheel"
+msgstr "Ctrl+滑鼠滾輪"
+
+msgid "Adjust section view"
+msgstr "調整剖面檢視"
+
+msgid "Warning: The brim type is not set to \"painted\",the brim ears will not take effect !"
+msgstr "警告：Brim型別未設定為繪製模式，耳狀Brim將不會生效！"
+
+msgid "Set the brim type of this object to \"painted\""
+msgstr "設定此物件brim型別為\"繪製\""
+
+msgid " invalid brim ears"
+msgstr "個無效耳狀Brim"
+
+msgid "Brim Ears"
+msgstr "耳狀Brim"
+
+msgid "Choose SVG file for emboss:"
+msgstr "選擇SVG檔案進行浮雕:"
+
+#, boost-format
+msgid "File does NOT exist (%1%)."
+msgstr "檔案不存在（%1%）。"
+
+#, boost-format
+msgid "Filename has to end with \".svg\" but you selected %1%"
+msgstr "檔名必須以“.svg”結尾，但您選擇了%1%"
+
+#, boost-format
+msgid "Nano SVG parser can't load from file (%1%)."
+msgstr "Nano SVG解析器不能載入檔案（%1%）。"
+
+#, boost-format
+msgid "%1% contains some unsupported data. Please use third-party software to convert the SVG to path data before reimporting."
+msgstr "%1%中存在部分暫不支援的資料，請使用第三方軟體轉換該SVG為路徑資料後重新匯入。"
+
+#. TRN - Input label. Be short as possible
+msgid "Mirror"
+msgstr "映象"
+
+#, boost-format
+msgid "Opacity (%1%)"
+msgstr "不透明度 (%1%)"
+
+#, boost-format
+msgid "Color gradient (%1%)"
+msgstr "顏色漸變(%1%)"
+
+msgid "Undefined fill type"
+msgstr "未定義填充型別"
+
+msgid "Linear gradient"
+msgstr "線性漸變"
+
+msgid "Radial gradient"
+msgstr "放射漸變"
+
+msgid "Open filled path"
+msgstr "開啟填充路徑"
+
+msgid "Undefined stroke type"
+msgstr "未定義筆劃型別"
+
+msgid "Path can't be healed from selfintersection and multiple points."
+msgstr "路徑無法從自切入和多個點修復。"
+
+msgid "Final shape constains selfintersection or multiple points with same coordinate."
+msgstr "最終形狀恆定自截面或具有相同座標的多個點。"
+
+#, boost-format
+msgid "Shape is marked as invisible (%1%)."
+msgstr "形狀標記為不可見（%1%）。"
+
+#. TRN: The first placeholder is shape identifier, the second one is text describing the problem.
+#, boost-format
+msgid "Fill of shape (%1%) contains unsupported: %2%."
+msgstr "形狀填充（%1%）包含不受支援的：%2%。"
+
+#, boost-format
+msgid "Stroke of shape (%1%) is too thin (minimal width is %2% mm)."
+msgstr "形狀的筆劃（%1%）太薄（最小寬度為%2%mm）。"
+
+#, boost-format
+msgid "Stroke of shape (%1%) contains unsupported: %2%."
+msgstr "形狀筆劃（%1%）包含不受支援的：%2%。"
+
+msgid "Not valid state please report reproduction steps on github"
+msgstr "狀態無效，請在github上報告此問題步驟。"
+
+msgid "No embossed file"
+msgstr "沒有浮雕檔案。"
+
+msgid "Missing svg file in embossed shape"
+msgstr "缺少浮雕形狀的svg檔案"
+
+msgid "Missing data of svg file"
+msgstr "svg檔案資料缺失"
+
+msgid "Tip:If you want to place svg file on another part surface,you should select part first, and then drag svg file to the part surface."
+msgstr "提示：如果要將 SVG 檔案放置在另一個零件表面，請先選擇零件，再將 SVG 檔案拖到零件表面。"
+
+#. TRN - Preview of filename after clear local filepath.
+msgid "Unknown filename"
+msgstr "未知檔名"
+
+#, boost-format
+msgid "SVG file path is \"%1%\""
+msgstr "SVG檔案路徑為 \"%1%\""
+
+msgid "Reload SVG file from disk."
+msgstr "從磁碟重新載入SVG檔案"
+
+msgid "Change file"
+msgstr "改變檔案"
+
+msgid "Change to another .svg file"
+msgstr "更改為另一個.svg檔案"
+
+#. TRN: An menu option to convert the SVG into an unmodifiable model part.
+msgid "Bake to model"
+msgstr "烘焙成模型"
+
+#. TRN: Tooltip for the menu item.
+msgid "Bake into model as uneditable part"
+msgstr "將模型烘焙為不可編輯的部分"
+
+msgid "Save as"
+msgstr "另存為"
+
+msgid "Save SVG file"
+msgstr "儲存SVG檔案"
+
+msgid "Save as '.svg' file"
+msgstr "另存為'.svg'檔案"
+
+msgid "Size in emboss direction."
+msgstr "浮雕方向上的大小"
+
+#. TRN: The placeholder contains a number.
+#, boost-format
+msgid "Scale also changes amount of curve samples (%1%)"
+msgstr "縮放也會改變曲線樣本的數量（%1%）"
+
+msgid "set width and height keep ratio with width"
+msgstr "設定寬度和保持比例的寬度"
+
+msgid "Width of SVG."
+msgstr "SVG寬度"
+
+msgid "Height of SVG."
+msgstr "SVG高度"
+
+msgid "Lock/unlock the aspect ratio of the SVG."
+msgstr "鎖定/解鎖SVG的寬高比。"
+
+msgid "Reset scale"
+msgstr "重置縮放"
+
+msgid "Distance of the center of the SVG to the model surface."
+msgstr "SVG中心到模型表面的距離。"
+
+msgid "Reset distance"
+msgstr "重置距離"
+
+msgid "Rotate text Clock-wise."
+msgstr "順時針旋轉文字"
+
+msgid "Lock/unlock rotation angle when dragging above the surface."
+msgstr "在曲面上方拖動時鎖定/解鎖旋轉角度。"
+
+msgid "Mirror vertically"
+msgstr "垂直映象"
+
+msgid "Mirror horizontally"
+msgstr "水平映象"
+
+msgid "Set Mirror"
+msgstr "設定映象"
+
+msgid "Face the camera"
+msgstr "面向相機"
+
+msgid "Join"
+msgstr "合併"
+
+#. TRN: This is the name of the action that shows in undo/redo stack (changing part type from SVG to something else).
+msgid "Change SVG Type"
+msgstr "改變SVG型別"
+
+msgid "Ctrl+"
+msgstr ""
+
+msgid "Notice"
+msgstr "通知"
+
+msgid "Undefined"
+msgstr "未定義"
+
+#, boost-format
+msgid "%1% was replaced with %2%"
+msgstr "%1%已被%2%替換"
+
+msgid "The configuration may be generated by a newer version of BambuStudio."
+msgstr "此配置可能由新版本的Bambu Studio生成。"
+
+msgid "Some values have been replaced. Please check them:"
+msgstr "部分數值已被替換，請檢查："
+
+msgid "Process"
+msgstr "工藝"
+
+msgid "Filament"
+msgstr "耗材絲"
+
+msgid "Machine"
+msgstr "印表機"
+
+msgid "Configuration package was loaded, but some values were not recognized."
+msgstr "配置包已被載入，但部分數值未被識別。"
+
+#, boost-format
+msgid "Configuration file \"%1%\" was loaded, but some values were not recognized."
+msgstr "配置檔案“%1%”已被載入，但部分數值未被識別。"
+
+msgid "Internal Version"
+msgstr "內部版本"
+
+msgid "Beta Version"
+msgstr "Beta 版本"
+
+msgid "V"
+msgstr "V"
+
+msgid "BambuStudio will terminate because of running out of memory.It may be a bug. It will be appreciated if you report the issue to our team."
+msgstr "系統記憶體耗盡，Bambu Studio即將終止執行。這可能是個缺陷，希望您可以報告此問題，我們將非常感激。"
+
+msgid "Fatal error"
+msgstr "致命錯誤"
+
+msgid "BambuStudio will terminate because of a localization error. It will be appreciated if you report the specific scenario this issue happened."
+msgstr "遇到本地化錯誤，Bambu Studio即將終止執行。希望您可以報告發生此問題的具體場景，我們將非常感激。"
+
+msgid "Critical error"
+msgstr "嚴重錯誤"
+
+#, boost-format
+msgid "BambuStudio got an unhandled exception: %1%"
+msgstr "Bambu Studio捕捉到一個未處理的異常：%1%"
+
+msgid "This file is not from a trusted site, do you want to open it anyway?"
+msgstr "This file is not from a trusted site; do you want to open it anyway?"
+
+msgid "Untitled"
+msgstr "未命名"
+
+msgid "Downloading Bambu Network Plug-in"
+msgstr "正在下載Bambu網路外掛"
+
+msgid "Login information expired. Please login again."
+msgstr "登入資訊過期。請重新登入。"
+
+msgid "Failed to connect to the cloud device server. Please check your network and firewall."
+msgstr "無法連線到雲裝置伺服器。請檢查您的網路和防火牆。"
+
+msgid "Incorrect password"
+msgstr "訪問碼不正確"
+
+#, c-format, boost-format
+msgid "Connect %s failed! [SN:%s, code=%s]"
+msgstr "連線 %s 失敗。[SN:%s, code=%s]"
+
+msgid "BambuStudio configuration file read failed. Please manually backup and delete it, and then restart BambuStudio software."
+msgstr "BambuStudio配置檔案讀取失敗。請手動備份並刪除它，然後重新啟動BambuStudio軟體。"
+
+#, c-format, boost-format
+msgid ""
+"Failed to install preset files to %s.\n"
+"Please make sure Bambu Studio has permission to delete and write in this directory,\n"
+"and it is not being occupied by the system or other applications."
+msgstr ""
+"無法將預設檔案安裝到%s。\n"
+"請確保Bambu Studio對該目錄有刪除和寫入許可權，\n"
+"並且該目錄沒有被系統或其他應用程式佔用。"
+
+#, c-format, boost-format
+msgid ""
+"%s\n"
+"Do you want to continue?"
+msgstr "%s 是否繼續？"
+
+msgid "Remember my choice"
+msgstr "記住我的選擇"
+
+msgid "Loading configuration"
+msgstr "正在載入配置"
+
+#, c-format, boost-format
+msgid "Click to download new version in default browser: %s"
+msgstr "在預設瀏覽器中點選下載最新版本: %s"
+
+msgid "The Bambu Studio needs an upgrade"
+msgstr "Bambu Studio需要進行升級"
+
+msgid "This is the newest version."
+msgstr "已經是最新版本。"
+
+msgid "Info"
+msgstr "資訊"
+
+msgid "Rebuild"
+msgstr "重新構建"
+
+msgid "Loading current presets"
+msgstr "載入當前預設"
+
+msgid "Loading a mode view"
+msgstr "載入模式檢視"
+
+msgid "Choose one file (3mf):"
+msgstr "選擇一個檔案（3mf）："
+
+msgid "Choose one or more files (3mf/step/stl/svg/obj/amf/usd*/abc/ply):"
+msgstr "選擇一個或多個檔案（3mf/step/stl/svg/obj/amf/usd*/abc/ply）："
+
+msgid "Choose one or more files (3mf/step/stl/svg/obj/amf):"
+msgstr "選擇一個或多個檔案（3mf/step/stl/svg/obj/amf）："
+
+msgid "Choose one file (gcode/.gco/.g/.ngc/ngc):"
+msgstr "選擇一個檔案（gcode/.gco/.g/.ngc/ngc）："
+
+msgid "Some presets are modified."
+msgstr "預設已被修改。"
+
+msgid "You can keep the modified presets for the new project, discard or save changes as new presets."
+msgstr "您可以保留未儲存修改的預設應用到新專案中，或者選擇忽略。"
+
+msgid "User logged out"
+msgstr "使用者登出"
+
+msgid "Install network plug-in"
+msgstr "安裝網路外掛"
+
+msgid "Please Install network plug-in before log in."
+msgstr "請在登入前安裝網路外掛。"
+
+msgid "Install Network Plug-in"
+msgstr "安裝網路外掛"
+
+msgid "new or open project file is not allowed during the slicing process!"
+msgstr "在切片過程不允許新建或開啟專案檔案！"
+
+msgid "Open Project"
+msgstr "開啟專案"
+
+msgid "The Bambu Studio version is too old to enable cloud service. Please download the latest version from Bambu Lab website."
+msgstr "當前BambuStudio的版本過低導致雲端服務不可用,請從官網更新BambuStudio到最新版本。"
+
+msgid "Your software certificate has been revoked, please update Bambu Studio software."
+msgstr "您的軟體證書已失效。請升級Bambu Studio軟體"
+
+msgid "Retrieving printer information, please try again later."
+msgstr "正在獲取印表機資訊，請稍後重試"
+
+msgid "Please try updating Bambu Studio and then try again."
+msgstr "請嘗試升級Bambu Studio後重試"
+
+msgid "The certificate has expired. Please check the time settings or update Bambu Studio and try again."
+msgstr "您的軟體證書已過期，請檢查系統時間設定或者更新Bambu Studio後重試"
+
+msgid "The certificate is no longer valid and the printing functions are unavailable. If you need printing. Please visit the official website at https://bambulab.com/ to download and update."
+msgstr "該證書已失效，列印功能無法使用。如果您需要列印，請訪問官方網站https://bambulab.com/進行下載和更新"
+
+msgid "Internal error. Please try upgrading the firmware and Studio version. If the issue persists, contact customer support."
+msgstr "內部錯誤，請嘗試升級韌體和Bambu Studio版本。如果問題仍然存在，請聯絡售後"
+
+msgid "Your software is not signed, and some printing functions have been restricted. Please use the officially signed software version."
+msgstr "您的軟體未簽名，部分列印功能受限使用。請使用官方簽名的軟體版本。"
+
+msgid "Privacy Policy Update"
+msgstr "隱私協議更新"
+
+msgid "The number of user presets cached in the cloud has exceeded the upper limit, newly created user presets can only be used locally."
+msgstr "雲端快取的使用者預設數量已超過上限，新建立的使用者預設只能在本地使用。"
+
+msgid "Sync user presets"
+msgstr "同步使用者預設"
+
+msgid "Loading user preset"
+msgstr "正在載入使用者預設"
+
+msgid "Switching application language"
+msgstr "切換應用程式語言"
+
+msgid "Select the language"
+msgstr "選擇語言"
+
+msgid "Language"
+msgstr "語言"
+
+msgid "*"
+msgstr "*"
+
+msgid "The uploads are still ongoing"
+msgstr "上傳任務依然在繼續"
+
+msgid "Stop them and continue anyway?"
+msgstr "停止它們並且繼續？"
+
+msgid "Ongoing uploads"
+msgstr "正在進行的上傳"
+
+msgid "Install presets failed"
+msgstr ""
+
+msgid "Select a G-code file:"
+msgstr "選擇一個G-code檔案："
+
+msgid "Import File"
+msgstr "匯入檔案"
+
+msgid "Choose files"
+msgstr "選擇檔案"
+
+msgid "New Folder"
+msgstr "新建資料夾"
+
+msgid "Open"
+msgstr "開啟"
+
+msgid "Rename"
+msgstr "重新命名"
+
+msgid "Bambu Studio GUI initialization failed"
+msgstr "Bambu Studio圖形介面初始化失敗"
+
+#, boost-format
+msgid "Fatal error, exception caught: %1%"
+msgstr "致命錯誤，捕獲到異常：%1%"
+
+msgid "Quality"
+msgstr "質量"
+
+msgid "Shell"
+msgstr "外殼"
+
+msgid "Infill"
+msgstr "填充"
+
+msgid "Support"
+msgstr "支撐"
+
+msgid "Flush options"
+msgstr "換料沖刷選項"
+
+msgid "Speed"
+msgstr "速度"
+
+msgid "Strength"
+msgstr "強度"
+
+msgid "Ironing"
+msgstr "熨燙"
+
+msgid "Fuzzy Skin"
+msgstr "絨毛表面"
+
+msgid "Extruders"
+msgstr "擠出機"
+
+msgid "Extrusion Width"
+msgstr "擠出寬度"
+
+msgid "Wipe options"
+msgstr "擦除選項"
+
+msgid "Bed adhension"
+msgstr "熱床粘接"
+
+msgid "Add part"
+msgstr "新增部件"
+
+msgid "Add negative part"
+msgstr "新增負零件"
+
+msgid "Add modifier"
+msgstr "新增修改器"
+
+msgid "Add support blocker"
+msgstr "新增支撐遮蔽"
+
+msgid "Add support enforcer"
+msgstr "新增支撐生成器"
+
+msgid "Add text"
+msgstr "新增文字"
+
+msgid "Add negative text"
+msgstr "新增負零件文字"
+
+msgid "Add text modifier"
+msgstr "新增文字修改器"
+
+msgid "Add SVG part"
+msgstr "新增svg零件"
+
+msgid "Add negative SVG"
+msgstr "新增負零件SVG"
+
+msgid "Add SVG modifier"
+msgstr "新增SVG修改器"
+
+msgid "Select settings"
+msgstr "選擇設定"
+
+msgid "Hide"
+msgstr "隱藏"
+
+msgid "Show"
+msgstr "顯示"
+
+msgid "Delete the selected object"
+msgstr "刪除所選物件"
+
+msgid "Delete all cutter"
+msgstr "刪除所有聯結器"
+
+msgid "Del"
+msgstr "刪除"
+
+msgid "Edit Text"
+msgstr "編輯文字"
+
+msgid "Edit SVG"
+msgstr "編輯SVG"
+
+msgid "Change SVG source file, projection, size, ..."
+msgstr "改變svg的來原始檔，投影，大小..."
+
+msgid "Load..."
+msgstr "載入..."
+
+msgid "Cube"
+msgstr "立方體"
+
+msgid "Cylinder"
+msgstr "圓柱體"
+
+msgid "Cone"
+msgstr "錐體"
+
+msgid "Double Tear Romboid Cylinder"
+msgstr "雙淚滴狀柱體"
+
+msgid "Disc"
+msgstr "小圓片"
+
+msgid "Torus"
+msgstr "圓環"
+
+msgid "Rounded Rectangle"
+msgstr "圓角矩形"
+
+msgid "Bambu Cube"
+msgstr "Bambu方塊"
+
+msgid "Bambu Cube V2"
+msgstr "Bambu方塊 V2"
+
+msgid "3DBenchy"
+msgstr "小船"
+
+msgid "ksr FDMTest"
+msgstr "歐特克FDM測試"
+
+msgid "SVG"
+msgstr ""
+
+msgid "Height range Modifier"
+msgstr "高度範圍修改器"
+
+msgid "Add settings"
+msgstr "新增設定"
+
+msgid "Change type"
+msgstr "更改型別"
+
+msgid "Set as an individual object"
+msgstr "設定為獨立物件"
+
+msgid "Set as individual objects"
+msgstr "設定為獨立物件"
+
+msgid "Printable"
+msgstr "可列印的"
+
+msgid "Fix model"
+msgstr "修復模型"
+
+msgid "Export as one STL"
+msgstr "匯出為一個STL"
+
+msgid "Export as STLs"
+msgstr "匯出為多個STL"
+
+msgid "Reload from disk"
+msgstr "從磁碟重新載入"
+
+msgid "Reload the selected parts from disk"
+msgstr "從磁碟重新載入選中的零件"
+
+msgid "Replace with STL"
+msgstr "替換為STL"
+
+msgid "Replace the selected part with new STL"
+msgstr "用新的STL替換選中的零件"
+
+msgid "Change filament"
+msgstr "更換耗材絲"
+
+msgid "Set filament for selected items"
+msgstr "設定所選項的耗材絲"
+
+msgid "Default"
+msgstr "預設"
+
+#, c-format, boost-format
+msgid "Filament %d"
+msgstr "耗材絲%d"
+
+msgid "current"
+msgstr "當前"
+
+msgid "Scale to print volume"
+msgstr "縮放到列印體積"
+
+msgid "Scale the selected object to fit the print volume"
+msgstr "縮放所選物件以適應列印體積"
+
+msgid "Flush Options"
+msgstr "換料沖刷選項"
+
+msgid "Flush into objects' infill"
+msgstr "沖刷到物件的填充"
+
+msgid "Flush into this object"
+msgstr "沖刷到這個物件"
+
+msgid "Flush into objects' support"
+msgstr "沖刷到物件的支撐"
+
+msgid "Edit in Parameter Table"
+msgstr "在參數列格中編輯"
+
+msgid "Convert from inch"
+msgstr "從英寸轉換"
+
+msgid "Restore to inch"
+msgstr "恢復到英寸"
+
+msgid "Convert from meter"
+msgstr "從米轉換"
+
+msgid "Restore to meter"
+msgstr "恢復到米"
+
+msgid "Merge"
+msgstr "組合"
+
+msgid "Assemble the selected objects to an object with multiple parts"
+msgstr "組合所選物件為一個多零件物件"
+
+msgid "Assemble the selected objects to an object with single part"
+msgstr "組合所選物件為一個單零件物件"
+
+msgid "Mesh boolean"
+msgstr "網格布林操作"
+
+msgid "Mesh boolean operations including union and subtraction"
+msgstr "包括並集和差集的網格布林運算"
+
+msgid "Merge into Single Part"
+msgstr "合併為單個零件"
+
+msgid "Merge the selected parts into one part"
+msgstr "將選中的零件合併成一個零件"
+
+msgid "Along X axis"
+msgstr "沿 X 軸"
+
+msgid "Mirror along the X axis"
+msgstr "沿X軸映象"
+
+msgid "Along Y axis"
+msgstr "沿 Y 軸"
+
+msgid "Mirror along the Y axis"
+msgstr "沿Y軸映象"
+
+msgid "Along Z axis"
+msgstr "沿 Z 軸"
+
+msgid "Mirror along the Z axis"
+msgstr "沿Z軸映象"
+
+msgid "Mirror object"
+msgstr "映象物件"
+
+msgid "Invalidate cut info"
+msgstr "解除切割關係"
+
+msgid "Add Primitive"
+msgstr "新增標準模型"
+
+msgid "Show Labels"
+msgstr "顯示標籤"
+
+msgid "To objects"
+msgstr "拆分到物件"
+
+msgid "Split the selected object into multiple objects"
+msgstr "拆分所選物件為多個物件"
+
+msgid "To parts"
+msgstr "到零件"
+
+msgid "Split the selected object into multiple parts"
+msgstr "拆分所選物件為多個零件"
+
+msgid "Split"
+msgstr "拆分"
+
+msgid "Split the selected object"
+msgstr "拆分所選物件"
+
+msgid "Auto orientation"
+msgstr "自動朝向"
+
+msgid "Auto orient the object to improve print quality."
+msgstr "自動調整物件朝向以提高列印質量。"
+
+msgid "Edit"
+msgstr "編輯"
+
+msgid "Delete this filament"
+msgstr "刪除此耗材絲"
+
+msgid "Merge with"
+msgstr "合併到"
+
+msgid "Select All"
+msgstr "全選"
+
+msgid "select all objects on current plate"
+msgstr "全選當前盤物件"
+
+msgid "Delete All"
+msgstr "刪除所有"
+
+msgid "delete all objects on current plate"
+msgstr "刪除當前盤所有物件"
+
+msgid "Arrange"
+msgstr "自動擺放"
+
+msgid "arrange current plate"
+msgstr "在當前盤執行自動擺放"
+
+msgid "Auto Rotate"
+msgstr "自動朝向"
+
+msgid "auto rotate current plate"
+msgstr "在當前盤執行自動朝向"
+
+msgid "Expand all"
+msgstr "展開所有"
+
+msgid "Expand all objects on this plate"
+msgstr "展開此盤上的所有物件"
+
+msgid "Collapse all"
+msgstr "摺疊所有"
+
+msgid "Collapse all objects on this plate"
+msgstr "摺疊此盤上的所有物件"
+
+msgid "Delete Plate"
+msgstr "刪除盤"
+
+msgid "Remove the selected plate"
+msgstr "刪除所選盤"
+
+msgid "Move Plate"
+msgstr "移動盤"
+
+msgid "Clone"
+msgstr "克隆"
+
+msgid "Simplify Model"
+msgstr "簡化模型"
+
+msgid "Subdivision mesh"
+msgstr "細分網格"
+
+msgid "(Lost color)"
+msgstr "(丟失顏色)"
+
+msgid "Center"
+msgstr "居中"
+
+msgid "Align/Distribute"
+msgstr "對齊/分佈"
+
+msgid "Align and distribute objects"
+msgstr "對齊/分佈物件或零件"
+
+msgid "Sub merge"
+msgstr "子合併"
+
+msgid "Edit Process Settings"
+msgstr "編輯工藝引數"
+
+msgid "Copy Process Settings"
+msgstr "複製工藝設定"
+
+msgid "Paste Process Settings"
+msgstr "貼上工藝設定"
+
+msgid "Edit print parameters for a single object"
+msgstr "編輯單個物件的列印引數"
+
+msgid "Change Filament"
+msgstr "更換耗材絲"
+
+msgid "Set Filament for selected items"
+msgstr "設定所選項的耗材絲"
+
+msgid "Unlock"
+msgstr "解鎖"
+
+msgid "Lock"
+msgstr "鎖定"
+
+msgid "Fill bed with copies"
+msgstr "鋪滿列印板"
+
+msgid "Fill the remaining area of bed with copies of the selected object"
+msgstr "用選定物件的副本填充床的剩餘區域"
+
+msgid "Edit Plate Name"
+msgstr "編輯盤名"
+
+msgid "Name"
+msgstr "名稱"
+
+msgid "Fila."
+msgstr "耗材絲"
+
+#, c-format, boost-format
+msgid "%1$d error repaired"
+msgid_plural "%1$d errors repaired"
+msgstr[0] "%1$d個錯誤被修復"
+
+#, c-format, boost-format
+msgid "Error: %1$d non-manifold edge."
+msgid_plural "Error: %1$d non-manifold edges."
+msgstr[0] "錯誤: %1$d 非流形邊."
+
+msgid "Remaining errors"
+msgstr "剩餘錯誤"
+
+#, c-format, boost-format
+msgid "%1$d non-manifold edge"
+msgid_plural "%1$d non-manifold edges"
+msgstr[0] "%1$d 非流形邊"
+
+msgid "Right click the icon to fix model object"
+msgstr "右鍵點選此圖示可修復模型物件"
+
+msgid "Right button click the icon to drop the object settings"
+msgstr "右鍵點選此圖示以捨棄物件的設定"
+
+msgid "Click the icon to reset all settings of the object"
+msgstr "點選此圖示可重置物件的所有設定"
+
+msgid "Right button click the icon to drop the object printable property"
+msgstr "右鍵點選此圖示以捨棄物件的可列印屬性"
+
+msgid "Click the icon to toggle printable property of the object"
+msgstr "點選此圖示可切換這個物件的可列印屬性"
+
+msgid "Click the icon to edit support painting of the object"
+msgstr "點選此圖示可編輯這個物件的支撐繪製"
+
+msgid "Click the icon to edit fuzzy skin painting of the object"
+msgstr "單擊該圖示可編輯物件的絨毛表面繪製"
+
+msgid "Click the icon to edit color painting of the object"
+msgstr "點選此圖示可編輯這個物件的顏色繪製"
+
+msgid "Click the icon to shift this object to the bed"
+msgstr "點選這個圖示可將物件移動到熱床上"
+
+msgid "Loading file"
+msgstr "載入檔案中"
+
+msgid "Error!"
+msgstr "錯誤！"
+
+msgid "Failed to get the model data in the current file."
+msgstr "無法獲取當前檔案中的模型資料。"
+
+msgid "Generic"
+msgstr "通用"
+
+msgid "Add Modifier"
+msgstr "新增修改器"
+
+msgid "Switch to per-object setting mode to edit modifier settings."
+msgstr "切換到物件模式以編輯修改器的設定。"
+
+msgid "Sub-merged body"
+msgstr "子合併體"
+
+msgid "Switch to per-object setting mode to edit process settings of selected objects."
+msgstr "切換到物件設定模式，以編輯所選物件的工藝引數"
+
+msgid "Delete connector from object which is a part of cut"
+msgstr "刪除的連線件屬於切割物件的一部分"
+
+msgid "Delete solid part from object which is a part of cut"
+msgstr "刪除的實體屬於切割物件的一部分"
+
+msgid "Delete negative volume from object which is a part of cut"
+msgstr "刪除的負體積屬於切割物件的一部分"
+
+msgid "To save cut correspondence you can delete all connectors from all related objects."
+msgstr "為保證切割關係，您可以將所有關聯物件的連線件一起刪除。"
+
+msgid ""
+"This action will break a cut correspondence.\n"
+"After that model consistency can't be guaranteed .\n"
+"\n"
+"To manipulate solid parts or negative volumes you have to invalidate cut information first."
+msgstr ""
+"該行為將破壞切割關係，在此之後將無法保證模型一致性。\n"
+"\n"
+"如果要操作子部件或者負零件，需要先解除切割關係。"
+
+msgid "Delete all connectors"
+msgstr "刪除所有連線件"
+
+msgid "Deleting the last solid part is not allowed."
+msgstr "不允許刪除物件的最後一個實體零件。"
+
+msgid "The target object contains only one part and can not be split."
+msgstr "目標物件僅包含一個零件，無法被拆分。"
+
+msgid "Assembly"
+msgstr "組合體"
+
+msgid "Cut Connectors information"
+msgstr "切割連線件資訊"
+
+msgid "Object manipulation"
+msgstr "操作物件"
+
+msgid "Group manipulation"
+msgstr "操作組"
+
+msgid "Object Settings to modify"
+msgstr "要修改的物件設定"
+
+msgid "Part Settings to modify"
+msgstr "要修改的零件設定"
+
+msgid "Layer range Settings to modify"
+msgstr "要修改的圖層範圍設定"
+
+msgid "Part manipulation"
+msgstr "零件操作"
+
+msgid "Instance manipulation"
+msgstr "例項操作"
+
+msgid "Height ranges"
+msgstr "高度範圍"
+
+msgid "Settings for height range"
+msgstr "高度範圍設定"
+
+msgid "Layer"
+msgstr "層"
+
+msgid "Selection conflicts"
+msgstr "選擇衝突"
+
+msgid "If the first selected item is an object, the second one should also be an object."
+msgstr "如果第一個選擇的是物件，那麼第二個選擇的也必須是物件。"
+
+msgid "If the first selected item is a part, the second one should be part of the same object."
+msgstr "如果第一個選擇的是零件，那麼第二個選擇的也必須是同一個物件中的零件。"
+
+msgid "Negative Part"
+msgstr "負零件"
+
+msgid "Support Blocker"
+msgstr "支撐去除器"
+
+msgid "Support Enforcer"
+msgstr "支撐新增器"
+
+msgid "Type:"
+msgstr "型別："
+
+msgid "Choose part type"
+msgstr "選擇零件型別"
+
+msgid "The type of the last solid object part is not to be changed."
+msgstr "不允許修改物件中最後一個實體零件的型別。"
+
+msgid "Enter new name"
+msgstr "輸入新名稱"
+
+msgid "Renaming"
+msgstr "重新命名"
+
+msgid "Following model object has been repaired"
+msgid_plural "Following model objects have been repaired"
+msgstr[0] "以下模型物件已被修復"
+
+msgid "Failed to repair the following model object"
+msgid_plural "Failed to repair the following model object"
+msgstr[0] "以下模型物件修復失敗"
+
+msgid "Repairing was canceled"
+msgstr "修復被取消"
+
+#, c-format, boost-format
+msgid "\"%s\" will exceed 1 million faces after this subdivision, which may increase slicing time. Do you want to continue?"
+msgstr "細分後，“%s”將超過100萬個面片，這可能會增加切片時間。是否繼續？"
+
+msgid "BambuStudio warning"
+msgstr "BambuStudio警告"
+
+#, c-format, boost-format
+msgid "\"%s\" part's mesh contains errors. Please repair it first."
+msgstr "“%s”零件的網格存在錯誤。請先進行修復。"
+
+msgid "Additional process preset"
+msgstr "附加工藝預設"
+
+msgid "Remove parameter"
+msgstr "刪除引數"
+
+msgid "to"
+msgstr "到"
+
+msgid "Remove height range"
+msgstr "移除高度範圍"
+
+msgid "Add height range"
+msgstr "新增高度範圍"
+
+msgid "Invalid numeric."
+msgstr "數值錯誤。"
+
+msgid "one cell can only be copied to one or multiple cells in the same column"
+msgstr "一個單元格僅能被複制到同一列的一個或多個單元格"
+
+msgid "multiple cells copy is not supported"
+msgstr "不支援多個單元格的複製"
+
+msgid "Outside"
+msgstr "盤外"
+
+msgid " "
+msgstr " "
+
+msgid "Layer height"
+msgstr "層高"
+
+msgid "Wall loops"
+msgstr "牆層數"
+
+msgid "Infill density(%)"
+msgstr "填充密度(%)"
+
+msgid "Auto Brim"
+msgstr "自動Brim"
+
+msgid "Auto"
+msgstr "自動"
+
+msgid "Painted"
+msgstr "繪製"
+
+msgid "Outer brim only"
+msgstr "僅外側"
+
+msgid "Inner brim only"
+msgstr "僅內側"
+
+msgid "Outer and inner brim"
+msgstr "內側和外側"
+
+msgid "No-brim"
+msgstr "無brim"
+
+msgid "Outer wall speed"
+msgstr "外牆速度"
+
+msgid "Plate"
+msgstr "盤"
+
+msgid "Brim"
+msgstr "Brim"
+
+msgid "Object/Part Setting"
+msgstr "物件/零件設定"
+
+msgid "Reset parameter"
+msgstr "重置引數"
+
+msgid "Multicolor Print"
+msgstr "多色列印"
+
+msgid "Line Type"
+msgstr "走線型別"
+
+msgid "Color"
+msgstr "顏色"
+
+msgid "Pause"
+msgstr "暫停"
+
+msgid "Template"
+msgstr "模板"
+
+msgid "Custom"
+msgstr "自定義"
+
+msgid "Pause:"
+msgstr "暫停"
+
+msgid "Custom Template:"
+msgstr "自定義模板："
+
+msgid "Custom G-code:"
+msgstr "自定義G-code："
+
+msgid "Toggle path view to current layer/all layers"
+msgstr "切換走線檢視為當前層 / 所有層"
+
+msgid "Custom G-code"
+msgstr "自定義 G-code"
+
+msgid "Enter Custom G-code used on current layer:"
+msgstr "輸入當前層上使用的自定義G-code："
+
+msgid "Jump to Layer"
+msgstr "跳轉到層"
+
+msgid "Please enter the layer number"
+msgstr "請輸入層數"
+
+msgid "Add Pause"
+msgstr "新增暫停列印"
+
+msgid "Insert a pause command at the beginning of this layer."
+msgstr "在該層的起始位置插入暫停。"
+
+msgid "Add Custom G-code"
+msgstr "新增自定義G-code"
+
+msgid "Insert custom G-code at the beginning of this layer."
+msgstr "在該層的起始位置插入自定義G-code。"
+
+msgid "Add Custom Template"
+msgstr "新增自定義模板"
+
+msgid "Insert template custom G-code at the beginning of this layer."
+msgstr "在該層的起始位置插入模板自定義G-code。"
+
+msgid "Filament "
+msgstr "耗材絲"
+
+msgid "Change filament at the beginning of this layer."
+msgstr "在該層的起始位置更換耗材絲。"
+
+msgid "Delete Pause"
+msgstr "刪除暫停"
+
+msgid "Delete Custom Template"
+msgstr "刪除自定義模板"
+
+msgid "Edit Custom G-code"
+msgstr "編輯自定義G-code"
+
+msgid "Delete Custom G-code"
+msgstr "刪除自定義G-code"
+
+msgid "Delete Filament Change"
+msgstr "刪除耗材絲更換"
+
+msgid "No printer"
+msgstr "無印表機"
+
+msgid "..."
+msgstr "……"
+
+msgid "Failed to connect to the server"
+msgstr "無法連線伺服器"
+
+msgid "Check the status of current system services"
+msgstr "請檢查當前系統服務狀態"
+
+msgid "code"
+msgstr "程式碼"
+
+msgid "Failed to connect to cloud service"
+msgstr "無法連線到雲服務"
+
+msgid "Please click on the hyperlink above to view the cloud service status"
+msgstr "請點選上方的超連結以檢視雲服務狀態"
+
+msgid "Failed to connect to the printer"
+msgstr "無法連線印表機"
+
+msgid "Connection to printer failed"
+msgstr "連線印表機失敗"
+
+msgid "Please check the network connection of the printer and Studio."
+msgstr "請檢查印表機和工作室的網路連線"
+
+msgid "Connecting..."
+msgstr "連線中..."
+
+msgid "Auto-refill"
+msgstr "自動續料"
+
+msgid "Load"
+msgstr "進料"
+
+msgid "Unload"
+msgstr "退料"
+
+msgid "Choose an AMS slot then press \"Load\" or \"Unload\" button to automatically load or unload filaments."
+msgstr "選擇1個AMS槽位，然後點選進料/退料按鈕以自動進料/退料。"
+
+msgid "Filament type is unknown which is required to perform this action. Please set target filament's informations."
+msgstr "執行此操作的耗材型別未知。請設定槽位資訊。"
+
+msgid "Changing fan speed during printing may affect print quality, please choose carefully."
+msgstr "在列印過程中改變風扇速度可能會影響列印質量，請謹慎選擇。"
+
+msgid "Change Anyway"
+msgstr "仍然改動"
+
+msgid "Off"
+msgstr "關閉"
+
+msgid "Filter"
+msgstr "過濾"
+
+msgid "Enabling filtration redirects the right fan to filter gas, which may reduce cooling performance."
+msgstr ""
+
+msgid "Enabling filtration during printing may reduce cooling and affect print qulity. Please choose carefully"
+msgstr "開啟過濾後會降低冷卻效果，同時可能會影響列印質量，請確認是否開啟"
+
+msgid "The selected material only supports the current fan mode, and it can't be changed during printing."
+msgstr "所選材料只支援當前的風扇模式，在列印過程中無法更改"
+
+msgid "Cooling"
+msgstr "冷卻模式"
+
+msgid "Heating"
+msgstr "腔溫保持模式"
+
+msgid "Exhaust"
+msgstr "外排"
+
+msgid "Full Cooling"
+msgstr "強冷卻模式"
+
+msgid "Init"
+msgstr ""
+
+msgid "Chamber"
+msgstr "腔體"
+
+msgid "Innerloop"
+msgstr "內迴圈"
+
+#. TRN To be shown in the main menu View->Top
+msgid "Top"
+msgstr "頂部"
+
+msgid "The fan controls the temperature during printing to improve print quality.The system automatically adjusts the fan's switch and speed according to different printing materials."
+msgstr "風扇在列印中調控溫度以提升列印質量，系統會根據不同的列印材料自動調節風扇的開關和轉速。"
+
+msgid "Cooling mode is suitable for printing PLA/PETG/TPU materials and filters the chamber air."
+msgstr "冷卻模式適合列印PLA/PETG/TPU材質，同時能夠過濾腔內空氣"
+
+msgid "Heating mode is suitable for printing ABS/ASA/PC/PA materials and circulates filters the chamber air."
+msgstr "腔溫保持模式適合列印ABS/ASA/PC/PA材質，在機箱內部迴圈過濾腔內空氣"
+
+msgid "Strong cooling mode is suitable for printing PLA/TPU materials. In this mode, the printouts will be fully cooled."
+msgstr "強冷卻模式適合列印PLA/TPU材質。該模式下列印件會得到全方位的冷卻"
+
+#, c-format, boost-format
+msgid "Cooling mode is suitable for printing %s materials."
+msgstr "冷卻模式適合列印%s材質，同時能夠過濾腔內空氣"
+
+#, c-format, boost-format
+msgid "Heating mode is suitable for printing %s materials and circulates filters the chamber air."
+msgstr "腔溫保持模式適合列印%s材質，在機箱內部迴圈過濾腔內空氣。"
+
+msgctxt "air_duct"
+msgid "Right(Aux)"
+msgstr "右（輔助）"
+
+msgctxt "air_duct"
+msgid "Right(Filter)"
+msgstr "右（過濾）"
+
+msgctxt "air_duct"
+msgid "Left(Aux)"
+msgstr "左（輔助）"
+
+msgctxt "air_duct"
+msgid "Chamber"
+msgstr "機箱"
+
+msgid "Hotend"
+msgstr ""
+
+msgid "Parts"
+msgstr "部件"
+
+msgid "Aux"
+msgstr "輔助"
+
+msgid "Nozzle1"
+msgstr "噴嘴1"
+
+msgid "MC Board"
+msgstr ""
+
+msgid "Heat"
+msgstr "加熱"
+
+msgid "Fan"
+msgstr "風扇"
+
+msgid "Idling..."
+msgstr "空閒中"
+
+msgid "Heat the nozzle"
+msgstr "加熱噴嘴"
+
+msgid "Cut filament"
+msgstr "切斷耗材"
+
+msgid "Pull back current filament"
+msgstr "抽回耗材絲"
+
+msgid "Push new filament into extruder"
+msgstr "送出新耗材到擠出機"
+
+msgid "Grab new filament"
+msgstr "咬入耗材絲"
+
+msgid "Purge old filament"
+msgstr "沖刷舊耗材絲"
+
+msgid "Confirm extruded"
+msgstr "確認擠出"
+
+msgid "Check filament location"
+msgstr "檢查耗材位置"
+
+msgid "The maximum temperature cannot exceed "
+msgstr "最大溫度不超過"
+
+msgid "The minmum temperature should not be less than "
+msgstr "最低溫度不低於"
+
+msgid ""
+"All the selected objects are on the locked plate,\n"
+"We can not do auto-arrange on these objects."
+msgstr ""
+"所有選中的物件都處於被鎖定的盤上，\n"
+"無法對這些物件做自動擺盤。"
+
+msgid "No arrangeable objects are selected."
+msgstr "沒有可擺盤的物件被選中。"
+
+msgid "The following plates are skipped due to different arranging settings from global:"
+msgstr "由於單盤擺盤設定與全域性不同，以下盤被跳過："
+
+msgid ""
+"This plate is locked,\n"
+"We can not do auto-arrange on this plate."
+msgstr "該盤處於鎖定狀態，無法對其進行自動擺盤。"
+
+msgid "Arranging"
+msgstr "自動擺放"
+
+#, boost-format
+msgid "Object %1% has zero size and can't be arranged."
+msgstr "物件%1%的大小為零，無法排列。"
+
+msgid "Arrange failed. Found some exceptions when processing object geometries."
+msgstr "自動擺放失敗，處理物件幾何資料時遇到異常。"
+
+msgid "Arranging canceled."
+msgstr "已取消自動擺放。"
+
+msgid "Arranging is done but there are unpacked items. Reduce spacing and try again."
+msgstr "已完成自動擺放，但是有未被擺到盤內的項，可在減小間距後重試。"
+
+msgid "Arranging done."
+msgstr "已完成自動擺放。"
+
+msgid ""
+"All the selected objects are on the locked plate,\n"
+"We can not do auto-orient on these objects."
+msgstr ""
+"所有選中的物件都處於被鎖定的盤上，\n"
+"無法對這些物件做自動朝向。"
+
+msgid ""
+"This plate is locked,\n"
+"We can not do auto-orient on this plate."
+msgstr ""
+"該盤處於鎖定狀態，\n"
+"無法對其進行自動朝向。"
+
+msgid "Orienting..."
+msgstr "自動朝向中..."
+
+msgid "Orienting"
+msgstr "自動朝向中..."
+
+msgid "Filling"
+msgstr "正在填充"
+
+msgid "Bed filling canceled."
+msgstr "填充熱床已取消。"
+
+msgid "Bed filling done."
+msgstr "填充熱床已完成。"
+
+#. TRN: This is the title of the action appearing in undo/redo stack.
+#. It is same for Text and SVG.
+msgid "Emboss attribute change"
+msgstr "浮雕屬性更改"
+
+msgid "Add Emboss text object"
+msgstr "新增浮雕文字物件"
+
+msgid "Add Emboss text Volume"
+msgstr "新增浮雕文字Volume"
+
+msgid "Font doesn't have any shape for given text."
+msgstr "給定文字的字型沒有任何形狀。"
+
+msgid "There is no valid surface for text projection."
+msgstr "沒有用於文字投影的有效曲面。"
+
+msgid "Text mesh ie empty."
+msgstr "文字網格為空。"
+
+msgid "Text"
+msgstr ""
+
+msgid "Error! Unable to create thread!"
+msgstr "發生錯誤，無法建立執行緒！"
+
+msgid "Exception"
+msgstr "異常"
+
+msgid "Logging in"
+msgstr "登入中"
+
+msgid "Login failed"
+msgstr "登入失敗"
+
+msgid "Please check the printer network connection."
+msgstr "請檢查印表機的網路連線。"
+
+msgid "Abnormal print file data. Please slice again."
+msgstr "列印檔案資料異常，請重新切片"
+
+msgid "Task canceled."
+msgstr "任務已取消。"
+
+msgid "Upload task timed out. Please check the network status and try again."
+msgstr "上傳任務超時，請排查網路狀態後重試。"
+
+msgid "Cloud service connection failed. Please try again."
+msgstr "雲服務連線失敗，請重試"
+
+msgid "Print file not found. please slice again."
+msgstr "未找到列印檔案，請重新切片。"
+
+msgid "The print file exceeds the maximum allowable size (1GB). Please simplify the model and slice again."
+msgstr "列印檔案超過最大允許大小（1GB），請簡化模型後重新切片。"
+
+msgid "Failed to send the print job. Please try again."
+msgstr "無法傳送列印任務，請重試。"
+
+msgid "Failed to upload file to ftp. Please try again."
+msgstr "上傳檔案至FTP失敗，請重試。"
+
+msgid "Check the current status of the bambu server by clicking on the link above."
+msgstr "點選上方的連結檢查Bambu伺服器的當前狀態。"
+
+msgid "The size of the print file is too large. Please adjust the file size and try again."
+msgstr "列印檔案的大小過大，請調整檔案大小後重試。"
+
+msgid "Print file not found, Please slice it again and send it for printing."
+msgstr "未找到列印檔案，請重新切片後再傳送列印。"
+
+msgid "Failed to upload print file to FTP. Please check the network status and try again."
+msgstr "無法將列印檔案上傳至FTP。請檢查網路狀態並重試。"
+
+msgid "Sending print job over LAN"
+msgstr "正在透過區域網傳送列印任務"
+
+msgid "Sending print job through cloud service"
+msgstr "正在透過雲端服務傳送列印任務"
+
+msgid "Print task sending times out."
+msgstr "傳送列印任務超時。"
+
+msgid "Service Unavailable"
+msgstr "服務不可用"
+
+msgid "Unknown Error."
+msgstr "未知錯誤。"
+
+msgid "Sending print configuration"
+msgstr "正在傳送列印配置"
+
+#, c-format, boost-format
+msgid "Successfully sent. Will automatically jump to the device page in %ss"
+msgstr "已傳送完成，即將自動跳轉到裝置頁面（%s秒）"
+
+#, c-format, boost-format
+msgid "Successfully sent. Will automatically jump to the next page in %ss"
+msgstr "已成功傳送。將在%ss後自動跳轉到下一頁。"
+
+msgid "Storage needs to be inserted before printing via LAN."
+msgstr "透過區域網傳送列印任務，需要先插入儲存裝置。"
+
+msgid "Sending gcode file over LAN"
+msgstr "透過區域網傳送gcode檔案"
+
+msgid "Sending gcode file to sdcard"
+msgstr "傳送gcode檔案到sd卡"
+
+#, c-format, boost-format
+msgid "Successfully sent. Close current page in %s s"
+msgstr "成功傳送。即將關閉當前頁面（%s秒）"
+
+msgid "Storage needs to be inserted before sending to printer."
+msgstr "傳送到印表機前，需要先插入儲存裝置"
+
+msgid "Thermal Preconditioning for first layer optimization"
+msgstr "首層最佳化保溫準備"
+
+msgid "Remaining time: Calculating..."
+msgstr "剩餘時間：計算中"
+
+msgid "The heated bed's thermal preconditioning helps optimize the first layer print quality. Printing will start once preconditioning is complete."
+msgstr "保溫熱床可以最佳化首層列印質量，保溫完成後將發起列印。"
+
+#, c-format, boost-format
+msgid "Remaining time: %dmin%ds"
+msgstr "剩餘時間：%d分%d秒"
+
+msgid "Choose SLA archive:"
+msgstr "選擇SLA存檔："
+
+msgid "Import file"
+msgstr "匯入檔案"
+
+msgid "Import model and profile"
+msgstr "匯入模型和配置"
+
+msgid "Import profile only"
+msgstr "僅匯入配置"
+
+msgid "Import model only"
+msgstr "僅匯入模型"
+
+msgid "Accurate"
+msgstr "精確的"
+
+msgid "Balanced"
+msgstr "均衡的"
+
+msgid "Quick"
+msgstr "快速的"
+
+msgid "Importing SLA archive"
+msgstr "匯入SLA存檔"
+
+msgid "The SLA archive doesn't contain any presets. Please activate some SLA printer preset first before importing that SLA archive."
+msgstr "SLA存檔不包含任何預設。在匯入該SLA存檔之前，請先啟用一些SLA印表機預設。"
+
+msgid "Importing canceled."
+msgstr "匯入已取消。"
+
+msgid "Importing done."
+msgstr "匯入完成。"
+
+msgid "The imported SLA archive did not contain any presets. The current SLA presets were used as fallback."
+msgstr "匯入的SLA存檔不包含任何預設。當前的SLA預設被用作備用選項。"
+
+msgid "You cannot load SLA project with a multi-part object on the bed"
+msgstr "您不能載入一個在床上有多個部件的SLA專案"
+
+msgid "Please check your object list before preset changing."
+msgstr "請在預設更改之前檢查物件列表。"
+
+msgid "Attention!"
+msgstr "注意！"
+
+msgid "Downloading"
+msgstr "下載中"
+
+msgid "Download failed"
+msgstr "下載失敗"
+
+msgid "Cancelled"
+msgstr "已取消"
+
+msgid "Install successfully."
+msgstr "安裝成功。"
+
+msgid "Installing"
+msgstr "安裝中"
+
+msgid "Install failed"
+msgstr "安裝失敗"
+
+msgid "Portions copyright"
+msgstr "部分版權"
+
+msgid "Copyright"
+msgstr "版權"
+
+msgid "License"
+msgstr "許可證"
+
+msgid "Bambu Studio is licensed under "
+msgstr "Bambu Studio是在"
+
+msgid "GNU Affero General Public License, version 3"
+msgstr "GNU Affero 通用公共許可證，版本 3下授權的"
+
+msgid "Bambu Studio is based on PrusaSlicer by Prusa Research, which is from Slic3r by Alessandro Ranellucci and the RepRap community"
+msgstr "Bambu Studio是基於Prusa Research的PrusaSlicer開發的，而PrusaSlicer是基於來自Alessandro Ranellucci和RepRap社群的Slic3r開發的"
+
+msgid "Libraries"
+msgstr "庫"
+
+msgid "This software uses open source components whose copyright and other proprietary rights belong to their respective owners"
+msgstr "本軟體使用開源元件，其版權和其他所有權屬於各自的所有者"
+
+#, c-format, boost-format
+msgid "About %s"
+msgstr "關於 %s"
+
+msgid "Bambu Studio is based on PrusaSlicer by PrusaResearch and SuperSlicer by Merill(supermerill)."
+msgstr "Bambu Studio是以PrusaResearch的PrusaSlicer和Merill(supermerill)的SuperSlicer為基礎的。"
+
+msgid "PrusaSlicer is originally based on Slic3r by Alessandro Ranellucci."
+msgstr "PrusaSlicer最初是基於Alessandro Ranellucci的Slic3r。"
+
+msgid "Slic3r was created by Alessandro Ranellucci with the help of many other contributors."
+msgstr "Slic3r由Alessandro Ranellucci在其他眾多貢獻者的幫助下建立。"
+
+msgid "Bambu Studio also referenced some ideas from Cura by Ultimaker."
+msgstr "Bambu Studio還參考了Ultimaker的Cura中的一些想法。"
+
+msgid "There many parts of the software that come from community contributions, so we're unable to list them one-by-one, and instead, they'll be attributed in the corresponding code comments."
+msgstr "軟體中有很多部分來自於社群貢獻，因此我們不便逐一列出他們，作為替代，他們將在相應的程式碼註釋中被介紹。"
+
+msgid "AMS Materials Setting"
+msgstr "材料設定"
+
+msgid "Confirm"
+msgstr "確定"
+
+msgid "Close"
+msgstr "關閉"
+
+msgid "Colour"
+msgstr "顏色"
+
+msgid ""
+"Nozzle\n"
+"Temperature"
+msgstr "擠出頭溫度"
+
+msgid "max"
+msgstr "最大"
+
+msgid "min"
+msgstr "最小"
+
+#, boost-format
+msgid "The input value should be greater than %1% and less than %2%"
+msgstr "輸入的範圍在 %1% 和 %2% 之間"
+
+msgid "Factors of Flow Dynamics Calibration"
+msgstr "動態流量校準係數"
+
+msgid "Nozzle Type"
+msgstr "噴嘴型別"
+
+msgid "PA Profile"
+msgstr "PA 配置檔案"
+
+msgid "Factor K"
+msgstr "係數K"
+
+msgid "Factor N"
+msgstr "係數N"
+
+msgid "Setting AMS slot information while printing is not supported"
+msgstr "不支援在列印時設定AMS槽位資訊"
+
+msgid "Setting Virtual slot information while printing is not supported"
+msgstr "不支援在列印時設定虛擬槽位資訊"
+
+msgid "Are you sure you want to clear the filament information?"
+msgstr "您確定要清除耗材絲資訊嗎？"
+
+msgid "TPU needs a different feeding path and loading procedure. Otherwise clogging or jam may happen. Please read the tutorial before using TPU."
+msgstr "TPU 需採用特殊的進料路徑和流程，否則可能導致堵塞或卡料。請在使用前閱讀教程。"
+
+msgid "Go to Check"
+msgstr "前往檢視"
+
+msgid "You need to select the material type and color first."
+msgstr "您需要先選擇材料型別和顏色。"
+
+#, c-format, boost-format
+msgid "Please input a valid value (K in %.1f~%.1f)"
+msgstr "請輸入有效的數值（K的範圍為%.1f~%.1f）"
+
+#, c-format, boost-format
+msgid "Please input a valid value (K in %.1f~%.1f, N in %.1f~%.1f)"
+msgstr "請輸入有效的數值（K的範圍為%.1f~%.1f，N的範圍為%.1f~%.1f）"
+
+msgid "Note: The hotend number on the right extruder is tied to the holder. When the hotend is moved to a new holder, its number will update automatically."
+msgstr "注意：右擠出機上的熱端編號與刀架繫結。當熱端移動至新刀架時，其編號會自動更新。"
+
+msgid ""
+"The nozzle flow is not set. Please set the nozzle flow rate before editing the filament.\n"
+"'Device -> Print parts'"
+msgstr ""
+"噴嘴的流量未設定，無法編輯材料，請設定噴嘴流量後再操作。\n"
+"'裝置頁面->印表機零件'"
+
+msgid "AMS"
+msgstr "AMS"
+
+msgid "Other Color"
+msgstr "其他顏色"
+
+msgid "Custom Color"
+msgstr "自定義顏色"
+
+msgid "Dynamic flow calibration"
+msgstr "動態流量校準"
+
+msgid "The nozzle temp and max volumetric speed will affect the calibration results. Please fill in the same values as the actual printing. They can be auto-filled by selecting a filament preset."
+msgstr "噴嘴溫度和最大體積速度會影響到校準結果，請填寫與實際列印相同的數值。可透過選擇已有的材料預設來自動填寫。"
+
+msgid "Nozzle Diameter"
+msgstr "噴嘴直徑"
+
+msgid "Bed Type"
+msgstr "列印板型別"
+
+msgid "Nozzle temperature"
+msgstr "噴嘴溫度"
+
+msgid "Bed Temperature"
+msgstr "熱床溫度"
+
+msgid "Max volumetric speed"
+msgstr "最大體積速度"
+
+msgid "Bed temperature"
+msgstr "床溫"
+
+msgid "Start calibration"
+msgstr "開始"
+
+msgid "Next"
+msgstr "下一步"
+
+msgid "Calibration completed. Please find the most uniform extrusion line on your hot bed like the picture below, and fill the value on its left side into the factor K input box."
+msgstr "校準完成。請在您的熱床上找到如下圖所示的最均勻的擠出線，並將其左側的數值填入因子K的輸入框。"
+
+msgid "Save"
+msgstr "儲存"
+
+msgid "Last Step"
+msgstr "上一步"
+
+msgid "Example"
+msgstr "示例"
+
+#, c-format, boost-format
+msgid "Calibrating... %d%%"
+msgstr "校準中... %d%%"
+
+msgid "Calibration completed"
+msgstr "校準已完成"
+
+#, c-format, boost-format
+msgid "%s does not support %s"
+msgstr "%s 不支援 %s"
+
+msgid "Dynamic flow Calibration"
+msgstr "動態流量校準"
+
+msgid "Step"
+msgstr "步驟"
+
+msgid "Unmapped"
+msgstr "未匹配"
+
+msgid ""
+"Upper half area:  Original\n"
+"Lower half area: The filament from original project will be used when unmapped.\n"
+"And you can click it to modify"
+msgstr ""
+"上半部分：原專案耗材\n"
+"下半部分：未匹配則使用原專案耗材\n"
+"您可以單擊它進行修改"
+
+msgid ""
+"Upper half area:  Original\n"
+"Lower half area:  Filament in AMS\n"
+"And you can click it to modify"
+msgstr ""
+"上半部分：原專案耗材\n"
+"下半部分：AMS中的耗材\n"
+"您可以單擊它進行修改"
+
+msgid ""
+"Upper half area:  Original\n"
+"Lower half area:  Filament in AMS\n"
+"And you cannot click it to modify"
+msgstr ""
+"上半部分：原專案耗材\n"
+"下半部分：AMS中的耗材\n"
+"您不能單擊它進行修改"
+
+msgid "AMS Slots"
+msgstr "AMS艙內材料"
+
+msgid "Please select from the following filaments"
+msgstr "請從以下耗材中選擇"
+
+msgid "Select filament that installed to the left nozzle"
+msgstr "請選擇安裝到左噴嘴的耗材絲"
+
+msgid "Select filament that installed to the right nozzle"
+msgstr "請選擇安裝到右噴嘴的耗材絲"
+
+msgid "Left AMS"
+msgstr "左側AMS"
+
+msgid "External"
+msgstr "外部"
+
+msgid "Reset current filament mapping"
+msgstr "重置當前耗材對映"
+
+msgid "Right AMS"
+msgstr "右側AMS"
+
+msgid "Tips: To learn about the filaments matching rules, Please refer to Wiki before use->"
+msgstr "注意：如果想要不可選擇的材料，詳細說明請檢視Wiki->"
+
+msgid "Please select the filament installed on the left nozzle."
+msgstr "請選擇安裝在左噴嘴上的耗材絲。"
+
+msgid "Please select the filament installed on the right nozzle."
+msgstr "請選擇安裝在右噴嘴上的耗材絲。"
+
+msgid "Nozzle"
+msgstr "噴嘴"
+
+msgid "Ext"
+msgstr ""
+
+msgid "Select Filament && Hotends"
+msgstr "選擇材料預設和噴頭"
+
+msgid "Select Filament"
+msgstr ""
+
+#, c-format, boost-format
+msgid "Printing with the current nozzle may produce an extra %0.2f g of waste."
+msgstr "使用當前噴嘴列印可能會產生額外 %0.2f 克廢料。"
+
+#, c-format, boost-format
+msgid "Tips: the filament type(%s) does not match with the filament type(%s) in the slicing file. If you want to use this slot, you can install %s instead of %s and change slot information on the 'Device' page."
+msgstr "提示：耗材型別(%s)與切片檔案中的耗材型別(%s)不匹配。如果您想使用此槽位，可以安裝%s替代%s，並在“裝置”頁面更改槽位資訊。"
+
+#, c-format, boost-format
+msgid "Cannot select: the filament type(%s) does not match with the filament type(%s) in the slicing file. If you want to use this slot, you can install %s instead of %s and change slot information on the 'Device' page."
+msgstr "無法選擇：耗材型別(%s)與切片檔案中的耗材型別(%s)不匹配。如果您想使用此槽位，可以安裝%s替代%s，並在“裝置”頁面更改槽位資訊。"
+
+#, c-format, boost-format
+msgid "Cannot select: the slot is empty or undefined. If you want to use this slot, you can install %s and change slot information on the 'Device' page."
+msgstr "無法選擇：槽位為空或未定義。如果您想使用此槽位，可以安裝%s，並在“裝置”頁面更改槽位資訊。"
+
+msgid "Cannot select: No filament loaded in current slot."
+msgstr "無法選擇：當前槽位中未載入耗材。"
+
+msgid "Enable AMS"
+msgstr "啟用AMS"
+
+msgid "Print with filaments in the AMS"
+msgstr "採用AMS裡的材料列印"
+
+msgid "Disable AMS"
+msgstr "不啟用AMS"
+
+msgid "Print with the filament mounted on the back of chassis"
+msgstr "使用機箱背後掛載的材料列印"
+
+msgid "Please change the desiccant when it is too wet. The indicator may not represent accurately in following cases : when the lid is open or the desiccant pack is changed. it take hours to absorb the moisture, low temperatures also slow down the process."
+msgstr "*當乾燥劑過於潮溼時，請及時更換。以下幾種情況下, 指示器可能無法準確反映情況：蓋子開啟或乾燥劑包被替換時，乾燥劑需要數小時吸收潮氣；低溫也會延緩該過程。"
+
+msgid "Config which AMS slot should be used for a filament used in the print job"
+msgstr "配置當前列印任務應使用哪個AMS槽位"
+
+msgid "Filament used in this print job"
+msgstr "當前列印使用的耗材絲"
+
+msgid "AMS slot used for this filament"
+msgstr "當前耗材絲對應的AMS槽位"
+
+msgid "Click to select AMS slot manually"
+msgstr "點選以手動選擇AMS槽位"
+
+msgid "Do not Enable AMS"
+msgstr "不啟用AMS"
+
+msgid "Print using materials mounted on the back of the case"
+msgstr "使用安裝在機箱背面的材料進行列印"
+
+msgid "Print with filaments in AMS"
+msgstr "採用AMS裡的材料列印"
+
+msgid "Print with filaments mounted on the back of the chassis"
+msgstr "採用掛載在機箱背部的材料列印"
+
+msgid "Auto Refill"
+msgstr "自動續料"
+
+msgid "Left"
+msgstr "左"
+
+msgid "Right"
+msgstr "右"
+
+msgid "When the current material run out, the printer will continue to print in the following order."
+msgstr "當前材料耗盡時，印表機將按照以下順序繼續列印。"
+
+msgid "Identical filament: same brand, type and color"
+msgstr "相同的耗材: 相同的品牌、型別和顏色"
+
+msgid "Group"
+msgstr "組"
+
+msgid "When the current material runs out, the printer would use identical filament to continue printing."
+msgstr "當前材料用完時，印表機將使用相同的耗材繼續列印"
+
+msgid "The printer does not currently support auto refill."
+msgstr "印表機當前不支援自動重新填充。"
+
+msgid "AMS filament backup is not enabled, please enable it in the AMS settings."
+msgstr "AMS自動續料未啟用，請在AMS設定中啟用。"
+
+msgid ""
+"When the current filament runs out, the printer will use identical filament to continue printing.\n"
+"*Identical filament: same brand, type and color."
+msgstr ""
+"當前耗材用完時，印表機將使用相同的耗材繼續列印。\n"
+"*相同的耗材：相同的品牌、型別和顏色。"
+
+msgid "DRY"
+msgstr ""
+
+msgid "WET"
+msgstr ""
+
+msgid "AMS Settings"
+msgstr "AMS 設定"
+
+msgid "Insertion update"
+msgstr "插入料時更新"
+
+msgid "The AMS will automatically read the filament information when inserting a new Bambu Lab filament. This takes about 20 seconds."
+msgstr "當插入新的Bambu Lab耗材絲的時候，AMS會自動讀取耗材絲資訊。這個過程大約需要20秒。"
+
+msgid "Note: if a new filament is inserted during  printing, the AMS will not automatically read any information until printing is completed."
+msgstr "注意：如果是在列印過程中插入新的耗材絲，AMS會在列印結束後自動讀取此耗材絲資訊。"
+
+msgid "When inserting a new filament, the AMS will not automatically read its information, leaving it blank for you to enter manually."
+msgstr "在插入一卷新料時，AMS將不會自動讀取料卷資訊，預留一個空的料卷資訊等待您手動輸入。"
+
+msgid "Power on update"
+msgstr "開機時檢測"
+
+msgid "The AMS will automatically read the information of inserted filament on start-up. It will take about 1 minute.The reading process will roll filament spools."
+msgstr "每次開機時，AMS將會自動讀取其所插入的耗材資訊(讀取過程會轉料卷)。需要花時大約1分鐘。"
+
+msgid "The AMS will not automatically read information from inserted filament during startup and will continue to use the information recorded before the last shutdown."
+msgstr "AMS不會在啟動時自動讀取耗材絲資訊。它會使用上次關機前記錄的資訊。"
+
+msgid "Update remaining capacity"
+msgstr "更新剩餘容量"
+
+msgid "AMS will attempt to estimate the remaining capacity of the Bambu Lab filaments."
+msgstr "AMS 將會嘗試估算 Bambulab 官方耗材的剩餘容量。"
+
+msgid "AMS filament backup"
+msgstr "AMS自動續料"
+
+msgid "AMS will continue to another spool with the same properties of filament automatically when current filament runs out"
+msgstr "AMS料材絲耗盡後將自動切換到屬性完全相同的耗材絲"
+
+msgid "Air Printing Detection"
+msgstr "空打檢測"
+
+msgid "Detects clogging and filament grinding, halting printing immediately to conserve time and filament."
+msgstr "檢測到堵塞和耗材絲碾磨，立即停止列印以節約時間和耗材絲"
+
+msgid "AMS Type"
+msgstr "AMS 型別"
+
+msgid "Switching"
+msgstr "切換中"
+
+msgid "The printer is busy and cannot switch AMS type."
+msgstr "印表機正忙，無法切換AMS型別。"
+
+msgid "Please unload all filament before switching."
+msgstr "切換前請卸下所有耗材絲。"
+
+msgid "AMS type switching needs firmware update, taking about 30s. Switch now ?"
+msgstr "AMS 型別切換需要更新韌體，耗時約 30秒。現在切換嗎？"
+
+msgid "Arrange AMS Order"
+msgstr "重新排序 AMS"
+
+msgid "If you want a specific AMS ID sequence, please disconnect all AMS after clicking 'Reset', and then reconnect them in the desired order."
+msgstr "如果您想要特定的AMS ID序列，請在點選“重置”後斷開所有AMS，然後按所需順序重新連線它們。"
+
+msgid "Are you sure to reset the ID sequence of the connected AMS?"
+msgstr "您確定要重置已連線AMS的ID序列嗎？"
+
+msgid "Reset AMS Sequence"
+msgstr "重置AMS序列"
+
+msgid "File"
+msgstr "檔案"
+
+msgid "Calibration"
+msgstr "校準"
+
+msgid "Failed to download the plug-in. Please check your firewall settings and vpn software, check and retry."
+msgstr "外掛下載失敗。請檢查您的防火牆設定和vpn軟體,檢查後重試。"
+
+msgid "Failed to install the plug-in. Please check whether it is blocked or deleted by anti-virus software."
+msgstr "安裝外掛失敗。請檢查是否被防毒軟體遮蔽或刪除。"
+
+msgid "click here to see more info"
+msgstr "點選這裡檢視更多資訊"
+
+msgid "Please home all axes (click "
+msgstr "請先執行回原點（點選"
+
+msgid ") to locate the toolhead's position. This prevents device moving beyond the printable boundary and causing equipment wear."
+msgstr "）操作以定位當前工具頭位置，以防止軸移動時超出邊界造成裝置磨損"
+
+msgid "Go Home"
+msgstr "回原點"
+
+msgid "An error occurred. Maybe memory of system is not enough or it's a bug of the program"
+msgstr "發生錯誤。可能系統記憶體不足或者程式存在bug。"
+
+msgid "Please save project and restart the program. "
+msgstr "請儲存專案並重啟程式。"
+
+msgid "Processing G-Code from Previous file..."
+msgstr "從之前的檔案載入G程式碼..."
+
+msgid "Slicing complete"
+msgstr "切片完成"
+
+msgid "Access violation"
+msgstr "非法訪問"
+
+msgid "Illegal instruction"
+msgstr "非法指令"
+
+msgid "Divide by zero"
+msgstr "除零"
+
+msgid "Overflow"
+msgstr "上溢"
+
+msgid "Underflow"
+msgstr "下溢"
+
+msgid "Floating reserved operand"
+msgstr "浮點保留運算元"
+
+msgid "Stack overflow"
+msgstr "棧溢位"
+
+msgid "Running post-processing scripts"
+msgstr "執行後處理指令碼"
+
+msgid "Successfully executed post-processing script"
+msgstr "成功執行後處理指令碼"
+
+msgid "Unknown error when export G-code."
+msgstr "匯出G-code檔案發生未知錯誤。"
+
+#, boost-format
+msgid ""
+"Failed to save gcode file.\n"
+"Error message: %1%.\n"
+"Source file %2%."
+msgstr ""
+"無法儲存Gcode檔案。\n"
+"錯誤資訊：%1%。\n"
+"原始檔 %2%."
+
+msgid "Copying of the temporary G-code to the output G-code failed"
+msgstr "將臨時 G 程式碼複製到輸出 G 程式碼失敗"
+
+#, boost-format
+msgid "Scheduling upload to `%1%`. See Window -> Print Host Upload Queue"
+msgstr "計劃上傳到 `%1%`。請參閱視窗-> 列印主機上傳佇列"
+
+msgid "Origin"
+msgstr "原點"
+
+msgid "Size in X and Y of the rectangular plate."
+msgstr "矩形框在X和Y方向的尺寸。"
+
+msgid "Distance of the 0,0 G-code coordinate from the front left corner of the rectangle."
+msgstr "G-code 0,0 座標相對於矩形框左前角的距離。"
+
+msgid "Diameter of the print bed. It is assumed that origin (0,0) is located in the center."
+msgstr "熱床直徑。假定原點 (0,0) 位於中心。"
+
+msgid "Rectangular"
+msgstr "矩形"
+
+msgid "Circular"
+msgstr "圓"
+
+msgid "Settings"
+msgstr "設定"
+
+msgid "Texture"
+msgstr "紋理"
+
+msgid "Remove"
+msgstr "移除"
+
+msgid "Not found:"
+msgstr "未發現："
+
+msgid "Model"
+msgstr "模型"
+
+msgid "Choose an STL file to import bed shape from:"
+msgstr "選擇熱床形狀的 STL 檔案："
+
+msgid "Invalid file format."
+msgstr "無效的檔案格式。"
+
+msgid "Error! Invalid model"
+msgstr "錯誤！無效模型"
+
+msgid "The selected file contains no geometry."
+msgstr "所選檔案不包含任何幾何資料。"
+
+msgid "The selected file contains several disjoint areas. This is not supported."
+msgstr "所選檔案包含多個未連線的區域。不支援這種型別。"
+
+msgid "Choose a file to import bed texture from (PNG/SVG):"
+msgstr "選擇 (PNG/SVG) 檔案作為熱床紋理："
+
+#, c-format, boost-format
+msgid "The file exceeds %d MB, please import again."
+msgstr "檔案超過 %d MB，請重新匯入。"
+
+msgid "Exception in obtaining file size, please import again."
+msgstr "獲取檔案大小異常，請重新匯入。"
+
+msgid "Choose an STL file to import bed model from:"
+msgstr "選擇 STL 檔案來匯入床模型:"
+
+msgid "Bed Shape"
+msgstr "熱床形狀"
+
+msgid "The recommended minimum temperature is less than 190 degree or the recommended maximum temperature is greater than 300 degree.\n"
+msgstr "建議最低溫度低於 190 度或建議最高溫度高於 300 度。\n"
+
+msgid "The recommended minimum temperature cannot be higher than the recommended maximum temperature.\n"
+msgstr "推薦最低溫度不能大於推薦最高溫度。\n"
+
+msgid "Please check.\n"
+msgstr "請檢查。\n"
+
+msgid ""
+"Nozzle may be blocked when the temperature is out of recommended range.\n"
+"Please confirm whether to use the temperature for printing.\n"
+"\n"
+msgstr ""
+"當溫度超過建議的範圍時，噴嘴可能會堵塞。\n"
+"請確認是否使用該溫度列印\n"
+"\n"
+
+#, c-format, boost-format
+msgid "Recommended nozzle temperature of this filament type is [%d, %d] degree centigrade"
+msgstr "該耗材的推薦噴嘴溫度是[%d, %d]攝氏度"
+
+msgid ""
+"Too small max volumetric speed.\n"
+"Reset to 0.5"
+msgstr ""
+"最大體積流量設定過小\n"
+"重置為0.5"
+
+msgid ""
+"Should not large than 100%.\n"
+"Reset to defualt"
+msgstr "起始高度不應大於100%。將重置為預設值"
+
+#, c-format, boost-format
+msgid "Current chamber temperature is higher than the material's safe temperature,it may result in material softening and clogging.The maximum safe temperature for the material is %d"
+msgstr "當前腔體溫度高於材料的安全溫度，這可能導致材料軟化和堵塞。該材料的最高安全溫度為 %d。"
+
+msgid ""
+"Too small layer height.\n"
+"Reset to 0.2"
+msgstr "層高過小。將重置為0.2"
+
+msgid ""
+"Too large layer height.\n"
+"Reset to 0.2"
+msgstr "層高過大。將重置為0.2"
+
+msgid ""
+"Should not large than layer height.\n"
+"Reset to 10%"
+msgstr "起始高度不應大於層高度。重置為10%"
+
+msgid ""
+"Too small ironing spacing.\n"
+"Reset to 0.1"
+msgstr "熨燙線距過小。將重置為0.1"
+
+msgid ""
+"Too small support ironing spacing.\n"
+"Reset to 0.1"
+msgstr "支撐熨燙線距過小。將重置為0.1"
+
+msgid ""
+"Support ironing will not work with sparse support interface.\n"
+"Do you want to adjust the support interface config to use ironing?\n"
+"Yes: make the support interface solid.\n"
+"No: disable the support ironing."
+msgstr ""
+"支援熨燙功能不適用於稀疏的支撐介面。\n"
+"您要調整支撐介面配置以使用熨燙功能嗎？\n"
+"是：使支撐介面變為實心。\n"
+"否：禁用支撐熨燙。"
+
+msgid ""
+"Zero initial layer height is invalid.\n"
+"\n"
+"The first layer height will be reset to 0.2."
+msgstr ""
+"首層層高為無效的0值。\n"
+"將被重置為0.2。"
+
+msgid ""
+"This setting is only used for model size tuning with small value in some cases.\n"
+"For example, when the model size has slight errors and is difficult be assembled.\n"
+"For large size tuning, please use model scaling function.\n"
+"\n"
+"The value will be reset to 0."
+msgstr ""
+"這個設定僅用於在特定場景下微調模型尺寸。\n"
+"例如，當模型尺寸有小誤差，難以裝配。\n"
+"對於大尺寸的調整，請使用模型縮放功能。\n"
+"\n"
+"這個數值將被重置為0。"
+
+msgid ""
+"Too large elephant foot compensation is unreasonable.\n"
+"If really have serious elephant foot effect, please check other settings.\n"
+"For example, whether bed temperature is too high.\n"
+"\n"
+"The value will be reset to 0."
+msgstr ""
+"過大的象腳補償是不合理的。\n"
+"如果確實有嚴重的象腳效應，請檢查其他設定。\n"
+"例如，是否設定了過高的床溫。\n"
+"\n"
+"這個數值將被重置為0。"
+
+msgid ""
+"Prime tower does not work when Adaptive Layer Height or Independent Support Layer Height is on.\n"
+"Which do you want to keep?\n"
+"YES - Keep Prime Tower\n"
+"NO  - Keep Adaptive Layer Height and Independent Support Layer Height"
+msgstr ""
+"擦料塔不支援和自適應層高或支撐獨立層高。同時開啟\n"
+"如何選擇？\n"
+"是 - 選擇開啟擦料塔\n"
+"否 - 選擇保留自適應層高或支撐獨立層高"
+
+msgid ""
+"Prime tower does not work when Adaptive Layer Height is on.\n"
+"Which do you want to keep?\n"
+"YES - Keep Prime Tower\n"
+"NO  - Keep Adaptive Layer Height"
+msgstr ""
+"擦料塔不支援和自適應層高同時開啟。\n"
+"如何選擇？\n"
+"是 - 選擇開啟擦料塔\n"
+"否 - 選擇保留自適應層高"
+
+msgid ""
+"Prime tower does not work when Independent Support Layer Height is on.\n"
+"Which do you want to keep?\n"
+"YES - Keep Prime Tower\n"
+"NO  - Keep Independent Support Layer Height"
+msgstr ""
+"擦料塔不支援和支撐獨立層高同時開啟。\n"
+"如何選擇？\n"
+"是 - 選擇開啟擦料塔\n"
+"否 - 選擇保留支撐獨立層高"
+
+#, boost-format
+msgid "%1% infill pattern doesn't support 100%% density."
+msgstr "%1% 填充圖案不支援 100%% 密度。"
+
+msgid ""
+"Switch to rectilinear pattern?\n"
+"Yes - switch to rectilinear pattern automatically\n"
+"No  - reset density to default non 100% value automatically"
+msgstr ""
+"切換到直線圖案？\n"
+"是 - 自動切換到直線圖案\n"
+"否 - 自動將密度重置為預設的非100%值"
+
+msgid ""
+"While printing by Object, the extruder may collide skirt.\n"
+"Thus, reset the skirt layer to 1 to avoid that."
+msgstr "逐件列印時，擠出機可能與裙邊碰撞。因此將裙邊的層數重置為1。"
+
+#, c-format, boost-format
+msgid ""
+"lock depth should smaller than skin depth.\n"
+"Reset to 50%% of skin depth"
+msgstr ""
+"互鎖深度應該比表皮深度小,\n"
+"重設為表皮深度的一半"
+
+msgid "Spiral mode only works when wall loops is 1, support is disabled, clumping detection by probing is disabled, top shell layers is 0, sparse infill density is 0, timelapse type is traditional and smoothing wall speed in z direction is false."
+msgstr "花瓶模式僅在以下條件下可用：牆壁環數設定為 1，支撐禁用，觸碰裹頭檢測禁用，頂殼層數為 0，稀疏填充密度為 0，延時攝影型別為傳統，並且 Z 方向牆速度平滑不啟用。"
+
+msgid " But machines with I3 structure will not generate timelapse videos."
+msgstr "但是I3結構的機器將不會生成延時影片。"
+
+msgid ""
+"Change these settings automatically? \n"
+"Yes - Change these settings and enable spiral mode automatically\n"
+"No  - Give up using spiral mode this time"
+msgstr ""
+"自動調整這些設定？\n"
+"是 - 自動調整這些設定並開啟旋轉模式\n"
+"否 - 暫不使用旋轉模式"
+
+msgid "Printing"
+msgstr "列印中"
+
+msgid "Auto bed leveling"
+msgstr "自動熱床調平"
+
+msgid "Heatbed preheating"
+msgstr "預加熱熱床"
+
+msgid "Vibration compensation"
+msgstr "振動補償"
+
+msgid "Changing filament"
+msgstr "換料"
+
+msgid "M400 pause"
+msgstr "M400暫停"
+
+msgid "Paused (filament ran out)"
+msgstr "暫停（耗材用盡）"
+
+msgid "Heating nozzle"
+msgstr "加熱噴嘴"
+
+msgid "Calibrating dynamic flow"
+msgstr "動態流量校準"
+
+msgid "Scanning bed surface"
+msgstr "掃描熱床"
+
+msgid "Inspecting first layer"
+msgstr "掃描首層"
+
+msgid "Identifying build plate type"
+msgstr "識別列印板型別"
+
+msgid "Calibrating Micro Lidar"
+msgstr "雷達相機校準"
+
+msgid "Homing toolhead"
+msgstr "工具頭回中"
+
+msgid "Cleaning nozzle tip"
+msgstr "清理噴嘴頭"
+
+msgid "Checking extruder temperature"
+msgstr "檢查擠出溫度"
+
+msgid "Paused by the user"
+msgstr "使用者暫停"
+
+msgid "Pause (front cover fall off)"
+msgstr "暫停（工具頭前蓋掉落）"
+
+msgid "Calibrating the micro lidar"
+msgstr "鐳射雷達校準"
+
+msgid "Calibrating flow ratio"
+msgstr "校準流量比例"
+
+msgid "Pause (nozzle temperature malfunction)"
+msgstr "暫停（噴嘴溫控異常）"
+
+msgid "Pause (heatbed temperature malfunction)"
+msgstr "暫停（熱床溫控異常）"
+
+msgid "Filament unloading"
+msgstr "退料中"
+
+msgid "Pause (step loss)"
+msgstr "暫停（丟步）"
+
+msgid "Filament loading"
+msgstr "進料中"
+
+msgid "Motor noise cancellation"
+msgstr "電機降噪"
+
+msgid "Pause (AMS offline)"
+msgstr "暫停（AMS離線）"
+
+msgid "Pause (low speed of the heatbreak fan)"
+msgstr "暫停（熱阻風扇異常）"
+
+msgid "Pause (chamber temperature control problem)"
+msgstr "暫停（腔溫控制異常）"
+
+msgid "Cooling chamber"
+msgstr "腔溫冷卻中"
+
+msgid "Pause (Gcode inserted by user)"
+msgstr "暫停（使用者插入Gcode）"
+
+msgid "Motor noise showoff"
+msgstr "電機噪聲展示"
+
+msgid "Pause (nozzle clumping)"
+msgstr "暫停（裹頭）"
+
+msgid "Pause (cutter error)"
+msgstr "暫停（切刀異常）"
+
+msgid "Pause (first layer error)"
+msgstr "暫停（首層掃描異常）"
+
+msgid "Pause (nozzle clog)"
+msgstr "暫停（堵頭）"
+
+msgid "Measuring motion percision"
+msgstr "檢查運動精度"
+
+msgid "Enhancing motion percision"
+msgstr "運動精度增強"
+
+msgid "Measure motion accuracy"
+msgstr "校準後檢測印表機絕對精度"
+
+msgid "Nozzle offset calibration"
+msgstr "噴嘴偏移校準"
+
+msgid "high temperature auto bed levelling"
+msgstr "高溫熱床校準"
+
+msgid "Auto Check: Quick Release Lever"
+msgstr "自動檢測：快拆鎖釦"
+
+msgid "Auto Check: Door and Upper Cover"
+msgstr "自動檢測：前門及上蓋"
+
+msgid "Laser Calibration"
+msgstr "鐳射元件校準"
+
+msgid "Auto Check: Platform"
+msgstr "自動檢測：墊板"
+
+msgid "Confirming BirdsEye Camera location"
+msgstr "俯視攝像頭位置確認"
+
+msgid "Calibrating BirdsEye Camera"
+msgstr "俯視攝像頭校準"
+
+msgid "Auto bed leveling -phase 1"
+msgstr "自動熱床調平 –階段一"
+
+msgid "Auto bed leveling -phase 2"
+msgstr "自動熱床調平 –階段二"
+
+msgid "Heating chamber"
+msgstr "腔體加熱中 "
+
+msgid "Adjusting heatbed temperature"
+msgstr "熱床溫度調節中"
+
+msgid "Printing calibration lines"
+msgstr "列印標定線"
+
+msgid "Auto Check: Material"
+msgstr "自動檢測：材料"
+
+msgid "Live View Camera Calibration"
+msgstr "實況攝像頭校準"
+
+msgid "Waiting for heatbed to reach target temperature"
+msgstr "等待熱床溫度到位"
+
+msgid "Auto Check: Material Position"
+msgstr "自動檢測：材料位置"
+
+msgid "Cutting Module Offset Calibration"
+msgstr "刀切模組偏移校準"
+
+msgid "Measuring Surface"
+msgstr "曲面測量中"
+
+msgid "Homing Blade Holder"
+msgstr "刀架回到起始點"
+
+msgid "Calibrating Camera Offset"
+msgstr "攝像頭偏移校準"
+
+msgid "Calibrating Blade Holder Position"
+msgstr "刀架位置校準"
+
+msgid "Hotend Pick and Place Test"
+msgstr "熱端取放測試"
+
+msgid "Waiting for the Chamber temperature to equalize"
+msgstr "等待腔溫勻熱"
+
+msgid "Preparing Hotend"
+msgstr "熱端準備中"
+
+msgid "Calibrating the detection position of nozzle clumping"
+msgstr "裹頭檢測位置校準"
+
+msgid "Purifying the chamber air"
+msgstr "腔體空氣淨化中"
+
+msgid "Preparing AMS"
+msgstr "AMS準備中"
+
+msgid "Timelapse is not supported on this printer."
+msgstr "此印表機不支援延時攝影"
+
+msgid "Timelapse is not supported while the storage does not exist."
+msgstr "沒有儲存介質，故無法啟用延時攝影"
+
+msgid "Timelapse is not supported while the storage is unavailable."
+msgstr "儲存介質不可用，故無法啟用延時攝影"
+
+msgid "Timelapse is not supported while the storage is readonly."
+msgstr "儲存介質當前是隻讀的，故無法啟用延時攝影"
+
+msgid "To ensure your safety, certain processing tasks (such as laser) can only be resumed on printer."
+msgstr "為確保您的安全，部分加工任務（如鐳射）只能在印表機上恢復加工。"
+
+#, c-format, boost-format
+msgid "The chamber temperature is too high, which may cause the filament to soften. Please wait until the chamber temperature drops below %d℃. You may open the front door or enable fans to cool down."
+msgstr "腔溫過高，可能導致列印材料軟化。請等待腔溫降至%d℃。您可以開啟前門或啟用風扇進行降溫。"
+
+#, c-format, boost-format
+msgid "AMS temperature is too high, which may cause the filament to soften. Please wait until the AMS temperature drops below %d℃."
+msgstr "AMS 溫度過高，可能導致列印材料軟化。請等待 AMS 溫度降至%d℃ 以下。"
+
+msgid "The current chamber temperature or the target chamber temperature exceeds 45℃.In order to avoid extruder clogging,low temperature filament(PLA/PETG/TPU) is not allowed to be loaded."
+msgstr "當前腔溫或目標腔溫超過了45℃。為了避免擠出機堵塞，不允許載入低溫度的列印材料（如PLA/PETG/TPU）"
+
+msgid "Low temperature filament(PLA/PETG/TPU) is loaded in the extruder.In order to avoid extruder clogging,it is not allowed to set the chamber temperature."
+msgstr "擠出機中載入了低溫度的列印材料（如PLA/PETG/TPU）。為了避免擠出機堵塞，不允許設定腔溫。"
+
+msgid "When you set the chamber temperature below 40℃, the chamber temperature control will not be activated. And the target chamber temperature will automatically be set to 0℃."
+msgstr "當您設定的腔溫低於40℃時，腔溫控制將不會啟動。並且目標腔溫將自動設定為0℃。"
+
+msgid "Failed to start printing job"
+msgstr "發起列印任務失敗"
+
+msgid "Resume Printing"
+msgstr "繼續列印"
+
+msgid "Resume (defects acceptable)"
+msgstr "繼續 （缺陷可接受）"
+
+msgid "Resume (problem solved)"
+msgstr "繼續（問題已解決）"
+
+msgid "Stop Printing"
+msgstr "停止列印"
+
+msgid "Check Assistant"
+msgstr "前往機器助手"
+
+msgid "Filament Extruded, Continue"
+msgstr "耗材已擠出，繼續"
+
+msgid "Not Extruded Yet, Retry"
+msgstr "耗材未擠出，重試"
+
+msgid "Finished, Continue"
+msgstr "已完成，繼續"
+
+msgid "Load Filament"
+msgstr "進料並前往進料頁面"
+
+msgid "Filament Loaded, Resume"
+msgstr "耗材已載入，繼續"
+
+msgid "View Liveview"
+msgstr "檢視LiveView"
+
+msgid "No Reminder Next Time"
+msgstr "下次不再提醒"
+
+msgid "Ignore. Don't Remind Next Time"
+msgstr "忽略，下次不再提醒"
+
+msgid "Ignore this and Resume"
+msgstr "忽略此問題，繼續"
+
+msgid "Problem Solved and Resume"
+msgstr "問題已解決，繼續"
+
+msgid "Got it, Turn off the Fire Alarm."
+msgstr "我已知曉，關閉火警警報"
+
+msgid "Retry (problem solved)"
+msgstr "重試 (問題已解決）"
+
+msgid "Cancle"
+msgstr "取消"
+
+msgid "Stop Drying"
+msgstr "停止烘乾"
+
+msgid "Proceed"
+msgstr "繼續執行"
+
+msgid "Abort"
+msgstr "退出"
+
+msgid "Done"
+msgstr "完成"
+
+msgid "Retry"
+msgstr "重試"
+
+msgid "Resume"
+msgstr "繼續"
+
+msgid "Unknown error."
+msgstr "未知錯誤。"
+
+msgid "Loading ..."
+msgstr "載入中..."
+
+msgid "Network unavailable"
+msgstr "網路不可用"
+
+msgid "default"
+msgstr "預設"
+
+msgid "parameter name"
+msgstr "引數名稱"
+
+msgid "N/A"
+msgstr "N/A"
+
+#, c-format, boost-format
+msgid "%s can't be percentage"
+msgstr "%s 不可以是百分比"
+
+#, c-format, boost-format
+msgid "Value %s is out of range, continue?"
+msgstr "值 %s 越界，是否繼續？"
+
+msgid "Parameter validation"
+msgstr "引數驗證"
+
+#, c-format, boost-format
+msgid "Value %s is out of range. The valid range is from %d to %d."
+msgstr "值 %s 超出了範圍，有效的範圍是從 %d 到 %d 。"
+
+msgid "Value is out of range."
+msgstr "值越界。"
+
+#, c-format, boost-format
+msgid ""
+"Is it %s%% or %s %s?\n"
+"YES for %s%%, \n"
+"NO for %s %s."
+msgstr ""
+"%s%%還是%s %s？\n"
+"是：%s%%\n"
+"否：%s %s"
+
+#, boost-format
+msgid "Invalid format. Expected vector format: \"%1%\""
+msgstr "無效格式，應該是\"%1%\"這種陣列格式"
+
+msgid "Clear color"
+msgstr "清除顏色"
+
+msgid "L"
+msgstr ""
+
+msgid "R"
+msgstr ""
+
+#, c-format, boost-format
+msgid "%s %s:"
+msgstr ""
+
+msgid "Std"
+msgstr ""
+
+msgid "HF"
+msgstr ""
+
+msgid "L:"
+msgstr ""
+
+msgid "R:"
+msgstr ""
+
+msgid "Loading G-codes"
+msgstr "正在載入G-code"
+
+msgid "Loading gcode data"
+msgstr "正在載入gcode資料"
+
+msgid "Loading segments"
+msgstr "正在載入線段"
+
+msgid "Summary"
+msgstr "概要"
+
+msgid "Layer Height"
+msgstr "層高"
+
+msgid "Line Width"
+msgstr "線寬"
+
+msgid "Fan Speed"
+msgstr "風扇速度"
+
+msgid "Flow"
+msgstr "流量"
+
+msgid "Tool"
+msgstr "工具"
+
+msgid "Layer Time"
+msgstr "層時間"
+
+msgid "Thermal Index (min)"
+msgstr "熱指數（最小）"
+
+msgid "Thermal Index (max)"
+msgstr "熱指數（最大）"
+
+msgid "Thermal Index (mean)"
+msgstr "熱指數（平均）"
+
+msgid "Statistics of All Plates"
+msgstr "所有盤切片資訊"
+
+msgid "Display"
+msgstr "顯示"
+
+msgid "Flushed"
+msgstr "沖刷"
+
+msgid "Tower"
+msgstr "擦料塔"
+
+msgid "Total"
+msgstr "總計"
+
+msgid "Total cost"
+msgstr "總成本"
+
+msgid "Time"
+msgstr "時間"
+
+msgid "Time Estimation"
+msgstr "時間預估"
+
+msgid "up to"
+msgstr "達到"
+
+msgid "above"
+msgstr "高於"
+
+msgid "from"
+msgstr "從"
+
+msgid "Slicing Result"
+msgstr "切片結果"
+
+msgid "Color Scheme"
+msgstr "顏色方案"
+
+msgid "Percent"
+msgstr "百分比"
+
+msgid "Used filament"
+msgstr "使用的耗材絲"
+
+msgid "Layer Height (mm)"
+msgstr "層高（mm）"
+
+msgid "Line Width (mm)"
+msgstr "線寬（mm）"
+
+msgid "Speed (mm/s)"
+msgstr "速度（mm/s）"
+
+msgid "Fan Speed (%)"
+msgstr "風扇速度（%）"
+
+msgid "Temperature (°C)"
+msgstr "溫度（℃）"
+
+msgid "Volumetric flow rate (mm³/s)"
+msgstr "體積流量速度（mm³/s）"
+
+msgid "Travel"
+msgstr "空駛"
+
+msgid "Seams"
+msgstr "縫"
+
+msgid "Retract"
+msgstr "回抽"
+
+msgid "Unretract"
+msgstr "裝填回抽"
+
+msgid "Filament Changes"
+msgstr "耗材絲更換"
+
+msgid "Wipe"
+msgstr "擦拭"
+
+msgid "Options"
+msgstr "選項"
+
+msgid "travel"
+msgstr "空駛"
+
+msgid "Extruder"
+msgstr "擠出機"
+
+msgid "Cost"
+msgstr "成本"
+
+msgid "Total time"
+msgstr "總時間"
+
+msgid "Filament change times"
+msgstr "換料次數"
+
+msgid "View Summary"
+msgstr "檢視摘要"
+
+msgid "Color change"
+msgstr "顏色更換"
+
+msgid "Print"
+msgstr "列印"
+
+msgid "Printer"
+msgstr "印表機"
+
+msgid "Print settings"
+msgstr "列印設定"
+
+msgid "Total Estimation"
+msgstr "總預估"
+
+msgid "Normal mode"
+msgstr "普通模式"
+
+msgid "Total Filament"
+msgstr "總耗材絲"
+
+msgid "Model Filament"
+msgstr "模型耗材絲"
+
+msgid "Prepare and timelapse time"
+msgstr "準備與延時攝影時間"
+
+msgid "Prepare time"
+msgstr "準備時間"
+
+msgid "Model printing time"
+msgstr "模型列印時間"
+
+msgid "Switch to silent mode"
+msgstr "切換到靜音模式"
+
+msgid "Switch to normal mode"
+msgstr "切換到普通模式"
+
+msgid "Automatically re-slice according to the optimal filament grouping, and the grouping results will be displayed after slicing."
+msgstr "將會自動根據最優耗材分組重新切片，分組結果將會在切片後展示。"
+
+msgid "Filament Grouping"
+msgstr "耗材分組"
+
+msgid "Why this grouping"
+msgstr "為什麼這樣分組"
+
+msgid "Left nozzle"
+msgstr "左噴嘴"
+
+msgid "Right nozzle"
+msgstr "右噴嘴"
+
+msgid "Please place filaments on the printer based on grouping result."
+msgstr "請按上述分組結果到印表機放置耗材"
+
+msgid "Tips:"
+msgstr "提示："
+
+msgid "Current grouping of slice result is not optimal."
+msgstr "當前材料分組不是最優結果。"
+
+#, boost-format
+msgid "Increase %1%g filament and %2% changes compared to optimal grouping."
+msgstr "如果使用最優分組可多節省%1%g耗材和%2%次換料。"
+
+#, boost-format
+msgid "Increase %1%g filament and save %2% changes compared to optimal grouping."
+msgstr "相較於最優分組，多使用%1%g耗材，減少%2%次換料。"
+
+#, boost-format
+msgid "Save %1%g filament and increase %2% changes compared to optimal grouping."
+msgstr "相較於最優分組，節省%1%g耗材，增加%2%次換料。"
+
+#, boost-format
+msgid "Save %1%g filament and %2% changes compared to a printer with one nozzle."
+msgstr "相較於單頭印表機可節省%1%g耗材和%2%次換料。"
+
+#, boost-format
+msgid "Save %1%g filament and increase %2% changes compared to a printer with one nozzle."
+msgstr "相較於單頭印表機，節省%1%g耗材，增加%2%次換料。"
+
+#, boost-format
+msgid "Increase %1%g filament and save %2% changes compared to a printer with one nozzle."
+msgstr "相較於單頭印表機，多使用%1%g耗材，減少%2%次換料。"
+
+msgid "Set to Optimal"
+msgstr "設定為最優"
+
+msgid "Regroup filament"
+msgstr "重新分組"
+
+msgid "Height: "
+msgstr "層高: "
+
+msgid "Width: "
+msgstr "線寬: "
+
+msgid "Speed: "
+msgstr "速度: "
+
+msgid "Flow: "
+msgstr "擠出流量: "
+
+msgid "Layer Time: "
+msgstr "層時間: "
+
+msgid "Fan Speed: "
+msgstr "風扇速度: "
+
+msgid "Temperature: "
+msgstr "溫度: "
+
+msgid "Thermal Index"
+msgstr "熱指數"
+
+msgid "Min: "
+msgstr "最小: "
+
+msgid "Max: "
+msgstr "最大: "
+
+msgid "Mean: "
+msgstr "平均: "
+
+msgid "Generating geometry vertex data"
+msgstr "正在生成幾何頂點資料"
+
+msgid "Generating geometry index data"
+msgstr "正在生成幾何索引資料"
+
+msgid ""
+"An object is placed in the left/right nozzle-only area or exceeds the printable height of the left nozzle.\n"
+"Please ensure the filaments used by this object are not arranged to other nozzles."
+msgstr ""
+
+msgid ""
+"An object is laid over the boundary of plate or exceeds the height limit.\n"
+"Please solve the problem by moving it totally on or off the plate, and confirming that the height is within the build volume."
+msgstr ""
+"物件被放置在列印板的邊界上或超過高度限制。\n"
+"請透過將其完全移動到列印板內或列印板外，並確認高度在列印空間以內來解決問題。"
+
+msgid "Variable layer height"
+msgstr "可變層高"
+
+msgid "Adaptive"
+msgstr "自適應"
+
+msgid "Quality / Speed"
+msgstr "細節/速度"
+
+msgid "Smooth"
+msgstr "平滑模式"
+
+msgid "Radius"
+msgstr "半徑"
+
+msgid "Keep min"
+msgstr "保留最小"
+
+msgid "Left mouse button:"
+msgstr "滑鼠左鍵："
+
+msgid "Add detail"
+msgstr "減小層高"
+
+msgid "Right mouse button:"
+msgstr "滑鼠右鍵："
+
+msgid "Remove detail"
+msgstr "增大層高"
+
+msgid "Shift + Left mouse button:"
+msgstr "Shift + 滑鼠左鍵："
+
+msgid "Reset to base"
+msgstr "設定到基礎層高"
+
+msgid "Shift + Right mouse button:"
+msgstr "Shift + 滑鼠右鍵："
+
+msgid "Smoothing"
+msgstr "平滑"
+
+msgid "Mouse wheel:"
+msgstr "滑鼠滾輪："
+
+msgid "Increase/decrease edit area"
+msgstr "增加/減小編輯區域"
+
+msgid "Sequence"
+msgstr "順序"
+
+msgid "object selection"
+msgstr "物體選擇"
+
+msgid "part selection"
+msgstr "零件選擇"
+
+msgid "number keys"
+msgstr "數字按鍵"
+
+msgid "number keys can quickly change the color of objects"
+msgstr "數字按鍵能快速修改物體的顏色"
+
+msgid "Following objects are laid over the boundary of plate or exceeds the height limit:\n"
+msgstr "以下物體位於盤的邊界上或超過了高度限制：\n"
+
+msgid "Please solve the problem by moving it totally on or off the plate, and confirming that the height is within the build volume.\n"
+msgstr "請透過將物體完全移動到盤上或移出盤來解決問題，並確認其高度在構建範圍內。\n"
+
+#, boost-format
+msgid "Assembly's bounding box is too large ( max size >= %1% in ) which may cause rendering issues.\n"
+msgstr ""
+
+#, boost-format
+msgid "Assembly's bounding box is too large ( max size >= %1% mm ) which may cause rendering issues.\n"
+msgstr ""
+
+#, boost-format
+msgid "Following objects are too far ( distance >= %1% in ) from the original of the world coordinate system:\n"
+msgstr ""
+
+#, boost-format
+msgid "Following objects are too far ( distance >= %1% mm ) from the original of the world coordinate system:\n"
+msgstr ""
+
+msgid "left nozzle"
+msgstr "左噴嘴"
+
+msgid "right nozzle"
+msgstr "右噴嘴"
+
+#, c-format, boost-format
+msgid "The position or size of some models exceeds the %s's printable range."
+msgstr "一些模型的位置或者尺寸超出了%s的可列印範圍。"
+
+#, c-format, boost-format
+msgid "The position or size of the model %s exceeds the %s's printable range."
+msgstr "模型%s的位置或者尺寸超出了%s的可列印範圍"
+
+msgid " Please check and adjust the part's position or size to fit the printable range:\n"
+msgstr " 請檢查並調整零件的位置或尺寸以適應列印範圍\n"
+
+#, boost-format
+msgid "Left nozzle: X:%1%-%2%, Y:%3%-%4%, Z:%5%-%6%\n"
+msgstr "左噴嘴：X:%1%-%2%，Y:%3%-%4%，Z:%5%-%6%\n"
+
+#, boost-format
+msgid "Right nozzle: X:%1%-%2%, Y:%3%-%4%, Z:%5%-%6%"
+msgstr "右噴嘴：X:%1%-%2%，Y:%3%-%4%，Z:%5%-%6%"
+
+msgid "Mirror Object"
+msgstr "映象物體"
+
+msgid "Tool Move"
+msgstr "工具 移動"
+
+msgid "Tool Rotate"
+msgstr "工具 旋轉"
+
+msgid "Move Object"
+msgstr "移動物件"
+
+msgid "Auto Orientation options"
+msgstr "自動朝向選項"
+
+msgid "Enable rotation"
+msgstr "開啟旋轉"
+
+msgid "Optimize support interface area"
+msgstr "最佳化接觸面面積"
+
+# src/slic3r/GUI/GLCanvas3D.cpp:4767
+msgid "Orient"
+msgstr "調整朝向"
+
+msgid "Arrange options"
+msgstr "自動擺放選項"
+
+msgid "Spacing"
+msgstr "間距"
+
+msgid "0 means auto spacing."
+msgstr "0 表示自動間距。"
+
+msgid "Save SVG"
+msgstr "儲存SVG"
+
+msgid "Auto rotate for arrangement"
+msgstr "自動旋轉以最佳化自動擺放效果"
+
+msgid "Allow multiple materials on same plate"
+msgstr "允許同一盤中包含多種材料"
+
+msgid "Avoid extrusion calibration region"
+msgstr "避開擠出校準區域"
+
+msgid "Align to Y axis"
+msgstr "對齊到Y軸"
+
+msgctxt "Camera"
+msgid "Left"
+msgstr "左面"
+
+msgctxt "Camera"
+msgid "Right"
+msgstr "右面"
+
+msgid "Add"
+msgstr "新增"
+
+msgid "Add plate"
+msgstr "新增新盤"
+
+msgid "Auto orient"
+msgstr "自動朝向"
+
+msgid "Arrange all objects"
+msgstr "全域性整理"
+
+msgid "Arrange objects on selected plates"
+msgstr "單盤整理"
+
+msgid "Split to objects"
+msgstr "拆分為物件"
+
+msgid "And it is valid when there are at least two parts in object or stl has at least two meshes."
+msgstr "並且當物件中存在至少兩個零件或者stl中存在至少兩個面網格，這個功能是有效的。"
+
+msgid "Split to parts"
+msgstr "拆分為零件"
+
+msgid "And it is valid when importing an stl with at least two meshes."
+msgstr "並且當匯入的一個stl中存在至少兩個面網格，這個功能是有效的。"
+
+msgid "Click to Extend"
+msgstr "點選展開"
+
+msgid "Click to Collapse"
+msgstr "點選摺疊"
+
+msgid "Assembly View"
+msgstr "裝配體檢視"
+
+msgid "Select Plate"
+msgstr "選擇盤"
+
+msgid "Assembly Return"
+msgstr "退出裝配體檢視"
+
+msgid "return"
+msgstr "返回"
+
+msgid "Fit camera"
+msgstr "相機適配"
+
+msgid "Fit camera to scene or selected object."
+msgstr "使相機適配場景或選定物件"
+
+msgid "Paint Toolbar"
+msgstr "上色工具條"
+
+msgid "Explosion Ratio"
+msgstr "爆炸比例"
+
+msgid "Section View"
+msgstr "剖面檢視"
+
+msgid "Assemble Control"
+msgstr "拼裝檢視控制"
+
+msgid "Selection Mode"
+msgstr "選擇模式"
+
+msgid "Total Volume:"
+msgstr "總體積："
+
+msgid "Assembly Info"
+msgstr "裝配體資訊"
+
+msgid "Volume:"
+msgstr "體積："
+
+msgid "Size:"
+msgstr "尺寸："
+
+#, c-format, boost-format
+msgid "Conflicts of gcode paths have been found at layer %d. Please separate the conflicted objects farther (%s <-> %s)."
+msgstr "發現第%d層存在重疊的走線，這可能導致列印失敗或列印出來的模型不可用。請將有衝突的物件分得更開。有衝突的物件為%s <-> %s。"
+
+msgid "An object is layed over the boundary of plate."
+msgstr "檢測到有物件放在盤的邊界上。"
+
+msgid "A G-code path goes beyond the max print height."
+msgstr "檢測出超出列印高度的G-code路徑。"
+
+msgid "A G-code path goes beyond the boundary of plate."
+msgstr "檢測超出熱床邊界的G-code路徑。"
+
+msgid "Not support printing 2 or more TPU filaments."
+msgstr "不支援同時列印2種（或以上）TPU材料。"
+
+#, c-format, boost-format
+msgid "Filament %s is placed in the %s, but the generated G-code path exceeds the printable range of the %s."
+msgstr "材料%s放置在%s中，但生成的G程式碼路徑超出了%s的可列印範圍。"
+
+#, c-format, boost-format
+msgid "Filaments %s is placed in the %s, but the generated G-code path exceeds the printable range of the %s."
+msgstr "材料%s放置在%s中，但生成的G程式碼路徑超出了%s的可列印範圍。"
+
+#, c-format, boost-format
+msgid "Filament %s is placed in the %s, but the generated G-code path exceeds the printable height of the %s."
+msgstr "材料%s放置在%s中，但生成的G程式碼路徑超過了%s的可列印高度。"
+
+#, c-format, boost-format
+msgid "Filaments %s is placed in the %s, but the generated G-code path exceeds the printable height of the %s."
+msgstr "材料%s放置在%s中，但生成的G程式碼路徑超過了%s的可列印高度。"
+
+msgid "Open wiki for more information."
+msgstr "開啟wiki以獲取更多資訊。"
+
+msgid "Only the object being edited is visible."
+msgstr "只有正在編輯的物件是可見的。"
+
+#, c-format, boost-format
+msgid "filaments %s cannot be printed directly on the surface of this plate."
+msgstr "材料 %s 不能在直接在當前列印板上列印。"
+
+msgid "PLA and PETG filaments detected in the mixture. Adjust parameters according to the Wiki to ensure print quality."
+msgstr "檢測到 PLA 和 PETG 同時列印，請根據 Wiki 中的建議調整列印引數來確保列印質量。"
+
+msgid "The prime tower improves multi-color print quality and is recommended."
+msgstr "擦料塔可提升多色列印質量，建議啟用。"
+
+msgid "The prime tower extends beyond the plate boundary."
+msgstr "料塔超出了列印版邊界。"
+
+msgid "Partial flushing volume set to 0. Multi-color printing may cause color mixing in models. Please redjust flushing settings."
+msgstr "部分沖刷體積設定為0，多色列印可能導致模型混色，請重新調整沖刷值。"
+
+msgid "Click Wiki for help."
+msgstr "點選Wiki尋求幫助。"
+
+msgid "Jump to: Prime tower"
+msgstr "轉跳到：擦料塔"
+
+msgid "Click here to regroup"
+msgstr "點選此處重新分組"
+
+msgid "Flushing Volume"
+msgstr "開啟沖刷表"
+
+msgid "Calibration step selection"
+msgstr "校準步驟選擇"
+
+msgid "Micro Lidar Calibration"
+msgstr "鐳射雷達校準"
+
+msgid "Auto Bed Leveling"
+msgstr "自動熱床調平"
+
+msgid "Vibration Compensation"
+msgstr "振動補償"
+
+msgid "Motor Noise Cancellation"
+msgstr "電機降噪"
+
+msgid "Nozzle Offset Calibration"
+msgstr "噴嘴偏移校準"
+
+msgid "High-temperature Bed Leveling"
+msgstr "高溫熱床調平"
+
+msgid "Nozzle Clumping Detection Calibration"
+msgstr "觸碰裹頭檢測校準"
+
+msgid "Calibration program"
+msgstr "校準程式"
+
+msgid ""
+"The calibration program detects the status of your device automatically to minimize deviation.\n"
+"It keeps the device performing optimally."
+msgstr ""
+"校準程式會自動檢測裝置以最小化裝置誤差。\n"
+"它可以讓裝置保持最佳效能。"
+
+msgid "Calibration Flow"
+msgstr "校準流程"
+
+msgid "Start Calibration"
+msgstr "開始校準"
+
+msgid "Completed"
+msgstr "已完成"
+
+msgid "Calibrating"
+msgstr "校準中"
+
+msgid "No step selected"
+msgstr "請選擇一項校準"
+
+msgid "Auto-record Monitoring"
+msgstr "監控錄影"
+
+msgid "Go Live"
+msgstr "開啟直播"
+
+msgid "Liveview Retry"
+msgstr "實時預覽重試"
+
+msgid "Resolution"
+msgstr "解析度"
+
+msgid "Show \"Live Video\" guide page."
+msgstr "顯示\"直播影片流\"指南。"
+
+msgid "ConnectPrinter(LAN)"
+msgstr "連線印表機（區域網）"
+
+msgid "Please input the printer access code:"
+msgstr "請輸入印表機訪問碼："
+
+msgid ""
+"You can find it in \"Settings > Network > Access code\"\n"
+"on the printer, as shown in the figure:"
+msgstr ""
+"您可以在印表機“設定->網路->訪問碼\"\n"
+"檢視，如下圖所示："
+
+msgid ""
+"You can find it in \"Setting > Setting > LAN only > Access Code\"\n"
+"on the printer, as shown in the figure:"
+msgstr ""
+"您可以在印表機“設定->設定->僅區域網->訪問碼\"\n"
+"檢視，如下圖所示："
+
+msgid "Invalid input."
+msgstr "非法輸入"
+
+msgid "New Window"
+msgstr "新視窗"
+
+msgid "Open a new window"
+msgstr "開啟新視窗"
+
+msgid "Application is closing"
+msgstr "正在關閉應用程式"
+
+msgid "Closing Application while some presets are modified."
+msgstr "正在關閉應用程式，部分預設已修改。"
+
+msgid "Logging"
+msgstr "日誌"
+
+msgid "Prepare"
+msgstr "準備"
+
+msgid "Preview"
+msgstr "預覽"
+
+msgid "The current page has unsaved changes. You can continue editing or choose to save/discard before leaving."
+msgstr "當前頁面有未儲存的更改。您可以繼續編輯，或選擇儲存/放棄後離開。"
+
+msgid "Device"
+msgstr "裝置"
+
+msgid "Multi-device"
+msgstr "多裝置"
+
+msgid "Project"
+msgstr "專案"
+
+msgid "Yes"
+msgstr "是"
+
+msgid "No"
+msgstr "否"
+
+msgid "will be closed before creating a new model. Do you want to continue?"
+msgstr "將會被關閉以建立新模型，是否繼續?"
+
+msgid "Unlock faster, more reliable, warp-free prints with Helio Additive."
+msgstr "使用 Helio Additive 解鎖更快、更可靠、更不易翹曲的列印。"
+
+msgid "Slice plate"
+msgstr "切片單盤"
+
+msgid "Print plate"
+msgstr "列印單盤"
+
+msgid ""
+"This is your first time slicing with the dual extruder machine.\n"
+"Would you like to watch a quick tutorial video?"
+msgstr ""
+"這是您第一次使用 雙擠出機機器進行切片操作。\n"
+"您需要觀看一個簡短的指導影片嗎？"
+
+msgid "First Guide"
+msgstr "首次指南"
+
+msgid ""
+"This is your first time printing tpu filaments with the dual extruder machine.\n"
+"Would you like to watch a quick tutorial video?"
+msgstr ""
+"這是您第一次使用雙擠出機機器列印TPU耗材。\n"
+"您需要觀看一個簡短的指導影片嗎？"
+
+msgid "PPS-CF/PPA-CF is brittle and could break in bended PTFE tube above Toolhead. Please refer to Wiki before use. "
+msgstr "PPS-CF/PPA-CF較脆, 容易斷在工具頭上方的彎折鐵氟龍管裡。請參考Wiki。"
+
+msgid "Tips"
+msgstr "提示"
+
+msgid "Slice all"
+msgstr "切片所有盤"
+
+msgid "Export G-code file"
+msgstr "匯出G-code檔案"
+
+msgid "Send"
+msgstr "傳送"
+
+msgid "Export plate sliced file"
+msgstr "匯出單盤切片檔案"
+
+msgid "Export all sliced file"
+msgstr "匯出所有切片檔案"
+
+msgid "Print all"
+msgstr "列印所有盤"
+
+msgid "Send all"
+msgstr "傳送所有盤"
+
+msgid "Send to Bambu Farm Manager Client"
+msgstr "傳送到Bambu農場管理軟體"
+
+msgid "Send to BFMC"
+msgstr "傳送到BFMC"
+
+msgid "Send to Multi-device"
+msgstr "傳送到多裝置"
+
+msgid "Keyboard Shortcuts"
+msgstr "快捷鍵"
+
+msgid "Show the list of the keyboard shortcuts"
+msgstr "顯示快捷鍵列表"
+
+msgid "Setup Wizard"
+msgstr "配置嚮導"
+
+msgid "Show Configuration Folder"
+msgstr "開啟配置資料夾"
+
+msgid "Show Tip of the Day"
+msgstr "展示每日小貼士"
+
+msgid "Report issue"
+msgstr "報告問題"
+
+msgid "Check for Update"
+msgstr "檢查新版本"
+
+msgid "Check for Presets Update"
+msgstr "檢查預設更新"
+
+msgid "Open Network Test"
+msgstr "開啟網路測試"
+
+#, c-format, boost-format
+msgid "&About %s"
+msgstr "關於 %s"
+
+msgid "Upload Models"
+msgstr "上傳模型"
+
+msgid "Download Models"
+msgstr "下載模型"
+
+msgid "Default View"
+msgstr "預設檢視"
+
+msgid "Top View"
+msgstr "頂部檢視"
+
+#. TRN To be shown in the main menu View->Bottom
+msgid "Bottom"
+msgstr "底部"
+
+msgid "Bottom View"
+msgstr "底部檢視"
+
+msgid "Front"
+msgstr "前面"
+
+msgid "Front View"
+msgstr "前檢視"
+
+msgid "Rear"
+msgstr "後面"
+
+msgid "Rear View"
+msgstr "後檢視"
+
+msgid "Left View"
+msgstr "左檢視"
+
+msgid "Right View"
+msgstr "右檢視"
+
+msgctxt "Camera"
+msgid "Isometric"
+msgstr "等軸測"
+
+msgid "Isometric View"
+msgstr "等軸測檢視"
+
+msgid "Start a new window"
+msgstr "開啟新視窗"
+
+msgid "New Project"
+msgstr "新建專案"
+
+msgid "Start a new project"
+msgstr "新建一個專案"
+
+msgid "Open a project file"
+msgstr "開啟專案檔案"
+
+msgid "Recent projects"
+msgstr "最近的專案"
+
+msgid "Save Project"
+msgstr "儲存專案"
+
+msgid "Save current project to file"
+msgstr "儲存當前專案到檔案"
+
+msgid "Save Project as"
+msgstr "專案另存為"
+
+msgid "Shift+"
+msgstr ""
+
+msgid "Save current project as"
+msgstr "專案另存為"
+
+msgid "Import 3MF/STL/STEP/SVG/OBJ/AMF"
+msgstr "匯入 3MF/STL/STEP/SVG/OBJ/AMF"
+
+msgid "Load a model"
+msgstr "載入模型"
+
+msgid "Import Configs"
+msgstr "匯入預設"
+
+msgid "Load configs"
+msgstr "載入配置"
+
+msgid "Import"
+msgstr "匯入"
+
+msgid "Export all objects as one STL"
+msgstr "匯出所有物件為一個STL"
+
+msgid "Export all objects as STLs"
+msgstr "匯出所有物件為多個STL"
+
+msgid "Export Generic 3MF"
+msgstr "匯出通用 3MF"
+
+msgid "Export 3mf file without using some 3mf-extensions"
+msgstr "匯出不含 3mf 擴充套件的 3mf 檔案"
+
+msgid "Export current sliced file"
+msgstr "匯出當前已切片的檔案"
+
+msgid "Export all plate sliced file"
+msgstr "匯出所有盤已切片的檔案"
+
+msgid "Export G-code"
+msgstr "匯出 G-code"
+
+msgid "Export current plate as G-code"
+msgstr "匯出當前盤的G-code"
+
+msgid "Export toolpaths as OBJ"
+msgstr "將工具路徑匯出為OBJ格式"
+
+msgid "Export Preset Bundle"
+msgstr "匯出預設包"
+
+msgid "Export current configuration to files"
+msgstr "匯出當前選擇的預設"
+
+msgid "Export"
+msgstr "匯出"
+
+msgid "Publish to MakerWorld"
+msgstr "釋出到MakerWorld"
+
+msgid "Batch Preset Management"
+msgstr "批次預設管理"
+
+msgid "Quit"
+msgstr "退出程式"
+
+msgid "Undo"
+msgstr "撤銷"
+
+msgid "Redo"
+msgstr "重做"
+
+msgid "Cut selection to clipboard"
+msgstr "剪下所選項到剪貼簿"
+
+msgid "Copy"
+msgstr "複製"
+
+msgid "Copy selection to clipboard"
+msgstr "複製所選項到剪貼簿"
+
+msgid "Paste"
+msgstr "貼上"
+
+msgid "Paste clipboard"
+msgstr "從剪貼簿貼上"
+
+msgid "Delete selected"
+msgstr "刪除所選項"
+
+msgid "Deletes the current selection"
+msgstr "刪除當前所選項"
+
+msgid "Delete all"
+msgstr "全部刪除"
+
+msgid "Deletes all objects"
+msgstr "刪除所有物件"
+
+msgid "Clone selected"
+msgstr "克隆所選項"
+
+msgid "Clone copies of selections"
+msgstr "克隆多份所選項"
+
+msgid "Select all"
+msgstr "選中所有"
+
+msgid "Selects all objects"
+msgstr "選中所有物件"
+
+msgid "Deselect all"
+msgstr "取消所有選中"
+
+msgid "Deselects all objects"
+msgstr "取消所有選中"
+
+msgid "Use Perspective View"
+msgstr "使用透視視角"
+
+msgid "Use Orthogonal View"
+msgstr "使用正交視角"
+
+msgid "Show 3D Navigator"
+msgstr "顯示3D導航"
+
+msgid "Show 3D navigator in Prepare and Preview scene"
+msgstr "在準備和預覽場景中顯示3D導航"
+
+msgid "Reset Window Layout"
+msgstr "重置視窗布局"
+
+msgid "Reset to default window layout"
+msgstr "重置為預設視窗布局"
+
+msgid "Show object labels in 3D scene"
+msgstr "在3D場景中顯示物件名稱"
+
+msgid "Show &Overhang"
+msgstr "顯示懸空高亮"
+
+msgid "Show object overhang highlight in 3D scene"
+msgstr "在3D場景中顯示懸空高亮"
+
+msgid "Set 3DConnexion"
+msgstr "設定3D滑鼠"
+
+msgid "Set 3DConnexion mouse"
+msgstr "設定3D滑鼠"
+
+msgid "Services"
+msgstr "服務"
+
+msgid "Hide BambuStudio"
+msgstr "隱藏BambuStudio"
+
+msgid "Hide Others"
+msgstr "隱藏其他"
+
+msgid "Show All"
+msgstr "顯示所有"
+
+msgid "Quit BambuStudio"
+msgstr "退出BambuStudio"
+
+msgid "Preferences"
+msgstr "偏好設定"
+
+msgid "View"
+msgstr "檢視"
+
+msgid "Help"
+msgstr "幫助"
+
+msgid "Temperature Calibration"
+msgstr "溫度校準"
+
+msgid "Pass 1"
+msgstr "透過 1"
+
+msgid "Flow rate test - Pass 1"
+msgstr "流量測試 - 透過 1"
+
+msgid "Pass 2"
+msgstr "透過2"
+
+msgid "Flow rate test - Pass 2"
+msgstr "流量測試 - 透過 2"
+
+msgid "Flow rate"
+msgstr "流量比例"
+
+msgid "Pressure advance"
+msgstr "壓力提升"
+
+msgid "Retraction test"
+msgstr "回抽測試"
+
+msgid "Max flowrate"
+msgstr "最大流速"
+
+msgid "VFA"
+msgstr ""
+
+msgid "More..."
+msgstr "更多..."
+
+msgid "Tutorial"
+msgstr "教程"
+
+msgid "Calibration help"
+msgstr "校準幫助"
+
+msgid "More calibrations"
+msgstr "更多校準"
+
+msgid "Window"
+msgstr "視窗"
+
+msgid "Minimize"
+msgstr "最小化"
+
+msgid "Zoom"
+msgstr "視角縮放"
+
+msgid "Tile Window to Left of Screen"
+msgstr "將視窗平鋪到螢幕左側"
+
+msgid "Tile Window to Right of Screen"
+msgstr "將視窗平鋪到螢幕右側"
+
+msgid "Replace Tiled Window"
+msgstr "替換平鋪視窗"
+
+msgid "Remove Window from Set"
+msgstr "從集合中移除視窗"
+
+msgid "Bring All to Front"
+msgstr "將所有視窗置於前臺"
+
+msgid "&Open G-code"
+msgstr "開啟G-code"
+
+msgid "Open a G-code file"
+msgstr "開啟G-code 檔案"
+
+msgid "Re&load from Disk"
+msgstr "從磁碟重新載入"
+
+msgid "Reload the plater from disk"
+msgstr "從磁碟重新載入平臺"
+
+msgid "Export &Toolpaths as OBJ"
+msgstr ""
+
+msgid "Open &Studio"
+msgstr "開啟Studio"
+
+msgid "Open Studio"
+msgstr "開啟Studio"
+
+msgid "&Quit"
+msgstr "退出"
+
+#, c-format, boost-format
+msgid "Quit %s"
+msgstr "退出 %s"
+
+msgid "&File"
+msgstr "檔案"
+
+msgid "&View"
+msgstr ""
+
+msgid "&Help"
+msgstr "幫助"
+
+#, c-format, boost-format
+msgid "A file exists with the same name: %s, do you want to override it."
+msgstr "有一個同名的檔案 %s。您想覆蓋它嗎？"
+
+#, c-format, boost-format
+msgid "A config exists with the same name: %s, do you want to override it."
+msgstr "有一個同名的配置 %s。您想覆蓋它嗎？"
+
+msgid "Overwrite file"
+msgstr "覆蓋檔案"
+
+msgid "Yes to All"
+msgstr "全是"
+
+msgid "No to All"
+msgstr "全否"
+
+msgid "Choose a directory"
+msgstr "選擇目錄"
+
+#, c-format, boost-format
+msgid "There is %d config exported. (Only non-system configs)"
+msgid_plural "There are %d configs exported. (Only non-system configs)"
+msgstr[0] "共匯出 %d 組預設（僅包含當前使用的非系統的預設）"
+
+msgid "Export result"
+msgstr "匯出結果"
+
+msgid "Select profile to load:"
+msgstr "選擇要載入的配置："
+
+#, c-format, boost-format
+msgid "There is %d config imported. (Only non-system and compatible configs)"
+msgid_plural "There are %d configs imported. (Only non-system and compatible configs)"
+msgstr[0] "共匯入 %d 組預設（僅包含非系統且與當前配置相容的預設）"
+
+msgid "Import result"
+msgstr "匯入結果"
+
+msgid "File is missing"
+msgstr "檔案丟失"
+
+msgid "The project is no longer available."
+msgstr "此專案不可用。"
+
+msgid "Filament Settings"
+msgstr "耗材絲設定"
+
+msgid ""
+"Do you want to synchronize your personal data from Bambu Cloud? \n"
+"It contains the following information:\n"
+"1. The Process presets\n"
+"2. The Filament presets\n"
+"3. The Printer presets"
+msgstr ""
+"是否從Bambu雲同步如下資訊：\n"
+"1.工藝預設\n"
+"2.材料預設\n"
+"3.印表機預設"
+
+msgid "Synchronization"
+msgstr "同步"
+
+msgid "The device cannot handle more conversations. Please retry later."
+msgstr "裝置無法處理更多的對話。請稍後重試。"
+
+msgid "Player is malfunctioning. Please reinstall the system player."
+msgstr "播放器異常，請重新安裝系統播放器。"
+
+msgid "The player is not loaded, please click \"play\" button to retry."
+msgstr "未能載入播放器，請重新點選“播放”按鈕。"
+
+msgid "Plugin library failed to load. Click here to view the solution."
+msgstr "外掛庫載入失敗，點選這裡檢視解決辦法。"
+
+msgid "Temporarily closed because there is no operation for a while."
+msgstr "長時間無操作，監控已關閉。"
+
+msgid "Temporarily closed because there is no printing for a while."
+msgstr "因有一段時間未列印，暫時關閉。"
+
+msgid "Please confirm if the printer is connected."
+msgstr "請確認印表機是否連線成功。"
+
+msgid "The printer is currently busy downloading. Please try again after it finishes."
+msgstr "印表機正在忙於下載，請等下載完成後再嘗試。"
+
+msgid "Printer camera is malfunctioning."
+msgstr "印表機攝像頭異常。"
+
+msgid "Problem occured. Please update the printer firmware and try again."
+msgstr "出現了一些問題。請更新印表機韌體後重試。"
+
+msgid "LAN Only Liveview is off. Please turn on the liveview on printer screen."
+msgstr "區域網模式直播未開啟，請前往印表機螢幕開啟。"
+
+msgid "Please enter the IP of printer to connect."
+msgstr "請輸入印表機IP後嘗試連線。"
+
+msgid "Initializing..."
+msgstr "正在初始化……"
+
+msgid "Connection Failed. Please check the network and try again"
+msgstr "連結失敗。請檢查網路後重試"
+
+msgid "Please check the network and try again, You can restart or update the printer if the issue persists."
+msgstr "檢查網路後重試。如仍未恢復，可重啟或更新印表機。"
+
+msgid "Multi-device/client simultaneous liveview is not supported. Please close the liveview on other devices/clients and try again."
+msgstr "不支援多裝置/客戶端同時檢視實時監控，請關閉其他裝置/客戶端的實時監控後重試。"
+
+msgid "Video Stopped."
+msgstr "影片已停止。"
+
+msgid "LAN Connection Failed (Failed to start liveview)"
+msgstr "區域網連線失敗（無法啟動直播）"
+
+msgid ""
+"Virtual Camera Tools is required for this task!\n"
+"Do you want to install them?"
+msgstr "該功能需要“虛擬攝像頭工具包”，是否下載並安裝該工具包？"
+
+msgid "Downloading Virtual Camera Tools"
+msgstr "正在下載“虛擬攝像頭工具包”"
+
+msgid ""
+"Another virtual camera is running.\n"
+"Bambu Studio supports only a single virtual camera.\n"
+"Do you want to stop this virtual camera?"
+msgstr ""
+"另一個虛擬攝像頭正在工作。\n"
+"Bambu Studio 同時只能支援一個虛擬攝像頭。\n"
+"是否停止前一個虛擬攝像頭？"
+
+#, c-format, boost-format
+msgid "Virtual camera initialize failed (%s)!"
+msgstr "虛擬攝像頭初始化失敗(%s)！"
+
+msgid "Network unreachable"
+msgstr "網路不可訪問"
+
+msgid "Information"
+msgstr "資訊"
+
+msgid "The live streaming feature relies on Bambu Studio to run,and the stream will end some time after the app is closed."
+msgstr "直播功能依賴 Bambu Studio 執行，關閉軟體後直播將在一段時間後結束。"
+
+msgid "Playing..."
+msgstr "正在播放中……"
+
+msgid "DLL load error"
+msgstr "DLL載入錯誤"
+
+msgid "Loading..."
+msgstr "正在載入影片……"
+
+msgid "Year"
+msgstr "年"
+
+msgid "Month"
+msgstr "月"
+
+msgid "All Files"
+msgstr "所有檔案"
+
+msgid "Group files by year, recent first."
+msgstr "按年份分組，從最近的開始展示"
+
+msgid "Group files by month, recent first."
+msgstr "按月份分組，從最近的開始展示"
+
+msgid "Show all files, recent first."
+msgstr "顯示所有檔案，從最近的開始展示。"
+
+msgid "Timelapse"
+msgstr "延時攝影"
+
+msgid "Switch to timelapse files."
+msgstr "切換到延時攝影檔案列表。"
+
+msgid "Video"
+msgstr "錄影"
+
+msgid "Switch to video files."
+msgstr "切換到影片檔案列表。"
+
+msgid "Switch to 3mf model files."
+msgstr "切換到3MF模型檔案。"
+
+msgid "Delete selected files from printer."
+msgstr "從印表機中刪除選中的檔案。"
+
+msgid "Download"
+msgstr "下載"
+
+msgid "Download selected files from printer."
+msgstr "從印表機中下載選擇的檔案。"
+
+msgid "Select"
+msgstr "選擇"
+
+msgid "Batch manage files."
+msgstr "批次管理檔案。"
+
+msgid "Refresh"
+msgstr "重新整理"
+
+msgid "Reload file list from printer."
+msgstr "從印表機重新載入檔案列表。"
+
+msgid "No printers."
+msgstr "未選擇印表機"
+
+msgid "Loading file list..."
+msgstr "載入檔案列表..."
+
+msgid "No files"
+msgstr "檔案列表為空"
+
+msgid "Load failed"
+msgstr "載入失敗"
+
+msgid "Browsing file in storage is not supported in current firmware. Please update the printer firmware."
+msgstr "當前韌體不支援瀏覽儲存裝置中的檔案。請更新印表機韌體。"
+
+msgid "LAN Connection Failed (Failed to view sdcard)"
+msgstr "區域網連線失敗（無法檢視SD卡）"
+
+msgid "Browsing file in storage is not supported in LAN Only Mode."
+msgstr "在僅區域網模式下不支援瀏覽儲存中的檔案。"
+
+#, c-format, boost-format
+msgid "You are going to delete %u file from printer. Are you sure to continue?"
+msgid_plural "You are going to delete %u files from printer. Are you sure to continue?"
+msgstr[0] "您將從印表機中刪除%u個檔案。確定要繼續嗎？"
+
+msgid "Delete files"
+msgstr "刪除檔案"
+
+#, c-format, boost-format
+msgid "Do you want to delete the file '%s' from printer?"
+msgstr "您確定要從印表機中刪除檔案'%s'嗎？"
+
+msgid "Delete file"
+msgstr "刪除檔案"
+
+msgid "Fetching model infomations ..."
+msgstr "正在獲取模型資訊..."
+
+msgid "Failed to fetch model information from printer."
+msgstr "無法從印表機獲取模型資訊。"
+
+msgid "Failed to parse model information."
+msgstr "解析模型資訊失敗。"
+
+msgid "The .gcode.3mf file contains no G-code data.Please slice it whth Bambu Studio and export a new .gcode.3mf file."
+msgstr ".gcode.3mf檔案中不包含G-code資料。請使用Bambu Studio進行切片並匯出新的.gcode.3mf檔案。"
+
+#, c-format, boost-format
+msgid "File '%s' was lost! Please download it again."
+msgstr "檔案%s丟失，請重新下載。"
+
+#, c-format, boost-format
+msgid ""
+"File: %s\n"
+"Title: %s\n"
+msgstr ""
+"檔案: %s\n"
+"標題: %s\n"
+
+msgid "Download waiting..."
+msgstr "等待下載中..."
+
+msgid "Play"
+msgstr "播放"
+
+msgid "Open Folder"
+msgstr "開啟目錄"
+
+msgid "Download finished"
+msgstr "下載完成"
+
+#, c-format, boost-format
+msgid "Downloading %d%%..."
+msgstr "下載中 %d%%..."
+
+msgid "Air Condition"
+msgstr "空調系統"
+
+msgid "Reconnecting the printer, the operation cannot be completed immediately, please try again later."
+msgstr "重新連線印表機，該操作無法立即完成，請稍後再試。"
+
+msgid "Timeout, please try again."
+msgstr "超時，請重試。"
+
+msgid "File does not exist."
+msgstr "檔案不存在。"
+
+msgid "File checksum error. Please retry."
+msgstr "檔案校驗和錯誤。請重試。"
+
+msgid "Not supported on the current printer version."
+msgstr "當前印表機的版本不支援。"
+
+msgid ""
+"Please check if the storage is inserted into the printer.\n"
+"If it still cannot be read, you can try formatting the storage."
+msgstr ""
+"請檢查儲存裝置是否已插入印表機。\n"
+"如果仍無法讀取，您可以嘗試格式化儲存裝置。"
+
+msgid "The firmware version of the printer is too low. Please update the firmware and try again."
+msgstr "印表機的韌體版本過低。請更新韌體然後再試一次。"
+
+msgid "The file already exists, do you want to replace it?"
+msgstr "檔案已存在，是否要替換它？"
+
+msgid "Insufficient storage space, please clear the space and try again."
+msgstr "儲存空間不足，請清空空間，然後重試。"
+
+msgid "File creation failed, please try again."
+msgstr "檔案建立失敗，請重試"
+
+msgid "File write failed, please try again."
+msgstr "檔案寫入失敗，請重試。"
+
+msgid "MD5 verification failed, please try again."
+msgstr "MD5驗證失敗，請重試"
+
+msgid "File renaming failed, please try again."
+msgstr "檔案重新命名失敗，請重試。"
+
+msgid "File upload failed, please try again."
+msgstr "檔案上傳失敗，請重試。"
+
+#, c-format, boost-format
+msgid "Error code: %d"
+msgstr "錯誤碼：%d"
+
+msgid "User cancels task."
+msgstr "使用者取消任務。"
+
+msgid "Failed to read file, please try again."
+msgstr "讀取檔案失敗，請重試。"
+
+msgid "Speed:"
+msgstr "速度："
+
+msgid "Deadzone:"
+msgstr "死區："
+
+msgid "Options:"
+msgstr "選項："
+
+msgid "Translation/Zoom"
+msgstr "平移/縮放"
+
+msgid "3Dconnexion settings"
+msgstr "3Dconnexion設定"
+
+msgid "Swap Y/Z axes"
+msgstr "交換Y/Z軸"
+
+msgid "(LAN)"
+msgstr "（區域網）"
+
+msgid "Search"
+msgstr "搜尋"
+
+msgid "My Device"
+msgstr "我的裝置"
+
+msgid "Other Device"
+msgstr "其他裝置"
+
+msgid "Online"
+msgstr "線上"
+
+msgid "Input access code"
+msgstr "輸入訪問碼"
+
+msgid "Can't find my devices?"
+msgstr "無法找到我的裝置？"
+
+msgid "Log out successful."
+msgstr "登出成功。"
+
+msgid "Offline"
+msgstr "離線"
+
+msgid "Busy"
+msgstr "忙碌"
+
+msgid "Modifying the device name"
+msgstr "修改印表機名稱"
+
+msgid "Name is invalid;"
+msgstr "無效名稱；"
+
+msgid "illegal characters:"
+msgstr "非法字元："
+
+msgid "illegal suffix:"
+msgstr "非法字尾："
+
+msgid "The name is not allowed to be empty."
+msgstr "名稱不允許為空。"
+
+msgid "The name is not allowed to start with space character."
+msgstr "名稱不允許以空格開頭。"
+
+msgid "The name is not allowed to end with space character."
+msgstr "名稱不允許以空格結尾。"
+
+msgid "The name is not allowed to exceeds 32 characters."
+msgstr "名稱不允許超過32個字元。"
+
+msgid "Bind with Pin Code"
+msgstr "透過PIN碼繫結"
+
+msgid "Bind with Access Code"
+msgstr "透過訪問碼繫結"
+
+msgid ""
+"Please log in before binding your device with a PIN code.\n"
+"Alternatively, you can use LAN mode to bind your device. Learn about LAN mode."
+msgstr ""
+"請在用PIN碼繫結裝置之前登入\n"
+"或者，您可以使用LAN模式繫結裝置。瞭解LAN模式。"
+
+msgid "Go to Login"
+msgstr "轉到登入"
+
+msgctxt "Quit_Switching"
+msgid "Quit"
+msgstr "取消"
+
+msgid "Switching..."
+msgstr "換頭中..."
+
+msgid "Switching failed"
+msgstr "換頭失敗"
+
+msgid "Printing Progress"
+msgstr "列印進度"
+
+msgid "Pausing"
+msgstr "暫停"
+
+msgid "Stopping"
+msgstr "停止中"
+
+msgid "Parts Skip"
+msgstr "零件跳過"
+
+msgid "Stop"
+msgstr "停止"
+
+msgid "Layer: N/A"
+msgstr "層： N/A"
+
+msgid "Click to view thermal preconditioning explanation"
+msgstr "點選檢視保溫處理說明"
+
+msgid "Estimated finish time: "
+msgstr "預估完成時間: "
+
+msgid ""
+"The estimated printing time for \n"
+"multi-color models may be inaccurate."
+msgstr "多色模型的估計列印時間可能不準確。"
+
+msgid "Clear"
+msgstr "清除"
+
+msgid ""
+"You have completed printing the mall model, \n"
+"but the synchronization of rating information has failed."
+msgstr "您已經完成了商城模型的列印，但是評分資訊的同步失敗了。"
+
+msgid "How do you like this printing file?"
+msgstr "您喜歡這個列印檔案嗎？"
+
+msgid "(The model has already been rated. Your rating will overwrite the previous rating.)"
+msgstr "（該模型已經被評分。您的評分將覆蓋先前的評分。）"
+
+msgid "Rate"
+msgstr "評分"
+
+#, c-format, boost-format
+msgid "%dday%dh%dmin%ds"
+msgstr "%d天%d小時%d分%d秒"
+
+#, c-format, boost-format
+msgid "%dh%dmin%ds"
+msgstr "%d小時%d分%d秒"
+
+#, c-format, boost-format
+msgid "%dmin%ds"
+msgstr "%d分%d秒"
+
+#, c-format, boost-format
+msgid "%ds"
+msgstr "%d秒"
+
+msgid "Finished"
+msgstr "完成"
+
+msgid "Camera"
+msgstr "攝像機"
+
+msgid "Storage"
+msgstr "儲存介質"
+
+msgid "Camera Setting"
+msgstr "相機設定"
+
+msgid "Control"
+msgstr "控制"
+
+msgid "Printer Parts"
+msgstr "印表機零件"
+
+msgid "Print Options"
+msgstr "列印選項"
+
+msgid "Safety Options"
+msgstr "安全選項"
+
+msgid "Hotends"
+msgstr "熱端"
+
+msgid "100%"
+msgstr "100%"
+
+msgid "Lamp"
+msgstr "LED燈"
+
+msgid "Bed"
+msgstr "熱床"
+
+msgid "Filament loading..."
+msgstr "換料中..."
+
+msgid "No Storage"
+msgstr "無儲存"
+
+msgid "Storage Abnormal"
+msgstr "儲存異常"
+
+msgid "Cancel print"
+msgstr "取消列印"
+
+msgid "Are you sure you want to stop this print?"
+msgstr "您確定要停止列印嗎？"
+
+msgid "The printer is busy on other print job"
+msgstr "印表機正在執行其他列印任務"
+
+msgid "When printing is paused, filament loading and unloading are only supported for external slots."
+msgstr "當列印暫停時，只有外掛耗材槽位支援進/退料。"
+
+msgid "Current extruder is busy changing filament"
+msgstr "當前擠出機正在換料"
+
+msgid "Current slot has alread been loaded"
+msgstr "當前槽位已載入"
+
+msgid "The selected slot is empty."
+msgstr "當前選擇的槽位是空的"
+
+msgid "No extruder found for the selected slot."
+msgstr "未找到所選槽位的擠出機。"
+
+msgid "The selected slot is not loaded in the extruder."
+msgstr "選定的槽位未被載入到擠出機中。"
+
+msgid "Printer 2D mode does not support 3D calibration"
+msgstr "印表機 2D 模式不支援 3D 校準"
+
+msgid "Downloading..."
+msgstr "下載中..."
+
+msgid "Cloud Slicing..."
+msgstr "雲切片中..."
+
+#, c-format, boost-format
+msgid "In Cloud Slicing Queue, there are %s tasks ahead."
+msgstr "前面還有%s個任務在雲端切片佇列中。"
+
+#, c-format, boost-format
+msgid "Layer: %s"
+msgstr "層： %s"
+
+#, c-format, boost-format
+msgid "Layer: %d/%d"
+msgstr "層： %d/%d"
+
+#, c-format, boost-format
+msgid "(%d)"
+msgstr ""
+
+msgid "Auto homing"
+msgstr "自動回中"
+
+msgid "Are you sure you want to trigger auto homing?"
+msgstr "確定觸發自動回中嗎？"
+
+msgid "Homing"
+msgstr "回中"
+
+msgid "Please heat the nozzle to above 170 degree before loading or unloading filament."
+msgstr "請在進料或退料前把噴嘴升溫到170℃以上。"
+
+msgid "Right extruder hotend not detected. Cannot set nozzle temperature."
+msgstr "未檢測到擠出機熱端。無法設定噴嘴溫度。"
+
+msgid "Chamber temperature cannot be changed in cooling mode while printing."
+msgstr "列印過程中，冷卻模式下無法調節腔溫。"
+
+msgid "If the chamber temperature exceeds 40℃, the system will automatically switch to heating mode. Please confirm whether to switch."
+msgstr "如果腔室溫度超過40℃, 系統將自動切換到腔溫保持模式。請確認是否切換。"
+
+msgid "Please select an AMS slot before calibration"
+msgstr "請先選擇一個AMS槽位後進行校準"
+
+msgid "Cannot read filament info: the filament is loaded to the tool head,please unload the filament and try again."
+msgstr "無法讀取耗材絲資訊：耗材絲已經載入到工具頭，請退出耗材絲後再重試。"
+
+msgid "This only takes effect during printing"
+msgstr "僅在列印過程中生效"
+
+msgid "Silent"
+msgstr "靜音"
+
+msgid "Sport"
+msgstr "運動"
+
+msgid "Ludicrous"
+msgstr "狂暴"
+
+msgid "Turning off the lights during the task will cause the failure of AI monitoring, like spaghetti detection. Please choose carefully."
+msgstr "任務過程中關燈會導致炒麵檢測等AI監控失效，請謹慎選擇。"
+
+msgid "Keep it On"
+msgstr "保持開啟"
+
+msgid "Still turn it Off"
+msgstr "仍然關閉"
+
+msgid "Can't start this without storage."
+msgstr "沒有外部儲存就無法啟動"
+
+msgid "Rate the Print Profile"
+msgstr "評價列印配置檔案"
+
+msgid "Comment"
+msgstr "評論"
+
+msgid "Rate this print"
+msgstr "為此次列印評分"
+
+msgid "Add Photo"
+msgstr "新增照片"
+
+msgid "Delete Photo"
+msgstr "刪除照片"
+
+msgid "Submit"
+msgstr "提交"
+
+msgid "Please click on the star first."
+msgstr "請先點選星星。"
+
+msgid "InFo"
+msgstr "資訊"
+
+msgid "Get oss config failed."
+msgstr "獲取oss配置失敗。"
+
+msgid "Upload Pictures"
+msgstr "上傳圖片"
+
+msgid "Number of images successfully uploaded"
+msgstr "成功上傳的影象數量"
+
+msgid " upload failed"
+msgstr "上傳失敗"
+
+msgid " upload config parse failed\n"
+msgstr "上傳配置解析失敗\n"
+
+msgid " No corresponding storage bucket\n"
+msgstr "沒有匹配的儲存桶\n"
+
+msgid " can not be opened\n"
+msgstr "不能被開啟\n"
+
+msgid ""
+"The following issues occurred during the process of uploading images. Do you want to ignore them?\n"
+"\n"
+msgstr ""
+"在上傳影象過程中出現了以下問題。您是否要忽略它們？\n"
+"\n"
+
+msgid "info"
+msgstr "資訊"
+
+msgid "Synchronizing the printing results. Please retry a few seconds later."
+msgstr "正在同步列印結果。請稍後重試。"
+
+msgid "Upload failed\n"
+msgstr "上傳失敗\n"
+
+msgid "obtaining instance_id failed\n"
+msgstr "獲取instance id失敗\n"
+
+msgid ""
+"Your comment result cannot be uploaded due to some reasons. As follows:\n"
+"\n"
+"  error code: "
+msgstr ""
+"由於某些原因，無法上傳您的評論結果。如下所示：\n"
+"\n"
+"  錯誤程式碼："
+
+msgid "error message: "
+msgstr "錯誤資訊："
+
+msgid ""
+"\n"
+"\n"
+"Would you like to redirect to the webpage for rating?"
+msgstr ""
+"\n"
+"\n"
+"您是否想要重定向到評分網頁？"
+
+msgid "Some of your images failed to upload. Would you like to redirect to the webpage for rating?"
+msgstr "您的一些影象上傳失敗。您是否想要重定向到評分網頁？"
+
+msgid "You can select up to 16 images."
+msgstr "您最多能選擇16張圖片。"
+
+msgid ""
+"At least one successful print record of this print profile is required \n"
+"to give a positive rating(4 or 5stars)."
+msgstr "至少需要一個成功的列印記錄，才能給出積極的評價（4星或5星）。"
+
+msgid "Step file import parameters"
+msgstr "匯入step檔案選項"
+
+msgid "Smaller linear and angular deflections result in higher-quality transformations but increase the processing time."
+msgstr "較小的線偏轉值和角偏轉值會產生更高質量的轉換，但會增加處理時間。"
+
+msgid "View Wiki for more information"
+msgstr "檢視Wiki以獲取更多資訊"
+
+msgid "Linear Deflection"
+msgstr "線偏轉值"
+
+msgid "Please input a valid value (0.001 < linear deflection < 0.1)"
+msgstr "請輸入有效值（0.001<線偏轉值<0.1）"
+
+msgid "Angle Deflection"
+msgstr "角偏轉值"
+
+msgid "Please input a valid value (0.01 < angle deflection < 1.0)"
+msgstr "請輸入有效值（0.01<角偏轉值<0.1）"
+
+msgid "Split compound and compsolid into multiple objects"
+msgstr "將複合體和複合實體拆分為多個物件"
+
+msgid "Number of triangular facets"
+msgstr "三角面數量"
+
+msgid "0"
+msgstr ""
+
+msgid "Don't show again"
+msgstr "不再顯示"
+
+msgid "Calculating, please wait..."
+msgstr "計算中，請等待..."
+
+msgid "Status"
+msgstr "裝置狀態"
+
+msgctxt "Firmware"
+msgid "Update"
+msgstr "韌體更新"
+
+msgid "Assistant(HMS)"
+msgstr "助手(HMS)"
+
+msgid "Go to"
+msgstr "前往"
+
+msgid "Later"
+msgstr "稍後再說"
+
+#, c-format, boost-format
+msgid "%s error"
+msgstr "%s 錯誤"
+
+#, c-format, boost-format
+msgid "%s has encountered an error"
+msgstr "%s 遇到一個錯誤"
+
+#, c-format, boost-format
+msgid "%s warning"
+msgstr "%s 警告"
+
+#, c-format, boost-format
+msgid "%s has a warning"
+msgstr "%s 有一個警告"
+
+#, c-format, boost-format
+msgid "%s info"
+msgstr "%s 資訊"
+
+#, c-format, boost-format
+msgid "%s information"
+msgstr "%s 資訊"
+
+msgid "Skip"
+msgstr "跳過"
+
+msgid "Newer 3mf version"
+msgstr "較新的3mf版本"
+
+msgid "The 3mf file version is in Beta and it is newer than the current Bambu Studio version."
+msgstr "3mf檔案為Beta版本，並且比當前的Bambu Studio版本新。"
+
+msgid "If you would like to try Bambu Studio Beta, you may click to"
+msgstr "如果您想嘗試Bambu Studio Beta版本，請點選"
+
+msgid "Download Beta Version"
+msgstr "下載Beta版本"
+
+msgid "The 3mf file version is newer than the current Bambu Studio version."
+msgstr "3mf檔案版本比當前的Bambu Studio版本新。"
+
+msgid "Update your Bambu Studio could enable all functionality in the 3mf file."
+msgstr "更新您的 Bambu Studio 可以啟用 3mf 檔案中的所有功能。"
+
+msgid "Current Version: "
+msgstr "當前版本："
+
+msgid "Latest Version: "
+msgstr "最新版本："
+
+msgctxt "Software"
+msgid "Update"
+msgstr "現在更新"
+
+msgid "Not for now"
+msgstr "稍後更新"
+
+msgid "Server Exception"
+msgstr "伺服器異常"
+
+msgid "The server is unable to respond. Please click the link below to check the server status."
+msgstr "伺服器無法響應。請單擊下面的連結檢查伺服器狀態。"
+
+msgid "If the server is in a fault state, you can temporarily use offline printing or local network printing."
+msgstr "如果伺服器處於故障狀態，您可以暫時使用離線列印或本地網路列印。"
+
+msgid "How to use LAN only mode"
+msgstr "如何使用僅區域網模式"
+
+msgid "Don't show this dialog again"
+msgstr "不再顯示此對話方塊？"
+
+msgid "3D Mouse disconnected."
+msgstr "3D滑鼠斷連。"
+
+msgid "Configuration can update now."
+msgstr "配置現在可以升級。"
+
+msgid "Detail."
+msgstr "詳情。"
+
+msgid "Integration was successful."
+msgstr "整合成功。"
+
+msgid "Integration failed."
+msgstr "整合失敗。"
+
+msgid "Undo integration was successful."
+msgstr "整合取消成功。"
+
+msgid "New network plug-in available."
+msgstr "新的網路外掛可用。"
+
+msgid "Details"
+msgstr "詳情"
+
+msgid "New printer config available."
+msgstr "有新的印表機配置可用。"
+
+msgid "Wiki"
+msgstr "Wiki"
+
+msgid "Undo integration failed."
+msgstr "整合取消失敗。"
+
+msgid "Exporting."
+msgstr "正在匯出。"
+
+msgid "Software has New version."
+msgstr "發現新的軟體版本。"
+
+msgid "Goto download page."
+msgstr "前往下載網站。"
+
+msgid "More"
+msgstr "詳情"
+
+msgid "Open Folder."
+msgstr "開啟目錄。"
+
+msgid "Safely remove hardware."
+msgstr "安全移除硬體。"
+
+#, c-format, boost-format
+msgid "%1$d Object has custom support."
+msgid_plural "%1$d Objects have custom support."
+msgstr[0] "%1$d 模型有自定義支撐。"
+
+#, c-format, boost-format
+msgid "%1$d Object has color painting."
+msgid_plural "%1$d Objects have color painting."
+msgstr[0] "%1$d物件有塗色。"
+
+#, c-format, boost-format
+msgid "%1$d Object has fuzzy skin."
+msgid_plural "%1$d Objects have fuzzy skin."
+msgstr[0] ""
+
+#, c-format, boost-format
+msgid "%1$d object was loaded as a part of cut object."
+msgid_plural "%1$d objects were loaded as parts of cut object"
+msgstr[0] "%1$d物件載入為一個切割物件的子部件。"
+
+msgid "ERROR"
+msgstr "錯誤"
+
+msgid "CANCELED"
+msgstr "已取消"
+
+msgid "COMPLETED"
+msgstr "已完成"
+
+msgid "Cancel upload"
+msgstr "取消上傳"
+
+msgid "Jump to"
+msgstr "跳轉到"
+
+msgid "Error:"
+msgstr "錯誤："
+
+msgid "Warning:"
+msgstr "警告："
+
+msgid "Export successfully."
+msgstr "傳送成功。"
+
+msgid "Model file downloaded."
+msgstr "已下載模型檔案。"
+
+msgid "Serious warning:"
+msgstr "嚴重警告："
+
+msgid " Click here to install it."
+msgstr "點選此處安裝。"
+
+msgid "WARNING:"
+msgstr "警告："
+
+msgid "Your model needs support ! Please make support material enable."
+msgstr "您的模型需要支撐才能列印。請開啟材料支撐選項。"
+
+msgid "Gcode path overlap"
+msgstr "Gcode路徑有重疊"
+
+msgid "Support painting"
+msgstr "支撐繪製"
+
+msgid "Fuzzy skin"
+msgstr "絨毛表面"
+
+msgid "Color painting"
+msgstr "顏色繪製"
+
+msgid "Cut connectors"
+msgstr "切割連線件"
+
+msgid "Layers"
+msgstr "層"
+
+msgid "Range"
+msgstr "範圍"
+
+msgid "The application cannot run normally because OpenGL version is lower than 2.0.\n"
+msgstr "應用程式無法正常執行，因為OpenGL的版本低於2.0。\n"
+
+msgid "Please upgrade your graphics card driver."
+msgstr "請升級您的顯示卡驅動。"
+
+msgid "Unsupported OpenGL version"
+msgstr "不支援的OpenGL版本"
+
+#, c-format, boost-format
+msgid ""
+"Unable to load shaders:\n"
+"%s"
+msgstr "無法載入Shader: %s"
+
+msgid "Error loading shaders"
+msgstr "載入shader程式時發生錯誤"
+
+msgctxt "Layers"
+msgid "Top"
+msgstr "頂部"
+
+msgctxt "Layers"
+msgid "Bottom"
+msgstr "底部"
+
+msgid "When enabled, the printer will automatically capture photos of printed parts and upload them to the cloud. Would you like to enable this option?"
+msgstr "啟用後，印表機會自動拍攝列印部件的照片並上傳到雲端。您想啟用此選項嗎？"
+
+msgid "Confirm Enable Print Status Snapshot"
+msgstr "確認啟用列印狀態快照"
+
+msgid "Unavailable during the task"
+msgstr "任務期間不可用"
+
+msgid "Purifies the chamber air as the print finishes, based on the selected mode."
+msgstr "每次列印結束時，根據所選方式淨化印表機的腔體空氣。"
+
+msgid "Purifies the chamber air through internal circulation as each print finishes."
+msgstr "每次列印結束時，透過內迴圈淨化印表機的腔體空氣。"
+
+msgid "Enable detection of build plate position"
+msgstr "啟用列印板位置檢測"
+
+msgid "The localization tag of build plate is detected, and printing is paused if the tag is not in predefined range."
+msgstr "檢測列印板的定位標記，如果標記不在預定義範圍內時暫停列印。"
+
+msgid "Build Plate Detection"
+msgstr "列印板檢測"
+
+msgid "Identifies the type and position of the build plate on the heatbed. Pausing printing if a mismatch is detected."
+msgstr "檢測列印板的型別與位置。若檢測到列印板不匹配，則停止列印。"
+
+msgid "AI Detections"
+msgstr "AI檢測"
+
+msgid "Printer will send assistant message or pause printing if any of the following problem is detected."
+msgstr "如果檢測到以下任何問題，印表機將傳送助手訊息或暫停列印。"
+
+msgid "Enable AI monitoring of printing"
+msgstr "啟用列印過程的AI監控"
+
+msgid "Pausing Sensitivity:"
+msgstr "暫停列印的靈敏度為："
+
+msgid "Spaghetti Detection"
+msgstr "炒麵檢測"
+
+msgid "Detects spaghetti failure(scattered lose filament)."
+msgstr "檢測到炒麵（散落的耗材絲）。"
+
+msgid "Purge Chute Pile-Up Detection"
+msgstr "堆料檢測"
+
+msgid "Monitors if the waste is piled up in the purge chute."
+msgstr "監控沖刷料是否在垃圾桶中發生堆積。"
+
+msgid "Nozzle Clumping Detection"
+msgstr "裹頭檢測"
+
+msgid "Checks if the nozzle is clumping by filaments or other foreign objects."
+msgstr "檢查噴嘴是否被耗材或其他異物堵塞。"
+
+msgid "Detects air printing caused by nozzle clogging or filament grinding."
+msgstr "檢測由噴嘴堵塞引起的空打。"
+
+msgid "Ensures the build plate type and placement are correct."
+msgstr "確保盤的型別及放置位置正確。"
+
+msgid "Type Detection"
+msgstr "型別檢測"
+
+msgid "Pauses printing when the detected build plate type does not match the selected one."
+msgstr "檢測到的列印板型別與所選型別不匹配時暫停列印。"
+
+msgid "Alignment Detection"
+msgstr "偏移檢測"
+
+msgid "Pauses printing when build plate misalignment is detected."
+msgstr "若檢測到列印板偏移，則暫停列印。"
+
+msgid "First Layer Inspection"
+msgstr "首層掃描"
+
+msgid "Purify Air at Print End"
+msgstr "列印結束時淨化空氣"
+
+msgid "Internal Circulation"
+msgstr "內迴圈"
+
+msgid "Auto-recovery from step loss"
+msgstr "自動從丟步中恢復"
+
+msgid "Store Sent Files on External Storage"
+msgstr "將傳送的檔案儲存到外部儲存"
+
+msgid "Save the printing files initiated from Bambu Studio, Bambu Handy and MakerWorld on External Storage"
+msgstr "將從 Bambu Studio、Bambu Handy 和 MakerWorld 啟動的列印檔案儲存在外部儲存中"
+
+msgid "Enable notification sounds"
+msgstr "啟用通知音效"
+
+msgid "Filament Tangle Detect"
+msgstr "纏料檢測"
+
+msgid "Checks if the nozzle is clumping by filament or other foreign objects."
+msgstr "檢查噴嘴是否被耗材或其他異物堵塞。"
+
+msgid "Open Door Detection"
+msgstr "開門檢測"
+
+msgid "Choose the behavior when the door is opened during tasks."
+msgstr "選擇列印過程中門開啟時的行為。"
+
+msgid "Notification"
+msgstr "通知"
+
+msgid "Pause printing"
+msgstr "暫停列印"
+
+msgid "Print Status Snapshot"
+msgstr "列印狀態快照"
+
+msgid "Automatically capture and upload print photos, showing defects during printing and the final result for remote viewing."
+msgstr "自動拍攝列印件照片並上傳雲端，包括列印過程中檢測到的缺陷和任務結束時的列印件狀態，便於遠端檢視。"
+
+msgctxt "Nozzle Type"
+msgid "Type"
+msgstr "型別"
+
+msgctxt "Nozzle Diameter"
+msgid "Diameter"
+msgstr "直徑"
+
+msgctxt "Nozzle Flow"
+msgid "Flow"
+msgstr "流量"
+
+msgid "Please change the nozzle settings on the printer."
+msgstr "如需修改噴嘴資訊，請去印表機操作。"
+
+msgid "View wiki"
+msgstr ""
+
+msgid "Left Nozzle"
+msgstr "左噴嘴"
+
+msgid "Right Nozzle"
+msgstr "右噴嘴"
+
+msgid "Brass"
+msgstr "黃銅"
+
+msgid "High flow"
+msgstr "高流量"
+
+msgid "TPU High flow"
+msgstr "TPU高流量"
+
+msgid "No wiki link available for this printer."
+msgstr ""
+
+msgid "Refreshing"
+msgstr "重新整理中"
+
+msgid "Unavailable while heating maintenance function is on."
+msgstr "因其他加熱維護功能已開啟，本功能暫不可用。"
+
+msgid "Idle Heating Protection"
+msgstr "空閒加熱保護"
+
+msgid "Stops heating automatically after 5 mins of idle to ensure safety."
+msgstr "閒置5分鐘後自動停止加熱以保障安全。"
+
+msgid "Global"
+msgstr "全域性"
+
+msgid "Objects"
+msgstr "物件"
+
+msgid "Advance"
+msgstr "高階"
+
+msgid "Compare presets"
+msgstr "比較預設"
+
+msgid "View all object's settings"
+msgstr "檢視所有物件的配置"
+
+msgid "Filament settings"
+msgstr "耗材絲設定"
+
+msgid "Printer settings"
+msgstr "印表機設定"
+
+msgid "Remove current plate (if not last one)"
+msgstr "刪除當前盤(如果不是最後一個)"
+
+msgid "Auto orient objects on current plate"
+msgstr "自動調整當前盤上的物件方向"
+
+msgid "Arrange objects on current plate"
+msgstr "在當前盤上擺放物件"
+
+msgid "Unlock current plate"
+msgstr "解鎖當前盤"
+
+msgid "Lock current plate"
+msgstr "鎖定當前盤"
+
+msgid "Edit filament grouping"
+msgstr "編輯材料分組"
+
+msgid "Edit current plate name"
+msgstr "編輯當前盤名稱"
+
+msgid "Customize current plate"
+msgstr "自定義當前盤"
+
+#, c-format, boost-format
+msgid "The %s nozzle can not print %s."
+msgstr "%s噴嘴不可以列印%s"
+
+#, boost-format
+msgid "Mixing %1% with %2% in printing is not recommended.\n"
+msgstr ""
+
+msgid " nozzle"
+msgstr "噴嘴"
+
+#, boost-format
+msgid "It is not recommended to print the following filament(s) with %1%: %2%\n"
+msgstr "不推薦使用%1%列印材料：%2%\n"
+
+msgid "It is not recommended to use the following nozzle and filament combinations:\n"
+msgstr "不推薦噴嘴和材料這樣搭配使用：\n"
+
+#, boost-format
+msgid "%1% with %2%\n"
+msgstr "%1%列印：%2%\n"
+
+#, c-format, boost-format
+msgid "The %s nozzle does not support automatic filament switching.\n"
+msgstr "%s 噴嘴不支援自動更換耗材。\n"
+
+msgid "Please change the nozzle type or reassign the filaments and try again."
+msgstr "請更換噴嘴型別或重新分配耗材，然後重試。"
+
+#, boost-format
+msgid " plate %1%: "
+msgstr " 盤 %1%: "
+
+msgid "Invalid name, the following characters are not allowed:"
+msgstr "無效名稱，不允許使用以下字元："
+
+msgid "(Including its escape characters)"
+msgstr "(包括跳脫字元）"
+
+msgid "Sliced Info"
+msgstr "切片資訊"
+
+msgid "Used Filament (m)"
+msgstr "耗材絲消耗長度 (m)"
+
+msgid "Used Filament (mm³)"
+msgstr "耗材絲消耗體積 (mm³)"
+
+msgid "Used Filament (g)"
+msgstr "耗材絲消耗重量(g)"
+
+msgid "Used Materials"
+msgstr "材料消耗"
+
+msgid "Estimated time"
+msgstr "預估列印時間"
+
+msgid "Filament changes"
+msgstr "材料切換"
+
+msgid "Set the number of AMS installed on the nozzle."
+msgstr "設定該噴嘴上安裝的AMS數量。"
+
+msgid "AMS(4 slots)"
+msgstr "AMS（4槽）"
+
+msgid "AMS(1 slot)"
+msgstr "AMS（單槽）"
+
+msgid "Not installed"
+msgstr "未安裝"
+
+msgid ""
+"The software does not support using different diameter of nozzles for one print.\n"
+"If the left and right nozzles are inconsistent, we can only proceed with single-head printing.\n"
+"Please confirm which nozzle you would like to use for this project."
+msgstr ""
+"軟體暫不支援使用兩種不同直徑的噴嘴同時列印。\n"
+"由於您設定的左右噴嘴直徑不一致，我們只能採用單頭列印。\n"
+"請確認使用哪個噴嘴列印當前專案。"
+
+msgid "Switch diameter"
+msgstr "設定噴嘴直徑"
+
+#, c-format, boost-format
+msgid "Left nozzle: %smm"
+msgstr "左噴嘴：%smm"
+
+#, c-format, boost-format
+msgid "Right nozzle: %smm"
+msgstr "右噴嘴：%smm"
+
+msgid "Sync printer information"
+msgstr "同步印表機資訊"
+
+msgid ""
+"The currently selected machine preset is inconsistent with the connected printer type.\n"
+"Are you sure to continue syncing?"
+msgstr ""
+"當前選擇的印表機預設與連線的印表機預設型別不一致。\n"
+"您確定要繼續同步嗎？"
+
+msgid "There are unset nozzle types. Please set the nozzle types of all extruders before synchronizing."
+msgstr "有未設定的噴嘴型別。請在同步之前設定所有擠出機的噴嘴型別"
+
+msgid "Sync extruder infomation"
+msgstr "同步擠出機資訊"
+
+msgid "Click to edit preset"
+msgstr "點選編輯配置"
+
+msgid "Connection"
+msgstr "連線"
+
+msgid "Click to view the wiki of the current plate type"
+msgstr "點選檢視當前熱床型別的wiki"
+
+msgid "Sync info"
+msgstr "同步資訊"
+
+msgid "Synchronize nozzle information and the number of AMS"
+msgstr "同步噴嘴資訊和AMS編號"
+
+msgid "Project Filaments"
+msgstr "專案耗材列表"
+
+msgid "Purge mode"
+msgstr "沖刷模式"
+
+msgid "Flushing volumes"
+msgstr "沖刷體積"
+
+msgid "Add one filament"
+msgstr "增加一個材料"
+
+msgid "Remove last filament"
+msgstr "刪除最後一個材料"
+
+msgid "Synchronize filament list from AMS"
+msgstr "從AMS同步材料列表"
+
+msgid "Set filaments to use"
+msgstr "配置可選擇的材料"
+
+msgid "Search plate, object and part."
+msgstr "搜尋盤、模型和零件。"
+
+#, c-format, boost-format
+msgid "After completing your operation, %s project will be closed and create a new project."
+msgstr "執行完成該操作後，%s 專案將會被關閉並建立一個新專案。"
+
+msgid "There are no compatible filaments, and sync is not performed."
+msgstr "沒有任何相容的材料，同步操作未執行。"
+
+msgid "Sync filaments with AMS"
+msgstr "同步到 AMS 的材料列表"
+
+msgid ""
+"There are some unknown or uncompatible filaments mapped to generic preset.\n"
+"Please update Bambu Studio or restart Bambu Studio to check if there is an update to system presets."
+msgstr ""
+"有一些未知或不相容的耗材對映到通用預設。\n"
+"請更新Bambu Studio或重新啟動Bambu Studio，以檢查是否有系統預設的更新。"
+
+msgid "Filament type and color information have been synchronized, but slot information is not included."
+msgstr "耗材型別和顏色資訊已同步，但不包括槽位資訊。"
+
+#, boost-format
+msgid "Do you want to save changes to \"%1%\"?"
+msgstr "是否儲存修改到“%1%”？"
+
+#, c-format, boost-format
+msgid "Successfully unmounted. The device %s(%s) can now be safely removed from the computer."
+msgstr "解除安裝成功。裝置%s(%s)現在可能安全地從電腦移除。"
+
+#, c-format, boost-format
+msgid "Ejecting of device %s(%s) has failed."
+msgstr "彈出裝置%s(%s)失敗。"
+
+msgid ""
+"It seems that you have projects that were not closed properly. Would you like to restore your last unsaved project?\n"
+"If you have a currently opened project and click \"Restore\", the current project will be closed."
+msgstr ""
+"檢測到您有一些專案未正確關閉。是否要恢復您最後一個未儲存的專案？\n"
+"如果您當前有開啟的專案並點選“恢復”，當前專案將被關閉。"
+
+msgid "Restore"
+msgstr "恢復"
+
+msgid "There is a G-code script present in the current 3mf file, please verify the content of the script."
+msgstr "當前 3mf 檔案中存在 G-code 指令碼，請核實指令碼內容。"
+
+msgid "The current hot bed temperature is relatively high. The nozzle may be clogged when printing this filament in a closed enclosure. Please open the front door and/or remove the upper glass."
+msgstr "當前熱床溫度相對較高。在封閉式外殼中列印這種絲可能會導致噴嘴堵塞。請開啟前門和/或取下上部玻璃。"
+
+msgid "The nozzle hardness required by the filament is higher than the default nozzle hardness of the printer. Please replace the hardened nozzle or filament, otherwise, the nozzle will be attrited or damaged."
+msgstr "耗材絲所要求的噴嘴硬度高於印表機預設的噴嘴硬度。請更換硬化的噴嘴或耗材絲，否則噴嘴可能被磨損或損壞。"
+
+msgid "Enabling traditional timelapse photography may cause surface imperfections. It is recommended to change to smooth mode."
+msgstr "開啟傳統模式延時攝影可能導致表面瑕疵，建議修改為平滑模式。"
+
+msgid "\n"
+msgstr ""
+
+msgid "(Path to modify: 'Process'-'Others'-'Special Mode'-'Timelapsed')"
+msgstr "（修改路徑：“工藝”-”其他“-”特殊模式“-”延時攝影“）"
+
+msgid "Smooth mode for timelapse is enabled, but the prime tower is off, which may cause print defects. Please enable the prime tower, re-slice and print again."
+msgstr "檢測到您使用了延時攝影的平滑模式，但未啟用擦料塔，這可能導致列印瑕疵。建議開啟擦料塔後重新切片列印。"
+
+msgid "Expand sidebar"
+msgstr "展開側邊欄"
+
+msgid "Collapse sidebar"
+msgstr "收起側邊欄"
+
+#, c-format, boost-format
+msgid "Loading file: %s"
+msgstr "載入檔案：%s"
+
+msgid "The 3mf is not from Bambu Lab, load geometry data only."
+msgstr "該3mf檔案不是來自Bambu Lab，將只載入幾何資料。"
+
+msgid "Load 3mf"
+msgstr "載入3mf"
+
+msgid "The Config can not be loaded."
+msgstr "配置無法載入。"
+
+msgid "Due to the lower version of Bambu Studio, this 3mf file cannot be fully loaded. Please update Bambu Studio to the latest version"
+msgstr "由於Bambu Studio版本較低，無法完整地載入此3mf檔案。請將Bambu Studio更新到最新版本。"
+
+msgid "Found following keys unrecognized:\n"
+msgstr "找到以下未能識別的關鍵字：\n"
+
+msgid "The 3mf is not from Bambu Lab, load geometry data and color data only."
+msgstr "該3mf檔案不是來自Bambu Lab，將只載入幾何資料和顏色資料。"
+
+msgid "The 3mf is generated by old Bambu Studio, load geometry data only."
+msgstr "該3mf檔案來自舊版本的Bambu Studio，將只載入幾何資料。"
+
+msgid "Invalid values found in the 3mf:"
+msgstr "在3mf檔案中發現無效值："
+
+msgid "Please correct them in the param tabs"
+msgstr "請在引數頁更正它們"
+
+msgid "The 3mf has following modified G-codes in filament or printer presets:"
+msgstr "該3mf檔案中的材料或者印表機預設包含以下修改過的G-codes:"
+
+msgid "Please confirm that these modified G-codes are safe to prevent any damage to the machine!"
+msgstr "請確認這些修改過的G-codes是否安全，以防止對機器造成任何損壞！"
+
+msgid "Modified G-codes"
+msgstr "修改過的G-codes"
+
+msgid "The 3mf has following customized filament or printer presets:"
+msgstr "該3MF檔案包含以下自定義的材料或印表機預設:"
+
+msgid "Please confirm that the G-codes within these presets are safe to prevent any damage to the machine!"
+msgstr "請確認這些預設中的G-codes是否安全，以防止對機器造成任何損壞!"
+
+msgid "Customized Preset"
+msgstr "自定義的預設"
+
+msgid "Name of components inside step file is not UTF8 format!"
+msgstr "step 檔案中的部件名稱包含非UTF8格式的字元！"
+
+msgid "The name may show garbage characters!"
+msgstr "此名稱可能顯示亂碼字元！"
+
+#, boost-format
+msgid "Failed loading file \"%1%\". An invalid configuration was found."
+msgstr "載入檔案“%1%”失敗。發現無效配置。"
+
+msgid "Objects with zero volume removed"
+msgstr "體積為零的物件已被移除"
+
+msgid "The volume of the object is zero"
+msgstr "物件的體積為零"
+
+#, c-format, boost-format
+msgid ""
+"The object from file %s is too small, and maybe in meters or inches.\n"
+" Do you want to scale to millimeters?"
+msgstr ""
+"檔案 %s 中物件的尺寸似乎是以米或者英寸為單位定義的。\n"
+"BambuStudio的內部單位為毫米。是否要轉換成毫米？"
+
+msgid "Object too small"
+msgstr "物件尺寸過小"
+
+msgid ""
+"This file contains several objects positioned at multiple heights.\n"
+"Instead of considering them as multiple objects, should \n"
+"the file be loaded as a single object having multiple parts?"
+msgstr ""
+"該檔案包含多個位於不同高度的物件。\n"
+"是否將檔案載入為一個由多個零件組合而成的物件，而非多個單零件的物件？"
+
+msgid "Multi-part object detected"
+msgstr "檢測到多部分物件"
+
+msgid "Load these files as a single object with multiple parts?\n"
+msgstr "將這些檔案載入為一個多零件物件？\n"
+
+msgid "Object with multiple parts was detected"
+msgstr "檢測到多零件物件"
+
+msgid "The file does not contain any geometry data."
+msgstr "此檔案不包含任何幾何資料。"
+
+msgid "Your object appears to be too large, Do you want to scale it down to fit the heat bed automatically?"
+msgstr "物件看起來太大，希望將物件自動縮小以適應熱床嗎？"
+
+msgid "Object too large"
+msgstr "物件太大"
+
+msgid "Export STL file:"
+msgstr "匯出 STL 檔案："
+
+msgid "Export AMF file:"
+msgstr "匯出 AMF 檔案："
+
+msgid "Save file as:"
+msgstr "檔案另存為："
+
+msgid "Export OBJ file:"
+msgstr "匯出 OBJ 檔案："
+
+#, c-format, boost-format
+msgid ""
+"The file %s already exists\n"
+"Do you want to replace it?"
+msgstr ""
+"檔案 %s 已經存在\n"
+"您是否要替換它？"
+
+msgid "Comfirm Save As"
+msgstr "確認另存為"
+
+msgid "Delete object which is a part of cut object"
+msgstr "刪除切割物件的一部分"
+
+msgid ""
+"You try to delete an object which is a part of a cut object.\n"
+"This action will break a cut correspondence.\n"
+"After that model consistency can't be guaranteed."
+msgstr "您正嘗試刪除切割物件的一部分，這將破壞切割對應關係，刪除之後，將無法再保證模型的一致性。"
+
+msgid "The selected object couldn't be split."
+msgstr "選中的模型不可分裂。"
+
+msgid "Another export job is running."
+msgstr "有其他匯出任務正在進行中。"
+
+msgid "Unable to replace with more than one volume"
+msgstr "超過1個零件，無法替換"
+
+msgid "Error during replace"
+msgstr "替換時發生錯誤"
+
+msgid "Replace from:"
+msgstr "替換："
+
+msgid "Select a new file"
+msgstr "選擇新檔案"
+
+msgid "File for the replace wasn't selected"
+msgstr "未選擇替換檔案"
+
+msgid "Please select a file"
+msgstr "請選擇一個檔案"
+
+msgid "Do you want to replace it"
+msgstr "您是否要替換"
+
+msgid "Message"
+msgstr "資訊"
+
+msgid "Reload from:"
+msgstr "重新載入："
+
+msgid "Unable to reload:"
+msgstr "無法重新載入："
+
+msgid "Error during reload"
+msgstr "重新載入時發生錯誤：。"
+
+msgid "Slicing"
+msgstr "正在切片"
+
+msgid "There are warnings after slicing models:"
+msgstr "模型切片警告："
+
+msgid "warnings"
+msgstr "警告"
+
+msgid "Invalid data"
+msgstr "無效資料"
+
+msgid "Slicing Canceled"
+msgstr "切片已取消"
+
+msgid "Great! Now click the Helio button to start optimization."
+msgstr "太好了！現在點選 Helio 按鈕開始最佳化。"
+
+#, c-format, boost-format
+msgid "Slicing Plate %d"
+msgstr "正在切片盤%d"
+
+msgid "Multiple Filament Materials Detected"
+msgstr "檢測到多種耗材材料"
+
+msgid "⚠ Multiple Filament Materials Detected"
+msgstr "⚠ 檢測到多種耗材材料"
+
+msgid " (unsupported)"
+msgstr " （不支援）"
+
+msgid "Multicolour simulation currently supports only a single filament material.\n"
+msgstr "多色模擬目前僅支援單一耗材材料。\n"
+
+#, c-format, boost-format
+msgid "You have selected multiple materials: %s"
+msgstr "你已選擇多種材料：%s"
+
+msgid ""
+"\n"
+"\n"
+"Note: Unsupported materials will use the selected reference material for simulation."
+msgstr ""
+"\n"
+"\n"
+"注意：不支援的材料將使用所選參考材料進行模擬。"
+
+msgid "True multi-material support will be added in a future update."
+msgstr "真正的多材料支援將在後續更新中加入。"
+
+msgid "Option 1: Proceed using a single filament type"
+msgstr "選項 1：繼續使用單一耗材型別"
+
+msgid "Select which filament to use for simulation:"
+msgstr "選擇用於模擬的耗材："
+
+msgid "⚠ This is not recommended. Filament formulations vary significantly between manufacturers and materials. Helio cannot guarantee reliable results in this configuration."
+msgstr "⚠ 不推薦此操作。不同廠商與材料的耗材配方差異很大。在這種配置下，Helio 無法保證結果可靠。"
+
+msgid "Proceed Anyway"
+msgstr "仍然繼續"
+
+msgid "Option 2: Go back and change filament selection"
+msgstr "選項 2：返回並更改耗材選擇"
+
+msgid "✓ Recommended"
+msgstr "✓ 推薦"
+
+msgid "Change your filament selection to use the same type for all colours, then try again."
+msgstr "將所有顏色的耗材型別改為一致，然後重試。"
+
+msgid "See supported materials"
+msgstr "檢視支援的材料"
+
+msgid "Go Back"
+msgstr "返回"
+
+msgid "Unsupported Materials Detected"
+msgstr "檢測到不支援的材料"
+
+msgid "⚠ Unsupported Materials Detected"
+msgstr "⚠ 檢測到不支援的材料"
+
+msgid "Some of your selected materials are not directly supported by Helio:\n"
+msgstr "你選擇的部分材料未被 Helio 直接支援：\n"
+
+msgid "Option 1: Proceed with a reference material"
+msgstr "選項 1：繼續使用參考材料"
+
+msgid "Select a similar material type to use for simulation:"
+msgstr "選擇一種相近的材料型別用於模擬："
+
+msgid "Note: Using a reference material may result in approximate or erroneous results."
+msgstr "注意：使用參考材料可能導致結果近似或出現誤差。"
+
+msgid "Change your filament selection to use a supported material, then try again."
+msgstr "將耗材更換為受支援的材料，然後重試。"
+
+msgid "A Helio simulation or optimization task is in progress."
+msgstr "Helio 模擬或最佳化任務正在進行中。"
+
+msgid "Invalid printer preset. Unable to slice with Helio."
+msgstr "印表機預設無效，無法使用 Helio 功能。"
+
+#, c-format, boost-format
+msgid ""
+"Helio found a potential printer match using token-based matching:\n"
+"\n"
+"Your printer: %s\n"
+"Matched printer: %s\n"
+"\n"
+"Do you want to use this match, or would you prefer to rename your printer profile?"
+msgstr ""
+"Helio 透過基於 token 的匹配找到了一個可能的印表機匹配項：\n"
+"\n"
+"你的印表機：%s\n"
+"匹配的印表機：%s\n"
+"\n"
+"你想使用該匹配項，還是更希望重新命名你的印表機配置檔案？"
+
+msgid "Helio Printer Match Confirmation"
+msgstr "Helio 印表機匹配確認"
+
+msgid "Unsupported Printer Detected"
+msgstr "檢測到不支援的印表機"
+
+msgid "⚠ Unsupported Printer Detected"
+msgstr "⚠ 檢測到不支援的印表機"
+
+#, c-format, boost-format
+msgid "You're using %s which is not officially supported by Helio."
+msgstr "你正在使用 %s，Helio 尚未正式支援該預設。"
+
+msgid "Option 1: Proceed with a reference printer"
+msgstr "選項 1：繼續使用參考印表機"
+
+msgid "Select a similar printer to use for simulation:"
+msgstr "選擇一臺相近的印表機用於模擬："
+
+msgid "Note: Using a reference printer may result in approximate or erroneous results."
+msgstr "注意：使用參考印表機可能導致結果近似或出現誤差。"
+
+msgid "Option 2: Go back and change printer selection"
+msgstr "選項 2：返回並更改印表機選擇"
+
+msgid "Change your printer selection to use a supported printer, then try again."
+msgstr "將印表機更換為受支援的型號，然後重試。"
+
+msgid "See supported printers"
+msgstr "檢視支援的印表機"
+
+msgid "The current printer preset cannot be sliced using Helio."
+msgstr "當前印表機預設無法使用 Helio 功能。"
+
+#, c-format, boost-format
+msgid ""
+"Helio found a potential material match using token-based matching:\n"
+"\n"
+"Your material: %s\n"
+"Matched material: %s\n"
+"\n"
+"Do you want to use this match, or would you prefer to rename your material profile?"
+msgstr ""
+"Helio 透過基於 token 的匹配找到了一個可能的材料匹配項：\n"
+"\n"
+"你的材料：%s\n"
+"匹配的材料：%s\n"
+"\n"
+"你想使用該匹配項，還是更希望重新命名你的材料配置檔案？"
+
+msgid "Helio Material Match Confirmation"
+msgstr "Helio 材料匹配確認"
+
+msgid "Unsupported Material Detected"
+msgstr "檢測到不支援的材料"
+
+msgid "⚠ Unsupported Material Detected"
+msgstr "⚠ 檢測到不支援的材料"
+
+msgid "Choose a Reference Material"
+msgstr "選擇一份參考材料"
+
+#, c-format, boost-format
+msgid "Helio does not support materials %s"
+msgstr "Helio 不支援材料 %s"
+
+msgid ""
+"Warning: Infill combination is currently unsupported by Helio.\n"
+"\n"
+"Proceeding with this setting enabled may return erroneous results.\n"
+"\n"
+"Do you want to continue anyway?"
+msgstr ""
+"警告：當前填充組合不受 Helio 支援。\n"
+"\n"
+"繼續啟用該設定可能導致結果錯誤。\n"
+"\n"
+"是否仍要繼續？"
+
+msgid "Helio Warning"
+msgstr "Helio 警告"
+
+msgid "Click the Optimize/Enhance button to start your first optimization."
+msgstr "點選最佳化/增強按鈕開始您的第一次最佳化。"
+
+msgid ""
+"No valid Helio-PAT detected. Helio simulation & optimization cannot proceed. \n"
+"Please request a new Helio-PAT."
+msgstr ""
+"未檢測到有效的Helio PAT。無法進行Helio模擬與最佳化。\n"
+"請申請新的Helio PAT。"
+
+msgid "Execution Blocked"
+msgstr "執行被阻止"
+
+msgid "Regenerate PAT"
+msgstr "重新生成 PAT"
+
+msgid "Failed to obtain Helio PAT, Click Refresh to obtain it again."
+msgstr "獲取 Helio-PAT 失敗，點選重新整理重新獲取。"
+
+msgid "Successfully obtained PAT."
+msgstr "成功獲得PAT。"
+
+msgid "The printer list and material list are being synchronized. Please try again later."
+msgstr "印表機列表和材料列表正在同步中。請稍後再試。"
+
+msgid "Synchronizing Helio"
+msgstr "正在同步 Helio"
+
+msgid "Please resolve the slicing errors and publish again."
+msgstr "請解決切片錯誤後再重新發布。"
+
+msgid "Failed to start Bambu Farm Manager Client."
+msgstr "啟動Bambu農場管理客戶端失敗。"
+
+msgid "No Bambu Farm Manager Client found."
+msgstr "未找到Bambu農場客戶端。"
+
+msgid "Network Plug-in is not detected. Network related features are unavailable."
+msgstr "未檢測到網路外掛。網路相關功能不可用。"
+
+msgid ""
+"Preview only mode:\n"
+"The loaded file contains gcode only, Can not enter the Prepare page"
+msgstr ""
+"僅預覽模式：\n"
+"被載入的檔案僅包含G-Code，不支援進入準備頁面"
+
+msgid ""
+"The nozzle type and AMS quantity information has not been synced from the connected printer.\n"
+"After syncing, software can optimize printing time and filament usage when slicing.\n"
+"Would you like to sync now ?"
+msgstr "噴嘴和AMS數量資訊尚未從當前連線的印表機同步。同步後，軟體能夠在切片時最佳化列印時間並減少列印時耗材浪費。是否現在同步？"
+
+msgid "Sync now"
+msgstr "立即同步"
+
+msgid "You can keep the modified presets to the new project or discard them"
+msgstr "您可以保留修改的預設到新專案中或者忽略這些修改"
+
+msgid "Creating a new project"
+msgstr "建立新專案"
+
+#, c-format, boost-format
+msgid ""
+"The currently connected printer '%s', is a %s model.\n"
+"To use this printer for printing, please switch the printer model of project file to %s."
+msgstr ""
+"當前連線的印表機 \"%s\" 為 %s機型。\n"
+"如果使用該印表機列印，請將專案檔案中的機型切換為 %s。"
+
+#, c-format, boost-format
+msgid ""
+"The currently connected printer '%s', is a %s model but not consistent with preset in project file.\n"
+"To use this printer for printing, please switch the preset first."
+msgstr ""
+"當前連線的印表機 \"%s\"是%s型號，但與專案檔案中的預設不一致。\n"
+"若要使用此印表機進行列印，請先切換預設。"
+
+msgid "Switch now"
+msgstr "現在切換"
+
+msgid "Load project"
+msgstr "載入專案"
+
+msgid ""
+"Failed to save the project.\n"
+"Please check whether the folder exists online or if other programs open the project file or if there is enough disk space."
+msgstr ""
+"儲存專案失敗。\n"
+"請檢查目錄是否存在，或者其他程式是否開啟了專案檔案，以及磁碟空間是否足夠。"
+
+msgid "Save project"
+msgstr "儲存專案"
+
+msgid "Importing Model"
+msgstr "正在匯入模型"
+
+msgid "prepare 3mf file..."
+msgstr "正在準備3mf檔案..."
+
+msgid "Download failed, unknown file format."
+msgstr "下載失敗，未知檔案格式。"
+
+msgid "downloading project ..."
+msgstr "專案下載中..."
+
+msgid "Download failed, File size exception."
+msgstr "下載失敗，檔案大小異常。"
+
+#, c-format, boost-format
+msgid "Project downloaded %d%%"
+msgstr "專案已下載%d%%"
+
+msgid "Importing to Bambu Studio failed. Please download the file and manually import it."
+msgstr "匯入到Bambu Studio失敗。請下載檔案並手動匯入。"
+
+msgid "The current settings produce a model that is too large. Please narrow the range or increase the step size. (Model size is proportional to (End - Start) / Step size.)"
+msgstr "當前設定下的模型尺寸超出了內建模型的最大支援範圍。請適當減小引數範圍或增大步長，使模型尺寸符合要求。（模型尺寸與（結束值-起始值）/步長 的結果成正比）"
+
+msgid "The selected file"
+msgstr "已選擇的檔案"
+
+msgid "does not contain valid gcode."
+msgstr "不包含有效的G-code檔案。"
+
+msgid "Error occurs while loading G-code file"
+msgstr "載入G-code檔案時遇到錯誤"
+
+msgid "Drop project file"
+msgstr "專案檔案操作"
+
+msgid "Please select an action"
+msgstr "請選擇處理方式"
+
+msgid "Open as project"
+msgstr "按專案開啟"
+
+msgid "Import geometry only"
+msgstr "僅匯入模型資料"
+
+msgid "Please import multiple files with the same suffix."
+msgstr "請匯入多個具有相同字尾的檔案。"
+
+msgid "Only one G-code file can be opened at the same time."
+msgstr "只能同時開啟一個G-code檔案。"
+
+msgid "G-code loading"
+msgstr "正在載入G-code檔案"
+
+msgid "G-code files can not be loaded with models together!"
+msgstr "G-code檔案不能和模型一起載入！"
+
+msgid "Can not add models when in preview mode!"
+msgstr "在預覽模式不允許新增模型！"
+
+msgid "Add Models"
+msgstr "新增模型"
+
+msgid "All objects will be removed, continue?"
+msgstr "即將刪除所有物件，是否繼續？"
+
+msgid "The current project has unsaved changes, save it before continue?"
+msgstr "當前專案包含未儲存的修改。是否先儲存？"
+
+msgid "Remember my choice."
+msgstr "記住我的選擇。"
+
+msgid "Number of copies:"
+msgstr "克隆數量："
+
+msgid "Copies of the selected object"
+msgstr "所選物件的克隆數量"
+
+msgid "Save G-code file as:"
+msgstr "G-code檔案另存為："
+
+msgid "Save SLA file as:"
+msgstr "SLA 檔案另存為："
+
+msgid "The provided file name is not valid."
+msgstr "無效的檔名。"
+
+msgid "The following characters are not allowed by a FAT file system:"
+msgstr "不允許使用以下字元："
+
+msgid "Save Sliced file as:"
+msgstr "切片檔案另存為："
+
+#, c-format, boost-format
+msgid "The file %s has been sent to the printer's storage space and can be viewed on the printer."
+msgstr "檔案%s已經傳送到印表機的儲存空間，可以在印表機上瀏覽。"
+
+msgid "The nozzle type is not set. Please set the nozzle and try again."
+msgstr "未設定噴嘴型別。請先設定噴嘴，然後重試。"
+
+msgid "The nozzle type is not set. Please check."
+msgstr "未設定噴嘴型別。請檢查噴嘴設定。"
+
+msgid "Unable to perform boolean operation on model meshes. You may fix the meshes and try again."
+msgstr "無法對模型網格執行布林運算。您可以修復網格，然後重試。"
+
+#, boost-format
+msgid "Reason: part \"%1%\" is empty."
+msgstr "原因：零件\"%1%\"為空。"
+
+#, boost-format
+msgid "Reason: part \"%1%\" does not bound a volume."
+msgstr "原因：零件\"%1%\"沒有封閉一個體積。"
+
+#, boost-format
+msgid "Reason: part \"%1%\" has self intersection."
+msgstr "原因：零件\"%1%\"有自相交。"
+
+#, boost-format
+msgid "Reason: \"%1%\" and another part have no intersection."
+msgstr "原因：零件\"%1%\"與另一個零件沒有交集。"
+
+msgid "Negative parts detected. Would you like to perform mesh boolean before exporting?"
+msgstr "檢測到負零件。在匯出前，您是否想執行網格布林運算？"
+
+msgid "It is not recommended to use PVA filaments with 0.2mm nozzles."
+msgstr "不建議使用0.2毫米噴嘴來列印PVA材料"
+
+msgid "Are you sure to use them? \n"
+msgstr "您確定要使用它嗎？ \n"
+
+msgid ""
+"Print By Object: \n"
+"Suggest to use auto-arrange to avoid collisions when printing."
+msgstr ""
+"逐件列印：\n"
+"建議使用自動擺盤避免列印時發生碰撞。"
+
+msgid "Send G-code"
+msgstr "傳送 G 程式碼"
+
+msgid "Send to printer"
+msgstr "傳送到印表機"
+
+msgid "Custom supports and color painting were removed before repairing."
+msgstr "自定義的支撐和塗色在模型修復之前將被清除。"
+
+msgid "Custom supports,seam_facets and color painting were removed before repairing,model name:"
+msgstr "在修復之前，刪除了支援、接縫和塗色資訊,模型名字:"
+
+#, c-format, boost-format
+msgid "Printer not connected. Please go to the device page to connect %s before syncing."
+msgstr "印表機未連線，在同步之前，請前往裝置頁連線 %s。"
+
+#, c-format, boost-format
+msgid "The currently connected printer on the device page is not %s. Please switch to %s before syncing."
+msgstr "裝置頁當前連線的印表機不是 %s ，無法同步，請切換成 %s 後再同步。"
+
+msgid "There are no filaments on the printer. Please load the filaments on the printer first."
+msgstr "印表機上沒有任何耗材，請先去機器上放置耗材。"
+
+msgid "The filaments on the printer are all unknown types. Please go to the printer screen or software device page to set the filament type."
+msgstr "印表機上的耗材均為未知型別，請先去印表機螢幕或者軟體裝置頁面設定耗材型別。"
+
+msgid "Device Page"
+msgstr "裝置頁"
+
+msgid "Synchronize AMS Filament Information"
+msgstr "同步AMS耗材資訊"
+
+msgid "Invalid number"
+msgstr "無效數字"
+
+msgid "Plate Settings"
+msgstr "盤引數設定"
+
+msgid "Prime Tower:"
+msgstr "擦料塔："
+
+msgid "A cube printed during a filament change to purge old color and ensure smooth color transition."
+msgstr "在換材料過程中列印的立方體，用於清除舊材料並確保平滑的顏色過渡"
+
+#, boost-format
+msgid "Number of currently selected parts: %1%\n"
+msgstr "當前選擇的零件數量: %1%\n"
+
+#, boost-format
+msgid "Number of currently selected objects: %1%\n"
+msgstr "當前選擇的物件數量: %1%\n"
+
+#, boost-format
+msgid "Part name: %1%\n"
+msgstr "零件名字：%1%\n"
+
+#, boost-format
+msgid "Object name: %1%\n"
+msgstr "物件名字：%1%\n"
+
+#, boost-format
+msgid "Size: %1% x %2% x %3% in\n"
+msgstr "大小：%1% x %2% x %3% 英寸\n"
+
+#, boost-format
+msgid "Size: %1% x %2% x %3% mm\n"
+msgstr "大小： %1% x %2% x %3% 毫米\n"
+
+#, boost-format
+msgid "Volume: %1% in³\n"
+msgstr "體積： %1% 英寸³\n"
+
+#, boost-format
+msgid "Volume: %1% mm³\n"
+msgstr "體積： %1% 毫米³\n"
+
+#, boost-format
+msgid "Triangles: %1%\n"
+msgstr "三角形：%1%\n"
+
+msgid " (Repair)"
+msgstr "（修復）"
+
+msgid "To repair the model, please use a third-party tool before importing it into Bambu Studio, such as "
+msgstr "如需修復模型，請使用第三方工具處理後再匯入 Bambu Studio，例如"
+
+#, c-format, boost-format
+msgid "Plate% d: %s is not suggested to be used to print filament %s(%s). If you still want to do this printing, please set this filament's bed temperature to non zero."
+msgstr "熱床% d：%s不建議被用於列印%s（%s）材料。如果您依然想列印，請設定耗材對應的熱床溫度為非零值。"
+
+msgid "Parameter recommendation"
+msgstr "引數推薦"
+
+msgid "In the process preset, under \"Others-Advanced\", check \"Enable clumping detection by probing\". This feature generates a small wipe tower and performs probing detection to identify clumping issues early in the print and stop printing, preventing print failures or printer damage.\n"
+msgstr "在工藝預設的“其他-高階”中，勾選“啟用觸碰裹頭檢測”。此功能將生成一個小型擦料塔，並執行觸碰裹頭檢測，以便在列印初期識別裹頭問題並停止列印，從而防止列印失敗或印表機損壞。\n"
+
+msgid "Currently, the object configuration form cannot be used with a multiple-extruder printer."
+msgstr "多噴嘴印表機暫不支援物件配置表單功能。"
+
+msgid "Not available"
+msgstr "不可用"
+
+msgid "Top front"
+msgstr "前上方"
+
+msgid "The current project has unsaved changes, save it before continuing?"
+msgstr "當前專案有未儲存的更改，是否儲存後再繼續？"
+
+msgid "Switching the language requires application restart.\n"
+msgstr "切換語言要求重啟應用程式。\n"
+
+msgid "Do you want to continue?"
+msgstr "是否繼續？"
+
+msgid "Language selection"
+msgstr "語言選擇"
+
+msgid "Switching application language while some presets are modified."
+msgstr "在切換應用語言之前發現某些引數預設有更改。"
+
+msgid "Changing application language"
+msgstr "正在為應用程式切換語言"
+
+msgid "Changing the region will log out your account.\n"
+msgstr "修改區域會自動登出您的賬號。\n"
+
+msgid "Region selection"
+msgstr "區域選擇"
+
+msgid "Second"
+msgstr "秒"
+
+msgid ""
+"Please note that the model show will undergo certain changes at small pixels case.\n"
+"Enabled LOD requires application restart."
+msgstr ""
+"請注意，模型顯示將在畫素塊較小的情況下發生一定變化。\n"
+"更改 LOD 設定需要重新啟動應用程式。  "
+
+msgid "Enable LOD"
+msgstr "啟用/關閉 LOD"
+
+msgid "Bed Temperature Difference Warning"
+msgstr "熱床溫差警告"
+
+msgid ""
+"Using filaments with significantly different temperatures may cause:\n"
+"• Extruder clogging\n"
+"• Nozzle damage\n"
+"• Layer adhesion issues\n"
+"\n"
+"Continue with enabling this feature?"
+msgstr ""
+"使用溫度差異較大的耗材可能導致：\n"
+"• 噴頭堵塞\n"
+"• 噴嘴損壞\n"
+"• 層間粘附問題\n"
+"\n"
+"仍要啟用此功能？"
+
+msgid "Browse"
+msgstr "瀏覽"
+
+msgid "Choose Download Directory"
+msgstr "選擇下載資料夾"
+
+msgid "General Settings"
+msgstr "通用設定"
+
+msgid "Asia-Pacific"
+msgstr "亞太"
+
+msgid "Chinese Mainland"
+msgstr "中國內地(大陸)"
+
+msgid "Europe"
+msgstr "歐洲"
+
+msgid "North America"
+msgstr "北美"
+
+msgid "Others"
+msgstr "其他"
+
+msgid "Login Region"
+msgstr "登入區域"
+
+msgid "Metric"
+msgstr "公制"
+
+msgid "Imperial"
+msgstr "英制"
+
+msgid "Units"
+msgstr "單位"
+
+msgid "Keep only one Bambu Studio instance"
+msgstr "只保留一個Bambu Studio例項"
+
+msgid "On OSX there is always only one instance of app running by default. However it is allowed to run multiple instances of same app from the command line. In such case this settings will allow only one instance."
+msgstr "在OSX上，預設情況下總是隻有一個應用程式例項在執行。但是，允許從命令列執行同一應用程式的多個例項。在這種情況下，此設定將只允許一個例項。"
+
+msgid "If this is enabled, when starting Bambu Studio and another instance of the same Bambu Studio is already running, that instance will be reactivated instead."
+msgstr "如果啟用此選項，當啟動Bambu Studio並且另一個Bambu Studio例項已經在執行時，該例項將被重新啟用。"
+
+msgid "Automatically transfer modified value when switching process and filament presets"
+msgstr "切換工藝和材料預設時自動遷移修改值"
+
+msgid "After closing, a popup will appear to ask each time"
+msgstr "關閉後，每次切換將彈窗詢問"
+
+msgid "Auto plate type"
+msgstr "自動列印板型別"
+
+msgid "Studio will remember build plate selected last time for certain printer model."
+msgstr "Studio會記住上次該型號印表機選擇的列印板。"
+
+msgid "All"
+msgstr "所有"
+
+msgid "Disabled"
+msgstr "關閉"
+
+msgid "Auto Flush"
+msgstr "自動沖刷計算"
+
+msgid "Auto calculate flush volumes"
+msgstr "自動計算沖刷體積"
+
+msgid "Multi-device Management(Take effect after restarting Studio)."
+msgstr "多裝置管理（重啟Studio後生效）"
+
+msgid "With this option enabled, you can send a task to multiple devices at the same time and manage multiple devices."
+msgstr "啟用此選項後，您可以同時向多個裝置傳送任務並管理多個裝置。"
+
+msgid "Show the step mesh parameter setting dialog."
+msgstr "顯示step引數設定對話方塊。"
+
+msgid "If enabled,a parameter settings dialog will appear during STEP file import."
+msgstr "如果啟用，匯入step檔案時將出現設定引數對話方塊。"
+
+msgid "Support beta version update."
+msgstr "支援beta版本更新"
+
+msgid "With this option enabled, you can receive beta version updates."
+msgstr "啟用此選項後，您可以接收測試版更新。"
+
+msgid "Remove the restriction on mixed printing of high and low temperature filaments."
+msgstr "取消高低溫材料混合列印的限制。"
+
+msgid "With this option enabled, you can print materials with a large temperature difference together."
+msgstr "啟用此選項後，您可以同時列印具有較大溫度差異的材料。"
+
+msgid "Clear my choice for synchronizing printer preset after loading the file."
+msgstr "清除載入檔案後同步印表機預設的設定。"
+
+msgid "Clear my choice for Load 3mf dialog settings."
+msgstr "清除 “載入 3mf” 對話方塊設定。"
+
+msgid "Show the warning dialog again when importing non-Bambu 3MF files"
+msgstr "匯入非 Bambu 3MF 檔案時再次顯示警告對話方塊"
+
+msgid "3D Settings"
+msgstr "3D設定"
+
+msgid "Zoom to mouse position"
+msgstr "放大到滑鼠位置"
+
+msgid "Zoom in towards the mouse pointer's position in the 3D view, rather than the 2D window center."
+msgstr "在3D視角放大到滑鼠位置，而不是2D視窗的中心。"
+
+msgid "Always show shells in preview"
+msgstr "在預覽介面總是顯示透明殼"
+
+msgid "Always show shells or not in preview view tab.If change value,you should reslice."
+msgstr "始終在預覽檢視選項卡中顯示或不顯示殼。如果更改值，您應該重新切片。"
+
+msgid "Import a single SVG and split it"
+msgstr "匯入一個SVG並拆分它"
+
+msgid "Import a single SVG and then split it to several parts."
+msgstr "匯入一個SVG並將它拆分成多個零件"
+
+msgid "Enable gamma correction for the imported obj file"
+msgstr "為匯入的obj檔案啟用gamma校正"
+
+msgid "Perform gamma correction on color after importing the obj model."
+msgstr "匯入obj模型後，對顏色進行伽瑪校正。"
+
+msgid "Remember last used color scheme"
+msgstr "記住上次使用的顏色方案"
+
+msgid "When enabled, the last used color scheme (e.g., Line Type, Speed) will be automatically applied on next startup."
+msgstr "啟用後，將在下次啟動Studio後切片自動應用上次切片時使用的顏色方案（如走線型別、速度）。"
+
+msgid "Improve rendering performance by lod"
+msgstr "透過lod提高渲染效能"
+
+msgid "Improved rendering performance under the scene of multiple plates and many models."
+msgstr "在多盤和多模型的場景下提高了渲染效能"
+
+msgid "Collapsible"
+msgstr "可摺疊"
+
+msgid "Uncollapsible"
+msgstr "不可摺疊"
+
+msgid "Toolbar Style"
+msgstr "工具欄風格"
+
+msgid "Enable advanced gcode viewer"
+msgstr "啟用高階 gcode 檢視器"
+
+msgid "Enable advanced gcode viewer."
+msgstr "啟用高階 gcode 檢視器。"
+
+msgid "Grabber scale"
+msgstr "抓手比例"
+
+msgid "Set grabber size for move,rotate,scale tool."
+msgstr "為平移，旋轉，縮放工具設定抓手比例"
+
+msgid "Value range"
+msgstr "值範圍"
+
+msgid "Tooltip offset"
+msgstr "資訊提示偏移量"
+
+msgid "Set tooltip offset for different mouse size."
+msgstr "設定不同滑鼠尺寸的資訊提示偏移量。"
+
+msgid "Presets"
+msgstr "預設"
+
+msgid "Auto sync user presets(Printer/Filament/Process)"
+msgstr "同步使用者預設（印表機/耗材絲/工藝）"
+
+msgid "If enabled, auto sync user presets with cloud after Bambu Studio startup or presets modified."
+msgstr "如果啟用，在 Bambu Studio 啟動後或預設被修改時，自動將使用者預設與雲端同步。"
+
+msgid "Auto check for system presets updates"
+msgstr "自動檢查系統預設更新"
+
+msgid "If enabled, auto check whether there are system presets updates after Bambu Studio startup."
+msgstr "如果啟用，在 Bambu Studio 啟動後自動檢查是否有系統預設更新。"
+
+msgid "Associate Files To Bambu Studio"
+msgstr "Bambu Studio檔案關聯"
+
+msgid "Associate .3mf files to Bambu Studio"
+msgstr "使用Bambu Studio開啟.3mf檔案"
+
+msgid "If enabled, sets Bambu Studio as default application to open .3mf files"
+msgstr "開啟後，將預設使用Bambu Studio開啟.3mf檔案"
+
+msgid "Associate .stl files to Bambu Studio"
+msgstr "使用Bambu Studio開啟.stl檔案"
+
+msgid "If enabled, sets Bambu Studio as default application to open .stl files"
+msgstr "開啟後，將預設使用Bambu Studio開啟.stl檔案"
+
+msgid "Associate .step/.stp files to Bambu Studio"
+msgstr "使用Bambu Studio開啟.step/.stp檔案"
+
+msgid "If enabled, sets Bambu Studio as default application to open .step files"
+msgstr "開啟後，將預設使用Bambu Studio開啟.step檔案"
+
+msgid "Online Models"
+msgstr "線上模型"
+
+msgid "Show online staff-picked models on the home page"
+msgstr "在主頁上顯示工作人員挑選的線上模型"
+
+msgid "Show history on the home page"
+msgstr "在主頁上顯示歷史"
+
+msgid "Reminder During Slicing"
+msgstr "切片時提醒"
+
+msgid "Automatic mode"
+msgstr "自動模式"
+
+msgid "Maximum recent projects"
+msgstr "近期專案的最大數量"
+
+msgid "Maximum count of recent projects"
+msgstr "近期專案的最大計數"
+
+msgid "Clear my choice on the unsaved projects."
+msgstr "清除對未儲存的專案的選擇。"
+
+msgid "No warnings when loading 3MF with modified G-codes"
+msgstr "載入具有修改的 G-Code 的 3MF 時不會出現警告"
+
+msgid "Auto-Backup"
+msgstr "自動備份"
+
+msgid "Backup your project periodically for restoring from the occasional crash."
+msgstr "定期備份您的專案，以便從偶爾的崩潰中恢復過來。"
+
+msgid "every"
+msgstr "每"
+
+msgid "The peroid of backup in seconds."
+msgstr "備份的週期。"
+
+msgid "Downloads"
+msgstr "下載"
+
+msgid "Media"
+msgstr "影片檔案"
+
+msgid "Keep liveview when printing."
+msgstr "列印時保持實時取景"
+
+msgid "By default, Liveview will pause after 15 minutes of inactivity on the computer. Check this box to disable this feature during printing."
+msgstr "預設情況下，Liveview將在計算機上處於非活動狀態15分鐘後暫停。選中此框可在列印過程中禁用此功能。"
+
+msgid "Dark Mode"
+msgstr "深色模式"
+
+msgid "Enable dark mode"
+msgstr "開啟深色模式"
+
+msgid "Pop up to select filament grouping mode"
+msgstr "彈窗以選擇耗材分組模式"
+
+msgid "User Experience"
+msgstr "使用者體驗"
+
+msgid "Join the User Experience Improvement Program."
+msgstr "加入使用者體驗改進計劃。"
+
+msgctxt "Preferences"
+msgid "Learn more"
+msgstr "瞭解更多"
+
+msgid "Auto-fill previously logged-in accounts."
+msgstr "自動填充歷史賬戶資訊"
+
+msgid "Develop Mode"
+msgstr "開發者模式"
+
+msgid "Develop mode"
+msgstr "開發者模式"
+
+msgid "Skip AMS blacklist check"
+msgstr "跳過AMS黑名單檢查"
+
+msgid "Home page and daily tips"
+msgstr "首頁和每日小貼士"
+
+msgid "Show home page on startup"
+msgstr "啟動時顯示主頁"
+
+msgid "Sync settings"
+msgstr "同步設定"
+
+msgid "User sync"
+msgstr "使用者同步"
+
+msgid "Preset sync"
+msgstr "配置同步"
+
+msgid "Preferences sync"
+msgstr "偏好設定同步"
+
+msgid "View control settings"
+msgstr "檢視控制設定"
+
+msgid "Rotate of view"
+msgstr "旋轉檢視"
+
+msgid "Move of view"
+msgstr "移動檢視"
+
+msgid "Zoom of view"
+msgstr "縮放檢視"
+
+msgid "Other"
+msgstr "其他"
+
+msgid "Mouse wheel reverses when zooming"
+msgstr "縮放時滑鼠滾輪反轉"
+
+msgid "Enable SSL(MQTT)"
+msgstr "啟用SSL（MQTT）"
+
+msgid "Enable SSL(FTP)"
+msgstr "啟用SSL（FTP）"
+
+msgid "Internal developer mode"
+msgstr "內部開發者模式"
+
+msgid "Log Level"
+msgstr "日誌級別"
+
+msgid "fatal"
+msgstr "致命"
+
+msgid "error"
+msgstr "錯誤"
+
+msgid "warning"
+msgstr "警告"
+
+msgid "debug"
+msgstr "除錯"
+
+msgid "trace"
+msgstr "跟蹤"
+
+msgid "Host Setting"
+msgstr ""
+
+msgid "DEV host: api-dev.bambu-lab.com/v1"
+msgstr ""
+
+msgid "QA  host: api-qa.bambu-lab.com/v1"
+msgstr ""
+
+msgid "PRE host: api-pre.bambu-lab.com/v1"
+msgstr ""
+
+msgid "Product host"
+msgstr "正式環境"
+
+msgid "debug save button"
+msgstr "儲存"
+
+msgid "save debug settings"
+msgstr "儲存除錯設定"
+
+msgid "DEBUG settings have saved successfully!"
+msgstr "DEBUG模式生效!"
+
+msgid "Switch cloud environment, Please login again!"
+msgstr "切換雲環境，請重新登入!"
+
+msgid "System presets"
+msgstr "系統配置"
+
+msgid "User presets"
+msgstr "使用者配置"
+
+msgid "Incompatible presets"
+msgstr "不相容的預設"
+
+msgid "My Printer"
+msgstr "我的印表機"
+
+msgid "Left filaments"
+msgstr "左側耗材絲"
+
+msgid "AMS filaments"
+msgstr "AMS 耗材絲"
+
+msgid "Right filaments"
+msgstr "右側耗材絲"
+
+msgid "Click to pick filament color"
+msgstr "點選設定材料顏色"
+
+msgid "Add/Remove presets"
+msgstr "新增/刪除配置"
+
+msgid "Edit preset"
+msgstr "編輯預設"
+
+msgid "Project-inside presets"
+msgstr "專案預設"
+
+msgid "System"
+msgstr ""
+
+msgid "Unsupported presets"
+msgstr "不支援的預設"
+
+msgid "Unsupported"
+msgstr "不支援的"
+
+msgid "Add/Remove filaments"
+msgstr "新增/刪除材料"
+
+msgid "Add/Remove materials"
+msgstr "新增/刪除材料"
+
+msgid "Select/Remove printers(system presets)"
+msgstr "選擇/移除印表機（系統預設）"
+
+msgid "Create printer"
+msgstr "建立印表機"
+
+msgid "Incompatible"
+msgstr "不相容的預設"
+
+msgid "The selected preset is null!"
+msgstr "選擇的預設為空！"
+
+msgid "End"
+msgstr ""
+
+msgid "Customize"
+msgstr "自定義"
+
+msgid "Other layer filament sequence"
+msgstr "其它層耗材列印順序"
+
+msgid "Please input layer value (>= 2)."
+msgstr "請輸入層號（>=2）。"
+
+msgid "Same as Global Plate Type"
+msgstr "跟隨全域性列印板型別"
+
+msgid "Bed type"
+msgstr "列印板型別"
+
+msgid "Same as Global Print Sequence"
+msgstr "跟隨全域性列印順序"
+
+msgid "Print sequence"
+msgstr "列印順序"
+
+msgid "Same as Global"
+msgstr "跟隨全域性"
+
+msgid "Enable"
+msgstr "開啟"
+
+msgid "Disable"
+msgstr "禁用"
+
+msgid "Spiral vase"
+msgstr "旋轉花瓶"
+
+msgid "First layer filament sequence"
+msgstr "首層耗材列印順序"
+
+msgid "Same as Global Bed Type"
+msgstr "跟隨全域性列印板型別"
+
+msgid "By Layer"
+msgstr "逐層"
+
+msgid "By Object"
+msgstr "逐件"
+
+msgid "Plate name"
+msgstr "盤名稱"
+
+msgid "Move the current plate to"
+msgstr "移動當前盤到"
+
+msgid "Move forward"
+msgstr "往前移"
+
+msgid "Move backwards"
+msgstr "往後移"
+
+msgid "Move to the front"
+msgstr "移動到最前面"
+
+msgid "Move to the back"
+msgstr "移動到最後面"
+
+msgid "Accept"
+msgstr "接受"
+
+msgid "Log Out"
+msgstr "登出"
+
+msgid "Slice all plate to obtain time and filament estimation"
+msgstr "正在切片以獲取切片資訊和預估列印時間"
+
+msgid "Packing project data into 3mf file"
+msgstr "正在打包資料到3mf檔案"
+
+msgid "Uploading 3mf"
+msgstr "正在上傳3mf"
+
+msgid "Jump to model publish web page"
+msgstr "跳轉到釋出頁面"
+
+msgid "Note: The preparation may take several minutes. Please be patient."
+msgstr "提示：釋出前需要一些準備時間，請耐心等待。"
+
+msgid "Publish"
+msgstr "釋出"
+
+msgid "Publish was cancelled"
+msgstr "釋出已取消"
+
+msgid "Slicing Plate 1"
+msgstr "正在切片盤 1"
+
+msgid "Packing data to 3mf"
+msgstr "打包資料到3mf"
+
+msgid "Jump to webpage"
+msgstr "跳轉到網頁"
+
+#, c-format, boost-format
+msgid "Save %s as"
+msgstr "另存%s為"
+
+msgid "User Preset"
+msgstr "使用者預設"
+
+msgid "Preset Inside Project"
+msgstr "專案預設"
+
+msgid "Name is unavailable."
+msgstr "名稱不可用。"
+
+msgid "Overwrite a system profile is not allowed"
+msgstr "不允許覆蓋系統預設"
+
+#, boost-format
+msgid "Preset \"%1%\" already exists."
+msgstr "預設“%1%”已存在。"
+
+#, boost-format
+msgid "Preset \"%1%\" already exists and is incompatible with current printer."
+msgstr "預設“%1%”已存在，並且和當前印表機不相容。"
+
+msgid "Please note that saving action will replace this preset"
+msgstr "請注意這個預設會在儲存過程中被替換"
+
+msgid "The name cannot be the same as a preset alias name."
+msgstr "名稱不能和一個預設的別名相同。"
+
+msgid "Save preset"
+msgstr "儲存預設"
+
+msgctxt "PresetName"
+msgid "Copy"
+msgstr "複製"
+
+#, boost-format
+msgid "Printer \"%1%\" is selected with preset \"%2%\""
+msgstr "選中印表機“%1%”和預設“%2%”"
+
+#, boost-format
+msgid "Please choose an action with \"%1%\" preset after saving."
+msgstr "請選擇儲存後對%1%預設的操作。"
+
+#, boost-format
+msgid "For \"%1%\", change \"%2%\" to \"%3%\" "
+msgstr "為“%1%，”把“%2%”更換為“%3%” "
+
+#, boost-format
+msgid "For \"%1%\", add \"%2%\" as a new preset"
+msgstr "為“%1%”，新增“%2%”為一個新預設"
+
+#, boost-format
+msgid "Simply switch to \"%1%\""
+msgstr "直接切換到“%1%”"
+
+msgid ""
+"Turning off this option will affect print quality if:\n"
+"1. Uncalibrated hotends is used\n"
+"2. The current nozzle, heatbed, or chamber temperature differs from the calibration conditions\n"
+"3. The toolhead hotend was manually removed or installed"
+msgstr ""
+"出現以下情況時，關閉該選項會影響列印質量：\n"
+"1.當前列印使用了未被校準的熱端\n"
+"2.當前列印的噴嘴溫度、熱床溫度、腔溫與校準時不同\n"
+"3.手動拆裝過工具頭熱端"
+
+msgid "After modifying this option, the system will reassign the nozzles based on the calibrated dynamic flow calibration coefficient."
+msgstr "修改此選項後，系統將根據校準後的動態流量校準係數重新分配噴嘴。"
+
+msgid "There are not enough available hotends currently."
+msgstr "目前可用的熱端數量不足。"
+
+msgid "No hotends available."
+msgstr "沒有可用的熱端。"
+
+msgid "Please complete the hotend rack setup and try again."
+msgstr "請先進行熱端掛架初始化後重試。"
+
+msgid "Please refresh the nozzle information and try again."
+msgstr "請重新整理噴嘴資訊後重試。"
+
+msgid "Please re-slice."
+msgstr "請重新切片。"
+
+msgid "Please re-slice to avoid filament waste."
+msgstr "請重新切片以避免耗材浪費。"
+
+msgid "Task canceled"
+msgstr "任務已取消"
+
+msgid "Bambu Cool Plate"
+msgstr "低溫列印板"
+
+msgid "Bamabu Engineering Plate"
+msgstr "工程材料列印板"
+
+msgid "Bamabu Smooth PEI Plate"
+msgstr "光面PEI列印板"
+
+msgid "High temperature Plate"
+msgstr "高溫列印板"
+
+msgid "Bamabu Textured PEI Plate"
+msgstr "紋理PEI列印板"
+
+msgid "Bambu Cool Plate SuperTack"
+msgstr "增穩低溫列印板"
+
+msgid "Send print job"
+msgstr "傳送列印任務"
+
+msgid "On"
+msgstr "開啟"
+
+msgid "Not satisfied with the grouping of filaments? Regroup and slice ->"
+msgstr "對耗材左右分組不滿意？重新分組並切片 ->"
+
+msgid "Manually change external spool during printing for multi-color printing"
+msgstr "列印期間手動更換外掛料以實現多色列印"
+
+msgid "Multi-color with external"
+msgstr "外掛料多色列印"
+
+msgid "Your filament grouping method in the sliced file is not optimal."
+msgstr "切片檔案中的材料分組不是最優結果。"
+
+msgid "To ensure print quality, the drying temperature will be lowered during printing."
+msgstr "為保證列印質量，列印過程中會適當降低烘乾溫度。"
+
+msgid ""
+"This checks the flatness of heatbed. Leveling makes extruded height uniform.\n"
+"*Automatic mode: Run a leveling check(about 10 seconds). Skip if surface is fine."
+msgstr ""
+"檢測熱床的平整度。調平可以使擠出的高度更均勻。\n"
+"*自動模式：先進行調平檢測（耗時10S左右）。若熱床平面沒有問題，則跳過調平。"
+
+msgid "Flow Dynamics Calibration"
+msgstr "動態流量校準"
+
+msgid ""
+"This process determines the dynamic flow values to improve overall print quality.\n"
+"*Automatic mode: Skip if the filament was calibrated recently."
+msgstr ""
+"此過程確定動態流量校準的最佳係數，從而提升列印質量。\n"
+"*自動模式：如果該耗材近期被校準過，則跳過流量校準。"
+
+msgid ""
+"Calibrate nozzle offsets to enhance print quality.\n"
+"*Automatic mode: Check for calibration before printing. Skip if unnecessary."
+msgstr ""
+"校準不同噴嘴的偏移量，從而提升列印質量。\n"
+"*自動模式：發起列印前檢測是否需要校準，無需校準則跳過校準。"
+
+msgid "Nozzles and filaments of the same type share the same PA profile"
+msgstr "同型別噴嘴與耗材共用PA配置檔案"
+
+msgid "send completed"
+msgstr "傳送完成"
+
+msgid "Error code"
+msgstr "錯誤程式碼"
+
+#, c-format, boost-format
+msgid "Filament %s does not match the filament in AMS slot %s. Please update the printer firmware to support AMS slot assignment."
+msgstr "材料編號%s和AMS槽位%s中的耗材絲材質不匹配，請更新印表機韌體以支援AMS槽位對映功能"
+
+msgid "Filament does not match the filament in AMS slot. Please update the printer firmware to support AMS slot assignment."
+msgstr "材料編號和AMS槽位中的耗材絲材質不匹配，請更新印表機韌體以支援AMS槽位對映功能"
+
+#, c-format, boost-format
+msgid "The selected printer (%s) is incompatible with the print file configuration (%s). Please adjust the printer preset in the prepare page or choose a compatible printer on this page."
+msgstr "當前選擇的印表機（%s）與列印檔案配置（%s）不相容，請前往準備介面重新選擇印表機預設，或在此頁面選擇相容的印表機。"
+
+msgid "When enable spiral vase mode, machines with I3 structure will not generate timelapse videos."
+msgstr "啟用螺旋花瓶模式時，具有I3結構的機器將不會生成延時影片。"
+
+msgid "The current printer does not support timelapse in Traditional Mode when printing By-Object."
+msgstr "當前印表機在逐件列印時不支援傳統模式下的延時攝影。"
+
+msgid "Errors"
+msgstr "錯誤"
+
+msgid "More than one filament types have been mapped to the same external spool, which may cause printing issues. The printer won't pause during printing."
+msgstr "多種耗材型別被對映到了同一外掛料，可能會引起列印不良。印表機在列印的過程中不會暫停。"
+
+msgid "The filament type setting of external spool is different from the filament in the slicing file."
+msgstr "外掛槽的耗材設定與切片檔案中的耗材不同，可能會引起列印不良。"
+
+msgid "The printer type selected when generating G-Code is not consistent with the currently selected printer. It is recommended that you use the same printer type for slicing."
+msgstr "生成G程式碼時選擇的印表機型別與當前選擇的印表機不一致。建議您使用相同的印表機型別進行切片。"
+
+msgid "There are some unknown filaments in the AMS mappings. Please check whether they are the required filaments. If they are okay, press \"Confirm\" to start printing."
+msgstr "AMS對映中存在一些未知的耗材。請檢查它們是否符合預期。如果符合，按“確定”以開始列印任務。"
+
+msgid "Please check the following:"
+msgstr "請檢查以下內容："
+
+msgid "Please fix the error above, otherwise printing cannot continue."
+msgstr "請修復上述錯誤，否則列印無法繼續。"
+
+msgid "Please click the confirm button if you still want to proceed with printing."
+msgstr "如果您仍然想繼續列印，請單擊“確定”按鈕。"
+
+msgid "This checks the flatness of heatbed. Leveling makes extruded height uniform."
+msgstr "檢測熱床的平整度。調平可以使擠出的高度更均勻。"
+
+msgid "This process determines the dynamic flow values to improve overall print quality."
+msgstr "此過程確定動態流量校準的最佳係數，從而提升列印質量。"
+
+msgid "Preparing print job"
+msgstr "正在準備列印任務"
+
+msgid "Abnormal print file data. Please slice again"
+msgstr "列印檔案資料異常，請重新切片"
+
+msgid "As the print job has been successfully sent, the cancellation will not bring the print job to a halt. If you need to terminate this job, please stop it in 'Device' page."
+msgstr "因列印任務已成功傳送，此次取消操作未能中止本次任務。如需終止任務，請在“裝置頁面”停止列印。"
+
+msgid "The name length exceeds the limit."
+msgstr "名稱長度超過限制。"
+
+#, c-format, boost-format
+msgid "Cost %dg filament and %d changes more than optimal grouping."
+msgstr "如果使用最優分組可多節省%dg耗材和%d次換料"
+
+msgid "nozzle"
+msgstr "噴嘴"
+
+msgid "both extruders"
+msgstr "兩側擠出機"
+
+#, c-format, boost-format
+msgid "[ %s ] requires printing in a high-temperature environment. Reminder to close the door if not already closed."
+msgstr "[ %s ] 需要在高溫環境下列印。若門尚未關閉，請關上門。"
+
+#, c-format, boost-format
+msgid "[ %s ] requires printing in a high-temperature environment."
+msgstr "[ %s ] 需要在高溫環境下列印。"
+
+#, c-format, boost-format
+msgid "The filament on %s may soften. Please unload."
+msgstr "%s的耗材可能會軟化，請退料。"
+
+#, c-format, boost-format
+msgid "The filament on %s is unknown and may soften. Please set filament."
+msgstr "%s中耗材未知，可能會軟化，請設定耗材->"
+
+msgid ""
+"Upper half area:  Original\n"
+"Middle  area:  Filament in AMS\n"
+"Lower half area:  Selected nozzle\n"
+"And you can click it to modify"
+msgstr ""
+"上半部分：原專案耗材\n"
+"中間部分：AMS中的耗材\n"
+"下半部分：選定的噴嘴\n"
+"您可以單擊它進行修改"
+
+msgid "Unable to automatically match to suitable filament. Please click to manually match."
+msgstr "無法自動匹配到合適的材料，請點選進行手動匹配"
+
+msgid "Install toolhead enhanced cooling fan to prevent filament softening."
+msgstr "為避免高環境溫度下耗材軟化，請安裝工具頭增強散熱風扇。"
+
+#, c-format, boost-format
+msgid "Refreshing information of hotends(%d/%d)."
+msgstr "正在重新整理噴嘴資訊(%d/%d)。"
+
+msgid "Please wait a moment..."
+msgstr "請稍等片刻……"
+
+msgid "The toolhead and hotend rack are full. Please remove at least one hotend before printing."
+msgstr "工具頭和熱端掛架已滿，請卸下至少一個熱端後再列印。"
+
+#, c-format, boost-format
+msgid "The nozzle flow setting of %s(%s) doesn't match with the slicing file(%s). Please make sure the nozzle installed matches with settings in printer, then set the corresponding printer preset while slicing."
+msgstr "%s的流量設定（%s）和切片檔案（%s）不一致，無法發起列印。請確保印表機上安裝噴嘴型別和機器設定中一致，並在切片時設定對應的噴嘴型別。"
+
+msgid "Tips: If you changed your nozzle of your printer lately, Please go to 'Device -> Printer parts' to change your nozzle setting."
+msgstr "注意: 如果您最近更換了噴嘴，請去“裝置-印表機零件”更改設定"
+
+#, c-format, boost-format
+msgid "The %s diameter(%.1fmm) of current printer doesn't match with the slicing file (%.1fmm). Please make sure the nozzle installed matches with settings in printer, then set the corresponding printer preset when slicing."
+msgstr "當前印表機的%s直徑（%.1fmm）和切片檔案（%.1fmm）不一致，無法發起列印。請確保印表機上安裝的噴嘴直徑和機器設定中一致，並在切片時設定相同的噴嘴直徑。"
+
+#, c-format, boost-format
+msgid "The current nozzle diameter (%.1fmm) doesn't match with the slicing file (%.1fmm). Please make sure the nozzle installed matches with settings in printer, then set the corresponding printer preset when slicing."
+msgstr "當前噴嘴直徑（%.1fmm）和切片檔案（%.1fmm）不一致，無法發起列印。請確保印表機上安裝噴嘴直徑和機器設定中一致，並在切片時設定對應的噴嘴直徑。"
+
+#, c-format, boost-format
+msgid "Failed to send nozzle auto-mapping request to printer { code: %d }. Please try to refresh the printer information. If it still does not recover, you can try to rebind the printer and check the network connection."
+msgstr "向印表機傳送噴嘴自動對映請求失敗 {錯誤程式碼：%d}。請嘗試重新整理印表機資訊。若問題仍未解決，可嘗試重新繫結印表機並檢查網路連線。"
+
+msgid "The printer is calculating nozzle mapping."
+msgstr "印表機正在計算噴嘴對映。"
+
+#, c-format, boost-format
+msgid "Failed to receive nozzle auto-mapping table from printer { msg: %s }. Please refresh the printer information."
+msgstr "未能從印表機接收噴嘴自動對映表 {訊息：%s}。請重新整理印表機資訊。"
+
+#, c-format, boost-format
+msgid "The printer failed to build the nozzle auto-mapping table { code: %d }. Please refreash nozzle information."
+msgstr "印表機未能構建噴嘴自動對映表 { code: %d }。請重新整理噴嘴資訊。"
+
+#, c-format, boost-format
+msgid "The current nozzle mapping may produce an extra %0.2f g of waste."
+msgstr "當前的噴嘴對映可能會產生額外 %0.2f 克的廢料。"
+
+msgid "Your current firmware version cannot start this print job. Please update to the latest version and try again."
+msgstr "您當前的韌體版本無法啟動此列印作業。請更新至最新版本並重試。"
+
+#, c-format, boost-format
+msgid "The hardness of current material (%s) exceeds the hardness of %s (%s). It may cause nozzle wear, leading to material leakage and unstable flow. Please exercise caution when using it."
+msgstr "當前材料（%s）的硬度高於 %s（%s）的硬度，可能導致噴嘴磨損，進而造成材料洩漏和流動不穩定。使用時請務必小心。"
+
+msgid "Cool"
+msgstr ""
+
+msgid "Engineering"
+msgstr ""
+
+msgid "High Temp"
+msgstr ""
+
+msgid "Cool(Supertack)"
+msgstr ""
+
+msgid "Click here if you can't connect to the printer"
+msgstr "如果您無法連線印表機，請點選這裡"
+
+msgid "Sliced file"
+msgstr "切片檔案"
+
+msgid "No login account, only printers in LAN mode are displayed"
+msgstr "未登入賬號，僅顯示區域網模式的印表機"
+
+msgid "Connecting to server"
+msgstr "正在連線伺服器..."
+
+msgid "Synchronizing device information"
+msgstr "正在同步裝置資訊"
+
+msgid "Synchronizing device information time out"
+msgstr "同步裝置資訊超時"
+
+msgid "Cannot send the print job when the printer is not at FDM mode"
+msgstr "印表機不在FDM模式下，無法發起列印任務"
+
+msgid "Cannot send the print job when the printer is updating firmware"
+msgstr "裝置升級中，無法傳送列印任務"
+
+msgid "The printer is executing instructions. Please restart printing after it ends"
+msgstr "印表機正在執行指令，請在其結束後重新發起列印"
+
+msgid "AMS is setting up. Please try again later."
+msgstr "AMS正在初始化。請稍後再試。"
+
+msgid "Not all filaments used in slicing are mapped to the printer. Please check the mapping of filaments."
+msgstr "部分切片所用的耗材未對映到印表機，請檢查切片耗材的對映。"
+
+msgid "Please do not mix-use the Ext with AMS"
+msgstr "請勿將Ext與AMS混用"
+
+msgid "Invalid nozzle information, please refresh or manually set nozzle information."
+msgstr "噴嘴資訊無效，請重新整理或手動設定噴嘴資訊"
+
+msgid "Storage is not available or is in read-only mode."
+msgstr "儲存裝置不可用或處於只讀模式。"
+
+msgid "Storage needs to be inserted before printing."
+msgstr "傳送列印任務前，需要先插入儲存裝置。"
+
+msgid "Cannot send the print job to a printer whose firmware is required to get updated."
+msgstr "需要更新印表機韌體後，才能將列印任務傳送到印表機"
+
+msgid "Cannot send the print job for empty plate"
+msgstr "無法為空盤傳送列印任務"
+
+msgid "Storage needs to be inserted to record timelapse."
+msgstr "錄製延時攝影需要先插入儲存裝置。"
+
+msgid "You have selected both external and AMS filaments for an extruder. You will need to manually switch the external filament during printing."
+msgstr "您在一個擠出機中同時選擇了使用外掛和AMS耗材，這將需要您在列印過程中手動進行換料，請謹慎選擇。"
+
+msgid "TPU 90A/TPU 85A is too soft and does not support automatic Flow Dynamics calibration."
+msgstr "TPU 90A/TPU 85A硬度過低，不支援自動流量校準。"
+
+msgid "Set dynamic flow calibration to 'OFF' to enable custom dynamic flow value."
+msgstr "您可以將動態流量校準設定為'關閉'來啟用自定義的動態流量校準值"
+
+msgid "This printer does not support printing all plates"
+msgstr "該印表機不支援列印所有盤"
+
+msgid "The current firmware supports a maximum of 16 materials. You can either reduce the number of materials to 16 or fewer on the Preparation Page, or try updating the firmware. If you are still restricted after the update, please wait for subsequent firmware support."
+msgstr "當前韌體最多支援 16 種材料。您可以在準備頁將材料數量減少至 16 種及以下，或嘗試更新韌體。若更新後仍受限，請等待後續韌體支援。"
+
+msgid "Please check if the required nozzle diameter and flow rate match the current display."
+msgstr "請確認所需噴嘴直徑和流量是否和當前顯示一致。"
+
+msgid "Please refer to Wiki before use->"
+msgstr "請在使用前檢視wiki。"
+
+msgid "How to install"
+msgstr "如何安裝"
+
+msgid "Upgrade"
+msgstr "升級"
+
+msgid "Current firmware does not support file transfer to internal storage."
+msgstr "當前韌體不支援向內部儲存傳輸檔案。"
+
+msgid "Send to Printer storage"
+msgstr "傳送到印表機儲存"
+
+msgid "Try to connect"
+msgstr "嘗試連線"
+
+msgid "Internal Storage"
+msgstr "內建儲存"
+
+msgid "External Storage"
+msgstr "外接儲存"
+
+msgid "Upload file timeout, please check if the firmware version supports it."
+msgstr "上傳檔案超時，請檢查韌體版本是否支援。"
+
+msgid "Connection timed out, please check your network."
+msgstr "連線超時，請檢查您的網路。"
+
+msgid "Connection failed. Click the icon to retry"
+msgstr "連線失敗，點選圖示重試"
+
+msgid "Cannot send the print task when the upgrade is in progress"
+msgstr "裝置升級中，無法傳送列印任務"
+
+msgid "The selected printer is incompatible with the chosen printer presets."
+msgstr "所選印表機與選擇的印表機預設不相容。"
+
+msgid "Storage needs to be inserted before send to printer."
+msgstr "傳送到印表機前，需要先插入儲存介質。"
+
+msgid "The printer is required to be in the same LAN as Bambu Studio."
+msgstr "印表機需要與Bambu Studio在同一個區域網內。"
+
+msgid "The printer does not support sending to printer storage."
+msgstr "印表機不支援傳送到印表機的儲存。"
+
+msgid "Sending..."
+msgstr "傳送中..."
+
+msgid "File upload timed out. Please check if the firmware version supports this operation or verify if the printer is functioning properly."
+msgstr "檔案上傳超時。請檢查韌體版本是否支援此操作或驗證印表機是否正常工作。"
+
+msgid "Sending failed, please try again!"
+msgstr "傳送失敗，請重試！"
+
+msgid "Helio action completed successfully."
+msgstr "Helio操作已成功完成。"
+
+msgid "Slice ok."
+msgstr "切片完成"
+
+msgid "View all Daily tips"
+msgstr "檢視所有每日貼士"
+
+msgid "Failed to create socket"
+msgstr "建立socket失敗"
+
+msgid "Failed to connect socket"
+msgstr "連線socket失敗"
+
+msgid "Failed to publish login request"
+msgstr "釋出登入請求失敗"
+
+msgid "Get ticket from device timeout"
+msgstr "從裝置獲取ticket超時"
+
+msgid "Get ticket from server timeout"
+msgstr "從伺服器獲取ticket超時"
+
+msgid "Failed to post ticket to server"
+msgstr "將ticket傳送到伺服器失敗"
+
+msgid "Failed to parse login report reason"
+msgstr "無法解析登入報告原因"
+
+msgid "Receive login report timeout"
+msgstr "接收登入報告超時"
+
+msgid "Unknown Failure"
+msgstr "發生錯誤"
+
+msgid ""
+"Please Find the Pin Code in Account page on printer screen,\n"
+" and type in the Pin Code below."
+msgstr "請在印表機螢幕上的“帳戶”頁面中找到Pin碼，然後在下面輸入Pin碼。"
+
+msgid "Can't find Pin Code?"
+msgstr "無法找到Pin碼？"
+
+msgid "Pin Code"
+msgstr "Pin碼"
+
+msgid "Binding..."
+msgstr "繫結..."
+
+msgid "Please confirm on the printer screen"
+msgstr "請在印表機螢幕上確認。"
+
+msgid ""
+"Login failed. Please check the following items:\n"
+"1. Ensure the Pin code is entered correctly.\n"
+"2. Confirm that the region settings of the printer and Bambu Studio are consistent."
+msgstr ""
+"登入失敗。請檢查以下專案：\n"
+"1. 請確保 Pin 碼輸入正確。\n"
+"2. 確認印表機和 Bambu Studio 的區域設定一致。"
+
+msgid "Log in printer"
+msgstr "登入印表機"
+
+msgid "Would you like to log in this printer with current account?"
+msgstr "您想使用當前賬號登入這臺印表機嗎?"
+
+msgid "Check the reason"
+msgstr "檢視原因"
+
+msgid "Read and accept"
+msgstr "我已閱讀並接受"
+
+msgid "Terms and Conditions"
+msgstr "使用者使用協議"
+
+msgid "Thank you for purchasing a Bambu Lab device.Before using your Bambu Lab device, please read the termsand conditions.By clicking to agree to use your Bambu Lab device, you agree to abide by the Privacy Policy and Terms of Use(collectively, the \"Terms\"). If you do not comply with or agree to the Bambu Lab Privacy Policy, please do not use Bambu Lab equipment and services."
+msgstr "感謝您購買Bambu Lab裝置，使用Bambu Lab裝置前，請閱讀一下條款，單擊同意使用您的Bambu Lab裝置即表示您同意遵守隱私政策以及使用條款（統稱為“條款”）。如果您不符合或不同意Bambu Lab隱私政策，請不要使用Bambu Lab裝置和服務。"
+
+msgid "and"
+msgstr "和"
+
+msgid "Privacy Policy"
+msgstr "隱私協議"
+
+msgid "We ask for your help to improve everyone's printer"
+msgstr "我們請求您的幫助來改善大家的印表機"
+
+msgid "Statement about User Experience Improvement Program"
+msgstr "關於使用者體驗改善計劃的宣告"
+
+#, c-format, boost-format
+msgid "In the 3D Printing community, we learn from each other's successes and failures to adjust our own slicing parameters and settings. %s follows the same principle and uses machine learning to improve its performance from the successes and failures of the vast number of prints by our users. We are training %s to be smarter by feeding them the real-world data. If you are willing, this service will access information from your error logs and usage logs, which may include information described in  Privacy Policy. We will not collect any Personal Data by which an individual can be identified directly or indirectly, including without limitation names, addresses, payment information, or phone numbers. By enabling this service, you agree to these terms and the statement about Privacy Policy."
+msgstr "在3D列印社群，我們從彼此的成功和失敗中學習調整自己的切片引數和設定。%s遵循同樣的原則，透過機器學習的方式從大量使用者列印的成功和失敗中獲取經驗，從而改善列印效能。我們正在透過向%s提供真實世界的資料來訓練他們變得更聰明。如果您願意，此服務將訪問您的錯誤日誌和使用日誌中的資訊，其中可能包括隱私政策中描述的資訊。我們不會收集任何可以直接或間接識別個人的個人資料，包括但不限於姓名、地址、支付資訊或電話號碼。啟用此服務即表示您同意這些條款和有關隱私政策的宣告。"
+
+msgid "Statement on User Experience Improvement Plan"
+msgstr "關於使用者體驗改善計劃的宣告"
+
+msgid "Log in successful."
+msgstr "登入成功"
+
+msgid "Log out printer"
+msgstr "登出印表機"
+
+msgid "Would you like to log out the printer?"
+msgstr "您想登出印表機嗎?"
+
+msgid "Please log in first."
+msgstr "請先登入。"
+
+msgid "There was a problem connecting to the printer. Please try again."
+msgstr "連線印表機時發生錯誤。 請重試。"
+
+msgid "Failed to log out."
+msgstr "登出失敗。"
+
+#. TRN "Save current Settings"
+#, c-format, boost-format
+msgid "Save current %s"
+msgstr "儲存當前 %s"
+
+msgid "Delete this preset"
+msgstr "刪除此預設"
+
+msgid "Search in preset"
+msgstr "在預設中搜尋"
+
+msgid "Synchronization of different extruder drives or nozzle volume types is not supported."
+msgstr "不支援不同擠出機驅動或噴嘴體積型別的同步操作。"
+
+msgid "Synchronize the modification of parameters to the corresponding parameters of another extruder."
+msgstr "將引數的修改與另一臺擠出機的相應引數同步。"
+
+msgid "Click to learn more"
+msgstr "點選瞭解更多"
+
+msgid "Click to reset all settings to the last saved preset."
+msgstr "點選以將所有設定還原到最後一次儲存的版本。"
+
+msgid "Prime tower is required for nozzle changing. There may be flaws on the model without prime tower. Are you sure you want to disable prime tower?"
+msgstr "切換噴嘴需要擦料塔，否則列印件上可能會有瑕疵。您確定要關閉擦料塔嗎？"
+
+msgid "Prime tower is required for smooth timeplase. There may be flaws on the model without prime tower. Are you sure you want to disable prime tower?"
+msgstr "平滑模式的延時攝影需要擦料塔，否則列印件上可能會有瑕疵。您確定要關閉擦料塔嗎？"
+
+msgid "Prime tower is required for clumping detection. There may be flaws on the model without prime tower. Are you sure you want to disable prime tower?"
+msgstr "觸碰裹頭檢測需要擦料塔，否則列印件上可能會有瑕疵。您確定關閉料塔嗎？"
+
+msgid "Enabling both precise Z height and the prime tower may cause the size of prime tower to increase. Do you still want to enable?"
+msgstr "同時啟用精準Z高度和料塔將可能導致擦料塔的尺寸變大，是否仍要開啟？"
+
+msgid "Prime tower is required for clumping detection. There may be flaws on the model without prime tower. Do you still want to enable clumping detection?"
+msgstr "觸碰裹頭檢測需要擦料塔，否則列印件上可能會有瑕疵。您確定開啟裹頭檢測嗎？"
+
+msgid "Prime tower is required for smooth timelapse. There may be flaws on the model without prime tower. Do you want to enable prime tower?"
+msgstr "平滑模式的延時攝影需要擦料塔，否則列印件上可能會有瑕疵。您想開啟擦料塔嗎？"
+
+msgid "Still print by object?"
+msgstr "仍然按物件列印嗎？"
+
+msgid ""
+"Non-soluble support materials are not recommended for support base. \n"
+"Are you sure to use them for support base? \n"
+msgstr ""
+"不建議將非可溶性支撐材料用作支撐主體。 \n"
+"您確定要用它們作為支撐主體嗎？ \n"
+
+msgid ""
+"When using PLA to support TPU, We recommend the following settings:\n"
+"0 top z distance, 0 interface spacing, 0 support/object xy distance, interlaced rectilinear pattern, disable \n"
+"independent support layer height and use PLA for both support interface and support base"
+msgstr ""
+"當使用PLA作為支撐材料支撐TPU時，我們推薦以下設定：\n"
+"0頂部z距離，0接觸面間距，0支撐/模型XY距離，交疊直線圖案，禁用支撐獨立層高，並將PLA同時用於支撐接觸面和支撐主體"
+
+msgid ""
+"When using soluble material for the support, We recommend the following settings:\n"
+"0 top z distance, 0 interface spacing, 0 support/object xy distance, interlaced rectilinear pattern, disable \n"
+"independent support layer height and use soluble materials for both support interface and support base"
+msgstr ""
+"當使用可溶性材料作為支撐時，我們推薦以下設定：\n"
+"0頂部z距離，0接觸面間距，0支撐/模型XY距離，交疊直線圖案，禁用支撐獨立層高，並將可溶性材料同時用於支撐接觸面和支撐主體"
+
+msgid ""
+"Change these settings automatically? \n"
+"Yes - Change these settings automatically\n"
+"No  - Do not change these settings for me"
+msgstr ""
+"自動調整這些設定？\n"
+"是 - 自動調整這些設定\n"
+"否 - 不用為我調整這些設定"
+
+msgid ""
+"When using support material for the support interface, We recommend the following settings:\n"
+"0 top z distance, 0 interface spacing, interlaced rectilinear pattern and disable independent support layer height"
+msgstr ""
+"當支撐接觸面使用支撐材料時，我們推薦以下設定：\n"
+"0頂部z距離，0接觸面間距，交疊直線圖案，並且禁用支撐獨立層高"
+
+msgid ""
+"When using soluble material for the support interface, We recommend the following settings:\n"
+"0 top z distance, 0 interface spacing, 0 support/object xy distance, interlaced rectilinear pattern, disable \n"
+"independent support layer height and use soluble materials for both support interface and support base"
+msgstr ""
+"當支撐接觸面使用可溶性材料時，我們推薦以下設定：\n"
+"0頂部z距離，0接觸面間距，0支撐/模型XY距離，交疊直線圖案，禁用支撐獨立層高，並將可溶性材料同時用於支撐接觸面和支撐主體"
+
+msgid ""
+"Layer height is too small.\n"
+"It will set to min_layer_height\n"
+msgstr ""
+"層高太小，\n"
+"將自動設定為最小層高的值。\n"
+
+msgid "Layer height exceeds the limit in Printer Settings -> Extruder -> Layer height limits ,this may cause printing quality issues."
+msgstr "層高超出了印表機設定->擠出機->層高限制中的範圍，這可能導致列印質量問題。"
+
+msgid "Adjust to the set range automatically? \n"
+msgstr "是否自動調整到範圍內？\n"
+
+msgid "Adjust"
+msgstr "調整"
+
+msgid "Ignore"
+msgstr "忽略"
+
+msgid "Experimental feature: Retracting and cutting off the filament at a greater distance during filament changes to minimize flush.Although it can notably reduce flush,  it may also elevate the risk of nozzle clogs or other printing complications."
+msgstr "實驗性選項。在更換耗材絲時，將耗材絲回抽一段距離後再切斷以最小化沖刷。雖然這可以顯著減少衝刷，但也可能增加噴嘴堵塞或其他列印問題的風險。"
+
+msgid "Experimental feature: Retracting and cutting off the filament at a greater distance during filament changes to minimize flush.Although it can notably reduce flush, it may also elevate the risk of nozzle clogs or other printing complications.Please use with the latest printer firmware."
+msgstr "實驗性選項。在更換耗材絲時，將耗材絲回抽一段距離後再切斷以最小化沖刷。雖然這可以顯著減少衝刷，但也可能增加噴嘴堵塞或其他列印問題的風險。請配合印表機最新韌體使用。"
+
+msgid ""
+"When recording timelapse without toolhead, it is recommended to add a \"Timelapse Wipe Tower\" \n"
+"by right-click the empty position of build plate and choose \"Add Primitive\"->\"Timelapse Wipe Tower\"."
+msgstr ""
+"在錄製無工具頭延時攝影影片時，建議新增“延時攝影擦料塔”\n"
+"右鍵單擊列印板的空白位置，選擇“新增標準模型”->“延時攝影擦料塔”。"
+
+msgid "Switching to a printer with different extruder types or numbers will discard or reset changes to extruder or multi-nozzle-related parameters."
+msgstr "切換到擠出機型別或數量不一樣的印表機，擠出機或多噴嘴相關引數的修改將會被丟棄或重置。"
+
+msgid "The notes are too large, and may not be synchronized to the cloud. Please keep it within 40k."
+msgstr "內容太大，可能無法同步到雲端。請將其控制在40k以內。"
+
+msgid "Line width"
+msgstr "線寬"
+
+msgid "Seam"
+msgstr "接縫"
+
+msgid "Precision"
+msgstr "精度"
+
+msgid "Wall generator"
+msgstr "牆生成器"
+
+msgid "Walls"
+msgstr "牆"
+
+msgid "Top/bottom shells"
+msgstr "頂部/底部外殼"
+
+msgid "Sparse infill"
+msgstr "稀疏填充"
+
+msgid "Initial layer speed"
+msgstr "首層速度"
+
+msgid "Other layers speed"
+msgstr "其他層速度"
+
+msgid "Overhang speed"
+msgstr "懸垂速度"
+
+msgid "This is the speed for various overhang degrees. Overhang degrees are expressed as a percentage of line width. 0 speed means no slowing down for the overhang degree range and wall speed is used"
+msgstr "不同懸垂程度的列印速度。懸垂程度使用相對於線寬的百分表示。速度為0代表這個懸垂程度範圍內不降速，直接使用牆的速度"
+
+msgid "Travel speed"
+msgstr "空駛速度"
+
+msgid "Acceleration"
+msgstr "加速度"
+
+msgid "Jerk(XY)"
+msgstr "抖動（XY軸）"
+
+msgid "Raft"
+msgstr "筏層"
+
+msgid "Support filament"
+msgstr "支撐耗材"
+
+msgid "Support ironing"
+msgstr "支撐熨燙"
+
+msgid "Tree Support"
+msgstr "樹狀支撐"
+
+msgid "Prime tower"
+msgstr "擦料塔"
+
+msgid "Special mode"
+msgstr "特殊模式"
+
+msgid "G-code output"
+msgstr "G-code 輸出"
+
+msgid "Post-processing scripts"
+msgstr "後處理指令碼"
+
+msgid "Notes"
+msgstr "註釋"
+
+msgid "Frequent"
+msgstr "常用"
+
+#, c-format, boost-format
+msgid ""
+"Following line %s contains reserved keywords.\n"
+"Please remove it, or will beat G-code visualization and printing time estimation."
+msgid_plural ""
+"Following lines %s contain reserved keywords.\n"
+"Please remove them, or will beat G-code visualization and printing time estimation."
+msgstr[0] ""
+"以下行%s包含保留關鍵字。\n"
+"請將其移除，否則將影響G程式碼視覺化和列印時間估算。"
+
+msgid "Reserved keywords found"
+msgstr "檢測到保留的關鍵字"
+
+msgid "Custom G-code files are too large, and may not be synchronized to the cloud. Please keep it within 40k."
+msgstr "自定義G-code程式碼檔案太大，可能無法同步到雲端。請將其保持在40k以內。"
+
+msgid "Setting Overrides"
+msgstr "引數覆蓋"
+
+msgid "Retraction"
+msgstr "回抽"
+
+msgid "Basic information"
+msgstr "基礎資訊"
+
+msgid "Filament prime volume"
+msgstr "材料清理量"
+
+msgid "The volume of material to prime extruder on tower."
+msgstr "擦料塔上的清理量。"
+
+msgid "Filament ramming length"
+msgstr "材料預沖刷長度"
+
+msgid "Filament length used in ramming."
+msgstr "。"
+
+msgid "Travel time after ramming"
+msgstr "預沖刷後的空駛時間"
+
+msgid "A reverse travel movement after ramming."
+msgstr "預沖刷後的一段反向空駛。"
+
+msgid "Precooling target temperature"
+msgstr "預降溫目標溫度"
+
+msgid "Precooling target temperature during ramming."
+msgstr "預沖刷過程中的預降溫目標溫度。"
+
+msgid "Recommended nozzle temperature"
+msgstr "建議噴嘴溫度"
+
+msgid "Recommended nozzle temperature range of this filament. 0 means no set"
+msgstr "該材料的建議噴嘴溫度範圍。0表示未設定"
+
+msgid "Print temperature"
+msgstr "列印溫度"
+
+msgid "Bed temperature when cool plate is installed. Value 0 means the filament does not support to print on the Bambu Cool Plate SuperTack"
+msgstr "安裝冷卻板時的床溫。值0表示耗材絲不支援在增穩低溫列印板上列印。"
+
+msgid "Cool Plate"
+msgstr "低溫列印板"
+
+msgid "Bed temperature when cool plate is installed. Value 0 means the filament does not support to print on the Cool Plate"
+msgstr "安裝低溫列印板時的熱床溫度。0值表示這個耗材絲不支援低溫列印熱板"
+
+msgid "Engineering Plate"
+msgstr "工程材料列印板"
+
+msgid "Bed temperature when engineering plate is installed. Value 0 means the filament does not support to print on the Engineering Plate"
+msgstr "安裝工程材料列印板時的熱床溫度。0值表示這個耗材絲不支援工程材料列印板"
+
+msgid "Smooth PEI Plate / High Temp Plate"
+msgstr "光面PEI列印板 / 高溫列印板"
+
+msgid "Bed temperature when Smooth PEI Plate/High temperature plate is installed. Value 0 means the filament does not support to print on the Smooth PEI Plate/High Temp Plate"
+msgstr "安裝光面PEI列印板/高溫列印板時的熱床溫度。0值表示這個耗材絲不支援光面PEI列印板/高溫列印板"
+
+msgid "Textured PEI Plate"
+msgstr "紋理PEI列印板"
+
+msgid "Bed temperature when Textured PEI Plate is installed. Value 0 means the filament does not support to print on the Textured PEI Plate"
+msgstr "安裝紋理PEI列印板時的熱床溫度。0值表示這個耗材絲不支援紋理PEI列印板"
+
+msgid "Nozzle temperature when printing"
+msgstr "列印時的噴嘴溫度"
+
+msgid "Volumetric speed limitation"
+msgstr "體積速度限制"
+
+msgid "Ramming volumetric speed"
+msgstr "預沖刷體積速度"
+
+msgid "The maximum volumetric speed for ramming, where -1 means using the maximum volumetric speed."
+msgstr "預沖刷的最大體積速度，-1表示使用最大體積速度。"
+
+msgid "Filament scarf seam settings"
+msgstr "材料斜拼接縫引數"
+
+msgid "Cooling for specific layer"
+msgstr "特定層冷卻"
+
+msgid "Special cooling settings"
+msgstr "特殊冷卻設定"
+
+msgid "set addition fan speed before fist x layer"
+msgstr "在第一層之前設定輔助風扇速度"
+
+msgid "Part cooling fan"
+msgstr "部件冷卻風扇"
+
+msgid "Min fan speed threshold"
+msgstr "最小風扇速度閾值"
+
+msgid "Part cooling fan speed will start to run at min speed when the estimated layer time is no longer than the layer time in setting. When layer time is shorter than threshold, fan speed is interpolated between the minimum and maximum fan speed according to layer printing time"
+msgstr "當預估的層時間不大於設定的數值時，部件冷卻風扇將開始執行在最小速度。層時間小於閾值時，實際風扇轉速將根據層列印時間在最大和最小風扇速度之間插值獲得"
+
+msgid "Max fan speed threshold"
+msgstr "最大風扇速度閾值"
+
+msgid "Part cooling fan speed will be max when the estimated layer time is shorter than the setting value"
+msgstr "當預計的層列印時間比設定值要短時，部件冷卻風扇轉速將達到最大值"
+
+msgid "Auxiliary part cooling fan"
+msgstr "輔助部件冷卻風扇"
+
+msgid "Exhaust fan"
+msgstr "排風扇"
+
+msgid "During print"
+msgstr "列印過程中"
+
+msgid "Complete print"
+msgstr "完成列印"
+
+msgid "Filament start G-code"
+msgstr "耗材絲起始G-code"
+
+msgid "Filament end G-code"
+msgstr "耗材絲結束G-code"
+
+msgid "Multi Filament"
+msgstr "多材料"
+
+msgid "Printable space"
+msgstr "可列印區域"
+
+msgid "Extruder Clearance"
+msgstr "擠出機避讓空間"
+
+msgid "Accessory"
+msgstr "配件"
+
+msgid "Machine gcode"
+msgstr "印表機G-code"
+
+msgid "Machine start G-code"
+msgstr "印表機起始G-code"
+
+msgid "Machine end G-code"
+msgstr "印表機結束G-code"
+
+msgid "Printing by object G-code"
+msgstr "逐件列印G-code"
+
+msgid "Before layer change G-code"
+msgstr "換層前G-code"
+
+msgid "Layer change G-code"
+msgstr "換層G-code"
+
+msgid "Time lapse G-code"
+msgstr "延時攝影G-code"
+
+msgid "Clumping Detection G-code"
+msgstr "觸碰裹頭檢測G-code"
+
+msgid "Change filament G-code"
+msgstr "耗材絲更換G-code"
+
+msgid "Pause G-code"
+msgstr "暫停 G-code"
+
+msgid "Template Custom G-code"
+msgstr "模板自定義G-code"
+
+msgid "Motion ability"
+msgstr "移動能力"
+
+msgid "Normal"
+msgstr "普通"
+
+msgid "Speed limitation"
+msgstr "速度限制"
+
+msgid "Acceleration limitation"
+msgstr "加速度限制"
+
+msgid "Jerk limitation"
+msgstr "抖動限制"
+
+msgid "Single extruder MM setup"
+msgstr "單擠出機MM設定"
+
+msgid "Single extruder multimaterial parameters"
+msgstr "單擠出機多材料引數"
+
+msgid "Layer height limits"
+msgstr "層高限制"
+
+msgid "Retraction when switching material"
+msgstr "切換材料時的回抽量"
+
+msgid ""
+"The Wipe option is not available when using the Firmware Retraction mode.\n"
+"\n"
+"Shall I disable it in order to enable Firmware Retraction?"
+msgstr ""
+"當使用韌體回抽模式時，擦拭選項不可用。 \n"
+"\n"
+"是否應禁用它以啟用韌體回抽？"
+
+msgid "Firmware Retraction"
+msgstr "韌體回抽"
+
+msgid "Detached"
+msgstr "分離的"
+
+#, c-format, boost-format
+msgid "%d Filament Preset and %d Process Preset is attached to this printer. Those presets would be deleted if the printer is deleted."
+msgstr "該印表機下已關聯 %d 個材料預設與 %d 個工藝預設。如刪除該印表機，材料與工藝預設將一併刪除。"
+
+msgid "Presets inherited by other presets can not be deleted!"
+msgstr "不能刪除被其他預設繼承的預設！"
+
+msgid "The following presets inherit this preset."
+msgid_plural "The following preset inherits this preset."
+msgstr[0] "以下預設繼承此預設。"
+
+#. TRN  Remove/Delete
+#, boost-format
+msgid "%1% Preset"
+msgstr "%1% 預設"
+
+msgid "Following preset will be deleted too."
+msgid_plural "Following presets will be deleted too."
+msgstr[0] "下列預設將被一起刪除。"
+
+msgid ""
+"Are you sure to delete the selected preset? \n"
+"If the preset corresponds to a filament currently in use on your printer, please reset the filament information for that slot."
+msgstr ""
+"確定要刪除所選預設嗎？\n"
+"如果預設對應當前在您的印表機上使用的材料，請重新設定該槽位的材料資訊。"
+
+#, boost-format
+msgid "Are you sure to %1% the selected preset?"
+msgstr "確定要%1%所選預設嗎？"
+
+msgid "Set"
+msgstr "設定"
+
+#, c-format, boost-format
+msgid "%s: %s"
+msgstr ""
+
+msgid "No modifications need to be copied."
+msgstr "沒有需要複製的引數修改。"
+
+msgid "Copy paramters"
+msgstr "複製引數"
+
+msgid "Modify paramters of right nozzle"
+msgstr "修改右噴嘴下的引數"
+
+msgid "Modify paramters of left nozzle"
+msgstr "修改左噴嘴下的引數"
+
+msgid "Do you want to modify the following parameters of the right nozzle to that of the left nozzle?"
+msgstr "是否要將右噴嘴下的引數修改為與左噴嘴相同的值？"
+
+msgid "Do you want to modify the following parameters of the left nozzle to that of the right nozzle?"
+msgstr "是否要將左噴嘴下的引數修改為與右噴嘴相同的值？"
+
+msgid "No available nozzles for current preset"
+msgstr "當前預設無可用噴嘴"
+
+msgid "Available nozzles for current preset: "
+msgstr "當前預設可用噴嘴: "
+
+msgid "Click to reset current value and attach to the global value."
+msgstr "點選該圖示，恢復到全域性的配置數值，並與全域性配置同步變化。"
+
+msgid "Click to drop current modify and reset to saved value."
+msgstr "點選該圖示，丟棄當前的修改，恢復到上次儲存的數值。"
+
+msgid "Process Settings"
+msgstr "工藝設定"
+
+msgid "Undef"
+msgstr "未定義"
+
+msgid "Discard or Use Modified Value"
+msgstr "丟棄或使用修改值"
+
+msgid "Save or Discard Modified Value"
+msgstr "儲存或丟棄修改值"
+
+msgid "Unsaved Changes"
+msgstr "未儲存的更改"
+
+msgid "Use Modified Value of Process Preset"
+msgstr "使用工藝預設的修改值"
+
+msgid "Use Modified Value of Filament Preset"
+msgstr "使用材料預設的修改值"
+
+msgid "Use Modified Value of Printer Preset"
+msgstr "使用機器預設的修改值"
+
+msgid "Preset(Old)"
+msgstr "預設（舊）"
+
+msgid "Modified Value(New)"
+msgstr "修改值（新）"
+
+msgid "Discard Modified Value"
+msgstr "丟棄修改值"
+
+msgid "Don't save"
+msgstr "不儲存"
+
+msgid "Use Modified Value"
+msgstr "使用修改值"
+
+msgid "Click the right mouse button to display the full text."
+msgstr "單擊滑鼠右鍵顯示全文。"
+
+msgid "All changes will not be saved"
+msgstr "所有的修改都不會被儲存"
+
+msgid "All changes will be discarded."
+msgstr "所有的修改都將被丟棄。"
+
+msgid "Save the selected options."
+msgstr "儲存所選項。"
+
+msgid "Keep the selected options."
+msgstr "保持所選項。"
+
+msgid "Transfer the selected options to the newly selected preset."
+msgstr "將所選項遷移到新的預設中。"
+
+#, boost-format
+msgid ""
+"Save the selected options to preset \n"
+"\"%1%\"."
+msgstr ""
+"儲存所選選項到預設 \n"
+"\"%1%\"."
+
+#, boost-format
+msgid ""
+"Transfer the selected options to the newly selected preset \n"
+"\"%1%\"."
+msgstr ""
+"將選擇的選項轉移到新選擇的預設 \n"
+"\"%1%\"."
+
+#, boost-format
+msgid "Preset \"%1%\" contains the following unsaved changes:"
+msgstr "預設 \"%1%\" 包含以下未儲存的修改:"
+
+#, boost-format
+msgid "Preset \"%1%\" is not compatible with the new printer profile and it contains the following unsaved changes:"
+msgstr "預設 \"%1%\" 與新的印表機預設不相容，並且包含以下未儲存的修改："
+
+#, boost-format
+msgid "Preset \"%1%\" is not compatible with the new process profile and it contains the following unsaved changes:"
+msgstr "預設“%1%”和新的工藝預設不相容，並且它包含以下未儲存的修改："
+
+#, boost-format
+msgid "You have changed the preset \"%1%\". "
+msgstr "您已更改了預設 “%1%” 。"
+
+msgid ""
+"\n"
+"Do you want to use the modified value in the new preset that you selected?"
+msgstr ""
+"\n"
+"您是否想在新選擇的預設中使用修改後的值？"
+
+msgid "You have changed the preset. "
+msgstr "您已更改了預設。"
+
+msgid ""
+"\n"
+"Do you want to save the modified values?"
+msgstr ""
+"\n"
+"您是否想儲存修改後的值？"
+
+msgid "Extruders count"
+msgstr "擠出機數量"
+
+msgid "General"
+msgstr "常規"
+
+msgid "Capabilities"
+msgstr "能力"
+
+msgid "Left: "
+msgstr "左: "
+
+msgid "Right: "
+msgstr "右:"
+
+msgid "Select presets to compare"
+msgstr "選擇要比較的預設"
+
+msgid "Show all presets (including incompatible)"
+msgstr "顯示所有預設(包括不相容的)"
+
+msgid "Add File"
+msgstr "新增檔案"
+
+msgid "Set as cover"
+msgstr "設定為封面"
+
+msgid "Cover"
+msgstr "封面"
+
+#, boost-format
+msgid "The name \"%1%\" already exists."
+msgstr "名字\"%1%\"已經存在。"
+
+msgid "Basic Info"
+msgstr "基本資訊"
+
+msgid "Pictures"
+msgstr "圖片"
+
+msgid "Bill of Materials"
+msgstr "物料清單"
+
+msgid "Assembly Guide"
+msgstr "組裝指南"
+
+msgid "Author"
+msgstr "作者"
+
+msgid "Model Name"
+msgstr "模型名字"
+
+#, c-format, boost-format
+msgid "%s Update"
+msgstr "%s 更新"
+
+msgid "A new version is available"
+msgstr "發現新版本"
+
+msgid "Configuration update"
+msgstr "配置更新"
+
+msgid "A new configuration package available, Do you want to install it?"
+msgstr "新的配置包可用，您需要安裝嗎？"
+
+msgid "Description:"
+msgstr "描述："
+
+msgid "Configuration incompatible"
+msgstr "配置不相容"
+
+msgid "the configuration package is incompatible with current application."
+msgstr "配置包和當前的應用程式不相容。"
+
+#, c-format, boost-format
+msgid ""
+"The configuration package is incompatible with current application.\n"
+"%s will update the configuration package, Otherwise it won't be able to start"
+msgstr ""
+"配置包和當前的應用程式不相容。\n"
+"%s會更新配置包，否則無法正常啟動"
+
+#, c-format, boost-format
+msgid "Exit %s"
+msgstr "退出 %s"
+
+msgid "the Configuration package is incompatible with current APP."
+msgstr "the Configuration package is incompatible with current APP."
+
+msgid "Configuration updates"
+msgstr "配置更新"
+
+msgid "No updates available."
+msgstr "沒有可用的更新。"
+
+msgid "The configuration is up to date."
+msgstr "當前配置已經是最新版本。"
+
+msgid "Open Wiki for more information >"
+msgstr "開啟Wiki瞭解更多資訊 >"
+
+msgid "Obj file Import color"
+msgstr "Obj檔案匯入顏色"
+
+msgid "Standard 3mf Import color"
+msgstr "標準3mf匯入顏色"
+
+msgid "Some faces don't have color defined."
+msgstr "有些面片未定義顏色。"
+
+msgid "mtl file exist error,could not find the material:"
+msgstr "mtl檔案存在錯誤，找不到材料："
+
+msgid "Please check obj or mtl file."
+msgstr "請檢查obj或mtl檔案。"
+
+msgid "Specify number of colors:"
+msgstr "指定顏色數量:"
+
+msgid "Enter or click the adjustment button to modify number again"
+msgstr "輸入或單擊調整按鈕可再次修改數字"
+
+msgid "Recommended "
+msgstr "推薦"
+
+msgid "view"
+msgstr "檢視"
+
+msgid "Current filament colors"
+msgstr "當前材料顏色"
+
+msgid "Matching"
+msgstr "匹配"
+
+msgid "Quick set"
+msgstr "快捷設定"
+
+msgid "There are color input errors."
+msgstr "存在顏色輸入錯誤。"
+
+msgid "Texture import is temporarily unavailable, partial coloring is automatically replaced with the default color."
+msgstr "紋理匯入暫時不可用，部分著色將自動替換為預設顏色。"
+
+msgid " And "
+msgstr " 並且"
+
+msgid "Note"
+msgstr "提示"
+
+msgid "The color has been selected, you can choose OK to continue or manually adjust it."
+msgstr "顏色已經預設匹配好了，您可以選中確認繼續或手動修改它。"
+
+msgctxt "ObjImport"
+msgid "Original"
+msgstr "原專案"
+
+msgid "After mapping"
+msgstr "匹配後"
+
+msgid "Color match"
+msgstr "顏色匹配"
+
+msgid "Approximate color matching."
+msgstr "近似的顏色匹配。"
+
+msgid "Append"
+msgstr "追加"
+
+msgid "Append to existing filaments"
+msgstr "在已有耗材後面追加耗材"
+
+msgid "Reset mapped extruders."
+msgstr "重置匹配的耗材絲。"
+
+msgid "—> "
+msgstr ""
+
+msgid ""
+"Synchronizing AMS filaments will discard your modified but unsaved filament presets.\n"
+"Are you sure you want to continue?"
+msgstr "同步AMS耗材將丟棄已修改但未儲存的耗材預設。您確定要繼續嗎？"
+
+msgctxt "Sync_AMS"
+msgid "Original"
+msgstr "原專案"
+
+msgid "After overwriting"
+msgstr "覆蓋後"
+
+msgctxt "Sync_AMS"
+msgid "Plate"
+msgstr "盤號"
+
+msgid "The connected printer does not match the currently selected printer. Please change the selected printer."
+msgstr "連線的印表機與當前選擇的印表機不匹配。請更改所選印表機。"
+
+msgid "Mapping"
+msgstr "匹配"
+
+msgid "Overwriting"
+msgstr "覆蓋"
+
+msgid "Reset all filament mapping"
+msgstr "重置所有耗材對映"
+
+msgid "Left Extruder"
+msgstr "左擠出機"
+
+msgid "(Recommended filament)"
+msgstr "(推薦的材料)"
+
+msgid "Right Extruder"
+msgstr "右擠出機"
+
+msgid "Advanced Options"
+msgstr "高階選項"
+
+msgid ""
+"Check heatbed flatness. Leveling makes extruded height uniform.\n"
+"*Automatic mode: Level first (about 10 seconds). Skip if surface is fine."
+msgstr ""
+"檢查加熱床的平整度。找平使擠壓高度均勻。\n"
+"*自動模式：先調平（約10秒）。如果表面良好，則跳過。"
+
+msgid ""
+"Calibrate nozzle offsets to enhance print quality.\n"
+"*Automatic mode: Check for calibration before printing; skip if unnecessary."
+msgstr ""
+"校準不同噴嘴的偏移量，提升列印質量。\n"
+"*自動模式：發起列印前檢測是否需要校準，無需校準則跳過校準。"
+
+msgid "Use AMS"
+msgstr "使用AMS"
+
+msgid "Tip"
+msgstr "提示"
+
+msgid "Only synchronize filament type and color, not including AMS slot information."
+msgstr "僅同步耗材型別和顏色，不包含AMS槽位資訊。"
+
+msgid "Replace the project filaments list sequentially based on printer filaments. And unused printer filaments will be automatically added to the end of the list."
+msgstr "使用印表機內的耗材，依次替換專案耗材列表。未使用的印表機耗材將自動新增至列表末尾。"
+
+msgid "Advanced settings"
+msgstr "高階設定"
+
+msgid "Add unused AMS filaments to filaments list."
+msgstr "將未使用的 AMS 耗材新增到耗材列表中。"
+
+msgid "Automatically merge the same colors in the model after mapping."
+msgstr "匹配後自動合併模型中的相同顏色。"
+
+msgid "After being synced, this action cannot be undone."
+msgstr "同步後，此操作不可撤銷。"
+
+msgid "After being synced, the project's filament presets and colors will be replaced with the mapped filament types and colors. This action cannot be undone."
+msgstr "同步後，專案耗材列表的預設和顏色將被對映後的耗材型別和顏色替代，此操作不可撤銷。"
+
+msgid "Are you sure to synchronize the filaments?"
+msgstr "確定要同步AMS中耗材資訊嗎？"
+
+msgid "Synchronize now"
+msgstr "立即同步"
+
+msgid "Synchronize Filament Information"
+msgstr "同步耗材資訊"
+
+msgid "Add unused filaments to filaments list."
+msgstr "將未使用的耗材新增到耗材列表中。"
+
+msgid "Only synchronize filament type and color, not including slot information."
+msgstr "僅同步耗材型別和顏色，不包含槽位資訊。"
+
+msgid "Ext spool"
+msgstr "外掛"
+
+msgid "Please check whether the nozzle type of the device is the same as the preset nozzle type."
+msgstr "請檢查裝置的噴嘴型別是否與預設的噴嘴型別相同。"
+
+#, c-format, boost-format
+msgid "The selected printer (%s) is incompatible with the chosen printer profile in the slicer (%s)."
+msgstr "所選印表機（%s）與切片軟體中選擇的印表機配置檔案（%s）不相容。"
+
+msgid "Timelapse is not supported because Print sequence is set to \"By object\"."
+msgstr "切片引數中開啟了逐件列印，無法支援延時攝影。"
+
+msgid "You selected external and AMS filament at the same time in an extruder, you will need manually change external filament."
+msgstr "您在同一擠出機中同時選擇了外部和AMS耗材，您需要手動更換外部耗材。"
+
+msgid "Successfully synchronized nozzle information."
+msgstr "噴嘴資訊同步成功。"
+
+msgid "Successfully synchronized nozzle and AMS number information."
+msgstr "噴嘴資訊和AMS數量同步成功。"
+
+msgid "Continue to sync filaments"
+msgstr "繼續同步耗材"
+
+msgctxt "Sync_Nozzle_AMS"
+msgid "Cancel"
+msgstr "知道了"
+
+msgid "Successfully synchronized color and type of filament from printer."
+msgstr "成功從印表機同步耗材顏色和型別。"
+
+msgctxt "FinishSyncAms"
+msgid "OK"
+msgstr "知道了"
+
+msgid "Studio would re-calculate your flushing volumes everytime the filaments color changed or filaments changed. You could disable the auto-calculate in Bambu Studio > Preferences"
+msgstr "Studio 將會在每一次更換耗材或顏色時重新計算您的沖刷體積，您可以在Bambu Studio > 偏好設定 中關閉自動計算"
+
+msgid "Flushing volume (mm³) for each filament pair."
+msgstr "在兩個耗材絲間切換所需的沖刷量（mm³）"
+
+#, c-format, boost-format
+msgid "Suggestion: Flushing Volume in range [%d, %d]"
+msgstr "建議：沖刷量設定在[%d, %d]範圍內"
+
+#, c-format, boost-format
+msgid "The multiplier should be in range [%.2f, %.2f]."
+msgstr "乘數的取值範圍是[%.2f, %.2f]"
+
+msgid "Re-calculate"
+msgstr "重新計算"
+
+msgid "Left extruder"
+msgstr "左擠出機"
+
+msgid "Right extruder"
+msgstr "右擠出機"
+
+msgid "Multiplier"
+msgstr "乘數"
+
+msgid "Flushing volumes for filament change"
+msgstr "耗材絲更換時的沖刷體積"
+
+msgid "Please choose the filament colour"
+msgstr "請選擇材料顏色"
+
+msgid "Bambu Network plug-in not detected."
+msgstr "未檢測到Bambu網路外掛。"
+
+msgid "Click here to download it."
+msgstr "點此下載"
+
+msgid "Login"
+msgstr "登入"
+
+msgid "The configuration package is changed to the previous Config Guide"
+msgstr "引數配置包在之前的配置嚮導中發生了變更"
+
+msgid "Configuration package changed"
+msgstr "引數配置包發生變更"
+
+msgid "Toolbar"
+msgstr "工具欄"
+
+msgid "Objects list"
+msgstr "物件列表"
+
+msgid "Import geometry data from STL/STEP/3MF/OBJ/AMF files"
+msgstr "從STL/STEP/3MF/OBJ/AMF檔案中匯入幾何資料"
+
+msgid "Paste from clipboard"
+msgstr "從剪下板貼上"
+
+msgid "Show/Hide 3Dconnexion devices settings dialog"
+msgstr "顯示/隱藏 3Dconnexion裝置的設定對話方塊"
+
+msgid "Switch tab page"
+msgstr "切換標籤頁"
+
+msgid "Show keyboard shortcuts list"
+msgstr "顯示鍵盤快捷鍵列表"
+
+msgid "Global shortcuts"
+msgstr "全域性快捷鍵"
+
+msgid "Rotate View"
+msgstr "旋轉視角"
+
+msgid "Pan View"
+msgstr "移動視角"
+
+msgid "Zoom View"
+msgstr "縮放視角"
+
+msgid "Shift+A"
+msgstr ""
+
+msgid "Shift+R"
+msgstr ""
+
+msgid "Auto orientates selected objects or all objects.If there are selected objects, it just orientates the selected ones.Otherwise, it will orientates all objects in the current disk."
+msgstr "自動調整選定零件/所有零件的方向,有選定零件時調整選定零件的朝向,沒有選擇零件時調整當前盤所有零件的朝向"
+
+msgid "Shift+Tab"
+msgstr ""
+
+msgid "Collapse/Expand the sidebar"
+msgstr "收起/展開 側邊欄"
+
+msgid "Any arrow"
+msgstr "方向鍵"
+
+msgid "Movement in camera space"
+msgstr "沿相機視角移動物件"
+
+msgid "Select a part"
+msgstr "選擇單個零件"
+
+msgid "Shift+Left mouse button"
+msgstr "Shift+滑鼠左鍵"
+
+msgid "Select objects by rectangle"
+msgstr "框選多個零件"
+
+msgid "Arrow Up"
+msgstr "上箭頭"
+
+msgid "Move selection 10 mm in positive Y direction"
+msgstr "Y方向移動 10mm"
+
+msgid "Arrow Down"
+msgstr "下箭頭"
+
+msgid "Move selection 10 mm in negative Y direction"
+msgstr "Y方向移動 10mm"
+
+msgid "Arrow Left"
+msgstr "左箭頭"
+
+msgid "Move selection 10 mm in negative X direction"
+msgstr "X方向移動 10mm"
+
+msgid "Arrow Right"
+msgstr "右箭頭"
+
+msgid "Move selection 10 mm in positive X direction"
+msgstr "X方向移動 10mm"
+
+msgid "Shift+Any arrow"
+msgstr "Shift+方向鍵"
+
+msgid "Movement step set to 1 mm"
+msgstr "沿X、Y軸以1mm為步進移動物件"
+
+msgid "keyboard 1-9: set filament for object/part"
+msgstr "按鍵1-9：設定物件/零件的耗材絲"
+
+msgid "Camera view - Default"
+msgstr "攝像機視角 - 預設"
+
+msgid "Camera view - Top"
+msgstr "攝像機視角 - 頂部"
+
+msgid "Camera view - Bottom"
+msgstr "攝像機視角 - 底部"
+
+msgid "Camera view - Front"
+msgstr "攝像機視角 - 前面"
+
+msgid "Camera view - Behind"
+msgstr "攝像機視角 - 後面"
+
+msgid "Camera view - Left"
+msgstr ""
+
+msgid "Camera view - Right"
+msgstr ""
+
+msgid "Camera view - Isometric"
+msgstr "攝像機視角 - 等軸測"
+
+msgid "Select all objects"
+msgstr "選擇所有物件"
+
+msgid "Shift+D"
+msgstr ""
+
+msgid "Gizmo move"
+msgstr "線框移動"
+
+msgid "Gizmo scale"
+msgstr "線框縮放"
+
+msgid "Gizmo rotate"
+msgstr "旋轉物件"
+
+msgid "Gizmo cut"
+msgstr "剪下物件"
+
+msgid "Gizmo Place face on bed"
+msgstr "選擇底面"
+
+msgid "Gizmo SLA support points"
+msgstr "SLA支撐點"
+
+msgid "Gizmo FDM paint-on seam"
+msgstr "FDM塗裝接縫"
+
+msgid "Plater"
+msgstr "準備"
+
+msgid "Support/Color Painting: adjust pen radius"
+msgstr "支撐/顏色繪製：調節畫筆半徑"
+
+msgid "Support/Color Painting: adjust section position"
+msgstr "支撐/色彩繪製：調節剖面位置"
+
+msgid "Gizmo"
+msgstr "小工具"
+
+msgid "Set extruder number for the objects and parts"
+msgstr "設定物件、零件使用的擠出機編號"
+
+msgid "Delete objects, parts, modifiers  "
+msgstr "刪除物件、零件、修改器"
+
+msgid "Space"
+msgstr "空格鍵"
+
+msgid "Select the object/part and press space to change the name"
+msgstr "選中物件、零件，按空格可修改名稱"
+
+msgid "Mouse click"
+msgstr "滑鼠點選"
+
+msgid "Select the object/part and mouse click to change the name"
+msgstr "選中物件、零件，雙擊零件名可修改名稱"
+
+msgid "Objects List"
+msgstr "物件列表"
+
+msgid "Vertical slider - Move active thumb Up"
+msgstr "垂直滑動條 - 向上移動一層"
+
+msgid "Vertical slider - Move active thumb Down"
+msgstr "垂直滑動條 - 向下移動一層"
+
+msgid "Horizontal slider - Move active thumb Left"
+msgstr "水平滑動條 - 向左移動一步"
+
+msgid "Horizontal slider - Move active thumb Right"
+msgstr "水平滑動條 - 向右移動一步"
+
+msgid "On/Off one layer mode of the vertical slider"
+msgstr "開啟/關閉垂直滑動條的單層模式"
+
+msgid "Move slider 5x faster"
+msgstr "5倍速移動滑動條"
+
+msgid "Shift+Mouse wheel"
+msgstr "Shift+滑鼠滾輪"
+
+msgid "Release Note"
+msgstr "更新說明"
+
+#, c-format, boost-format
+msgid "version %s update information :"
+msgstr "版本 %s 更新資訊"
+
+msgid "Network plug-in update"
+msgstr "網路外掛升級"
+
+msgid "Click OK to update the Network plug-in when Bambu Studio launches next time."
+msgstr "點選“確認”，將在Bambu Studio下次啟動之後自動升級網路外掛"
+
+#, c-format, boost-format
+msgid "A new Network plug-in(%s) available, Do you want to install it?"
+msgstr "新的網路外掛(%s) 可用，您是否需要安裝它？"
+
+msgid "New version of Bambu Studio"
+msgstr "新版本的Bambu Studio"
+
+msgid "Skip this Version"
+msgstr "跳過本版本"
+
+msgid "resume"
+msgstr "繼續"
+
+msgid "Confirm and Update Nozzle"
+msgstr "確認並更新噴嘴"
+
+msgid "Connect the printer using IP and access code"
+msgstr "使用IP和訪問程式碼連線列印"
+
+msgid "Try the following methods to update the connection parameters and reconnect to the printer."
+msgstr "嘗試以下方法更新連線引數並重新連線印表機。"
+
+msgid "1. Please confirm Bambu Studio and your printer are in the same LAN."
+msgstr "1. 請確認Bambu Studio和您的印表機在同一個區域網內。"
+
+msgid "2. If the IP and Access Code below are different from the actual values on your printer, please correct them."
+msgstr "2. 如果下面的IP和Access Code與您的印表機上的實際值不同，請更正。"
+
+msgid "3. Please obtain the device SN from the printer side; it is usually found in the device information on the printer screen."
+msgstr "3. 請從印表機端獲取裝置序列號，它通常位於印表機螢幕上的裝置資訊中。"
+
+msgid "Access Code"
+msgstr "訪問碼"
+
+msgid "Printer model"
+msgstr "印表機型號"
+
+msgid "Where to find your printer's IP and Access Code?"
+msgstr "在哪裡可以找到印表機的IP和訪問程式碼?"
+
+msgid "Connect"
+msgstr "連線"
+
+msgid "IP and Access Code Verified! You may close the window"
+msgstr "IP地址和訪問碼驗證成功！您可以關閉此視窗。"
+
+msgid "connecting..."
+msgstr "連線中..."
+
+msgid "Failed to connect to printer."
+msgstr "無法連線到印表機"
+
+msgid "Failed to publish login request."
+msgstr "釋出登入請求失敗"
+
+msgid "The printer has already been bound."
+msgstr "印表機已繫結。"
+
+msgid "The printer mode is incorrect, please switch to LAN Only."
+msgstr "印表機模式不正確，請切換到僅區域網。"
+
+msgid "Connecting to printer... The dialog will close later"
+msgstr "連線印表機中… 對話方塊稍後將自動關閉。"
+
+msgid "Connection failed, please double check IP and Access Code"
+msgstr "連線失敗，請再次檢查IP地址和訪問碼。"
+
+msgid ""
+"Connection failed! If your IP and Access Code is correct, \n"
+"please move to step 3 for troubleshooting network issues"
+msgstr ""
+"連線失敗！如果您的IP地址和訪問碼是正確的，\n"
+"請檢視第三步的提示，以便定位網路問題所在。"
+
+msgid "Connection failed! Please refer to the wiki page."
+msgstr "連線失敗！請參考wiki頁面"
+
+msgid "sending failed"
+msgstr "傳送失敗"
+
+msgid "Failed to send. Click Retry to attempt sending again. If retrying does not work, please check the reason."
+msgstr "傳送失敗。您可以點選“重試”再次傳送。如果重試無效，請檢查原因。"
+
+msgid "reconnect"
+msgstr "重新連線"
+
+msgid "Welcome to Helio Additive"
+msgstr "歡迎使用 Helio Additive"
+
+msgid "Know Your Print Will Work — Before You Hit Print"
+msgstr "在點選“列印”之前透過最佳化提升列印成功率"
+
+msgid "Physics-based analysis and optimization that makes prints faster, stronger, and far more reliable."
+msgstr "基於物理的分析與最佳化，讓列印更快、更強，並顯著提升可靠性。"
+
+msgid "Unlock a world of faster, more reliable printing with Helio's state of the art physics based 3d printing simulation technology."
+msgstr "藉助 Helio 先進的基於物理的 3D 列印模擬技術，解鎖更快、更可靠的列印體驗。"
+
+msgid "Fewer Failed Prints"
+msgstr "更少的列印失敗"
+
+msgid "Catch issues before printing and improve first-try success."
+msgstr "在列印前發現問題，提高一次成功率。"
+
+msgid "Faster Prints, Better Quality"
+msgstr "更快的列印，更好的質量"
+
+msgid "Automatically tune speed and extrusion without manual tweaking."
+msgstr "無需手動調參，自動最佳化速度與擠出。"
+
+msgid "Enable Helio Additive"
+msgstr "啟用 Helio Additive"
+
+msgid "Uninstall"
+msgstr "解除安裝"
+
+msgid "After slicing, click the Helio button to analyze your print."
+msgstr "切片完成後，點選 Helio 按鈕分析你的列印任務。"
+
+msgid "Helio Additive does not change your printer's firmware."
+msgstr "Helio Additive 不會更改你的印表機韌體。"
+
+msgid "Designed to help prints succeed — even if you're new to 3D printing."
+msgstr "即使你是 3D 列印新手，也能幫助你順利列印成功。"
+
+msgid "Are you sure you want to uninstall Helio Additive? This will disable all Helio features."
+msgstr "確定要解除安裝 Helio Additive 嗎？這將禁用所有 Helio 功能。"
+
+msgid "Uninstall Helio Additive"
+msgstr "解除安裝 Helio Additive"
+
+msgid "Legal & Activation Terms"
+msgstr "法律與啟用條款"
+
+msgid "Got it"
+msgstr "知道了"
+
+msgid "Failed to get Helio PAT, Click Refresh to obtain it again."
+msgstr "獲取 Helio-PAT 失敗，點選重新整理重新獲取。"
+
+msgid "Failed to obtain PAT. The quantity limit has been reached, so it cannot be obtained. Click the refresh button to re-obtain PAT."
+msgstr "獲取 Helio-PAT 失敗。已達到數量上限，無法再獲取。請點選重新整理按鈕重新獲取PAT。"
+
+msgid "You are activating Helio Additive's advanced simulation services."
+msgstr "你正在啟用 Helio Additive 的高階模擬服務。"
+
+msgid "Software Service Terms && Conditions"
+msgstr "軟體服務條款與條件"
+
+msgid "^"
+msgstr ""
+
+msgid "Helio Additive"
+msgstr ""
+
+msgid "Helio Additive Privacy Agreement"
+msgstr "Helio Additive 隱私協議"
+
+msgid "Helio Additive User Agreement"
+msgstr "Helio Additive 使用者協議"
+
+msgid "Unless otherwise specified, Bambu Lab only provides support for the software features officially provided. The slicing evaluation and slicing optimization features based on "
+msgstr "除非特殊說明，拓竹科技僅對官方提供的軟體功能提供支援。本軟體中基於"
+
+msgid "'s cloud service in this software will be developed, operated, provided, and maintained by "
+msgstr "雲端服務的切片評估和切片最佳化功能由 "
+
+msgid ". Helio Additive is responsible for the effectiveness and availability of this service. The optimization feature of this service may modify the default print commands, posing a risk of printer damage. These features will collect necessary user information and data to achieve relevant service functions. Subscriptions and payments may be involved. Please visit "
+msgstr "負責開發、維護以及對外提供服務。其服務效果和可用性由Helio Additive負責。本服務的最佳化功能可能修改預設的列印指令，存在印表機損壞的風險。同時這些功能將收集必要的使用者資訊和資料以實現相關服務功能，並可能涉及訂閱與付費，請訪問 "
+
+msgid " and refer to the "
+msgstr " 並參考 "
+
+msgid " and "
+msgstr " 和 "
+
+msgid " for detailed information."
+msgstr " 獲取詳細資訊。"
+
+msgid "Meanwhile, you understand that this product is provided to you \"as is\" based on "
+msgstr "同時，您理解本產品是“按原樣”向您提供基於 "
+
+msgid "'s services, and Bambu Lab makes no express or implied warranties of any kind, nor can it control the service effects. To the fullest extent permitted by applicable law, Bambu Lab or its licensors/affiliates do not provide any express or implied representations or warranties, including but not limited to warranties regarding merchantability, satisfactory quality, fitness for a particular purpose, accuracy, confidentiality, and non-infringement of third-party rights. Due to the nature of network services, Bambu Lab cannot guarantee that the service will be available at all times, and Bambu Lab reserves the right to terminate the service based on relevant circumstances. You agree not to use this product and its related updates to engage in the following activities:"
+msgstr "的服務，拓竹不存在任何形式的明示或暗示擔保，也無法控制服務效果，並且在適用法律允許的最大範圍內，拓竹、其許可方/附屬公司均不提供任何明示或暗示的陳述或保證，包括但不限於有關適銷性、滿意質量、適用於特定目的、準確性、保密權以及不侵犯第三方權利的保證。基於網路服務的特性，拓竹無法保證該服務隨時可達，並且拓竹有權根據相關情況終止該服務。您同意不使用本產品及相關更新內容從事以下行為："
+
+msgid "1. Copy or use any part of this product outside the authorized scope of Helio Additive and Bambu Lab;"
+msgstr "1. 在Helio Additive和拓竹授權範圍之外複製或使用本產品的任何一部分內容；"
+
+msgid "2. Attempt to disrupt, bypass, alter, invalidate, or evade any Digital Rights Management system related to and/or an integral part of this product;"
+msgstr "2. 企圖破壞、繞過、改變、作廢或者逃避和本產品相關的以及/或者屬於本產品有機組成的一部分的任何數字版權管理系統；"
+
+msgid "3. Using this software and services for any improper or illegal activities."
+msgstr "3. 利用本軟體和服務進行任何不當或違反法律的行為。"
+
+msgid "When you confirm to enable this feature, it means that you have confirmed and agreed to the above statements."
+msgstr "當您確認開啟此功能後，代表您已經確認和同意以上宣告。"
+
+msgid "Special Note && Privacy Policy"
+msgstr "特別說明與隱私政策"
+
+msgid "This service is provided and hosted by a third party, Helio Additive. All data collection and processing activities are solely managed by Helio Additive, and Bambu Lab assumes no responsibility in this regard. By clicking \"Agree and Proceed\", you agree to Helio Additive's privacy policy."
+msgstr "本服務由第三方 Helio Additive 提供並託管。所有資料收集與處理活動均由 Helio Additive 獨立管理，Bambu Lab 對此不承擔任何責任。點選“同意並繼續”即表示你同意 Helio Additive 的隱私政策。"
+
+msgid ""
+"I have read and agree to the terms\n"
+"and policies."
+msgstr "我已閱讀並同意相關條款與政策。"
+
+msgid "Agree and Proceed"
+msgstr "同意並繼續"
+
+msgid "Activation Successful!"
+msgstr "啟用成功！"
+
+msgid "Helio Additive is now active. You have unlocked free optimizations!"
+msgstr "Helio Additive 現已啟用。你已解鎖免費最佳化！"
+
+msgid "Applies only when first activated"
+msgstr "僅在首次啟用時適用"
+
+msgid "Run Your First Optimization"
+msgstr "執行你的首次最佳化"
+
+msgid "You're nearly there! Now that Helio is activated, your first optimization run for faster, more reliable printing takes only minutes! (Now referred to as 'Enhance' or 'Enhancement')"
+msgstr "就快完成了！現在 Helio 已啟用，你的首次最佳化只需幾分鐘即可獲得更快、更可靠的列印！（現稱為“Enhance/增強”或“Enhancement/增強效果”）"
+
+msgid ""
+"Add an object to the build plate, select a material and printer that Helio supports, then slice.\n"
+"\n"
+msgstr ""
+"將物件新增到列印板上，選擇 Helio 支援的材料與印表機，然後進行切片。\n"
+"\n"
+
+msgid "Supported printers and materials"
+msgstr "支援的印表機與材料"
+
+msgid "Copy PAT"
+msgstr "複製 PAT"
+
+msgid ""
+"Personal Access Token (PAT)\n"
+"\n"
+"A secure credential that verifies your identity with Helio services. It's automatically used by BambuStudio for optimizations and simulations.\n"
+"\n"
+"You may need to copy this to:\n"
+"• Integrate Helio with other slicers or tools\n"
+"• Use the Helio API directly\n"
+"• Provide to support when troubleshooting"
+msgstr ""
+"個人訪問令牌（PAT）\n"
+"\n"
+"用於向 Helio 服務驗證身份的安全憑證。BambuStudio 會自動使用它來進行最佳化與模擬。\n"
+"\n"
+"你可能需要複製它用於：\n"
+"• 將 Helio 整合到其他切片器或工具\n"
+"• 直接使用 Helio API\n"
+"• 排障時提供給技術支援"
+
+msgid "Copy successful!"
+msgstr "複製成功！"
+
+msgid "History"
+msgstr "歷史記錄"
+
+msgid "View and download recent optimizations and simulations"
+msgstr "檢視並下載最近的最佳化與模擬"
+
+msgid "Terms of Use"
+msgstr "使用條款"
+
+msgid "Activation Successful"
+msgstr "啟用成功"
+
+msgid "Assess"
+msgstr "評估"
+
+msgid "Formerly referred to as 'Simulate' or 'Simulation'"
+msgstr "之前稱為“Simulate/模擬”或“Simulation/模擬分析”"
+
+msgid "See where it will fail"
+msgstr "檢視可能失敗的位置"
+
+msgid "Enhance"
+msgstr "增強"
+
+msgid "Formerly referred to as 'Optimize' or 'Optimization'"
+msgstr "之前稱為“Optimize/最佳化”或“Optimization/最佳化處理”"
+
+msgid "Auto-fix with new speeds"
+msgstr "使用新速度自動修復"
+
+msgid "Environment Temperature"
+msgstr "環境溫度"
+
+msgid "Chamber Temperature"
+msgstr "腔溫"
+
+msgid "Refers to the environment temperature of the print (i.e. A-series - room temperature). Changing chamber temperature when running an assessment/simulation allows you to play around with different temperature scenarios."
+msgstr "指列印過程的環境溫度（例如 A 系列為室溫環境）。在執行評估/模擬時調整腔體溫度，可用於嘗試不同溫度場景。"
+
+msgid "Optional. More accurate temperatures ensures better results."
+msgstr "可選。溫度越準確，結果越可靠。"
+
+msgid "Helio's advanced feature for power users: available post purchase on its official website."
+msgstr "Helio 的高階功能，面向專業使用者：可在官方網站購買後獲得。"
+
+msgid "Account Status"
+msgstr "賬戶狀態"
+
+msgid "Subscription:"
+msgstr "訂閱："
+
+msgid "Loading subscription status..."
+msgstr "正在載入訂閱狀態……"
+
+msgid "Monthly quota:"
+msgstr "每月配額："
+
+msgid "Add-ons:"
+msgstr "附加項："
+
+msgid "Plans / Upgrades"
+msgstr "套餐 / 升級"
+
+msgid "Manage Account"
+msgstr "管理賬戶"
+
+msgid "Environment Settings"
+msgstr "環境設定"
+
+msgid "Uses the chamber temperature from Filament settings when available; otherwise estimates it from the build plate temperature."
+msgstr "若可用，則使用耗材設定中的腔體溫度；否則根據熱床溫度進行估算。"
+
+msgid "Optimization Settings"
+msgstr "最佳化設定"
+
+msgid "Now referred to as 'Enhance' or 'Enhancement'"
+msgstr "現稱為“Enhance/增強”或“Enhancement/增強效果”"
+
+msgid "Helio default (recommended)"
+msgstr "Helio 預設設定（推薦）"
+
+msgid "Slicer default"
+msgstr "切片軟體預設值"
+
+msgid "Limits"
+msgstr "限制"
+
+msgid "Set your own speed and flow rate limits - or rely on Helio's custom limit settings. With unsupported materials you need to supply your own data or rely on the slicer's built in data."
+msgstr "你可以自定義速度與流量上限，或使用 Helio 的自定義限制設定。對於不支援的材料，你需要提供自己的資料，或使用切片器內建資料。"
+
+msgid "Min Velocity"
+msgstr "最小速度"
+
+msgid "Max Velocity"
+msgstr "最大速度"
+
+msgid "Min Volumetric Speed"
+msgstr "最小體積速度"
+
+msgid "Max Volumetric Speed"
+msgstr "最大體積速度"
+
+msgid "Last Trace ID: "
+msgstr "最後跟蹤 ID: "
+
+msgid "Click for more details"
+msgstr "點選檢視更多詳情"
+
+msgid "Enhancement will only take a few minutes to complete, depending on the size of your object. (A lot of compute is happening in the background) (Formerly referred to as 'Optimize' or 'Optimization')"
+msgstr "增強處理通常只需幾分鐘，具體取決於模型大小。（後臺正在進行大量計算）（此前稱為“Optimize/最佳化”或“Optimization/最佳化處理”）"
+
+msgid "Assessment will only take a few minutes to complete, depending on the size of your object. (A lot of compute is happening in the background) (Formerly referred to as 'Simulate' or 'Simulation')"
+msgstr "評估通常只需幾分鐘，具體取決於模型大小。（後臺正在進行大量計算）（此前稱為“Simulate/模擬”或“Simulation/模擬分析”）"
+
+msgid "Start Free Trial"
+msgstr "開始免費試用"
+
+msgid "Activate your free trial to unlock premium enhancements"
+msgstr "啟用免費試用以解鎖高階增強功能"
+
+msgid "Go to our storefront to purchase more enhancements"
+msgstr "前往商店購買更多增強次數"
+
+msgid "Free Trial"
+msgstr "免費試用"
+
+msgid "Free Trial Expired"
+msgstr "免費試用已到期"
+
+msgid "Your free trial has ended. Explore our plans to continue using premium features."
+msgstr "你的免費試用已結束。檢視我們的套餐以繼續使用高階功能。"
+
+msgid "Start your free trial to unlock premium enhancements and faster, warp-free prints!"
+msgstr "開始免費試用，解鎖高階增強功能，獲得更快、更不易翹曲的列印！"
+
+msgid "Unlimited*"
+msgstr "不限量*"
+
+msgid "*Fair usage terms apply - click to learn more"
+msgstr "適用公平使用條款——點選瞭解更多"
+
+msgid "Restrict Helio's fixes to only certain layers, or keep them for all layers - the choice is yours! (Layer 1 attached to the bed is typically skipped.)"
+msgstr "可將 Helio 的修復限制在指定層，或應用於全部層——由你決定！（通常會跳過與熱床接觸的第 1 層。）"
+
+msgid "Print Priority"
+msgstr "列印優先順序"
+
+msgid "Loading print priority options..."
+msgstr "正在載入列印優先順序選項……"
+
+msgid "Fetching material-specific options from Helio API..."
+msgstr "正在從 Helio API 獲取材料專屬選項……"
+
+msgid "Preserve Surface Finish"
+msgstr "保持表面外觀"
+
+msgid "Speed & Strength"
+msgstr "速度與強度"
+
+msgid ""
+"Speed & Strength: Optimizes outer walls for improved performance.\n"
+"Preserve Surface Finish: Maintains original wall speeds to preserve visual finish.\n"
+"\n"
+"Note: Using fallback options - couldn't fetch material-specific settings from API."
+msgstr ""
+"速度與強度：最佳化外牆引數以提升效能。\n"
+"保持表面外觀：保持原始外牆速度以保留視覺效果。\n"
+"注意：正在使用備用選項——無法從 API 獲取材料專屬設定。"
+
+msgid "No print priority options available for this material"
+msgstr "此材料沒有可用的列印優先順序選項"
+
+msgid "This material does not support print priority optimization."
+msgstr "該材料不支援列印優先順序最佳化。"
+
+msgid "Optimizes outer walls for improved performance."
+msgstr "最佳化外牆以提升效能。"
+
+msgid "Maintains original wall speeds to preserve visual finish."
+msgstr "保持原有的牆體速度，以保持視覺效果。"
+
+msgid "Enhance Surface Gloss"
+msgstr "增強表面光澤"
+
+msgid "Optimizes for enhanced surface gloss."
+msgstr "最佳化以增強表面光澤。"
+
+msgid ""
+"Failed to load print priority options from Helio API.\n"
+"Using standard optimization method instead (same as before print priority feature)."
+msgstr ""
+"從 Helio API 載入列印優先順序選項失敗。\n"
+"將改用標準最佳化方法（與引入列印優先順序功能之前相同）。"
+
+msgid "Failed to obtain Helio PAT. The number of issued PATs has reached the upper limit. Please pay attention to the information on the Helio official website. Click Refresh to get it again once it is available."
+msgstr "獲取 Helio-PAT 失敗。已達到發行 PAT 的上限。請關注 Helio 官方網站的資訊。可點選重新整理重新獲取。"
+
+msgid "HELIO ADDITIVE"
+msgstr ""
+
+msgid "Print Time Improvement"
+msgstr "列印時間最佳化"
+
+msgid "Average Improvement"
+msgstr "平均最佳化效果"
+
+msgid "Consistency Improvement"
+msgstr "一致性最佳化效果"
+
+msgid "Estimate of improvement in print time before and after enhancement"
+msgstr "增強前後列印時間改善的估計值"
+
+msgid "Level of Strength & Warping improvement for this part after enhancement - average for the part"
+msgstr "該零件增強後的強度與抗翹曲改善水平（零件平均值）"
+
+msgid "Level of Strength & Warping improvement for this part after enhancement - change in overall consistency"
+msgstr "該零件增強後的強度與抗翹曲改善水平（整體一致性變化）"
+
+msgid "Your gcode has been improved for the best possible print. To further improve your print please check out our wiki for tips & tricks on what to do next."
+msgstr "您的G程式碼已完成最佳化，以實現最佳列印效果。若需進一步提升列印質量，可查閱我們的wiki文件，獲取後續操作的實用技巧與建議。"
+
+msgid "Rate the enhancement based on your expectations. 5 stars means awesome! 1 star means it didn't add much value for you."
+msgstr "請根據你的預期為此次增強評分。5 星表示非常棒；1 星表示對你幫助不大。"
+
+msgid "Save the enhanced gcode locally"
+msgstr "將增強後的 gcode 儲存到本地"
+
+msgid "Print Plate"
+msgstr "列印"
+
+msgid "Print the enhanced part immediately"
+msgstr "立即列印增強後的零件"
+
+msgid "View Details"
+msgstr "檢視詳情"
+
+msgid "Verify Print Success Results"
+msgstr "驗證列印成功結果"
+
+msgid "Simulates the thermal process to confirm your part will print without failure."
+msgstr "透過熱過程模擬確認你的零件能否無故障列印。"
+
+msgid "Now referred to as 'Assess' or 'Assessment'"
+msgstr "現稱為“Assess/評估”或“Assessment/評估結果”"
+
+msgid "Time saved: "
+msgstr "節省時間："
+
+msgid "From "
+msgstr "從 "
+
+msgid "Expected Outcome:"
+msgstr "預期結果："
+
+msgid "Analysis:"
+msgstr "分析："
+
+msgid "Additional observations:"
+msgstr "其他觀察："
+
+msgid "Fix suggestions"
+msgstr "修復建議"
+
+msgid "With Enhance Speed & Quality:"
+msgstr "使用“增強速度與質量”："
+
+msgid "This is the time that can be saved if you run the Helio Additive Enhance feature. Click the Enhance Speed and Quality button to proceed."
+msgstr "這是執行 Helio Additive “增強”功能後可節省的時間。點選“增強速度與質量”繼續。"
+
+msgid "Enhance Speed & Quality"
+msgstr "增強速度與質量"
+
+msgid "Applies Helio's optimized speed/flow/fan strategy."
+msgstr "應用 Helio 最佳化的速度/流量/風扇策略。"
+
+msgid "✅ Will Print"
+msgstr "✅ 可列印"
+
+msgid "⚠️ May Print with Issues"
+msgstr "⚠️ 可能可列印但存在問題"
+
+msgid "❌ Likely to Fail"
+msgstr "❌ 很可能失敗"
+
+msgid "Thermal conditions are balanced. The part is printing within safe temperature limits."
+msgstr "熱條件平衡。零件在安全溫度範圍內列印。"
+
+msgid "Material is cooling too rapidly before the next layer is applied. This can cause weak layer bonding, warping, or cracking."
+msgstr "在下一層鋪設前材料冷卻過快，可能導致層間粘結不足、翹曲或開裂。"
+
+msgid "Heat is building up in small layers faster than it can dissipate. This may cause sagging or loss of detail in fine features."
+msgstr "小層區域熱量累積速度超過散熱速度，可能導致下垂或細節丟失。"
+
+msgid "Ready to print"
+msgstr "可以列印"
+
+msgid "Too cold overall — see suggestions"
+msgstr "整體偏冷—檢視建議"
+
+msgid "Too hot overall — see suggestions"
+msgstr "整體偏熱—檢視建議"
+
+msgid "Your part is ready to print! Thermal conditions are within safe limits."
+msgstr "你的零件已可直接列印！熱條件在安全範圍內。"
+
+msgid "Too cold (overall)"
+msgstr "偏冷（整體）"
+
+msgid "The part cools too fast between layers on average. Some layers may behave differently—see observations."
+msgstr "平均來看，層與層之間冷卻過快。部分層可能表現不同——請檢視觀察結果。"
+
+msgid "Too hot (overall)"
+msgstr "偏熱（整體）"
+
+msgid "The part stays too warm between layers on average. Some layers may behave differently—see observations."
+msgstr "平均來看，層與層之間溫度偏高。部分層可能表現不同——請檢視觀察結果。"
+
+msgid "Suggestions"
+msgstr "建議"
+
+msgid "Quick fixes (beginner):"
+msgstr "快速修復（新手）："
+
+msgid "Expert"
+msgstr "專家"
+
+msgid "Learn more"
+msgstr "更多資訊檢視Wiki"
+
+msgid "Helio Flowchart"
+msgstr "Helio 流程圖"
+
+msgid "Fixing cold prints"
+msgstr "解決列印過冷"
+
+msgid "Air Pump"
+msgstr "氣泵"
+
+msgid "Laser 10W"
+msgstr "鐳射 10W"
+
+msgid "Laser 40W"
+msgstr "鐳射 40W"
+
+msgid "Cutting Module"
+msgstr "刀切模組"
+
+msgid "Rotary Attachment"
+msgstr "旋轉軸"
+
+msgid "Auto Fire Extinguishing System"
+msgstr "自動滅火裝置"
+
+msgid "Update firmware"
+msgstr "更新韌體"
+
+msgid "Hotends on Rack"
+msgstr "熱端&掛架"
+
+msgid "Beta version"
+msgstr "Beta版本"
+
+msgid "Refreshing hotend information..."
+msgstr "重新整理熱端資訊中..."
+
+msgid "Checking version..."
+msgstr "版本檢查中..."
+
+msgid "Updating"
+msgstr "更新中"
+
+msgid "Updating failed"
+msgstr "更新失敗"
+
+msgid "Updating successful"
+msgstr "更新成功"
+
+msgid "Are you sure you want to update? This will take about 10 minutes. Do not turn off the power while the printer is updating."
+msgstr "確定要更新嗎？更新需要大約10分鐘，在此期間請勿關閉電源。"
+
+msgid "An important update was detected and needs to be run before printing can continue. Do you want to update now? You can also update later from 'Upgrade firmware'."
+msgstr "檢測到重要更新，需要升級後才可進行列印。您想現在就開始升級嗎？您也可以稍後點選‘升級韌體’完成升級。"
+
+msgid "The firmware version is abnormal. Repairing and updating are required before printing. Do you want to update now? You can also update later on printer or update next time starting the studio."
+msgstr "當前韌體版本異常，需要進行修復升級，否則無法繼續列印。您想現在就開始升級嗎？您也可以稍後在印表機上升級，或者下一次啟動studio再升級。"
+
+msgid "Extension Board"
+msgstr "擴充套件板"
+
+msgid "Do you want to save the changes ?"
+msgstr "是否儲存當前更改？"
+
+msgid "Saving objects into the 3mf failed."
+msgstr "儲存物件到3mf失敗。"
+
+msgid "Only Windows 10 is supported."
+msgstr "僅支援Windows 10。"
+
+msgid "Failed to initialize the WinRT library."
+msgstr "初始化WinRT庫失敗。"
+
+msgid "Exporting objects"
+msgstr "正在匯出物件"
+
+msgid "Failed loading objects."
+msgstr "載入物件失敗。"
+
+msgid "Repairing object by Windows service"
+msgstr "透過Windows服務修復物件"
+
+msgid "Repair failed."
+msgstr "修復失敗。"
+
+msgid "Loading repaired objects"
+msgstr "正在載入修復的物件。"
+
+msgid "Exporting 3mf file failed"
+msgstr "匯出3mf失敗"
+
+msgid "Import 3mf file failed"
+msgstr "匯入3mf失敗"
+
+msgid "Repaired 3mf file does not contain any object"
+msgstr "已修復的3mf檔案不包含任何物件"
+
+msgid "Repaired 3mf file contains more than one object"
+msgstr "已修復的3mf檔案包含了不止一個物件"
+
+msgid "Repaired 3mf file does not contain any volume"
+msgstr "修復的3mf檔案不包含任何零件"
+
+msgid "Repaired 3mf file contains more than one volume"
+msgstr "已修復的3mf檔案包含多個零件"
+
+msgid "Repair finished"
+msgstr "修復已完成"
+
+msgid "Repair canceled"
+msgstr "修復被取消"
+
+msgid "Need to check the unsaved changes before configuration updates."
+msgstr "需要在配置更新之前檢查沒有儲存的引數修改。"
+
+msgid "Configuration package updated to "
+msgstr "配置包已更新到"
+
+msgid "Open G-code file:"
+msgstr "開啟G-code檔案："
+
+msgid "The following object(s) have empty initial layer and can't be printed. Please cut the bottom or enable supports."
+msgstr "模型出現空層無法列印。請切掉底部或開啟支撐。"
+
+#, boost-format
+msgid "Object can't be printed for empty layer between %1% and %2%."
+msgstr "模型在%1%和%2%之間出現空層，無法列印。"
+
+#, boost-format
+msgid "Object: %1%"
+msgstr "模型：%1%"
+
+msgid "Maybe parts of the object at these height are too thin, or the object has faulty mesh"
+msgstr "部分模型在這些高度可能過薄，或者模型存在面片錯誤"
+
+msgid "Flush volumes matrix do not match to the correct size!"
+msgstr ""
+
+msgid "No object can be printed. Maybe too small"
+msgstr "沒有可列印的物件。可能是因為尺寸過小。"
+
+msgid ""
+"Failed to generate gcode for invalid custom G-code.\n"
+"\n"
+msgstr ""
+"由於錯誤的自定義G-code，G-code生成失敗。\n"
+"\n"
+
+msgid "Please check the custom G-code or use the default custom G-code.\n"
+msgstr "請檢查自定義G-code，或者使用預設的。\n"
+
+msgid "You can find them from 'Printer settings' -> 'Machine G-code' and 'Filament settings' -> 'Advanced'."
+msgstr "您可以在“印表機設定”->“印表機 G-code”和“耗材設定”->“高階”中找到它們。"
+
+msgid "You can find it from 'Printer settings' -> 'Machine G-code'."
+msgstr "您可以在“印表機設定”->“印表機 G-code”中找到它。"
+
+msgid "You can find it from 'Filament settings' -> 'Advanced'."
+msgstr "您可以在“耗材設定”->“高階”中找到它"
+
+#, boost-format
+msgid "Generating G-code: layer %1%"
+msgstr "正在生成G-code：層%1%"
+
+msgid "Smoothing z direction speed"
+msgstr "z方向速度平滑"
+
+msgid "Exporting G-code"
+msgstr "正在匯出G-code"
+
+msgid "Grouping error: filament"
+msgstr "分組錯誤：耗材"
+
+msgid " can not be placed in the "
+msgstr "不能放置在"
+
+msgid "Filament Grouping Error: Filament "
+msgstr "耗材分組錯誤：耗材 "
+
+msgid " is not supported by the "
+msgstr " 不支援在 "
+
+msgid " nozzle. "
+msgstr " 噴嘴. "
+
+msgid "Please change the nozzle type or reassign the filament and try again."
+msgstr "請更換噴嘴型別或重新分配耗材，然後重試。"
+
+msgid "No valid nozzle found. Please check nozzle count."
+msgstr "未找到有效的噴嘴。請檢查噴嘴數量。"
+
+msgid "Group error in manual mode. Please check nozzle count or regroup."
+msgstr "自定義模式分組錯誤。請檢查噴嘴數量或重新分組。"
+
+msgid "Inner wall"
+msgstr "內牆"
+
+msgid "Outer wall"
+msgstr "外牆"
+
+msgid "Overhang wall"
+msgstr "懸空牆"
+
+msgid "Floating vertical shell"
+msgstr ""
+
+msgid "Internal solid infill"
+msgstr "內部實心填充"
+
+msgid "Top surface"
+msgstr "頂面"
+
+msgid "Bottom surface"
+msgstr "底面"
+
+msgid "Bridge"
+msgstr "橋接"
+
+msgid "Gap infill"
+msgstr "填縫"
+
+msgid "Support interface"
+msgstr "支撐面"
+
+msgid "Support transition"
+msgstr "支撐轉換層"
+
+msgid "Multiple"
+msgstr "多個"
+
+msgid "Flush"
+msgstr "沖刷"
+
+#, boost-format
+msgid "Failed to calculate line width of %1%. Can not get value of \"%2%\" "
+msgstr "計算 %1%的線寬失敗。無法獲得 \"%2%\" 的值"
+
+msgid "undefined error"
+msgstr "未定義錯誤"
+
+msgid "too many files"
+msgstr "檔案過多"
+
+msgid "file too large"
+msgstr "檔案太大"
+
+msgid "unsupported method"
+msgstr "不支援的壓縮方法"
+
+msgid "unsupported encryption"
+msgstr "不支援的加密方式"
+
+msgid "unsupported feature"
+msgstr "不支援的功能"
+
+msgid "failed finding central directory"
+msgstr "查詢中心目錄失敗"
+
+msgid "not a ZIP archive"
+msgstr "不是一個zip壓縮包"
+
+msgid "invalid header or corrupted"
+msgstr "無效檔案頭或檔案已損壞"
+
+msgid "unsupported multidisk"
+msgstr "不支援多磁碟存檔"
+
+msgid "decompression failed"
+msgstr "解壓縮失敗或存檔已損壞"
+
+msgid "compression failed"
+msgstr "壓縮失敗"
+
+msgid "unexpected decompressed size"
+msgstr "意外的解壓縮大小"
+
+msgid "CRC check failed"
+msgstr "CRC檢查失敗"
+
+msgid "unsupported central directory size"
+msgstr "不支援的中央目錄大小"
+
+msgid "allocation failed"
+msgstr "分配記憶體失敗"
+
+msgid "file open failed"
+msgstr "檔案開啟失敗"
+
+msgid "file create failed"
+msgstr "檔案建立失敗"
+
+msgid "file write failed"
+msgstr "檔案寫入失敗"
+
+msgid "file read failed"
+msgstr "檔案讀取失敗"
+
+msgid "file close failed"
+msgstr "檔案關閉失敗"
+
+msgid "file seek failed"
+msgstr "檔案隨機訪問失敗"
+
+msgid "file stat failed"
+msgstr "檔案統計資訊失敗"
+
+msgid "invalid parameter"
+msgstr "無效引數"
+
+msgid "invalid filename"
+msgstr "無效的檔名"
+
+msgid "buffer too small"
+msgstr "緩衝區太小"
+
+msgid "internal error"
+msgstr "內部錯誤"
+
+msgid "file not found"
+msgstr "檔案未找到"
+
+msgid "archive too large"
+msgstr "存檔檔案太大"
+
+msgid "validation failed"
+msgstr "驗證失敗"
+
+msgid "write callback failed"
+msgstr "寫入回撥失敗"
+
+#, boost-format
+msgid "%1% is too close to exclusion area, there may be collisions when printing."
+msgstr "%1%離遮蔽區域太近，可能會發生碰撞。"
+
+#, boost-format
+msgid "%1% is too close to others, and collisions may be caused."
+msgstr "%1%離其它物件太近，可能會發生碰撞。"
+
+#, boost-format
+msgid "%1% is too tall, and collisions will be caused."
+msgstr "%1%太高，會發生碰撞。"
+
+msgid " is too close to exclusion area, there may be collisions when printing."
+msgstr "太靠近遮蔽區域，列印時可能會發生碰撞。"
+
+msgid " is too close to clumping detection area, there may be collisions when printing."
+msgstr "太靠近裹頭檢測觸碰區域，列印時可能發生碰撞。"
+
+msgid "Prime Tower"
+msgstr "擦料塔"
+
+msgid " is too close to others, and collisions may be caused.\n"
+msgstr "離其它物件太近，可能會發生碰撞。\n"
+
+msgid " is too close to exclusion area, and collisions will be caused.\n"
+msgstr "離不可列印區域太近，會發生碰撞。\n"
+
+msgid " is too close to clumping detection area, and collisions will be caused.\n"
+msgstr " 太靠近裹頭檢測區域，會發生碰撞。\n"
+
+msgid "Printing high-temp and low-temp filaments together may cause nozzle clogging or printer damage."
+msgstr "同時列印高溫和低溫材料可能導致噴嘴堵塞或印表機損壞。"
+
+msgid "Printing high-temp and low-temp filaments together may cause nozzle clogging or printer damage. If you still want to print, you can enable the option in Preferences."
+msgstr "同時列印高溫和低溫材料可能導致噴嘴堵塞或印表機損壞。若仍需列印，可在偏好設定中啟用該選項。"
+
+msgid "Printing different-temp filaments together may cause nozzle clogging or printer damage."
+msgstr "同時列印不同溫度的耗材可能導致噴嘴堵塞或印表機損壞。"
+
+msgid "Printing high-temp and mid-temp filaments together may cause nozzle clogging or printer damage."
+msgstr "同時列印高溫和中溫材料可能導致噴嘴堵塞或印表機損壞。"
+
+msgid "Printing mid-temp and low-temp filaments together may cause nozzle clogging or printer damage."
+msgstr "同時列印中溫和低溫材料可能導致噴嘴堵塞或印表機損壞。"
+
+msgid "No extrusions under current settings."
+msgstr "根據當前設定，不會生成任何列印。"
+
+msgid "Smooth mode of timelapse is not supported when \"by object\" sequence is enabled."
+msgstr "平滑模式的延時攝影不支援在逐件列印模式下使用。"
+
+msgid "Clumping detection is not supported when \"by object\" sequence is enabled."
+msgstr "觸碰裹頭檢測不支援在逐件列印模式下使用。"
+
+msgid "Prime tower is required for clumping detection; otherwise, there may be flaws on the model."
+msgstr "觸碰裹頭檢測需要擦料塔，否則列印件上可能會有瑕疵。"
+
+msgid "Please select \"By object\" print sequence to print multiple objects in spiral vase mode."
+msgstr "請選擇逐件列印以支援在旋轉花瓶模式下列印多個物件。"
+
+msgid "The spiral vase mode does not work when an object contains more than one materials."
+msgstr "不支援在包含多個材料的列印中使用旋轉花瓶模式。"
+
+msgid "Variable layer height is not supported with Organic supports."
+msgstr "不支援同時使用可變層高和有機樹支撐。"
+
+msgid "Different nozzle diameters and different filament diameters is not allowed when prime tower is enabled."
+msgstr "啟用擦料塔時，不允許使用不同的噴嘴直徑和不同的材料直徑。"
+
+msgid "The Wipe Tower is currently only supported with the relative extruder addressing (use_relative_e_distances=1)."
+msgstr "當前僅支援使用相對擠出器定址（use_relative_e_distances=1）的情況下使用擦料塔。"
+
+msgid "Ooze prevention is currently not supported with the prime tower enabled."
+msgstr "當啟用擦料塔時，目前不支援防滴功能。"
+
+msgid "The prime tower is currently only supported for the Marlin, RepRap/Sprinter, RepRapFirmware and Repetier G-code flavors."
+msgstr "擦料塔目前僅支援Marlin、RepRap/Sprinter、RepRapFirmware和Repetier G-code風格。"
+
+msgid "The prime tower is not supported in \"By object\" print."
+msgstr "擦料塔不支援在逐件列印模式下使用。"
+
+msgid "The prime tower is not supported when adaptive layer height is on. It requires that all objects have the same layer height."
+msgstr "不支援在可變層高開啟時使用擦料塔。它要求所有物件擁有相同的層高。"
+
+msgid "The prime tower requires \"support gap\" to be multiple of layer height"
+msgstr "擦料塔要求”支撐間隙“為層高的整數倍"
+
+msgid "The prime tower requires that all objects have the same layer heights"
+msgstr "擦料塔要求各個物件擁有同樣的層高"
+
+msgid "The prime tower requires that all objects are printed over the same number of raft layers"
+msgstr "擦料塔要求各個物件使用同樣的筏層數量"
+
+msgid "The prime tower requires that all objects are sliced with the same layer heights."
+msgstr "擦料塔要求各個物件擁有同樣的層高。"
+
+msgid "The prime tower is only supported if all objects have the same variable layer height"
+msgstr "各個物件的層高存在差異，無法啟用擦料塔"
+
+msgid "Too small line width"
+msgstr "線寬太小"
+
+msgid "Too large line width"
+msgstr "線寬太大"
+
+msgid "The prime tower requires that support has the same layer height as object."
+msgstr "擦料塔要求支撐和物件採用同樣的層高。"
+
+msgid "Support enforcers are used but support is not enabled. Please enable support."
+msgstr "使用了支撐新增器但沒有開啟支撐。請開啟支撐。"
+
+msgid "Layer height cannot exceed nozzle diameter"
+msgstr "層高不能超過噴嘴直徑"
+
+#, c-format, boost-format
+msgid "Plate %d: %s does not support filament %s"
+msgstr "盤%d：%s不支援耗材絲 %s"
+
+msgid "Precise outer wall will be ignored unless the order of walls is set to inner/outer"
+msgstr "除非牆體順序設定為內部/外部，否則精準外牆將被忽略"
+
+msgid "Generating skirt & brim"
+msgstr "正在生成skirt和brim"
+
+msgid "Generating G-code"
+msgstr "正在生成G-code"
+
+msgid "Failed processing of the filename_format template."
+msgstr "處理檔名格式模板失敗。"
+
+msgid "Printable area"
+msgstr "可列印區域"
+
+msgid "Extruder printable area"
+msgstr "擠出機可列印區域"
+
+msgid "Bed exclude area"
+msgstr "不可列印區域"
+
+msgid "Unprintable area in XY plane. For example, X1 Series printers use the front left corner to cut filament during filament change. The area is expressed as polygon by points in following format: \"XxY, XxY, ...\""
+msgstr "XY平面上的不可列印區域。例如，X1系列印表機在換料過程中，會使用左前角區域來切斷耗材絲。這個多邊形區域由以下格式的點表示：“XxY，XxY，…”"
+
+msgid "Bed custom texture"
+msgstr "自定義熱床紋理"
+
+msgid "Bed custom model"
+msgstr "自定義熱床模型"
+
+msgid "Elephant foot compensation"
+msgstr "象腳補償"
+
+msgid "Shrink the initial layer on build plate to compensate for elephant foot effect"
+msgstr "將首層收縮用於補償象腳效應"
+
+msgid "Slicing height for each layer. Smaller layer height means more accurate and more printing time"
+msgstr "每一層的切片高度。越小的層高意味著更高的精度和更長的列印時間。"
+
+msgid "Printable height"
+msgstr "可列印高度"
+
+msgid "Maximum printable height which is limited by mechanism of printer"
+msgstr "由印表機結構約束的最大可列印高度"
+
+msgid "Extruder printable height"
+msgstr "擠出機可列印高度"
+
+msgid "Maximum printable height of this extruder which is limited by mechanism of printer"
+msgstr "由印表機結構約束的當前擠出機的最大可列印高度"
+
+msgid "Printer preset names"
+msgstr "印表機預設名"
+
+msgid "Hostname, IP or URL"
+msgstr "主機名，IP或URL"
+
+msgid "Slic3r can upload G-code files to a printer host. This field should contain the hostname, IP address or URL of the printer host instance. Print host behind HAProxy with basic auth enabled can be accessed by putting the user name and password into the URL in the following format: https://username:password@your-octopi-address/"
+msgstr "Slic3r可以將G-code檔案上傳到印表機主機。此欄位應包含印表機主機例項的主機名、IP地址或URL。啟用基本身份驗證的Print host可以透過將使用者名稱和密碼放入以下格式的URL中來訪問：https://username:password@your-octopi-address/"
+
+msgid "Device UI"
+msgstr "裝置介面"
+
+msgid "Specify the URL of your device user interface if it's not same as print_host"
+msgstr "如果裝置使用者介面與印表機主機不同，請指定裝置使用者介面的URL。"
+
+msgid "API Key / Password"
+msgstr "API秘鑰/密碼"
+
+msgid "Slic3r can upload G-code files to a printer host. This field should contain the API Key or the password required for authentication."
+msgstr "Slic3r可以將G-code檔案上傳到印表機主機。此欄位應包含用於身份驗證的API金鑰或密碼。"
+
+msgid "Name of the printer"
+msgstr "印表機名稱"
+
+msgid "HTTPS CA File"
+msgstr "HTTPS CA檔案"
+
+msgid "Custom CA certificate file can be specified for HTTPS OctoPrint connections, in crt/pem format. If left blank, the default OS CA certificate repository is used."
+msgstr "可以為HTTPS OctoPrint連線指定自定義CA證書檔案，格式為crt/pem。如果留空，則使用預設的作業系統CA證書儲存庫。"
+
+msgid "User"
+msgstr "使用者名稱"
+
+msgid "Password"
+msgstr "密碼"
+
+msgid "Ignore HTTPS certificate revocation checks"
+msgstr "忽略HTTPS證書吊銷檢查"
+
+msgid "Ignore HTTPS certificate revocation checks in case of missing or offline distribution points. One may want to enable this option for self signed certificates if connection fails."
+msgstr "在缺少或離線分發點的情況下忽略HTTPS證書吊銷檢查。如果連線失敗，可以啟用此選項來處理自簽名證書。"
+
+msgid "Names of presets related to the physical printer"
+msgstr "與物理印表機相關的預設名稱"
+
+msgid "Authorization Type"
+msgstr "授權型別"
+
+msgid "API key"
+msgstr "API秘鑰"
+
+msgid "HTTP digest"
+msgstr "HTTP摘要"
+
+msgid "Avoid crossing wall"
+msgstr "避免跨越外牆"
+
+msgid "Detour and avoid traveling across wall which may cause blob on surface"
+msgstr "空駛時繞過外牆以避免在模型外觀面產生斑點"
+
+msgid "Smoothing wall speed along Z(experimental)"
+msgstr "平滑z方向外牆速度（實驗）"
+
+msgid "Smoothing outwall speed in z direction to get better surface quality. Print time will increases. This does not work on spiral vase mode."
+msgstr "。"
+
+msgid "Avoid crossing wall - Max detour length"
+msgstr "避免跨越外牆-最大繞行長度"
+
+msgid "Maximum detour distance for avoiding crossing wall. Don't detour if the detour distance is larger than this value. Detour length could be specified either as an absolute value or as percentage (for example 50%) of a direct travel path. Zero to disable"
+msgstr "避免跨越外牆時的最大繞行距離。當繞行距離比這個數值大時，此次空駛不繞行。繞行距離可表達為絕對值，或者相對直線空駛長度的百分比(例如50%)。0表示禁用"
+
+msgid "mm or %"
+msgstr "mm 或 %"
+
+msgid "Avoid crossing wall - Includes support"
+msgstr "避免跨越外牆-包含支撐"
+
+msgid "Including support while avoiding crossing wall."
+msgstr "避免跨越外牆的時候，包含支撐。"
+
+msgid "Other layers"
+msgstr "其它層"
+
+msgid "Bed temperature for layers except the initial one. Value 0 means the filament does not support to print on the Cool Plate"
+msgstr "非首層熱床溫度。0值表示這個耗材絲不支援低溫列印熱床"
+
+msgid "Bed temperature for layers except the initial one. Value 0 means the filament does not support to print on the Engineering Plate"
+msgstr "非首層熱床溫度。0值表示這個耗材絲不支援工程材料熱床"
+
+msgid "Bed temperature for layers except the initial one. Value 0 means the filament does not support to print on the High Temp Plate"
+msgstr "非首層熱床溫度。0值表示這個耗材絲不支援高溫列印熱床"
+
+msgid "Bed temperature for layers except the initial one. Value 0 means the filament does not support to print on the Textured PEI Plate"
+msgstr "非首層熱床溫度。0值表示這個耗材絲不支援紋理PEI熱床"
+
+msgid "Initial layer"
+msgstr "首層"
+
+msgid "Initial layer bed temperature"
+msgstr "首層床溫"
+
+msgid "Bed temperature of the initial layer. Value 0 means the filament does not support to print on the Bambu Cool Plate SuperTack"
+msgstr "初始層的床溫。值0表示耗材絲不支援在增穩低溫列印板上列印"
+
+msgid "Bed temperature of the initial layer. Value 0 means the filament does not support to print on the Cool Plate"
+msgstr "首層熱床溫度。0值表示這個耗材絲不支援低溫列印熱床"
+
+msgid "Bed temperature of the initial layer. Value 0 means the filament does not support to print on the Engineering Plate"
+msgstr "首層熱床溫度。0值表示這個耗材絲不支援工程材料熱床"
+
+msgid "Bed temperature of the initial layer. Value 0 means the filament does not support to print on the High Temp Plate"
+msgstr "首層熱床溫度。0值表示這個耗材絲不支援高溫列印熱床"
+
+msgid "Bed temperature of the initial layer. Value 0 means the filament does not support to print on the Textured PEI Plate"
+msgstr "首層熱床溫度。0值表示這個耗材絲不支援紋理PEI熱床"
+
+msgid "Bed types supported by the printer"
+msgstr "印表機所支援的列印板型別"
+
+msgid "First layer print sequence"
+msgstr "首層列印順序"
+
+msgid "Other layers print sequence"
+msgstr "其他層列印順序"
+
+msgid "The number of other layers print sequence"
+msgstr "其他層的列印順序數量"
+
+msgid "Other layers filament sequence"
+msgstr "其他層的耗材列印順序"
+
+msgid "This G-code is inserted at every layer change before lifting z"
+msgstr "在每次換層抬升z高度之前插入這段G-code"
+
+msgid "Bottom shell layers"
+msgstr "底部殼體層數"
+
+msgid "This is the number of solid layers of bottom shell, including the bottom surface layer. When the thickness calculated by this value is thinner than bottom shell thickness, the bottom shell layers will be increased"
+msgstr "底部殼體實心層層數，包括底面。當由該層數計算的厚度小於底部殼體厚度，切片時會增加底部殼體的層數"
+
+msgid "Bottom shell thickness"
+msgstr "底部殼體厚度"
+
+msgid "The number of bottom solid layers is increased when slicing if the thickness calculated by bottom shells layers is thinner than this value. This can avoid having too thin shell when layer height is small. 0 means that this setting is disabled and thickness of bottom shell is absolutely determained by bottom shell layers"
+msgstr "如果由底部殼體層數算出的厚度小於這個數值，那麼切片時將自動增加底部殼體層數。這能夠避免當層高很小時，底部殼體過薄。0表示關閉這個設定，同時底部殼體的厚度完全由底部殼體層數決定"
+
+msgid "Force cooling for overhang and bridge"
+msgstr "懸垂/橋接強制冷卻"
+
+msgid "Enable this option to optimize part cooling fan speed for overhang and bridge to get better cooling"
+msgstr "勾選這個選項將自動最佳化橋接和懸垂的風扇轉速以獲得更好的冷卻"
+
+msgid "Fan speed for overhang"
+msgstr "懸垂風扇速度"
+
+msgid "Force part cooling fan to be at this speed when printing bridge or overhang wall which has large overhang degree. Forcing cooling for overhang and bridge can get better quality for these part"
+msgstr "當列印橋接和超過設定閾值的懸垂時，強制部件冷卻風扇為設定的速度值。強制冷卻能夠使懸垂和橋接獲得更好的列印質量"
+
+msgid "Pre start fan time"
+msgstr "風扇預啟動時間"
+
+msgid "Force fan start early(0-5 second) when encountering overhangs. This is because the fan needs time to physically increase its speed."
+msgstr "遇到懸垂結構時，因為風扇需要時間來提升轉速，提前啟動風扇（0-5秒）。"
+
+msgid "s"
+msgstr "秒"
+
+msgid "Cooling overhang threshold"
+msgstr "冷卻懸空閾值"
+
+#, c-format
+msgid "Force cooling fan to be specific speed when overhang degree of printed part exceeds this value. Expressed as percentage which indicides how much width of the line without support from lower layer. 0% means forcing cooling for all outer wall no matter how much overhang degree"
+msgstr "當列印件的懸空程度超過此值時，強制冷卻風扇達到特定速度。用百分比表示，表明沒有下層支撐的線的寬度是多少。0%%意味著無論懸垂程度如何，都要對所有外壁強制冷卻。"
+
+msgid "Overhang threshold for participating cooling"
+msgstr "參與冷卻降速的懸垂閾值"
+
+#, c-format
+msgid "Decide which overhang part join the cooling function to slow down the speed.Expressed as percentage which indicides how much width of the line without support from lower layer. 100% means forcing cooling for all outer wall no matter how much overhang degree"
+msgstr "決定多少閾值的懸垂參與冷卻降速.用百分比表示超出線寬的範圍。"
+
+msgid "Bridge direction"
+msgstr "橋接方向"
+
+msgid "Bridging angle override. If left to zero, the bridging angle will be calculated automatically. Otherwise the provided angle will be used for external bridges. Use 180°for zero angle."
+msgstr "搭橋角度覆蓋。如果設定為零，該角度將自動計算。否則外部的橋接將用提供的值。180°表示0度。"
+
+msgid "Bridge flow"
+msgstr "橋接流量"
+
+msgid "Decrease this value slightly(for example 0.9) to reduce the amount of material for bridge, to improve sag"
+msgstr "稍微減小這個數值（比如0.9）可以減小橋接的材料量，來改善下垂。"
+
+msgid "Top surface flow ratio"
+msgstr "頂部表面流量比例"
+
+msgid "This factor affects the amount of material for top solid infill. You can decrease it slightly to have smooth surface finish"
+msgstr "這個因素影響著頂部實心填充的材料用量。您可以略微減小它，以獲得光滑的表面質感"
+
+msgid "Initial layer flow ratio"
+msgstr "首層流量比"
+
+msgid "This factor affects the amount of material for the initial layer"
+msgstr "該因素影響首層的材料用量"
+
+msgid "Only one wall on top surfaces"
+msgstr "頂面單層牆"
+
+msgid "Use only one wall on flat top surface, to give more space to the top infill pattern. Could be applied on topmost surface or all top surface."
+msgstr "頂面只使用單層牆，從而更多的空間能夠使用頂部填充圖案。可以應用於最頂部表面或所有頂部表面。"
+
+msgid "Not apply"
+msgstr "不使用"
+
+msgid "Top surfaces"
+msgstr "頂面"
+
+msgid "Topmost surface"
+msgstr "最頂面"
+
+msgid "Top area threshold"
+msgstr "頂部區域閾值"
+
+msgid "The min width of top areas in percentage of perimeter line width."
+msgstr "頂部區域的最小寬度，單位是牆線寬的百分比。"
+
+msgid "Only one wall on first layer"
+msgstr "首層僅單層牆"
+
+msgid "Use only one wall on the first layer of model"
+msgstr "在模型的首層僅生成單層牆"
+
+msgid "Slow down for overhang"
+msgstr "懸垂降速"
+
+msgid "Enable this option to slow printing down for different overhang degree"
+msgstr "開啟這個選項將降低不同懸垂程度的走線的列印速度"
+
+msgid "mm/s"
+msgstr "mm/s"
+
+#, c-format, boost-format
+msgid "Speed of 100%% overhang wall which has 0 overlap with the lower layer."
+msgstr ""
+
+msgid "Slow down by height"
+msgstr "隨高度降速"
+
+msgid "Enable this option to slow printing down by height"
+msgstr "啟用此選項可以定義列印過程中當列印高度z處於區間[“起始高度”, “結束高度”]時，列印速度和加速度的上限, 此上限為z的函式。以列印速度為例，z處速度上限透過對“起始高度處速度”和“結束高度處速度”在區間[“起始高度”, “結束高度”]內按z進行線性插值得到。"
+
+msgid "Starting height"
+msgstr "起始高度"
+
+msgid "The height starts to slow down"
+msgstr "高度開始減緩。"
+
+msgid "Speed at starting height"
+msgstr "起始高度處速度"
+
+msgid "Acceleration at starting height"
+msgstr "起始高度處加速度"
+
+msgid "mm/s²"
+msgstr "mm/s²"
+
+msgid "Ending height"
+msgstr "結束高度"
+
+msgid "The height finishes slowing down, Ending height should be larger than Starting height, or the slowing down will not work!"
+msgstr "引數“結束高度”應大於“起始高度“，否則”隨高度降速“功能將不起作用！"
+
+msgid "Speed at ending height"
+msgstr "結束高度處速度"
+
+msgid "Acceleration at ending height"
+msgstr "結束高度處加速度"
+
+msgid "Speed of bridge and completely overhang wall"
+msgstr "橋接和完全懸空的外牆的列印速度"
+
+msgid "Brim width"
+msgstr "Brim寬度"
+
+msgid "Distance from model to the outermost brim line"
+msgstr "從模型到最外圈brim走線的距離"
+
+msgid "Brim type"
+msgstr "Brim型別"
+
+msgid "This controls the generation of the brim at outer and/or inner side of models. Auto means the brim width is analysed and calculated automatically."
+msgstr "該引數控制在模型的外側和/或內側生成brim。自動是指自動分析和計算邊框的寬度。"
+
+msgid "Brim-object gap"
+msgstr "Brim與模型的間隙"
+
+msgid "A gap between innermost brim line and object can make brim be removed more easily"
+msgstr "在brim和模型之間設定間隙，能夠讓brim更容易剝離"
+
+msgid "Compatible machine"
+msgstr "相容的機器"
+
+msgid "upward compatible machine"
+msgstr "向上相容的機器"
+
+msgid "Compatible machine condition"
+msgstr "相容的機器的條件"
+
+msgid "Compatible process profiles"
+msgstr "相容的切片配置"
+
+msgid "Compatible process profiles condition"
+msgstr "相容的切片配置的條件"
+
+msgid "Print sequence, layer by layer or object by object"
+msgstr "列印順序，逐層列印或者逐件列印"
+
+msgid "By layer"
+msgstr "逐層"
+
+msgid "By object"
+msgstr "逐件"
+
+msgid "Slow printing down for better layer cooling"
+msgstr "降低列印速度 以得到更好的冷卻"
+
+msgid "Enable this option to slow printing speed down to make the final layer time not shorter than the layer time threshold in \"Max fan speed threshold\", so that layer can be cooled for a longer time. This can improve the cooling quality for needle and small details"
+msgstr "勾選這個選項，將降低列印速度，使得最終的層列印時間不小於\"最大風扇速度閾值\"裡的層時間閾值，從而使得該層獲得更久的冷卻。這能夠改善尖頂和小細節的冷卻效果"
+
+msgid "Don't slow down outer walls"
+msgstr "不減慢外牆速度"
+
+msgid ""
+"If enabled, this setting will ensure external perimeters are not slowed down to meet the minimum layer time. This is particularly helpful in the below scenarios:\n"
+"1. To avoid changes in shine when printing glossy filaments\n"
+"2. To avoid changes in external wall speed which may create slight wall artifacts that appear like Z banding\n"
+"3. To avoid printing at speeds which cause VFAs (fine artifacts) on the external walls"
+msgstr ""
+"啟用此設定後，將確保外牆不會為了滿足最小層時間而減慢速度。這在以下情況下尤其有用：\n"
+"1. 列印光澤絲材時，避免光澤度變化\n"
+"2. 避免外壁速度變化，因為這可能會產生類似 Z 形條紋的輕微壁面缺陷\n"
+"3. 避免以不同的速度列印導致外牆出現細微缺陷"
+
+msgid "Cooling slowdown logic"
+msgstr "冷卻減速邏輯"
+
+msgid ""
+"Determines how the printer slows down when minimum layer time isn't reached.\n"
+"\n"
+"'Uniform cooling' slows down all print features equally (current default behavior).\n"
+"\n"
+"'Consistent surface' prioritizes slowing infill and internal perimeters first, preserving external perimeter speed for better surface finish on glossy filaments. This helps reduce VFA (Vertical Fine Artifacts) and maintains consistent surface shine."
+msgstr ""
+"確定當未達到最小層時間時印表機如何減速。\n"
+"\n"
+"“均勻冷卻”會使所有列印特徵等速減速（當前預設行為）。\n"
+"\n"
+"“一致表面”優先減慢填充和內部輪廓的速度，保留外部輪廓速度，以在光滑的耗材上獲得更好的表面效果。這有助於減少垂直細紋（VFA），並保持表面光澤的一致性。"
+
+msgid "Uniform cooling"
+msgstr "均勻冷卻"
+
+msgid "Consistent surface"
+msgstr "表面一致性"
+
+msgid "Perimeter transition distance"
+msgstr "外圍過渡距離"
+
+msgid ""
+"Distance in millimeters before the end of slowed perimeters where the original print speed is gradually restored. This reduces quality issues when transitioning from slowed features to fast external perimeter printing.\n"
+"\n"
+"Only applies when 'Consistent surface' cooling logic is selected.\n"
+"Recommended value: 5-10mm. Set to 0 to disable."
+msgstr ""
+"在放慢周邊結束前，逐漸恢復原始列印速度的距離（單位：毫米）。這減少了從減速特徵過渡到快速外部周邊列印時的質量問題。\n"
+"\n"
+"僅當選擇“表面均勻”冷卻邏輯時適用。\n"
+"推薦值：5-10毫米。設定為0則禁用。"
+
+msgid "Normal printing"
+msgstr "普通列印"
+
+msgid "The default acceleration of both normal printing and travel except initial layer"
+msgstr "除首層之外的預設的列印和空駛的加速度"
+
+msgid "The acceleration of travel except initial layer"
+msgstr ""
+
+msgid "Short travel"
+msgstr "短程移動"
+
+msgid ""
+"Acceleration used for short travel moves near external perimeters. Short travels are moves shorter than the 'Retraction minimum travel' distance.\n"
+"\n"
+"Lower values (e.g., 250-500 mm/s²) reduce ringing artifacts on sharp corners without significantly impacting print time.\n"
+"\n"
+"Set to 0 to disable (uses normal travel acceleration)."
+msgstr ""
+"用於外部輪廓附近短距離移動的加速度。短距離移動是指長度小於“回抽最小移動距離”的移動。\n"
+"\n"
+"較低的值（例如250-500毫米/秒²）可以減少銳角處的振鈴偽影，同時不會顯著影響列印時間。\n"
+"\n"
+"設定為0以禁用（使用正常的移動加速度）。"
+
+msgid "Initial layer travel"
+msgstr "首層空駛"
+
+msgid "The acceleration of travel of initial layer"
+msgstr ""
+
+msgid "Default filament profile"
+msgstr "預設耗材配置"
+
+msgid "Default filament profile when switch to this machine profile"
+msgstr "該機器配置的預設耗材配置"
+
+msgid "Default process profile"
+msgstr "預設切片配置"
+
+msgid "Default process profile when switch to this machine profile"
+msgstr "該機器的預設切片配置"
+
+msgid "Activate air filtration"
+msgstr "空氣過濾增強"
+
+msgid "Activate for better air filtration"
+msgstr "啟用後獲得更好的過濾效果"
+
+msgid "Fan speed"
+msgstr "風扇速度"
+
+msgid "Speed of exhaust fan during printing.This speed will overwrite the speed in filament custom gcode"
+msgstr "列印過程中排風扇的速度。此速度將覆蓋材料的自定義G程式碼中的速度。"
+
+msgid "Speed of exhuast fan after printing completes"
+msgstr "列印完成後排風扇的速度。"
+
+msgid "For the first"
+msgstr "在最初的"
+
+msgid "Set special cooling fan for the first certain layers.The part cooling fan of the first layer used to be closed to get better build plate adhesion and used for auto cooling function"
+msgstr "為前幾層設定專用冷卻風扇。首層的部件冷卻風扇通常關閉，以獲得更好的列印平臺附著力，同時用於自動冷卻功能"
+
+msgid "layers"
+msgstr "層"
+
+msgid "Special auxiliary cooling fan speed, effective only for the first x layers"
+msgstr "該值僅用於輔助散熱風扇，在前x層生效。"
+
+msgid "Don't support bridges"
+msgstr "不支撐橋接"
+
+msgid "Don't support the whole bridge area which makes support very large. Bridge usually can be printing directly without support if not very long"
+msgstr "不對整個橋接面進行支撐，否則支撐體會很大。不是很長的橋接通常可以無支撐直接列印。"
+
+msgid "Thick bridges"
+msgstr "厚橋"
+
+msgid "If enabled, bridges are more reliable, can bridge longer distances, but may look worse. If disabled, bridges look better but are reliable just for shorter bridged distances."
+msgstr "如果啟用，橋接會更可靠，可以橋接更長的距離，但可能看起來更糟。如果關閉，橋樑看起來更好，但只適用於較短的橋接距離。"
+
+msgid "Max bridge length"
+msgstr "最大橋接長度"
+
+msgid "Max length of bridges that don't need support. Set it to 0 if you want all bridges to be supported, and set it to a very large value if you don't want any bridges to be supported."
+msgstr "不需要支撐的橋接的最大長度。如果希望支援所有橋接，請將其設定為0；如果不希望支援任何橋接，請將其設定為非常大的值。"
+
+msgid "End G-code"
+msgstr "結尾G-code"
+
+msgid "End G-code when finish the whole printing"
+msgstr "所有列印結束時的結尾G-code"
+
+msgid "Between Object Gcode"
+msgstr "物件之間Gcode"
+
+msgid "Insert Gcode between objects. This parameter will only come into effect when you print your models object by object"
+msgstr "在物件之間插入 Gcode。此引數僅在逐個列印模型物體時生效。"
+
+msgid "End G-code when finish the printing of this filament"
+msgstr "結束使用該耗材列印時的結尾G-code"
+
+msgid "Ensure vertical shell thickness"
+msgstr "確保垂直外殼厚度"
+
+msgid "Add solid infill near sloping surfaces to guarantee the vertical shell thickness (top+bottom solid layers)"
+msgstr "在斜面表面附近新增實心填充，以保證垂直外殼厚度（頂部+底部實心層）"
+
+msgid "Partial"
+msgstr "部分"
+
+msgid "Enabled"
+msgstr "開啟"
+
+msgid "Vertical shell speed"
+msgstr "斜面填充速度"
+
+msgid "Speed for vertical shells with overhang regions. If expressed as percentage (for example: 80%) it will be calculated onthe internal solid infill speed above"
+msgstr "包含懸垂區域的斜面填充速度。如果表示為百分比（如80%），則基數為內部實心填充速度。"
+
+msgid "mm/s or %"
+msgstr "mm/s 或 %"
+
+msgid "Detect floating vertical shells"
+msgstr "識別懸空實心填充"
+
+msgid "Detect overhang paths in vertical shells and slow them by bridge speed."
+msgstr "識別斜面填充中的懸空路徑，並使用橋接速度降速。"
+
+msgid "Internal bridge support thickness"
+msgstr "內部橋接支撐厚度"
+
+msgid "When sparse infill density is low, the internal solid infill or internal bridge may have no archor at the end of line. This causes falling and bad quality when printing internal solid infill. When enable this feature, loop paths will be added to the sparse fill of the lower layers for specific thickness, so that better archor can be provided for internal bridge. 0 means disable this feature"
+msgstr "如果開啟，Studio會沿著內部橋接的邊沿在其下方生成支撐輪廓。這些支撐輪廓可以防止懸空地列印內部橋接並提高頂面質量，特別是在填充密度較低的情況下。這個設定用於調整支撐輪廓的厚度，0表示關閉此特性。"
+
+msgid "Top surface pattern"
+msgstr "頂面圖案"
+
+msgid "Line pattern of top surface infill"
+msgstr "頂面填充的走線圖案"
+
+msgid "Concentric"
+msgstr "同心"
+
+msgid "Rectilinear"
+msgstr "直線"
+
+msgid "Monotonic"
+msgstr "單調"
+
+msgid "Monotonic line"
+msgstr "單調線"
+
+msgid "Aligned Rectilinear"
+msgstr "直線排列"
+
+msgid "Hilbert Curve"
+msgstr "希爾伯特曲線"
+
+msgid "Archimedean Chords"
+msgstr "阿基米德螺旋"
+
+msgid "Octagram Spiral"
+msgstr "八角螺旋"
+
+msgid "Top surface density"
+msgstr "頂面密度"
+
+msgid "Density of top surface infill, 100% means a fully solid filled top layer.Lower values create a textured top surface, at 0%, only the walls are created on the top layer.Intended for aesthetic or functional purposes, not to fix issues such as over-extrusion."
+msgstr "頂面的填充密度，100%表示頂層完全實心填充。較低值會產生有紋理的頂層表面，0%時只有頂層牆體被建立。此設定用於美觀或功能性目的，不用於解決諸如過量擠出等問題。"
+
+msgid "Bottom surface pattern"
+msgstr "底面圖案"
+
+msgid "Line pattern of bottom surface infill, not bridge infill"
+msgstr "除了橋接外的底面填充的走線圖案"
+
+msgid "Bottom surface density"
+msgstr "底面密度"
+
+#, c-format
+msgid "Density of bottom surface infill, 100% means a fully solid filled top layer.Lower values create a textured bottom surface, Intended for aesthetic or functional purposes, not to fix issues such as over-extrusion.WARNING: Lowering this value may negatively affect bed adhesion."
+msgstr "底面的填充密度，100%%表示底面為完全實心填充。較低數值會產生紋理化的底面，旨在滿足美觀或功能需求，而非用於修復諸如過度擠出等問題。警告：降低此值可能會負面影響列印平臺附著性。"
+
+msgid "Internal solid infill pattern"
+msgstr "內部實心填充圖案"
+
+msgid "Line pattern of internal solid infill. if the detect narrow internal solid infill be enabled, the concentric pattern will be used for the small area."
+msgstr "內部實心填充的線型圖案。如果啟用了檢測狹窄的內部實心填充，將使用同心圓圖案來填充小區域。"
+
+msgid "Line width of outer wall"
+msgstr "外牆的線寬"
+
+msgid "Speed of outer wall which is outermost and visible. It's used to be slower than inner wall speed to get better quality."
+msgstr "外牆的列印速度。它通常使用比內壁速度慢的速度，以獲得更好的質量。"
+
+msgid "Small perimeters"
+msgstr "小輪廓"
+
+msgid "This setting will affect the speed of perimeters having radius <= small perimeter threshold(usually holes). If expressed as percentage (for example: 80%) it will be calculated onthe outer wall speed setting above. Set to zero for auto."
+msgstr "這個設定將影響半徑小於等於小輪廓閾值的輪廓（通常是孔）的速度。如果以百分比形式表示（例如：80%），則將根據外牆速度進行計算。設定為0代表自動調速。"
+
+msgid "Small perimeter threshold"
+msgstr "小輪廓閾值"
+
+msgid "This sets the threshold for small perimeter length. Default threshold is 0mm"
+msgstr "這設定了小輪廓長度的閾值。預設閾值為0毫米。"
+
+msgid "Order of walls"
+msgstr "牆順序"
+
+msgid "Print sequence of inner wall and outer wall. "
+msgstr "內圈牆/外圈牆的列印順序"
+
+msgid "inner/outer"
+msgstr "內牆/外牆"
+
+msgid "outer/inner"
+msgstr "外牆/內牆"
+
+msgid "inner wall/outer wall/inner wall"
+msgstr "內牆/外牆/內牆"
+
+msgid "Print infill first"
+msgstr "首先列印填充"
+
+msgid "Order of wall/infill. false means print wall first. "
+msgstr "牆/填充的順序。False 表示首先列印牆。"
+
+msgid "Height to rod"
+msgstr "到橫杆高度"
+
+msgid "Distance of the nozzle tip to the lower rod. Used for collision avoidance in by-object printing."
+msgstr "噴嘴尖端到下方滑桿的距離。用於在逐件列印中避免碰撞。"
+
+msgid "Height to lid"
+msgstr "到頂蓋高度"
+
+msgid "Distance of the nozzle tip to the lid. Used for collision avoidance in by-object printing."
+msgstr "噴嘴尖端到頂蓋的距離。用於在逐件列印中避免碰撞。"
+
+msgid "Distance to rod"
+msgstr "到滑桿距離"
+
+msgid "Horizontal distance of the nozzle tip to the rod's farther edge. Used for collision avoidance in by-object printing."
+msgstr "噴嘴尖端到滑桿的較遠邊緣的水平距離。用於在逐件列印中避免碰撞。"
+
+msgid "Nozzle height"
+msgstr "噴嘴高度"
+
+msgid "The height of nozzle tip."
+msgstr "噴嘴尖端的高度。"
+
+msgid "Max Radius"
+msgstr "最大半徑"
+
+msgid "Max clearance radius around extruder. Used for collision avoidance in by-object printing."
+msgstr "擠出機四周的最大避讓半徑。用於在逐件列印中避免碰撞。"
+
+msgid "Grab length"
+msgstr "抓手長度"
+
+msgid "Extruder Color"
+msgstr "擠出機顏色"
+
+msgid "Only used as a visual help on UI"
+msgstr "只作為介面上的視覺化輔助"
+
+msgid "Extruder offset"
+msgstr "擠出機偏移"
+
+msgid "Flow ratio"
+msgstr "流量比例"
+
+msgid "The material may have volumetric change after switching between molten state and crystalline state. This setting changes all extrusion flow of this filament in gcode proportionally. Recommended value range is between 0.95 and 1.05. Maybe you can tune this value to get nice flat surface when there has slight overflow or underflow"
+msgstr "材料經過融化後凝固可能會產生體積差異。這個設定會等比例改變所有擠出走線的擠出量。推薦的範圍為0.95到1.05。發現大平層模型的頂面有輕微的缺料或多料時，或許可以嘗試微調這個引數。"
+
+msgid "Object flow ratio"
+msgstr "物件流量比率"
+
+msgid "The flow ratio set by object, the meaning is the same as flow ratio."
+msgstr "由物件設定的流量比率，其含義與流量比率相同。"
+
+msgid "Enable pressure advance"
+msgstr "啟用壓力提前補償"
+
+msgid "Enable pressure advance, auto calibration result will be overwriten once enabled. Useless for Bambu Printer"
+msgstr "啟用壓力提前補償，啟用後自動校準結果將被覆蓋。對於Bambu印表機無效。"
+
+msgid "Pressure advance(Klipper) AKA Linear advance factor(Marlin). Useless for Bambu Printer"
+msgstr "壓力提前補償（Klipper）也稱為線性提前補償因子（Marlin）。對於Bambu印表機無效。"
+
+msgid "Filament notes"
+msgstr ""
+
+msgid "You can put your notes regarding the filament here."
+msgstr "您可以把材料的註釋放在這裡。"
+
+msgid "Process notes"
+msgstr ""
+
+msgid "You can put your notes regarding the process here."
+msgstr "您可以把工藝的註釋放在這裡。"
+
+msgid "Printer notes"
+msgstr "印表機注意事項"
+
+msgid "You can put your notes regarding the printer here."
+msgstr "您可以把印表機的註釋放在這裡。"
+
+msgid "Default line width if some line width is set to be zero"
+msgstr "當線寬設定為0時走線的預設線寬"
+
+msgid "Keep fan always on"
+msgstr "保持風扇常開"
+
+msgid "If enable this setting, part cooling fan will never be stopped and will run at least at minimum speed to reduce the frequency of starting and stopping"
+msgstr "如果勾選這個選項，部件冷卻風扇將永遠不會停止，並且會至少執行在最小風扇轉速值以減少風扇的啟停頻次"
+
+msgid "Layer time"
+msgstr "層時間"
+
+msgid "Part cooling fan will be enabled for layers of which estimated time is shorter than this value. Fan speed is interpolated between the minimum and maximum fan speeds according to layer printing time"
+msgstr "當層預估列印時間小於該數值時，部件冷卻風扇將會被開啟。風扇轉速將根據層列印時間在最大和最小風扇轉速之間插值獲得"
+
+msgid "Default color"
+msgstr "預設顏色"
+
+msgid "Default filament color"
+msgstr "預設材料顏色"
+
+msgid "Required nozzle HRC"
+msgstr "噴嘴硬度要求"
+
+msgid "Minimum HRC of nozzle required to print the filament. Zero means no checking of nozzle's HRC."
+msgstr "列印此材料的所需的最小噴嘴硬度。零值表示不檢查噴嘴硬度。"
+
+msgid "Filament map to extruder"
+msgstr "耗材絲匹配至擠出機"
+
+msgid "filament mapping mode"
+msgstr "耗材絲匹配模式"
+
+msgid "Auto For Flush"
+msgstr ""
+
+msgid "Auto For Match"
+msgstr ""
+
+msgid "Manual"
+msgstr "手動"
+
+msgid "Nozzle Manual"
+msgstr ""
+
+msgid "Flush temperature"
+msgstr "沖刷溫度"
+
+msgid "temperature when flushing filament. 0 indicates the upper bound of the recommended nozzle temperature range"
+msgstr "耗材沖刷時的溫度。0表示使用最大建議噴嘴溫度。"
+
+msgid "Flush volumetric speed"
+msgstr "沖刷體積流量"
+
+msgid "Volumetric speed when flushing filament. 0 indicates the max volumetric speed"
+msgstr "耗材沖刷時的體積速度。0表示使用耗材最大體積速度。"
+
+msgid "mm³/s"
+msgstr "mm³/s"
+
+msgid "This setting stands for how much volume of filament can be melted and extruded per second. Printing speed is limited by max volumetric speed, in case of too high and unreasonable speed setting. Can't be zero"
+msgstr "這個設定表示在1秒內能夠融化和擠出的耗材絲體積。列印速度會受到最大體積速度的限制，防止設定過高和不合理的速度。不允許設定為0。"
+
+msgid "Extruder change"
+msgstr "擠出機更換"
+
+msgid "The maximum volumetric speed for ramming before extruder change, where -1 means using the maximum volumetric speed."
+msgstr "換出擠出機前的最大預沖刷體積速度，-1 表示使用最大體積速度。"
+
+msgid "Hotend change"
+msgstr "熱端更換"
+
+msgid "The maximum volumetric speed for ramming before a hotend change, where -1 means using the maximum volumetric speed."
+msgstr "熱端更換前的最大預沖刷體積速度，其中 -1 表示使用最大體積速度。"
+
+msgid "Minimal purge on wipe tower"
+msgstr "擦料塔上的最小清理量"
+
+msgid "mm³"
+msgstr "mm³"
+
+msgid "Filament load time"
+msgstr "載入耗材絲的時間"
+
+msgid "Time to load new filament when switch filament. For statistics only"
+msgstr "切換耗材絲時，載入新耗材絲所需的時間。只用於統計資訊。"
+
+msgid "Filament unload time"
+msgstr "解除安裝耗材絲的時間"
+
+msgid "Time to unload old filament when switch filament. For statistics only"
+msgstr "切換耗材絲時，解除安裝舊的耗材絲所需時間。只用於統計資訊。"
+
+msgid "Extruder switch time"
+msgstr "擠出機切換時間"
+
+msgid "Time to switch extruder. For statistics only"
+msgstr "切換擠出機所需時間。僅用於統計"
+
+msgid "Hotend change time"
+msgstr "熱端更換時間"
+
+msgid "Time to change hotend."
+msgstr "熱端更換時間。"
+
+msgid "Bed temperature type"
+msgstr "熱床溫度型別"
+
+msgid "This option determines how the bed temperature is set during slicing: based on the temperature of the first filament or the highest temperature of the printed filaments."
+msgstr "此選項決定切片時熱床溫度的設定方式：根據第一個耗材的溫度或列印材料中的最高溫度。"
+
+msgid "By First filament"
+msgstr "依據首個材料"
+
+msgid "By Highest Temp"
+msgstr "依據最高溫"
+
+msgid "Filament diameter is used to calculate extrusion in gcode, so it's important and should be accurate"
+msgstr "耗材絲直徑被用於計算G-code檔案中的擠出量。因此很重要，應儘可能精確。"
+
+msgid "Adaptive volumetric speed"
+msgstr "自適應體積速度"
+
+msgid "When enabled, the extrusion flow is limited by the smaller of the fitted value (calculated from line width and layer height) and the user-defined maximum flow. When disabled, only the user-defined maximum flow is applied."
+msgstr "啟用時，體積速度取“擬合值（由線寬和層高計算）“與”使用者定義的最大值”中的較小值。禁用時，僅應用使用者定義的最大值。"
+
+msgid "Max volumetric speed multinomial coefficients"
+msgstr "最大體積速度多項式係數"
+
+msgid "Shrinkage"
+msgstr "收縮"
+
+#, no-c-format, no-boost-format
+msgid ""
+"Enter the shrinkage percentage that the filament will get after cooling (94% if you measure 94mm instead of 100mm). The part will be scaled in xy to compensate. Only the filament used for the perimeter is taken into account.\n"
+"Be sure to allow enough space between objects, as this compensation is done after the checks."
+msgstr ""
+"輸入耗材冷卻後將會產生的收縮百分比（如果測量值為94毫米而不是100毫米，則為94%）。零件將在XY方向上縮放以進行補償。僅考慮用於外周的耗材。  \n"
+"請確保物件之間有足夠的空間，因為補償是在檢查之後進行的。"
+
+msgid "Velocity Adaptation Factor"
+msgstr "速度適應係數"
+
+msgid "This parameter reflects the speed at which a material transitions from one state to another. It, along with the smooth coefficient, determines the final length of the transition zone. A larger value: requires a shorter transition zone. A smaller value: requires a longer transition zone to avoid flow instability."
+msgstr ""
+"此引數反映材料從一種狀態過渡到另一種狀態的速度。它與平滑係數一起決定過渡區的最終長度。\n"
+"大數值：需要較短的過渡區。\n"
+"小數值：需要較長的過渡區以避免流動不穩定。"
+
+msgid "Adhesiveness Category"
+msgstr "粘接性類別"
+
+msgid "Filament category"
+msgstr "材料類別"
+
+msgid "Density"
+msgstr "密度"
+
+msgid "Filament density. For statistics only"
+msgstr "耗材絲的密度。只用於統計資訊。"
+
+msgid "g/cm³"
+msgstr "g/cm³"
+
+msgid "The material type of filament"
+msgstr "耗材絲的材料型別"
+
+msgid "Soluble material"
+msgstr "可溶性材料"
+
+msgid "Soluble material is commonly used to print support and support interface"
+msgstr "可溶性材料通常用於列印支撐和支撐面"
+
+msgid "Scarf seam type"
+msgstr "斜拼接縫型別"
+
+msgid "Set scarf seam type for this filament. This setting could minimize seam visibiliy."
+msgstr "設定這個材料的斜拼接縫型別，這個選項可以最小化接縫的可見性。"
+
+msgid "Contour"
+msgstr "輪廓"
+
+msgid "Contour and hole"
+msgstr "輪廓和孔"
+
+msgid "Scarf start height"
+msgstr "斜拼接縫起始高度"
+
+msgid "This amount can be specified in millimeters or as a percentage of the current layer height."
+msgstr "可以設定為毫米也可以設定為設定的層高的百分比。"
+
+msgid "mm/%"
+msgstr "mm/%"
+
+msgid "Scarf slope gap"
+msgstr "斜拼接縫間隔"
+
+msgid "In order to reduce the visiblity of the seam in closed loop, the inner wall and outer wall are shortened by a specified amount."
+msgstr "為了改善縫隙的可見度，內牆和外牆會被縮短指定長度。"
+
+msgid "Scarf length"
+msgstr "斜拼接縫長度"
+
+msgid "Length of the scarf. Setting this parameter to zero effectively disables the scarf."
+msgstr "斜拼接縫的長度。長度為0時會禁用斜拼接縫。"
+
+msgid "When changing the extruder, it is recommended to extrude a certain length of filament from the original extruder. This helps minimize nozzle oozing."
+msgstr "更換擠出機時，建議從原擠出機中擠出一定長度的耗材絲。這有助於最大限度地減少噴嘴漏料。"
+
+msgid "When changing the hotend, it is recommended to extrude a certain length of filament from the original nozzle. This helps minimize nozzle oozing."
+msgstr "更換熱端時，建議從原熱端中擠出一定長度的耗材絲。這有助於最大限度地減少噴嘴漏料。"
+
+msgid "Support material"
+msgstr "支撐材料"
+
+msgid "Support material is commonly used to print support and support interface"
+msgstr "支撐材料通常用於列印支撐體和支撐接觸面"
+
+msgid "Filament printable"
+msgstr "主體耗材可列印性"
+
+msgid "The filament is printable in extruder"
+msgstr ""
+
+msgid "Filament change"
+msgstr "耗材絲更換"
+
+msgid "The volume of material required to prime the extruder on the tower, excluding a hotend change."
+msgstr "除了換熱端外的擦拭塔上的清理量。"
+
+msgid "The volume of material required to prime the extruder for a hotend change on the tower."
+msgstr "換熱端所需的擦料塔上的清理量。"
+
+msgid "Wipe tower cooling"
+msgstr "擦料塔冷卻"
+
+msgid "Temperature drop before entering filament tower"
+msgstr "進入擦料塔前的降溫量"
+
+msgid "Interface layer pre-extrusion distance"
+msgstr "接觸層預擠出距離"
+
+msgid "Pre-extrusion distance for prime tower interface layer (where different materials meet)."
+msgstr "擦拭塔接觸層（不同材料交界處）的預擠出距離。"
+
+msgid "Interface layer pre-extrusion length"
+msgstr "接觸層預擠出長度"
+
+msgid "Pre-extrusion length for prime tower interface layer (where different materials meet)."
+msgstr "擦拭塔接觸層（不同材料交界處）的預擠出長度。"
+
+msgid "Tower ironing area"
+msgstr "擦拭塔熨燙麵積"
+
+msgid "Ironing area for prime tower interface layer (where different materials meet)."
+msgstr "擦拭塔的起始點熨燙麵積"
+
+msgid "mm²"
+msgstr "mm²"
+
+msgid "Interface layer purge length"
+msgstr "擦拭塔沖刷長度"
+
+msgid "Purge length for prime tower interface layer (where different materials meet)."
+msgstr ""
+
+msgid "Interface layer print temperature"
+msgstr "接觸層列印溫度"
+
+msgid "Print temperature for prime tower interface layer (where different materials meet). If set to -1, use max recommended nozzle temperature."
+msgstr "料塔接觸層（不同材料交界處）的列印溫度。如果設定為-1，使用最大推薦噴嘴列印溫度。"
+
+msgid "°C"
+msgstr "°C"
+
+msgid "Softening temperature"
+msgstr "軟化溫度"
+
+msgid "The material softens at this temperature, so when the bed temperature is equal to or greater than it, it's highly recommended to open the front door and/or remove the upper glass to avoid cloggings."
+msgstr "材料在這個溫度下會軟化，因此當熱床溫度等於或高於這個溫度時，強烈建議開啟前門和/或去除上玻璃以避免堵塞。"
+
+msgid "To prevent oozing, the nozzle will perform a reverse travel movement for a certain period after the ramming is complete. The setting define the travel time."
+msgstr "為了防止溢料，預沖刷完成後，噴嘴會進行一段時間的反向空駛。該設定用於定義空駛時間。"
+
+msgid "To prevent oozing, the nozzle temperature will be cooled during ramming. Therefore, the ramming time must be greater than the cooldown time. 0 means disabled."
+msgstr "為了防止溢料，預沖刷時會降低噴嘴溫度。因此，預沖刷時間必須大於冷卻時間。0 表示禁用。"
+
+msgid "To prevent oozing, the nozzle temperature will be cooled during ramming. Note: only a cooldown command and fan activation are triggered, reaching the target temperature is not guaranteed. 0 means disabled."
+msgstr "為防止溢料，預沖刷過程中噴嘴溫度會降低。注意：僅觸發冷卻指令並啟動風扇，不保證達到目標溫度。0 表示禁用。"
+
+msgid "Price"
+msgstr "價格"
+
+msgid "Filament price. For statistics only"
+msgstr "耗材絲的價格。只用於統計資訊。"
+
+msgid "money/kg"
+msgstr "money/kg"
+
+msgid "Vendor"
+msgstr "供應商"
+
+msgid "Vendor of filament. For show only"
+msgstr "列印耗材的供應商。僅用於展示。"
+
+msgid "(Undefined)"
+msgstr "（未定義）"
+
+msgid "Infill direction"
+msgstr "填充方向"
+
+msgid "Angle for sparse infill pattern, which controls the start or main direction of line"
+msgstr "稀疏填充圖案的角度，決定走線的開始或整體方向。"
+
+msgid "Sparse infill density"
+msgstr "稀疏填充密度"
+
+#, c-format
+msgid "Density of internal sparse infill, 100% means solid throughout"
+msgstr "稀疏填充密度, 100%% 意味著完全實心。"
+
+msgid "Fill multiline"
+msgstr "填充多線"
+
+msgid "Using multiple lines for the infill pattern, if supported by infill pattern."
+msgstr "啟用多線填充模式，當所選填充圖案支援時生效。"
+
+msgid "Sparse infill pattern"
+msgstr "稀疏填充圖案"
+
+msgid "Line pattern for internal sparse infill"
+msgstr "內部稀疏填充的走線圖案"
+
+msgid "Grid"
+msgstr "網格"
+
+msgid "Line"
+msgstr "線"
+
+msgid "Cubic"
+msgstr "立方體"
+
+msgid "Tri-hexagon"
+msgstr "內六邊形"
+
+msgid "Gyroid"
+msgstr "螺旋體"
+
+msgid "Honeycomb"
+msgstr "蜂窩"
+
+msgid "Adaptive Cubic"
+msgstr "自適應立方體"
+
+msgid "3D Honeycomb"
+msgstr "3D 蜂窩"
+
+msgid "Support Cubic"
+msgstr "支撐立方體"
+
+msgid "Lightning"
+msgstr "閃電"
+
+msgid "Cross Hatch"
+msgstr "交叉層疊"
+
+msgid "Zig Zag"
+msgstr ""
+
+msgid "Cross Zag"
+msgstr ""
+
+msgid "Locked Zag"
+msgstr ""
+
+msgid "2D Lattice"
+msgstr "二維晶格"
+
+msgid "Skin infill pattern"
+msgstr "表皮填充圖案"
+
+msgid "Line pattern for skin"
+msgstr "表皮填充的走線圖案"
+
+msgid "Skeleton infill pattern"
+msgstr "骨架填充圖案"
+
+msgid "Line pattern for skeleton"
+msgstr "骨架填充的走線圖案"
+
+msgid "Acceleration of top surface infill. Using a lower value may improve top surface quality"
+msgstr "頂面填充的加速度。使用較低值可能會改善頂面質量"
+
+msgid "Acceleration of outer wall. Using a lower value can improve quality"
+msgstr "外牆加速度。使用較小的值可以提高質量。"
+
+msgid "Acceleration of inner walls. 0 means using normal printing acceleration"
+msgstr "內部壁的加速度。0表示使用正常的列印加速度。"
+
+msgid "Acceleration of sparse infill. If the value is expressed as a percentage (e.g. 100%), it will be calculated based on the default acceleration."
+msgstr "稀疏填充的加速度。如果該值表示為百分比（例如100%），則將根據預設加速度進行計算。"
+
+msgid "mm/s² or %"
+msgstr "mm/s² 或 %"
+
+msgid "Acceleration of initial layer. Using a lower value can improve build plate adhensive"
+msgstr "首層加速度。使用較低值可以改善和列印板的粘接。"
+
+msgid "Enable accel_to_decel"
+msgstr ""
+
+msgid "Klipper's max_accel_to_decel will be adjusted automatically"
+msgstr ""
+
+msgid "accel_to_decel"
+msgstr ""
+
+msgid "Klipper's max_accel_to_decel will be adjusted to this percent of acceleration"
+msgstr ""
+
+msgid "Default jerk"
+msgstr "預設抖動"
+
+msgid "Jerk of outer walls"
+msgstr "外牆抖動"
+
+msgid "Jerk of inner walls"
+msgstr "內牆抖動"
+
+msgid "Jerk of infill"
+msgstr "填充抖動"
+
+msgid "Jerk of top surface"
+msgstr "頂層表面抖動"
+
+msgid "First layer"
+msgstr "首層"
+
+msgid "Jerk of first layer"
+msgstr "首層抖動"
+
+msgid "Jerk of travel"
+msgstr "行程抖動"
+
+msgid "Line width of initial layer"
+msgstr "首層的線寬"
+
+msgid "Initial layer height"
+msgstr "首層層高"
+
+msgid "Height of initial layer. Making initial layer height thick slightly can improve build plate adhension"
+msgstr "初始層高度。使初始層高度略厚可以提高建築板的附著力。"
+
+msgid "Speed of initial layer except the solid infill part"
+msgstr "首層除實心填充之外的其他部分的列印速度"
+
+msgid "Initial layer infill"
+msgstr "首層填充"
+
+msgid "Speed of solid infill part of initial layer"
+msgstr "首層實心填充的列印速度"
+
+msgid "Initial layer nozzle temperature"
+msgstr "首層列印溫度"
+
+msgid "Nozzle temperature to print initial layer when using this filament"
+msgstr "列印首層時的噴嘴溫度"
+
+msgid "Full fan speed at layer"
+msgstr "滿速風扇在"
+
+msgid "Randomly jitter while printing the wall, so that the surface has a rough look. This setting controls the fuzzy position"
+msgstr "列印外牆時隨機抖動，使外表面產生絨效果。這個設定決定適用的位置。"
+
+msgid "None(allow paint)"
+msgstr "無(允許繪製)"
+
+msgid "All walls"
+msgstr "所有牆"
+
+msgid "Fuzzy skin thickness"
+msgstr "絨毛表面厚度"
+
+msgid "The width within which to jitter. It's adversed to be below outer wall line width"
+msgstr "產生絨毛的抖動的寬度。建議小於外圈牆的線寬。"
+
+msgid "Fuzzy skin point distance"
+msgstr "絨毛表面點間距"
+
+msgid "The average distance between the random points introduced on each line segment"
+msgstr "產生絨毛表面時，插入的隨機點之間的平均距離"
+
+msgid "Filter out tiny gaps"
+msgstr "過濾掉微小間隙"
+
+msgid "Filter out gaps smaller than the threshold specified. Gaps smaller than this threshold will be ignored"
+msgstr "過濾掉小於指定閾值的間隙。小於此閾值的間隙將被忽略"
+
+msgid "Precise wall"
+msgstr "精準外牆尺寸"
+
+msgid "Improve shell precision by adjusting outer wall spacing. This also improves layer consistency."
+msgstr "透過調整外牆間隙以提高外牆列印精度，該最佳化也能減少層紋。"
+
+msgid "Speed of gap infill. Gap usually has irregular line width and should be printed more slowly"
+msgstr "填縫的速度。縫隙通常有不一致的線寬，應改用較慢速度列印。"
+
+msgid "Precise Z height"
+msgstr "精準Z高度"
+
+msgid "Enable this to get precise z height of object after slicing. It will get the precise object height by fine-tuning the layer heights of the last few layers. Note that this is an experimental parameter."
+msgstr "開啟這個設定，物件在切片後將得到精準的Z高度。它將透過微調物件最後幾層的層高來確保物件Z高度精準。注意這是一個實驗性引數。"
+
+msgid "Arc fitting"
+msgstr "圓弧擬合"
+
+msgid "Enable this to get a G-code file which has G2 and G3 moves. And the fitting tolerance is the same as resolution"
+msgstr "開啟這個設定，匯出的G-code將包含G2 G3指令。圓弧擬合的容許值和精度相同。"
+
+msgid "Add line number"
+msgstr "標註行號"
+
+msgid "Enable this to add line number(Nx) at the beginning of each G-Code line"
+msgstr "開啟這個設定，G-code的每一行的開頭會增加Nx標註行號。"
+
+msgid "Scan first layer"
+msgstr "首層掃描"
+
+msgid "Enable this to enable the camera on printer to check the quality of first layer"
+msgstr "開啟這個設定將開啟印表機上的攝像頭用於檢查首層列印質量。"
+
+msgid "Enable clumping detection"
+msgstr "開啟觸碰裹頭檢測"
+
+msgid "Clumping detection layers"
+msgstr "觸碰裹頭檢測層數"
+
+msgid "Clumping detection layers."
+msgstr "觸碰裹頭檢測層數。"
+
+msgid "Probing exclude area of clumping"
+msgstr "探測排除裹頭檢測區域"
+
+msgid "Probing exclude area of clumping."
+msgstr "探測排除裹頭檢測區域。"
+
+msgid "Thumbnail size"
+msgstr "縮圖大小"
+
+msgid "Decides the size of thumbnail stored in gcode files"
+msgstr "決定儲存在Gcode檔案中的縮圖大小"
+
+msgid "Nozzle type"
+msgstr "噴嘴型別"
+
+msgid "The metallic material of nozzle. This determines the abrasive resistance of nozzle, and what kind of filament can be printed"
+msgstr "噴嘴的金屬材料。這將決定噴嘴的耐磨性，以及可列印材料的種類"
+
+msgid "Undefine"
+msgstr "未定義"
+
+msgid "Hardened steel"
+msgstr "硬化鋼"
+
+msgid "Stainless steel"
+msgstr "不鏽鋼"
+
+msgid "Tungsten carbide"
+msgstr "碳化鎢"
+
+msgid "Printer structure"
+msgstr "印表機結構"
+
+msgid "The physical arrangement and components of a printing device"
+msgstr "列印裝置的物理排列和元件"
+
+msgid "Best object position"
+msgstr "最佳物件位置"
+
+msgid "Best auto arranging position in range [0,1] w.r.t. bed shape."
+msgstr "相對於熱床尺寸的最佳自動擺放位置，範圍為[0,1]。"
+
+msgid "Enable this option if machine has auxiliary part cooling fan"
+msgstr "如果機器有輔助部件冷卻風扇，勾選該選項"
+
+msgid "Fan direction"
+msgstr "風扇方向"
+
+msgid "Cooling fan direction of the printer"
+msgstr "印表機冷卻風扇方向"
+
+msgid "Both"
+msgstr "兩者都"
+
+msgid "Support control chamber temperature"
+msgstr "支援腔溫控制"
+
+msgid "This option is enabled if machine support controlling chamber temperature"
+msgstr "此選項在支援腔溫控制時啟用。"
+
+msgid "Apply top surface compensation"
+msgstr "應用頂面補償"
+
+msgid "Enable this option to extend the travel distance between top surface lines, improving the adhesion between the top surface infill and the walls."
+msgstr "啟用此選項以延長頂面線之間的移動距離，從而提升頂面填充與牆體之間的粘附性。"
+
+msgid "Air filtration enhancement"
+msgstr "支援空氣過濾增強"
+
+msgid "Enable this if printer support air filtration enhancement."
+msgstr "如果印表機支援空氣過濾增強，請啟用此選項。"
+
+msgid "Use cooling filter"
+msgstr "開啟冷卻過濾"
+
+msgid "Enable this if printer support cooling filter"
+msgstr "開啟該功能後，當腔溫過高時，會自動關閉過濾以提高冷卻效果"
+
+msgid "G-code flavor"
+msgstr "G-code風格"
+
+msgid "What kind of gcode the printer is compatible with"
+msgstr "印表機相容的G-code風格'"
+
+msgid "Exclude objects"
+msgstr "排除物件"
+
+msgid "Enable this option to add EXCLUDE OBJECT command in g-code for klipper firmware printer"
+msgstr "啟用此選項以在Klipper韌體印表機的G程式碼中新增“EXCLUDE OBJECT”命令。"
+
+msgid "Infill combination"
+msgstr "合併填充"
+
+msgid "Automatically Combine sparse infill of several layers to print together to reduce time. Wall is still printed with original layer height."
+msgstr "自動合併若干層稀疏填充一起列印以可縮短時間。內外牆依然保持原始層高列印。"
+
+msgid "Infill shift step"
+msgstr "填充移動步長"
+
+msgid "This parameter adds a slight displacement to each layer of infill to create a cross texture."
+msgstr "這個引數給每層填充新增輕微平移以塑造交錯花紋。"
+
+msgid "Infill rotate step"
+msgstr "填充旋轉步長"
+
+msgid "This parameter adds a slight rotation to each layer of infill to create a cross texture."
+msgstr "這個引數給每層填充新增輕微旋轉以塑造交錯花紋。"
+
+msgid "Skeleton infill density"
+msgstr "骨架填充密度"
+
+msgid "The remaining part of the model contour after removing a certain depth from the surface is called the skeleton. This parameter is used to adjust the density of this section.When two regions have the same sparse infill settings but different skeleton densities, their skeleton areas will develop overlapping sections.default is as same as infill density."
+msgstr "去除表面一定深度之後餘留的部分被稱作骨架。這個引數用於調整骨架部分的密度。兩個有同樣的稀疏填充密度但是不同骨架密度的區域走線會有重疊的部分。預設值和稀疏填充密度一致。"
+
+msgid "Skin infill density"
+msgstr "表皮填充密度"
+
+msgid "The portion of the model's outer surface within a certain depth range is called the skin. This parameter is used to adjust the density of this section.When two regions have the same sparse infill settings but different skin densities, This area will not be split into two separate regions.default is as same as infill density."
+msgstr "整個模型輪廓往下去一定深度的區域被稱作表皮。這個引數使用者設定這個區域的密度。如果兩個區域有同樣的稀疏填充密度，但表皮密度不同，這個區域會被拆成兩個表皮區域生成。預設引數和稀疏填充密度相同。"
+
+msgid "Skin infill depth"
+msgstr "表皮填充深度"
+
+msgid "The parameter sets the depth of skin."
+msgstr "這個引數設定表皮區域的深度"
+
+msgid "Infill lock depth"
+msgstr "填充互鎖深度"
+
+msgid "The parameter sets the overlapping depth between the interior and skin."
+msgstr "這個引數設定表皮和骨架重疊區域的深度"
+
+msgid "Skin line width"
+msgstr "表皮線寬"
+
+msgid "Adjust the line width of the selected skin paths."
+msgstr "調整選擇的表皮走線的線寬"
+
+msgid "Skeleton line width"
+msgstr "骨架線寬"
+
+msgid "Adjust the line width of the selected skeleton paths."
+msgstr "為選擇的骨架走線設定線寬"
+
+msgid "Symmetric infill y axis"
+msgstr "填充關於y軸對稱"
+
+msgid "If the model has two parts that are symmetric about the y-axis, and you want these parts to have symmetric textures, please click this option on one of the parts."
+msgstr "如果一個模型中有兩個關於y軸對稱的部件，並且您希望使得這兩個部分的填充紋理關於y軸對稱。請在其中一個部件上勾選上這個功能。"
+
+msgid "Lattice angle 1"
+msgstr "晶格角度 1"
+
+msgid "The angle of the first set of 2D lattice elements in the Z direction. Zero is vertical."
+msgstr "2D晶格的第一組在Z方向的排列角度。零度為垂直排列。"
+
+msgid "Lattice angle 2"
+msgstr "晶格角度 2"
+
+msgid "The angle of the second set of 2D lattice elements in the Z direction. Zero is vertical."
+msgstr "2D晶格的第二組在Z方向的排列角度。零度為垂直排列。"
+
+msgid "Length of sparse infill anchor"
+msgstr "稀疏填充鉚線長度"
+
+msgid "Connect a sparse infill line to an internal perimeter with a short segment of an additional perimeter. If expressed as percentage (example: 15%) it is calculated over sparse infill line width. Slicer tries to connect two close infill lines to a short perimeter segment. If no such perimeter segment shorter than infill_anchor_max is found, the infill line is connected to a perimeter segment at just one side and the length of the perimeter segment taken is limited to this parameter, but no longer than anchor_length_max. Set this parameter to zero to disable anchoring perimeters connected to a single infill line."
+msgstr "使用一小段額外的走線將稀疏填充和內牆連線在一起。如果表示為百分比(例如:15%)，則數值表示相對於稀疏填充的線寬。切片軟體嘗試將兩條緊密的填充線連線到一個短的輪廓線段上。如果找不到短於“填充錨點最大值”的輪廓線段，則填充線只在一側連線到輪廓線段，並且所選取的輪廓線段的長度僅限於此引數，但不超過“錨點長度最大值”。將此引數設定為零以禁用連線到單個填充線的錨點輪廓。"
+
+msgid "0 (no open anchors)"
+msgstr "0 (無鉚線)"
+
+msgid "1000 (unlimited)"
+msgstr "1000（無限制）"
+
+msgid "Maximum length of sparse infill anchor"
+msgstr "稀疏填充鉚線最大長度"
+
+msgid "Connect a sparse infill line to an internal perimeter with a short segment of an additional perimeter. If expressed as percentage (example: 15%) it is calculated over sparse infill line width. Slicer tries to connect two close infill lines to a short perimeter segment. If no such perimeter segment shorter than this parameter is found, the infill line is connected to a perimeter segment at just one side and the length of the perimeter segment taken is limited to infill_anchor, but no longer than this parameter. Set this parameter to zero to disable anchoring."
+msgstr "使用一小段額外的走線將稀疏填充和內牆連線在一起。如果表示為百分比(例如:15%)，則數值表示相對於稀疏填充的線寬。切片軟體嘗試將兩條緊密的填充線連線到一個短的輪廓線段上。如果找不到短於該引數的輪廓線段，則填充線只在一側連線到輪廓線段，並且所選取的輪廓線段的長度僅限於“填充錨點”，但不超過此引數。將此引數設定為零以禁用錨點。"
+
+msgid "0 (not anchored)"
+msgstr "0（無）"
+
+msgid "Sparse infill filament"
+msgstr "稀疏填充耗材"
+
+msgid "Filament to print internal sparse infill."
+msgstr "用於列印內部稀疏填充的耗材"
+
+msgid "Line width of internal sparse infill"
+msgstr "內部稀疏填充的線寬"
+
+msgid "Infill/Wall overlap"
+msgstr "填充/牆 重疊"
+
+msgid "Infill area is enlarged slightly to overlap with wall for better bonding. The percentage value is relative to line width of sparse infill"
+msgstr "填充區域被輕微擴大，並和外牆產生重疊，進而產生更好的粘接。表示為相對稀疏填充的線寬的百分比。"
+
+msgid "Speed of internal sparse infill"
+msgstr "內部稀疏填充的列印速度"
+
+msgid "Interface shells"
+msgstr "接觸面外殼"
+
+msgid "Force the generation of solid shells between adjacent materials/volumes. Useful for multi-extruder prints with translucent materials or manual soluble support material"
+msgstr "強制在相鄰材料/體積之間生成實體殼層。對於使用半透明材料或手動可溶性支撐材料的多擠出頭列印非常有用。"
+
+msgid "Maximum width of a segmented region"
+msgstr "分段區域的最大寬度"
+
+msgid "Maximum width of a segmented region. Zero disables this feature."
+msgstr "分段區域的最大寬度。將其設定為零會禁用此功能。"
+
+msgid "Interlocking depth of a segmented region"
+msgstr "分割區域的交錯深度"
+
+msgid "Interlocking depth of a segmented region. Zero disables this feature."
+msgstr "分割區域的交錯深度。0 則禁用此功能。"
+
+msgid "Use beam interlocking"
+msgstr "啟用互鎖梁"
+
+msgid "Generate interlocking beam structure at the locations where different filaments touch. This improves the adhesion between filaments, especially models printed in different materials."
+msgstr "在不同位置生成互鎖梁結構細絲接觸。這提高了細絲之間的附著力，尤其是用不同材料印刷的模型。"
+
+msgid "Interlocking beam width"
+msgstr "互鎖梁寬度"
+
+msgid "The width of the interlocking structure beams."
+msgstr "互鎖結構梁的寬度。"
+
+msgid "Interlocking direction"
+msgstr "互鎖方向"
+
+msgid "Orientation of interlock beams."
+msgstr "互鎖梁的方向"
+
+msgid "Interlocking beam layers"
+msgstr "互鎖梁層數"
+
+msgid "The height of the beams of the interlocking structure, measured in number of layers. Less layers is stronger, but more prone to defects."
+msgstr "互鎖結構的梁的高度，以層數來衡量。層數越少，越堅固，但更容易出現缺陷。"
+
+msgid "Interlocking depth"
+msgstr "互鎖深度"
+
+msgid "The distance from the boundary between filaments to generate interlocking structure, measured in cells. Too few cells will result in poor adhesion."
+msgstr "從耗材絲之間的邊界到產生互鎖的距離以細胞為單位測量的結構。細胞太少會導致粘附不良。"
+
+msgid "Interlocking boundary avoidance"
+msgstr "邊界留白量"
+
+msgid "The distance from the outside of a model where interlocking structures will not be generated, measured in cells."
+msgstr "互鎖結構與模型外部的距離不生成，以單元格為單位測量。"
+
+msgid "Ironing Type"
+msgstr "熨燙型別"
+
+msgid "Ironing is using small flow to print on same height of surface again to make flat surface more smooth. This setting controls which layer being ironed"
+msgstr "熨燙指的是使用小流量在表面的同高度列印，從而使平面更加光滑。這個設定用於設定哪些層進行熨燙。"
+
+msgid "No ironing"
+msgstr "不熨燙"
+
+msgid "All solid layer"
+msgstr "所有實心層"
+
+msgid "Ironing Pattern"
+msgstr "熨燙模式"
+
+msgid "Ironing flow"
+msgstr "熨燙流量"
+
+msgid "The amount of material to extrude during ironing. Relative to flow of normal layer height. Too high value results in overextrusion on the surface"
+msgstr "熨燙時相對正常層高流量的材料量。過高的數值將會導致表面材料過擠出。"
+
+msgid "Ironing line spacing"
+msgstr "熨燙間距"
+
+msgid "The distance between the lines of ironing"
+msgstr "熨燙走線的間距"
+
+msgid "Ironing inset"
+msgstr "熨燙內縮"
+
+msgid "The distance to keep the from the edges of ironing line. 0 means not apply."
+msgstr "這個表示熨燙區域距離輪廓邊界的距離，0表示不使用。"
+
+msgid "Ironing speed"
+msgstr "熨燙速度"
+
+msgid "Print speed of ironing lines"
+msgstr "熨燙的列印速度"
+
+msgid "ironing direction"
+msgstr "熨燙方向"
+
+msgid "Angle for ironing, which controls the relative angle between the top surface and ironing"
+msgstr "熨燙的角度，控制頂部表面和熨燙之間的相對角度"
+
+msgid "This gcode part is inserted at every layer change after lift z"
+msgstr "在每次換層抬升Z高度之後插入這段G-code。"
+
+msgid "Clumping detection G-code"
+msgstr "觸碰裹頭檢測G-code"
+
+msgid "Supports silent mode"
+msgstr "支援靜音模式"
+
+msgid "Whether the machine supports silent mode in which machine use lower acceleration to print"
+msgstr "機器是否支援使用低加速度列印的靜音模式。"
+
+msgid "This G-code will be used as a code for the pause print. User can insert pause G-code in gcode viewer"
+msgstr "該G-code用於暫停列印。您可以在gcode預覽中插入暫停G-code"
+
+msgid "This G-code will be used as a custom code"
+msgstr "該G-code是定製化指令"
+
+msgid "Maximum speed X"
+msgstr "X最大速度"
+
+msgid "Maximum speed Y"
+msgstr "Y最大速度"
+
+msgid "Maximum speed Z"
+msgstr "Z最大速度"
+
+msgid "Maximum speed E"
+msgstr "E最大速度"
+
+msgid "Machine limits"
+msgstr "機器限制"
+
+msgid "Maximum X speed"
+msgstr "X最大速度"
+
+msgid "Maximum Y speed"
+msgstr "Y最大速度"
+
+msgid "Maximum Z speed"
+msgstr "Z最大速度"
+
+msgid "Maximum E speed"
+msgstr "E最大速度"
+
+msgid "Maximum acceleration X"
+msgstr "X最大加速度"
+
+msgid "Maximum acceleration Y"
+msgstr "Y最大加速度"
+
+msgid "Maximum acceleration Z"
+msgstr "Z最大加速度"
+
+msgid "Maximum acceleration E"
+msgstr "E最大加速度"
+
+msgid "Maximum acceleration of the X axis"
+msgstr "X軸的最大加速度"
+
+msgid "Maximum acceleration of the Y axis"
+msgstr "Y軸的最大加速度"
+
+msgid "Maximum acceleration of the Z axis"
+msgstr "Z軸的最大加速度"
+
+msgid "Maximum acceleration of the E axis"
+msgstr "E軸的最大加速度"
+
+msgid "Maximum jerk X"
+msgstr "X最大抖動"
+
+msgid "Maximum jerk Y"
+msgstr "Y最大抖動"
+
+msgid "Maximum jerk Z"
+msgstr "Z最大抖動"
+
+msgid "Maximum jerk E"
+msgstr "E最大抖動"
+
+msgid "Maximum jerk of the X axis"
+msgstr "X軸最大抖動"
+
+msgid "Maximum jerk of the Y axis"
+msgstr "Y軸最大抖動"
+
+msgid "Maximum jerk of the Z axis"
+msgstr "Z軸最大抖動"
+
+msgid "Maximum jerk of the E axis"
+msgstr "E軸最大抖動"
+
+msgid "Minimum speed for extruding"
+msgstr "最小擠出速度"
+
+msgid "Minimum speed for extruding (M205 S)"
+msgstr "最小擠出速度(M205 S)"
+
+msgid "Minimum travel speed"
+msgstr "最小空駛速度"
+
+msgid "Minimum travel speed (M205 T)"
+msgstr "最小空駛速度(M205 T)"
+
+msgid "Maximum acceleration for extruding"
+msgstr "擠出最大加速度"
+
+msgid "Maximum acceleration for extruding (M204 P)"
+msgstr "擠出時的最大加速度(M204 P)"
+
+msgid "Maximum acceleration for retracting"
+msgstr "回抽最大加速度"
+
+msgid "Maximum acceleration for retracting (M204 R)"
+msgstr "回抽最大加速度(M204 R)"
+
+msgid "Maximum acceleration for travel"
+msgstr "空駛最大加速度"
+
+msgid "Maximum acceleration for travel (M204 T)"
+msgstr "空駛最大加速度(M204 T)"
+
+msgid "Part cooling fan speed may be increased when auto cooling is enabled. This is the maximum speed limitation of part cooling fan"
+msgstr "啟用自動冷卻時，可能會提高部件冷卻風扇的轉速。這是部件冷卻風扇的最大速度限制"
+
+msgid "Max"
+msgstr "最大"
+
+msgid "The largest printable layer height for extruder. Used to limit the maximum layer height when enable adaptive layer height"
+msgstr "擠出頭最大可列印的層高。用於限制開啟自適應層高時的最大層高。"
+
+msgid "Minimum speed for part cooling fan"
+msgstr "部件冷卻風扇的最小轉速"
+
+msgid "Speed of auxiliary part cooling fan. Auxiliary fan will run at this speed during printing except the first several layers which are defined by no cooling layers"
+msgstr "輔助部件冷卻風扇的轉速。輔助部件冷卻風扇將一直執行在該速度，除了設定的無需冷卻的前若干層"
+
+msgid "Min"
+msgstr "最小"
+
+msgid "The lowest printable layer height for extruder. Used to limit the minimum layer height when enable adaptive layer height"
+msgstr "擠出頭最小可列印的層高。用於限制開啟自適應層高時的最小層高。"
+
+msgid "Min print speed"
+msgstr "最小列印速度"
+
+msgid "The minimum printing speed when slow down for cooling"
+msgstr "自動冷卻降速的最小列印速度"
+
+msgid "Nozzle diameter"
+msgstr "噴嘴直徑"
+
+msgid "Diameter of nozzle"
+msgstr "噴嘴直徑"
+
+msgid "Host Type"
+msgstr "主機型別"
+
+msgid "Slic3r can upload G-code files to a printer host. This field must contain the kind of the host."
+msgstr "Slic3r可以將G-code檔案上傳到印表機主機。此欄位必須包含主機型別。"
+
+msgid "Nozzle volume"
+msgstr "噴嘴內腔體積"
+
+msgid "Volume of nozzle between the cutter and the end of nozzle"
+msgstr "從切刀位置到噴嘴尖端的內腔體積"
+
+msgid "Start end points"
+msgstr "起始終止點"
+
+msgid "The start and end points which are from cutter area to garbage can."
+msgstr "從切割區域到垃圾桶的起始和結束點。"
+
+msgid "Reduce infill retraction"
+msgstr "減小填充回抽"
+
+msgid "Don't retract when the travel is in infill area absolutely. That means the oozing can't been seen. This can reduce times of retraction for complex model and save printing time, but make slicing and G-code generating slower"
+msgstr "當空駛完全在填充區域內時不觸發回抽。這意味著即使漏料也是不可見的。對於複雜模型，該設定能夠減少回抽次數以及列印時長，但是會造成G-code生成變慢"
+
+msgid "Filename format"
+msgstr "檔名格式"
+
+msgid "User can self-define the project file name when export"
+msgstr "使用者可以自定義匯出專案檔案的名稱。"
+
+msgid "Detect overhang wall"
+msgstr "識別懸空外牆"
+
+msgid "Detect the overhang percentage relative to line width and use different speed to print. For 100 percent overhang, bridge speed is used."
+msgstr "檢測懸空相對於線寬的百分比，並應用不同的速度列印。100%的懸空將使用橋接速度。"
+
+msgid "Smooth speed discontinuity area"
+msgstr "平滑速度不連續區域"
+
+msgid "Add the speed transition between discontinuity area."
+msgstr "在速度不連續區域新增速度過渡區"
+
+msgid "Smooth coefficient"
+msgstr "平滑係數"
+
+msgid "The smaller the number, the longer the speed transition path. 0 means not apply."
+msgstr "數值越小速度過渡區越大。0表示不應用。"
+
+msgid "Walls filament"
+msgstr "牆耗材"
+
+msgid "Filament to print walls"
+msgstr "用於列印牆體的耗材"
+
+msgid "Line width of inner wall"
+msgstr "內牆的線寬"
+
+msgid "Speed of inner wall"
+msgstr "內圈牆列印速度"
+
+msgid "Number of walls of every layer"
+msgstr "每一層的牆層數"
+
+msgid "Embedding the wall into the infill"
+msgstr "將牆體嵌入填充中"
+
+msgid "Embedding the wall into parts where the wall loops are absent ensures that the wall connects seamlessly to the infill."
+msgstr "將牆體嵌入沒有外牆的區域以確保牆體與填充物無縫連線。"
+
+msgid "Post-processing Scripts"
+msgstr "後處理指令碼"
+
+msgid "If you want to process the output G-code through custom scripts, just list their absolute paths here. Separate multiple scripts with a semicolon. Scripts will be passed the absolute path to the G-code file as the first argument, and variables of settings also can be read"
+msgstr "如果您想透過自定義指令碼來處理輸出的G程式碼，只需在這裡列出它們的絕對路徑。用分號來分隔多個指令碼。指令碼將被傳遞給G程式碼檔案的絕對路徑作為第一個引數，設定的變數也可以被讀取。"
+
+msgid "Raft contact Z distance"
+msgstr "筏層Z間距"
+
+msgid "Z gap between object and raft. Ignored for soluble interface"
+msgstr "模型和筏層之間的Z間隙"
+
+msgid "Raft expansion"
+msgstr "筏層擴充套件"
+
+msgid "Expand all raft layers in XY plane"
+msgstr "在XY平面擴充套件所有筏層"
+
+msgid "Initial layer density"
+msgstr "首層密度"
+
+msgid "Density of the first raft or support layer"
+msgstr "筏和支撐的首層密度"
+
+msgid "Initial layer expansion"
+msgstr "首層擴充套件"
+
+msgid "Expand the first raft or support layer to improve bed plate adhesion, -1 means auto"
+msgstr "擴充套件筏層和支撐的首層可以改善和熱床的粘接，-1 表示自動"
+
+msgid "Raft layers"
+msgstr "筏層"
+
+msgid "Object will be raised by this number of support layers. Use this function to avoid warping when print ABS"
+msgstr "模型會在相應層數的支撐上抬高進行列印。使用該功能通常用於列印ABS時翹曲。"
+
+msgid "G-code path is generated after simplifying the contour of model to avoid too many points and gcode lines in the gcode file. Smaller value means higher resolution and more time to slice"
+msgstr "為了避免G-code檔案中過密集的點和走線，G-code走線通常是在簡化模型的外輪廓之後生成。越小的數值代表更高的解析度，同時需要更長的切片時間。"
+
+msgid "Travel distance threshold"
+msgstr "空駛距離閾值"
+
+msgid "Only trigger retraction when the travel distance is longer than this threshold"
+msgstr "只在空駛距離大於該數值時觸發回抽。"
+
+msgid "Retract amount before wipe"
+msgstr "擦拭前的回抽量"
+
+msgid "The length of fast retraction before wipe, relative to retraction length"
+msgstr "擦拭之前的回抽長度，用總回抽長度的百分比表示。"
+
+msgid "Retract when change layer"
+msgstr "換層時回抽"
+
+msgid "Force a retraction when changes layer"
+msgstr "強制在換層時回抽。"
+
+msgid "Retraction Length"
+msgstr "回抽長度"
+
+msgid "Some amount of material in extruder is pulled back to avoid ooze during long travel. Set zero to disable retraction"
+msgstr "擠出機中的一些材料會被拉回特定長度，避免空駛較長時材料滲出。設定為0表示關閉回抽。"
+
+msgid "Long retraction when cut(experimental)"
+msgstr "切料時回抽（實驗）"
+
+msgid "Experimental feature.Retracting and cutting off the filament at a longer distance during changes to minimize purge.While this reduces flush significantly, it may also raise the risk of nozzle clogs or other printing problems."
+msgstr "實驗性選項。在更換耗材絲時，將耗材絲回抽一段距離後再切斷以最小化沖刷。雖然這大大減少了沖刷，但也可能增加噴嘴堵塞或其他列印問題的風險。"
+
+msgid "Retraction distance when cut"
+msgstr "切料回抽距離"
+
+msgid "Experimental feature.Retraction length before cutting off during filament change"
+msgstr "實驗性選項。在更換耗材絲時，切斷前的回抽長度"
+
+msgid "Long retraction when extruder change"
+msgstr "切換噴嘴時回抽"
+
+msgid "Retraction distance when extruder change"
+msgstr "切換噴嘴回抽距離"
+
+msgid "Z hop when retract"
+msgstr "回抽時抬升Z"
+
+msgid "Whenever the retraction is done, the nozzle is lifted a little to create clearance between nozzle and the print. It prevents nozzle from hitting the print when travel moves. Using spiral line to lift z can prevent stringing"
+msgstr "回抽完成之後，噴嘴輕微抬升，和列印件之間產生一定間隙。這能夠避免空駛時噴嘴和列印件剮蹭和碰撞。使用螺旋線抬升z能夠減少拉絲。"
+
+msgid "Z hop lower boundary"
+msgstr "Z抬升範圍下限"
+
+msgid "Z hop will only come into effect when Z is above this value and is below the parameter: \"Z hop upper boundary\""
+msgstr "只有當Z抬升值在Z抬升下限和Z抬升上限之間時Z抬升才會生效"
+
+msgid "Z hop upper boundary"
+msgstr "Z抬升範圍上限"
+
+msgid "If this value is positive, Z hop will only come into effect when Z is above the parameter: \"Z hop lower boundary\" and is below this value"
+msgstr "如果這個值為正，只有當Z抬升值在Z抬升下限和Z抬升上限之間時Z抬升才會生效"
+
+msgid "Z Hop Type"
+msgstr "Z抬升方式"
+
+msgid "Slope"
+msgstr "斜向"
+
+msgid "Spiral"
+msgstr "螺旋"
+
+msgid "Direct Drive"
+msgstr "直接驅動"
+
+msgid "Bowden"
+msgstr "遠端"
+
+msgid "Nozzle Volume Type"
+msgstr "噴嘴體積型別"
+
+msgid "Default Nozzle Volume Type"
+msgstr "預設噴嘴體積型別"
+
+msgid "Saving"
+msgstr "儲存中"
+
+msgid "length when change hotend"
+msgstr "換熱端時回抽量"
+
+msgid "When this retraction value is modified, it will be used as the amount of filament retracted inside the hotend before changing hotends."
+msgstr "當修改此回抽數值時，將用於熱端內在更換熱端前回抽的耗材量。"
+
+msgid "Extra length on restart"
+msgstr "額外回填長度"
+
+msgid "When the retraction is compensated after the travel move, the extruder will push this additional amount of filament. This setting is rarely needed."
+msgstr "在空駛結束後進行回抽補償時，擠出機會多擠出相應的耗材。這個設定通常不需要調整。"
+
+msgid "When the retraction is compensated after changing tool, the extruder will push this additional amount of filament."
+msgstr "當在更換工具頭後進行回抽補償時，擠出機會額外推送這部分耗材。"
+
+msgid "Retraction Speed"
+msgstr "回抽速度"
+
+msgid "Speed of retractions"
+msgstr "回抽速度"
+
+msgid "Deretraction Speed"
+msgstr "裝填速度"
+
+msgid "Speed for reloading filament into extruder. Zero means the same speed as retraction"
+msgstr "耗材絲裝填的速度，0表示和回抽速度一致。"
+
+msgid "Seam position"
+msgstr "接縫位置"
+
+msgid "The start position to print each part of outer wall"
+msgstr "開始列印外牆的位置"
+
+msgid "Nearest"
+msgstr "最近"
+
+msgid "Aligned"
+msgstr "對齊"
+
+msgid "Back"
+msgstr "背面"
+
+msgid "Random"
+msgstr "隨機"
+
+msgid "Seam placement away from overhangs(experimental)"
+msgstr "接縫遠離懸垂點放置（實驗）"
+
+msgid "Ensure seam placement away from overhangs for alignment and backing modes."
+msgstr "接縫避讓懸垂附近，對齊模式生效"
+
+msgid "Seam gap"
+msgstr "接縫間隔"
+
+msgid ""
+"In order to reduce the visibility of the seam in a closed loop extrusion, the loop is interrupted and shortened by a specified amount.\n"
+"This amount as a percentage of the current extruder diameter. The default value for this parameter is 15"
+msgstr ""
+"為了減少閉環擠出中接縫的可見性，迴圈會被中斷並縮短指定的長度。\n"
+"這個長度是當前擠出器直徑的百分比。該引數的預設值為15。"
+
+msgid "Smart scarf seam application"
+msgstr "智慧應用斜拼接縫"
+
+msgid "Apply scarf joints only to smooth perimeters where traditional seams do not conceal the seams at sharp corners effectively."
+msgstr "當牆壁沒有合適的銳角以至於傳統接縫無法有效隱藏的時候使用斜拼接縫。"
+
+msgid "Scarf application angle threshold"
+msgstr "斜拼角度閾值"
+
+msgid ""
+"This option sets the threshold angle for applying a conditional scarf joint seam.\n"
+"If the seam angle within the perimeter loop exceeds this value (indicating the absence of sharp corners), a scarf joint seam will be used. The default value is 155°."
+msgstr ""
+"此選項設定判斷是否應用斜拼接縫的角度閾值。\n"
+"如果圍牆環內的最大角度超過了這個值（表示沒有足夠銳的角），則使用斜拼接縫接縫。預設值為155°。"
+
+msgid "Scarf around entire wall"
+msgstr "圍繞整個圍牆"
+
+msgid "The scarf extends to the entire length of the wall."
+msgstr "將斜拼接縫延伸到整個圍牆"
+
+msgid "Scarf steps"
+msgstr "斜拼段數"
+
+msgid "Minimum number of segments of each scarf."
+msgstr "斜拼接縫所需的最少段數"
+
+msgid "Scarf joint for inner walls"
+msgstr "應用斜拼於內牆"
+
+msgid "Use scarf joint for inner walls as well."
+msgstr "同時應用斜拼接縫於內牆"
+
+msgid "Override filament scarf seam setting"
+msgstr "覆蓋材料的斜拼接縫引數"
+
+msgid "Overrider filament scarf seam setting and could control settings by modifier."
+msgstr "覆蓋斜拼接縫設定並可透過修改器控制設定。"
+
+msgid "Wipe speed"
+msgstr "擦拭速度"
+
+msgid "The wipe speed is determined by the speed setting specified in this configuration.If the value is expressed as a percentage (e.g. 80%), it will be calculated based on the travel speed setting above.The default value for this parameter is 80%"
+msgstr "擦拭速度是根據此配置中指定的速度設定確定的。如果該值以百分比形式表示（例如80%），則將根據上方的移動速度設定進行計算。該引數的預設值為80%。"
+
+msgid "Role-based wipe speed"
+msgstr "自動擦拭速度"
+
+msgid "The wipe speed is determined by speed of current extrusion role. e.g if a wipe action is executed immediately following an outer wall extrusion, the speed of the outer wall extrusion will be utilized for the wipe action."
+msgstr "擦拭速度由當前擠出型別的速度決定。例如，如果擦拭動作緊隨外牆，擦拭速度將使用外牆速度。"
+
+msgid "Skirt distance"
+msgstr "Skirt距離"
+
+msgid "Distance from skirt to brim or object"
+msgstr "從skirt到模型或者brim的距離"
+
+msgid "Skirt height"
+msgstr "Skirt高度"
+
+msgid "How many layers of skirt. Usually only one layer"
+msgstr "skirt有多少層。通常只有一層"
+
+msgid "Skirt loops"
+msgstr "Skirt圈數"
+
+msgid "Number of loops for the skirt. Zero means disabling skirt"
+msgstr "skirt的圈數。0表示關閉skirt。"
+
+msgid "The printing speed in exported gcode will be slowed down, when the estimated layer time is shorter than this value, to get better cooling for these layers"
+msgstr "當層預估列印時間小於這個數值時，列印速度將會降低，從而獲得更好的冷卻效果。"
+
+msgid "Minimum sparse infill threshold"
+msgstr "稀疏填充最小閾值"
+
+msgid "Sparse infill area which is smaller than threshold value is replaced by internal solid infill"
+msgstr "小於這個閾值的稀疏填充區域將會被內部實心填充替代。"
+
+msgid "Solid infill filament"
+msgstr "實心填充耗材"
+
+msgid "Filament to print solid infill"
+msgstr "用於列印實體填充的耗材"
+
+msgid "Line width of internal solid infill"
+msgstr "內部實心填充的線寬"
+
+msgid "Speed of internal solid infill, not the top and bottom surface"
+msgstr "內部實心填充的速度，不是頂面和底面。"
+
+msgid "Spiralize smooths out the z moves of the outer contour. And turns a solid model into a single walled print with solid bottom layers. The final generated model has no seam"
+msgstr "沿著物件的外輪廓螺旋上升，將實體模型轉變為只有底面實心層和側面單層牆壁的列印。最後生成的列印件沒有接縫。"
+
+msgid "Smooth Spiral"
+msgstr "平滑旋轉花瓶"
+
+msgid "Smooth Spiral smoothes out X and Y moves as wellresulting in no visible seam at all, even in the XY directions on walls that are not vertical"
+msgstr "平滑花瓶模式在XY平面上作偏移以達到隱藏接縫的結果。"
+
+msgid "Max XY Smoothing"
+msgstr "最大XY平滑閾值"
+
+msgid "Maximum distance to move points in XY to try to achieve a smooth spiralIf expressed as a %, it will be computed over nozzle diameter"
+msgstr "最大的XY平面移動距離。當以%為單位時，基於噴嘴直徑計算。"
+
+msgid "If smooth or traditional mode is selected, a timelapse video will be generated for each print. After each layer is printed, a snapshot is taken with the chamber camera. All of these snapshots are composed into a timelapse video when printing completes. If smooth mode is selected, the toolhead will move to the excess chute after each layer is printed and then take a snapshot. Since the melt filament may leak from the nozzle during the process of taking a snapshot, prime tower is required for smooth mode to wipe nozzle."
+msgstr "如果啟用平滑模式或者傳統模式，將在每次列印時生成延時攝影影片。列印完每層後，將用內建相機拍攝快照。列印完成後，所有這些快照會組合成一個延時影片。如果啟用平滑模式，列印完每層後，工具頭將移動到吐料槽，然後拍攝快照。由於平滑模式在拍攝快照的過程中熔絲可能會從噴嘴中洩漏，因此需要使用擦料塔進行噴嘴擦拭。"
+
+msgid "Traditional"
+msgstr "傳統模式"
+
+msgid "Temperature variation"
+msgstr "軟化溫度"
+
+msgid "Start G-code"
+msgstr "起始G-code"
+
+msgid "Start G-code when start the whole printing"
+msgstr "整個列印開始前的起始G-code"
+
+msgid "Start G-code when start the printing of this filament"
+msgstr "開始使用這個耗材絲列印的起始G-code"
+
+msgid "Slice gap closing radius"
+msgstr "切片間隙閉合半徑"
+
+msgid "Cracks smaller than 2x gap closing radius are being filled during the triangle mesh slicing. The gap closing operation may reduce the final print resolution, therefore it is advisable to keep the value reasonably low."
+msgstr "在三角形網格切片過程中，小於2倍間隙閉合半徑的裂紋將被填充。間隙閉合操作可能會降低最終列印解析度，因此建議降值保持在合理的較低水平"
+
+msgid "Slicing Mode"
+msgstr "切片模式"
+
+msgid "Use \"Even-odd\" for 3DLabPrint airplane models. Use \"Close holes\" to close all holes in the model."
+msgstr "對3DLabPrint的飛機模型使用 \"奇偶\"。使用 \"閉孔 \"來關閉模型上的所有孔。"
+
+msgid "Regular"
+msgstr "常規"
+
+msgid "Even-odd"
+msgstr "奇偶"
+
+msgid "Close holes"
+msgstr "閉孔"
+
+msgid "Enable support"
+msgstr "開啟支撐"
+
+msgid "Enable support generation."
+msgstr "開啟支撐生成。"
+
+msgid "normal(auto) and tree(auto) is used to generate support automatically. If normal(manual) or tree(manual) is selected, only support enforcers are generated"
+msgstr "普通（自動）和樹狀（自動）用於自動生成支撐體。如果選擇普通（手動）或樹狀（手動），僅會在支撐強制面上生成支撐。"
+
+msgid "normal(auto)"
+msgstr "普通(自動)"
+
+msgid "tree(auto)"
+msgstr "樹狀(自動)"
+
+msgid "normal(manual)"
+msgstr "普通(手動)"
+
+msgid "tree(manual)"
+msgstr "樹狀(手動)"
+
+msgid "Support/object xy distance"
+msgstr "支撐/模型xy間距"
+
+msgid "XY separation between an object and its support"
+msgstr "模型和支撐之間XY分離距離"
+
+msgid "Support/object first layer gap"
+msgstr "支撐/物件首層間距"
+
+msgid "XY separation between an object and its support at the first layer."
+msgstr "物體與其首層支撐之間的 XY 間隔。"
+
+msgid "Pattern angle"
+msgstr "模式角度"
+
+msgid "Use this setting to rotate the support pattern on the horizontal plane."
+msgstr "設定支撐圖案在水平面的旋轉角度。"
+
+msgid "On build plate only"
+msgstr "僅在列印板生成"
+
+msgid "Don't create support on model surface, only on build plate"
+msgstr "不在模型表面上生成支撐，只在熱床上生成。"
+
+msgid "Support critical regions only"
+msgstr "僅支撐關鍵區域"
+
+msgid "Only create support for critical regions including sharp tail, cantilever, etc."
+msgstr "僅對關鍵區域生成支撐，包括尖尾、懸臂等。"
+
+msgid "Remove small overhangs"
+msgstr "移除小懸空"
+
+msgid "Remove small overhangs that possibly need no supports."
+msgstr "移除可能並不需要支撐的小懸空。"
+
+msgid "Top Z distance"
+msgstr "頂部Z距離"
+
+msgid "The z gap between the top support interface and object"
+msgstr "支撐頂部和模型之間的z間隙"
+
+msgid "Bottom Z distance"
+msgstr "底部Z距離"
+
+msgid "The z gap between the bottom support interface and object"
+msgstr "支撐生成於模型表面時，支撐面底部和模型之間的z間隙"
+
+msgid "Support/raft base"
+msgstr "支撐/筏層主體"
+
+msgid "Filament to print support base and raft. \"Default\" means no specific filament for support and current filament is used"
+msgstr "列印支撐主體和筏層的耗材絲。\"預設\"代表不指定特定的耗材絲，並使用當前耗材"
+
+msgid "Avoid interface filament for base"
+msgstr "介面材料不用於主體"
+
+msgid "Avoid using support interface filament to print support base if possible."
+msgstr "避免使用支撐介面材料列印支撐主體。"
+
+msgid "Line width of support"
+msgstr "支撐的線寬"
+
+msgid "Interface use loop pattern"
+msgstr "接觸面採用圈形走線。"
+
+msgid "Cover the top contact layer of the supports with loops. Disabled by default."
+msgstr "使用圈形走線覆蓋頂部接觸面。預設關閉。"
+
+msgid "Support/raft interface"
+msgstr "支撐/筏層介面"
+
+msgid "Filament to print support interface. \"Default\" means no specific filament for support interface and current filament is used"
+msgstr "列印支撐接觸面的耗材絲。\"預設\"代表不指定特定的耗材絲，並使用當前耗材"
+
+msgid "Top interface layers"
+msgstr "頂部接觸面層數"
+
+msgid "Number of top interface layers"
+msgstr "頂部接觸面層數"
+
+msgid "Bottom interface layers"
+msgstr "底部接觸面層數"
+
+msgid "Number of bottom interface layers"
+msgstr "底部介面層的數量"
+
+msgid "Same as top"
+msgstr "和頂部相同"
+
+msgid "Top interface spacing"
+msgstr "頂部接觸面線距"
+
+msgid "Spacing of interface lines. Zero means solid interface.And zero spacing is required to access the enable_support_ironing option"
+msgstr "接觸面的線距。零表示實心接觸面。線距需要為零以使用enable_support_ironing"
+
+msgid "Enable ironing support interface"
+msgstr "啟用支撐介面熨燙"
+
+msgid "Ironing is using small flow to print on same height of surface again to make flat surface more smooth. This setting controls whether support interface or raft interface will be ironned.Support ironing could only works on solid interface,that is, support_interface_spacing was zero and support_interface_pattern was't grid"
+msgstr "熨燙指的是使用小流量在表面的同高度列印，從而使平面更加光滑。此設定控制是否對支撐介面進行熨燙。支援熨燙僅適用於實心介面，即 support_interface_spacing 為零且 support_interface_pattern 不是網格"
+
+msgid "Support ironing pattern"
+msgstr "支撐熨燙模式"
+
+msgid "Support ironing flow"
+msgstr "支撐熨燙流量"
+
+msgid "Support ironing line spacing"
+msgstr "支撐熨燙間距"
+
+msgid "Support ironing inset"
+msgstr "支撐熨燙內縮"
+
+msgid "Support ironing speed"
+msgstr "支撐熨燙速度"
+
+msgid "Support ironing direction"
+msgstr "支撐熨燙方向"
+
+msgid "Bottom interface spacing"
+msgstr "底部接觸面線距"
+
+msgid "Spacing of bottom interface lines. Zero means solid interface"
+msgstr "底部接觸面走線的線距。0表示實心接觸面。"
+
+msgid "Speed of support interface"
+msgstr "支撐面速度"
+
+msgid "Base pattern"
+msgstr "支撐主體圖案"
+
+msgid "Line pattern of support"
+msgstr "支撐走線圖案"
+
+msgid "Rectilinear grid"
+msgstr "直線網格"
+
+msgid "Hollow"
+msgstr "空心"
+
+msgid "Interface pattern"
+msgstr "支撐面圖案"
+
+msgid "Line pattern of support interface. Default pattern for support interface is Rectilinear Interlaced"
+msgstr "支撐接觸面的走線圖案。支撐接觸面的預設圖案為交疊的直線"
+
+msgid "Rectilinear Interlaced"
+msgstr "交疊的直線"
+
+msgid "Base pattern spacing"
+msgstr "主體圖案線距"
+
+msgid "Spacing between support lines"
+msgstr "支撐線距"
+
+msgid "Normal Support expansion"
+msgstr "普通支撐拓展"
+
+msgid "Expand (+) or shrink (-) the horizontal span of normal support"
+msgstr "在水平方向對普通支撐進行拓展（+）或收縮（-）"
+
+msgid "Speed of support"
+msgstr "支撐列印速度"
+
+msgid ""
+"Style and shape of the support. For normal support, projecting the supports into a regular grid will create more stable supports (default), while snug support towers will save material and reduce object scarring.\n"
+"For tree support, slim style will merge branches more aggressively and save a lot of material, strong style will make larger and stronger support structure and use more materials, while hybrid style is the combination of slim tree and normal support with normal nodes under large flat overhangs. Organic style will produce more organic shaped tree structure and less interfaces which makes it easer to be removed. The default style is organic tree for most cases, and hybrid tree if adaptive layer height or soluble interface is enabled."
+msgstr ""
+"支撐的樣式和形狀。對於普通支撐，將支撐投射到一個規則的網格中，將建立更穩定的支撐（預設），而緊貼的支撐塔將節省材料並減少物體的瑕疵。\n"
+"對於樹形支撐，苗條樹將更激進地合併樹枝，並節省大量的材料；粗壯樹會產生更大更強壯的支撐結構，但用料更多；而混合樹是苗條樹和普通支撐的結合，它會在大的平面懸垂下建立與正常支撐類似的結構；有機樹將產生更有機的樹狀結構，並且減少介面層，這使得它們更容易被移除。多數情況下，預設風格是有機樹，如果啟用了自適應層高或使用了可溶性支撐材料，則為混合樹。"
+
+msgid "Snug"
+msgstr "緊貼"
+
+msgid "Tree Slim"
+msgstr "苗條樹"
+
+msgid "Tree Strong"
+msgstr "粗壯樹"
+
+msgid "Tree Hybrid"
+msgstr "混合樹"
+
+msgid "Tree Organic"
+msgstr "有機樹"
+
+msgid "Z overrides X/Y"
+msgstr "Z 覆蓋 X/Y"
+
+msgid "When top z distance overrides support/object xy distance, give priority to ensuring that supports are generated beneath overhangs, and a gap of the same size as top z distance is leaved with the model. Whereas in the opposite case, the gap between supports and the model follows support/object xy distance all the time. Only recommended to enable when using HybridTree."
+msgstr "當頂部z距離覆蓋支撐/模型xy間距時，優先確保在懸垂下方生成支撐，並與模型保持與頂部z距離大小相同的間隙；反之，支撐與模型之間的間隙始終遵循支撐/模型xy間距。僅建議在使用混合樹時啟用此項。"
+
+msgid "Independent support layer height"
+msgstr "支撐獨立層高"
+
+msgid "Support layer uses layer height independent with object layer. This is to support customizing z-gap and save print time.This option will be invalid when the prime tower is enabled."
+msgstr "支撐層使用與物件層獨立的層高。這是為了支援自定義z-gap並且節省列印時間。當擦料塔被啟用時，這個選項將無效。"
+
+msgid "Threshold angle"
+msgstr "閾值角度"
+
+msgid "Support will be generated for overhangs whose slope angle is below the threshold."
+msgstr "將會為懸垂角度低於閾值的模型表面生成支撐。"
+
+msgid "Branch angle"
+msgstr "分支角度"
+
+msgid "This setting determines the maximum overhang angle that t he branches of tree support allowed to make.If the angle is increased, the branches can be printed more horizontally, allowing them to reach farther."
+msgstr "此設定確定了允許樹狀支撐的最大懸垂角度。如果角度增加，可以更水平地列印分支，使它們可以到達更遠的地方。"
+
+msgid "Branch distance"
+msgstr "分支距離"
+
+msgid "This setting determines the distance between neighboring tree support nodes."
+msgstr "此設定確定了樹狀支撐的相鄰節點之間的距離。"
+
+msgid "Branch diameter"
+msgstr "分支直徑"
+
+msgid "This setting determines the initial diameter of support nodes."
+msgstr "此設定確定了樹狀支撐節點的初始直徑。"
+
+msgid "Branch diameter angle"
+msgstr "分支直徑角度"
+
+msgid "The angle of the branches' diameter as they gradually become thicker towards the bottom. An angle of 0 will cause the branches to have uniform thickness over their length. A bit of an angle can increase stability of the tree support."
+msgstr "樹枝向底部逐漸變粗時的直徑角度。角度為 0 會使樹枝在整個長度上粗細一致。稍大一點的角度可以增加樹狀支撐的穩定性。"
+
+msgid "Support wall loops"
+msgstr "支撐外牆層數"
+
+msgid "This setting specifies the count of support walls in the range of [-1,2]. -1 means auto, and 0 means allowing infill-only mode where support is thick enough."
+msgstr "此設定指定 [-1,2] 範圍內的支撐牆數量。-1表示自動，0表示允許足夠厚的支撐區域使用僅填充模式。"
+
+msgid "Chamber temperature"
+msgstr "腔體溫度"
+
+msgid "Higher chamber temperature can help suppress or reduce warping and potentially lead to higher interlayer bonding strength for high temperature materials like ABS, ASA, PC, PA and so on.At the same time, the air filtration of ABS and ASA will get worse.While for PLA, PETG, TPU, PVA and other low temperature materials,the actual chamber temperature should not be high to avoid cloggings, so 0 which stands for turning off is highly recommended"
+msgstr "更高的腔溫可以幫助抑制或減少翹曲，同時可能會提高高溫材料（如ABS、ASA、PC、PA等）的層間粘合強度。與此同時，ABS和ASA的空氣過濾效能會變差。而對於PLA、PETG、TPU、PVA等低溫材料，為了避免堵塞，實際的腔溫不應該過高，因此強烈建議使用0（表示關閉）。"
+
+msgid "Nozzle temperature for layers after the initial one"
+msgstr "除首層外的其它層的噴嘴溫度"
+
+msgid "Impact Strength Z"
+msgstr "Z向衝擊強度"
+
+msgid "Detect thin wall"
+msgstr "檢查薄壁"
+
+msgid "Detect thin wall which can't contain two line width. And use single line to print. Maybe printed not very well, because it's not closed loop"
+msgstr "檢查無法容納兩條走線的薄壁。使用單條走線列印。可能會打得不是很好，因為走線不再閉合。"
+
+msgid "This gcode is inserted when change filament, including T command to trigger tool change"
+msgstr "換料時插入的G-code，包括T命令。"
+
+msgid "Line width for top surfaces"
+msgstr "頂面的線寬"
+
+msgid "Speed of top surface infill which is solid"
+msgstr "頂面實心填充的速度"
+
+msgid "Top shell layers"
+msgstr "頂部殼體層數"
+
+msgid "This is the number of solid layers of top shell, including the top surface layer. When the thickness calculated by this value is thinner than top shell thickness, the top shell layers will be increased"
+msgstr "頂部殼體實心層層數，包括頂面。當由該層數計算的厚度小於頂部殼體厚度，切片時會增加頂部殼體的層數"
+
+msgid "Top solid layers"
+msgstr "頂部殼體層數"
+
+msgid "Top shell thickness"
+msgstr "頂部殼體厚度"
+
+msgid "The number of top solid layers is increased when slicing if the thickness calculated by top shell layers is thinner than this value. This can avoid having too thin shell when layer height is small. 0 means that this setting is disabled and thickness of top shell is absolutely determained by top shell layers"
+msgstr "如果由頂部殼體層數算出的厚度小於這個數值，那麼切片時將自動增加頂部殼體層數。這能夠避免當層高很小時，頂部殼體過薄。0表示關閉這個設定，同時頂部殼體的厚度完全由頂部殼體層數決定"
+
+msgid "Top paint penetration layers"
+msgstr "頂部塗色滲透層數"
+
+msgid "This is  the number of layers of top paint penetration."
+msgstr "頂部塗色滲透的層數"
+
+msgid "Bottom paint penetration layers"
+msgstr "底部塗色滲透層數"
+
+msgid "This is the number of layers of bottom paint penetration."
+msgstr "底部塗色滲透的層數。"
+
+msgid "Use infill instead of top and bottom surfaces"
+msgstr "使用填充紋理以取代封閉的頂面和底面"
+
+msgid "Using infill instead of top and bottom surfaces."
+msgstr "使用填充紋理以取代封閉的頂面和底面。"
+
+msgid "Speed of travel which is faster and without extrusion"
+msgstr "空駛的速度。空駛是無擠出量的快速移動。"
+
+msgid "Use relative E distances"
+msgstr "使用相對E距離"
+
+msgid "If your firmware requires relative E values, check this, otherwise leave it unchecked. Must use relative e distance for Bambu printer"
+msgstr "如果您的韌體要求使用相對E值，請勾選此項；否則，請不要勾選。對於Bambu印表機，必須使用相對E距離。"
+
+msgid "Use firmware retraction"
+msgstr "硬體回抽"
+
+msgid "Convert the retraction moves to G10 and G11 gcode"
+msgstr "將回抽指令改為G10,G11"
+
+msgid "Wipe while retracting"
+msgstr "回抽時擦拭"
+
+msgid "Move nozzle along the last extrusion path when retracting to clean leaked material on nozzle. This can minimize blob when printing new part after travel"
+msgstr "當回抽時，讓噴嘴沿著前面的走線方向繼續移動，清除掉噴嘴上的漏料。這能夠避免空駛結束列印新的區域時產生斑點。"
+
+msgid "Wipe Distance"
+msgstr "擦拭距離"
+
+msgid "Describe how long the nozzle will move along the last path when retracting"
+msgstr "表示回抽時擦拭的移動距離。"
+
+msgid "The wiping tower can be used to clean up the residue on the nozzle and stabilize the chamber pressure inside the nozzle, in order to avoid appearance defects when printing objects."
+msgstr "擦料塔可以用來清理噴嘴上的殘留料和讓噴嘴內部的腔壓達到穩定狀態，以避免列印物體時出現外觀瑕疵。"
+
+msgid "Internal ribs"
+msgstr "內支撐肋"
+
+msgid "Enable internal ribs to increase the stability of the prime tower."
+msgstr "啟用內支撐肋以增強擦料塔的穩定性。"
+
+msgid "Auto circle contour-hole compensation"
+msgstr "自動圓形軸孔補償"
+
+msgid "Expirment feature to compensate the circle holes and circle contour. This feature is used to improve the accuracy of the circle holes and contour within the diameter below 50mm. Only support PLA Basic, PLA CF, PET CF, PETG CF and PETG HF."
+msgstr "補償孔軸的實驗功能。這個功能用於改善直徑低於50mm的孔軸的尺寸準確度。只支援PLA Basic, PLA CF, PET CF, PETG CF 和 PETG HF。"
+
+msgid "User Customized Offset"
+msgstr "使用者自設定補償"
+
+msgid "If you want to have tighter or looser assemble, you can set this value. When it is positive, it indicates tightening, otherwise, it indicates loosening"
+msgstr "如果您需要更緊或者更松的裝配，請調整這個引數。該引數為正時表示裝配調松，反之調緊"
+
+msgid "Scarf Seam On Compensation Circles"
+msgstr "在補償的圓形上應用斜拼接縫"
+
+msgid "Scarf seam will be applied on circles for better dimensional accuracy."
+msgstr "應用斜拼接縫以獲得更準確的尺寸"
+
+msgid "Circle Compensation Speed"
+msgstr ""
+
+msgid "circle_compensation_speed"
+msgstr ""
+
+msgid "Counter Coef 1"
+msgstr ""
+
+msgid "counter_coef_1"
+msgstr ""
+
+msgid "Contour Coef 2"
+msgstr ""
+
+msgid "counter_coef_2"
+msgstr ""
+
+msgid "Contour Coef 3"
+msgstr ""
+
+msgid "counter_coef_3"
+msgstr ""
+
+msgid "Hole Coef 1"
+msgstr ""
+
+msgid "hole_coef_1"
+msgstr ""
+
+msgid "Hole Coef 2"
+msgstr ""
+
+msgid "hole_coef_2"
+msgstr ""
+
+msgid "Hole Coef 3"
+msgstr ""
+
+msgid "hole_coef_3"
+msgstr ""
+
+msgid "Contour limit min"
+msgstr ""
+
+msgid "counter_limit_min"
+msgstr ""
+
+msgid "Contour limit max"
+msgstr ""
+
+msgid "counter_limit_max"
+msgstr ""
+
+msgid "Hole limit min"
+msgstr ""
+
+msgid "hole_limit_min"
+msgstr ""
+
+msgid "Hole limit max"
+msgstr ""
+
+msgid "hole_limit_max"
+msgstr ""
+
+msgid "Diameter limit"
+msgstr "直徑限制"
+
+msgid "diameter_limit"
+msgstr ""
+
+msgid "Purging volumes"
+msgstr "沖刷體積"
+
+msgid "Flush multiplier"
+msgstr "沖刷量乘數"
+
+msgid "The actual flushing volumes is equal to the flush multiplier multiplied by the flushing volumes in the table."
+msgstr "實際沖刷量等於沖刷量乘數乘以表格單元中的沖刷量"
+
+msgid "Width of prime tower"
+msgstr "擦料塔寬度"
+
+msgid "Max speed"
+msgstr "最大速度"
+
+msgid "The maximum printing speed on the prime tower excluding ramming."
+msgstr "擦料塔上除了預沖刷外的最大列印速度。"
+
+msgid "Brim width of prime tower, negative number means auto calculated width based on the height of prime tower."
+msgstr "擦料塔的Brim寬度，負數意味著寬度根據擦拭塔的高度自動計算。"
+
+msgid "Extra rib length"
+msgstr "斜肋額外的長度"
+
+msgid "Positive values can increase the size of the rib wall, while negative values can reduce the size.However, the size of the rib wall can not be smaller than that determined by the cleaning volume."
+msgstr "正值可以增大斜肋外牆的大小，而負值則可以減小其大小。然而，斜肋外牆的大小不能小於由清理量確定的最小值。"
+
+msgid "Rib width"
+msgstr "斜肋寬度"
+
+msgid "Rib width is always less than half the prime tower side length."
+msgstr "斜肋寬度始終小於擦料塔邊長的一半。"
+
+msgid "Skip points"
+msgstr "外牆缺口"
+
+msgid "The wall of prime tower will skip the start points of wipe path"
+msgstr "擦料塔的外牆跳過內部擦拭路徑的起點"
+
+msgid "Rib wall"
+msgstr "斜肋外牆"
+
+msgid "The wall of prime tower will add four ribs and make its cross-section as close to a square as possible, so the width will be fixed."
+msgstr "擦料塔的外牆增加四個肋角，並使其橫截面近似正方形，因此寬度不能修改。"
+
+msgid "Fillet wall"
+msgstr "外牆倒圓角"
+
+msgid "The wall of prime tower will fillet"
+msgstr "擦料塔外牆倒圓角"
+
+msgid "Infill gap"
+msgstr "填充間隙"
+
+msgid "Purging after filament change will be done inside objects' infills. This may lower the amount of waste and decrease the print time. If the walls are printed with transparent filament, the mixed color infill will be seen outside. It will not take effect, unless the prime tower is enabled."
+msgstr "換料後的過渡料會被用來列印物件的填充。這樣可以減少材料浪費和縮短列印時間，但是如果物件的內外牆是採用透明材料列印的，則可以從模型外觀上看到內部的混色過渡料。該功能只有在啟用擦料塔的時候才生效。"
+
+msgid "Purging after filament change will be done inside objects' support. This may lower the amount of waste and decrease the print time. It will not take effect, unless the prime tower is enabled."
+msgstr "換料後的過渡料會被用來列印物件的支撐。這樣可以減少材料浪費以及縮短列印時間。該功能只有在啟用擦料塔的時候才生效。"
+
+msgid "This object will be used to purge the nozzle after a filament change to save filament and decrease the print time. Colours of the objects will be mixed as a result. It will not take effect, unless the prime tower is enabled."
+msgstr "換料後的過渡料會被用來列印這個物件。這樣可以減少材料浪費和縮短列印時間，但是這個物件的外觀會是混色的。該功能只有在啟用擦料塔的時候才生效。"
+
+msgid "X-Y hole compensation"
+msgstr "X-Y 內輪廓尺寸補償"
+
+msgid "Holes of object will be grown or shrunk in XY plane by the configured value. Positive value makes holes bigger. Negative value makes holes smaller. This function is used to adjust size slightly when the object has assembling issue"
+msgstr "垂直的孔洞的尺寸將在X-Y方向收縮或拓展特定值。正值代表擴大孔洞。負值代表縮小孔洞。這個功能通常在模型有裝配問題時微調尺寸"
+
+msgid "X-Y contour compensation"
+msgstr "X-Y 外輪廓尺寸補償"
+
+msgid "Contour of object will be grown or shrunk in XY plane by the configured value. Positive value makes contour bigger. Negative value makes contour smaller. This function is used to adjust size slightly when the object has assembling issue"
+msgstr "模型外輪廓的尺寸將在X-Y方向收縮或拓展特定值。正值代表擴大。負值代表縮小。這個功能通常在模型有裝配問題時微調尺寸"
+
+msgid "Classic wall generator produces walls with constant extrusion width and for very thin areas is used gap-fill. Arachne engine produces walls with variable extrusion width"
+msgstr "經典牆生成器產生的牆走線具有一致的擠出寬度，對狹窄區域使用填縫。Arachne引擎則產生變線寬的牆走線"
+
+msgid "Classic"
+msgstr "經典"
+
+msgid "Arachne"
+msgstr "Arachne"
+
+msgid "Wall transition length"
+msgstr "牆過渡長度"
+
+msgid "When transitioning between different numbers of walls as the part becomes thinner, a certain amount of space is allotted to split or join the wall segments. It's expressed as a percentage over nozzle diameter"
+msgstr "當零件逐漸變薄導致牆的層數發生變化時，需要在過渡段分配一定的空間來分割和連線牆走線。引數值表示為相對於噴嘴直徑的百分比"
+
+msgid "Wall transitioning filter margin"
+msgstr "牆過渡過濾間距"
+
+msgid "Prevent transitioning back and forth between one extra wall and one less. This margin extends the range of extrusion widths which follow to [Minimum wall width - margin, 2 * Minimum wall width + margin]. Increasing this margin reduces the number of transitions, which reduces the number of extrusion starts/stops and travel time. However, large extrusion width variation can lead to under- or overextrusion problems. It's expressed as a percentage over nozzle diameter"
+msgstr "防止特定厚度變化規律的區域性在多一層牆和少一層牆之間來回轉換。這個引數將擠壓寬度的範圍擴大到[牆最小寬度-引數值, 2*牆最小寬度+引數值]。增大引數可以減少轉換的次數，從而減少擠出開始/停止和空駛的時間。然而，大的擠出寬度變化會導致過擠出或欠擠出的問題。引數值表示為相對於噴嘴直徑的百分比"
+
+msgid "Wall transitioning threshold angle"
+msgstr "牆過渡閾值角度"
+
+msgid "When to create transitions between even and odd numbers of walls. A wedge shape with an angle greater than this setting will not have transitions and no walls will be printed in the center to fill the remaining space. Reducing this setting reduces the number and length of these center walls, but may leave gaps or overextrude"
+msgstr "何時在偶數和奇數牆層數之間建立過渡段。角度大於這個閾值的楔形將不建立過渡段，並且不會在楔形中心列印牆走線以填補剩餘空間。減小這個數值能減少中心牆走線的數量和長度，但可能會導致間隙或者過擠出"
+
+msgid "Wall distribution count"
+msgstr "牆分佈計數"
+
+msgid "The number of walls, counted from the center, over which the variation needs to be spread. Lower values mean that the outer walls don't change in width"
+msgstr "從中心開始計算的牆層數，線寬變化需要分佈在這些牆走線上。較低的數值意味著外牆寬度更不易被改變"
+
+msgid "Minimum feature size"
+msgstr "最小特徵尺寸"
+
+msgid "Minimum thickness of thin features. Model features that are thinner than this value will not be printed, while features thicker than the Minimum feature size will be widened to the Minimum wall width. It's expressed as a percentage over nozzle diameter"
+msgstr "薄壁特徵的最小厚度。比這個數值還薄的特徵將不被列印，而比最小特徵厚度還厚的特徵將被加寬到牆最小寬度。引數值表示為相對噴嘴直徑的百分比"
+
+msgid "Minimum wall width"
+msgstr "牆最小線寬"
+
+msgid "Width of the wall that will replace thin features (according to the Minimum feature size) of the model. If the Minimum wall width is thinner than the thickness of the feature, the wall will become as thick as the feature itself. It's expressed as a percentage over nozzle diameter"
+msgstr "用於替換模型細小特徵（根據最小特徵尺寸）的牆線寬。如果牆最小線寬小於最小特徵的厚度，則牆將變得和特徵本身一樣厚。引數值表示為相對噴嘴直徑的百分比"
+
+msgid "Detect narrow internal solid infill"
+msgstr "識別狹窄內部實心填充"
+
+msgid "This option will auto detect narrow internal solid infill area. If enabled, concentric pattern will be used for the area to speed printing up. Otherwise, rectilinear pattern is used defaultly."
+msgstr "此選項用於自動識別內部狹窄的實心填充。開啟後，將對狹窄實心區域使用同心填充加快列印速度。否則使用預設的直線填充。"
+
+msgid "invalid value "
+msgstr "無效值"
+
+msgid "--use-firmware-retraction is only supported by Marlin, Klipper, Smoothie, RepRapFirmware, Repetier and Machinekit firmware"
+msgstr ""
+
+msgid "--use-firmware-retraction is not compatible with --wipe"
+msgstr ""
+
+#, c-format, boost-format
+msgid " doesn't work at 100%% density "
+msgstr " 填充圖案不支援 100%% 密度"
+
+msgid "Invalid value when spiral vase mode is enabled: "
+msgstr "旋轉花瓶模式下非法的值"
+
+msgid "too large line width "
+msgstr "線寬過大"
+
+msgid " not in range "
+msgstr " 不在合理的區間"
+
+msgid "No check"
+msgstr "不要檢查"
+
+msgid "Do not run any validity checks, such as gcode path conflicts check."
+msgstr "不要執行任何有效性檢查，如gcode路徑衝突檢查。"
+
+msgid "Error in zip archive"
+msgstr "zip檔案中存在錯誤"
+
+msgid "Generating walls"
+msgstr "生成內外牆"
+
+msgid "Generating infill regions"
+msgstr "正在生成填充區域"
+
+msgid "Generating infill toolpath"
+msgstr "正在生成填充走線"
+
+msgid "Detect overhangs for auto-lift"
+msgstr "探測懸空區域為自動抬升做準備"
+
+msgid "Checking support necessity"
+msgstr "正在檢查支撐必要性"
+
+msgid "floating regions"
+msgstr "浮空區域"
+
+msgid "floating cantilever"
+msgstr "浮空懸臂"
+
+msgid "large overhangs"
+msgstr "大面積懸空"
+
+#, c-format, boost-format
+msgid "It seems object %s has %s. Please re-orient the object or enable support generation."
+msgstr "似乎物件%s有%s。請重新調整物件的方向或啟用支撐生成。"
+
+msgid "Generating support"
+msgstr "正在生成支撐"
+
+msgid "Optimizing toolpath"
+msgstr "正在最佳化走線"
+
+msgid "Empty layers around bottom are replaced by nearest normal layers."
+msgstr "底部出現空層，已被最近的正常層替換。"
+
+msgid "The model has too many empty layers."
+msgstr "模型有太多空層。"
+
+msgid "Slicing mesh"
+msgstr "正在切片網格"
+
+msgid "No layers were detected. You might want to repair your STL file(s) or check their size or thickness and retry.\n"
+msgstr "沒有檢測到層。您可能需要修復STL檔案，或檢查模型尺寸、厚度等，之後再重試。\n"
+
+msgid ""
+"An object's XY size compensation will not be used because it is also color-painted.\n"
+"XY Size compensation can not be combined with color-painting."
+msgstr ""
+"物件的XY尺寸補償不會生效，因為在此物件上做過塗色操作。\n"
+"XY尺寸補償不能與塗色功能一起使用。"
+
+msgid ""
+"An object has enabled XY Size compensation which will not be used because it is also fuzzy skin painted.\n"
+"XY Size compensation cannot be combined with fuzzy skin painting."
+msgstr ""
+"物體啟用了 XY 大小補償，該補償將不予使用，因為它也是絨毛表面繪製的。\n"
+"XY 尺寸補償不能與絨毛表面繪製結合使用。"
+
+msgid "Object name"
+msgstr "物件名稱"
+
+msgid "Loading of a model file failed."
+msgstr "載入模型檔案失敗。"
+
+msgid "Meshing of a model file failed or no valid shape."
+msgstr ""
+
+msgid "The supplied file couldn't be read because it's empty"
+msgstr "無法讀取提供的檔案，因為該檔案為空。"
+
+msgid "Unknown file format. Input file must have .stl, .obj, .amf(.xml) extension."
+msgstr "未知的檔案格式。輸入檔案的副檔名必須為.stl、.obj 或 .amf（.xml）。"
+
+msgid "Unknown file format. Input file must have .3mf or .zip.amf extension."
+msgstr "未知的檔案格式。輸入檔案的副檔名必須為.3mf或.zip .amf。"
+
+msgid "Canceled"
+msgstr "已取消"
+
+msgid "load_obj: failed to parse"
+msgstr "載入物件：無法分析"
+
+msgid "load mtl in obj: failed to parse"
+msgstr "在 obj 中載入 mtl：無法解析"
+
+msgid "The file contains polygons with more than 4 vertices."
+msgstr "該檔案包含頂點超過4個的多邊形。"
+
+msgid "The file contains polygons with less than 2 vertices."
+msgstr "該檔案包含頂點少於2個的多邊形。"
+
+msgid "The file contains invalid vertex index."
+msgstr "檔案包含無效的頂點索引。"
+
+msgid "This OBJ file couldn't be read because it's empty."
+msgstr "無法讀取此OBJ檔案，因為它是空的。"
+
+msgid "Flow Rate Calibration"
+msgstr "流量比例校準"
+
+msgid "Max Volumetric Speed Calibration"
+msgstr "最大體積速度校準"
+
+msgid "Manage Result"
+msgstr "管理結果"
+
+msgid "Manual Calibration"
+msgstr "手動校準"
+
+msgid "Result can be read by human eyes."
+msgstr "結果可由人眼讀取。"
+
+msgid "Auto-Calibration"
+msgstr "自動校準"
+
+msgid "The printer will automatically read the calibration results."
+msgstr "印表機將自動讀取校準結果。"
+
+msgid "Prev"
+msgstr "上一個"
+
+msgid "Recalibration"
+msgstr "重新校準"
+
+msgid "Calibrate"
+msgstr "校準"
+
+msgid "Finish"
+msgstr "完成"
+
+msgid "How to use calibration result?"
+msgstr "如何使用校準結果？"
+
+msgid "You could change the Flow Dynamics Calibration Factor in material editing"
+msgstr "您可以在材料編輯中更改動態流量校準因子。"
+
+msgid ""
+"The current firmware version of the printer does not support calibration.\n"
+"Please upgrade the printer firmware."
+msgstr ""
+"印表機當前的韌體版本不支援校準。\n"
+"請升級印表機韌體。"
+
+msgid "Calibration not supported"
+msgstr "不支援校準"
+
+msgid "Error desc"
+msgstr "錯誤描述"
+
+msgid "Extra info"
+msgstr "額外資訊"
+
+msgid "Flow Dynamics"
+msgstr "動態流量"
+
+msgid "Flow Rate"
+msgstr "流量比例"
+
+msgid "The name cannot be empty."
+msgstr "名稱不能為空。"
+
+#, c-format, boost-format
+msgid "The selected preset: %s is not found."
+msgstr "未找到選定的預設：%s。"
+
+msgid "The name cannot be the same as the system preset name."
+msgstr "名稱不能與系統預設名稱相同。"
+
+msgid "The name is the same as another existing preset name"
+msgstr "該名稱與另一個現有預設名稱相同。"
+
+msgid "create new preset failed."
+msgstr "建立新預設失敗"
+
+#, c-format, boost-format
+msgid "Could not find parameter: %s."
+msgstr "找不到引數：%s。"
+
+msgid "Are you sure to cancel the current calibration and return to the home page?"
+msgstr "您確定要取消當前的校準並返回主頁嗎？"
+
+msgid "No Printer Connected!"
+msgstr "沒有連線印表機！"
+
+msgid "Printer is not connected yet."
+msgstr "印表機尚未連線。"
+
+msgid "Please select filament to calibrate."
+msgstr "請選擇要校準的耗材絲。"
+
+msgid "The input value size must be 3."
+msgstr "輸入值大小必須為3。"
+
+msgid ""
+"This machine type can only hold 16 history results per nozzle. You can delete the existing historical results and then start calibration. Or you can continue the calibration, but you cannot create new calibration historical results. \n"
+"Do you still want to continue the calibration?"
+msgstr "該機型每個噴嘴最多隻能儲存16個歷史結果。您可以刪除先已有歷史結果再開始校準。或者您可以直接開始校準，但是無法建立新的校準歷史結果。您仍繼續校準嗎？"
+
+#, c-format, boost-format
+msgid "Only one of the results with the same name: %s will be saved. Are you sure you want to override the other results?"
+msgstr "將僅儲存一個同名結果：%s。是否確實要覆蓋其他結果？"
+
+#, c-format, boost-format
+msgid "There is already a historical calibration result with the same name: %s. Only one of the results with the same name is saved. Are you sure you want to override the historical result?"
+msgstr "已經存在一個具有相同名稱的歷史校準結果：%s。相同名稱的結果只會儲存一個。您確定要覆蓋歷史結果嗎？"
+
+#, c-format, boost-format
+msgid ""
+"Within the same extruder, the name(%s) must be unique when the filament type, nozzle diameter, and nozzle flow are the same.\n"
+"Are you sure you want to override the historical result?"
+msgstr ""
+"在同一個擠出機內，當耗材型別、噴嘴直徑和噴嘴流量相同時，名稱 (%s) 必須是唯一的。\n"
+"您確定要覆蓋歷史結果嗎？"
+
+#, c-format, boost-format
+msgid "This machine type can only hold %d history results per nozzle. This result will not be saved."
+msgstr "該機型每個噴嘴最多隻能儲存%d個歷史結果, 該結果將不會被儲存"
+
+msgid "Connecting to printer..."
+msgstr "正在連線印表機..."
+
+msgid "The failed test result has been dropped."
+msgstr "測試失敗的結果已被刪除。"
+
+msgid "Flow Dynamics Calibration result has been saved to the printer"
+msgstr "動態流量校準的結果已儲存至印表機。"
+
+msgid "Internal Error"
+msgstr "內部錯誤"
+
+msgid "Please select at least one filament for calibration"
+msgstr "請至少選擇一種材料進行校準。"
+
+msgid "Flow rate calibration result has been saved to preset"
+msgstr "流量比例校準結果已儲存到預設"
+
+msgid "Max volumetric speed calibration result has been saved to preset"
+msgstr "最大體積速度校準結果已儲存到預設值"
+
+msgid "When do you need Flow Dynamics Calibration"
+msgstr "在什麼情況下需要進行動態流量校準"
+
+msgid ""
+"We now have added the auto-calibration for different filaments, which is fully automated and the result will be saved into the printer for future use. You only need to do the calibration in the following limited cases:\n"
+"1. If you introduce a new filament of different brands/models or the filament is damp;\n"
+"2. if the nozzle is worn out or replaced with a new one;\n"
+"3. If the max volumetric speed or print temperature is changed in the filament setting."
+msgstr ""
+"我們現在已經為不同的列印材料新增了自動校準功能，該功能是完全自動化的，並且結果將儲存在印表機中以供將來使用。您只需要在以下有限情況下進行校準：\n"
+"1. 如果您引入了不同品牌/型號的新列印材料，或者列印材料受潮；\n"
+"2. 如果噴嘴磨損或更換了新的噴嘴；\n"
+"3. 如果您在列印材料設定中更改了最大體積速度或列印溫度。"
+
+msgid "About this calibration"
+msgstr "關於此校準"
+
+msgid ""
+"Please find the details of Flow Dynamics Calibration from our wiki.\n"
+"\n"
+"Usually the calibration is unnecessary. When you start a single color/material print, with the \"flow dynamics calibration\" option checked in the print start menu, the printer will follow the old way, calibrate the filament before the print; When you start a multi color/material print, the printer will use the default compensation parameter for the filament during every filament switch which will have a good result in most cases.\n"
+"\n"
+"Please note that there are a few cases that can make the calibration results unreliable, such as insufficient adhesion on the build plate. Improving adhesion can be achieved by washing the build plate or applying glue. For more information on this topic, please refer to our Wiki.\n"
+"\n"
+"The calibration results have about 10 percent jitter in our test, which may cause the result not exactly the same in each calibration. We are still investigating the root cause to do improvements with new updates."
+msgstr ""
+"請從我們的wiki中找到動態流量校準的詳細資訊。\n"
+"\n"
+"通常情況下，校準是不必要的。當您開始單色/單材料列印，並在列印開始選單中勾選了“動態流量校準”選項時，印表機將按照舊的方式，在列印前校準絲料；當您開始多色/多材料列印時，印表機將在每次換絲料時使用預設的補償引數，這在大多數情況下會產生良好的效果。\n"
+"\n"
+"有幾種情況可能導致校準結果不可靠，例如列印板的的附著力不足。清洗列印板或者使用膠水可以增強列印板附著力。您可以在我們的維基上找到更多相關資訊。\n"
+"\n"
+"在我們的測試中，校準結果有約10%的波動，這可能導致每次校準的結果略有不同。我們仍在調查根本原因，並透過新的更新進行改進。"
+
+msgid "When to use Flow Rate Calibration"
+msgstr "何時使用流量比例校準"
+
+msgid ""
+"After using Flow Dynamics Calibration, there might still be some extrusion issues, such as:\n"
+"1. Over-Extrusion: Excess material on your printed object, forming blobs or zits, or the layers seem thicker than expected and not uniform.\n"
+"2. Under-Extrusion: Very thin layers, weak infill strength, or gaps in the top layer of the model, even when printing slowly.\n"
+"3. Poor Surface Quality: The surface of your prints seems rough or uneven.\n"
+"4. Weak Structural Integrity: Prints break easily or don't seem as sturdy as they should be."
+msgstr ""
+"使用動態流量校準後，仍可能出現一些擠出問題，例如：\n"
+"1. 過度擠出：列印物體上有過多的材料，形成凸起或小球，或者層次看起來比預期的厚而且不均勻。\n"
+"2. 不足擠出：層次非常薄，填充強度不足，或者在緩慢列印時模型頂層有缺陷。\n"
+"3. 表面質量差：列印的表面看起來粗糙或不均勻。\n"
+"4. 結構穩固性差：列印件容易斷裂，或者沒有應有的穩固性。"
+
+msgid "In addition, Flow Rate Calibration is crucial for foaming materials like LW-PLA used in RC planes. These materials expand greatly when heated, and calibration provides a useful reference flow rate."
+msgstr "此外，對於像用於遙控飛機的輕質發泡PLA（LW-PLA）這樣的發泡材料，流量比例校準非常重要。這些材料在加熱時會大幅膨脹，而校準提供了有用的流量比例參考。"
+
+msgid "Flow Rate Calibration measures the ratio of expected to actual extrusion volumes. The default setting works well in Bambu Lab printers and official filaments as they were pre-calibrated and fine-tuned. For a regular filament, you usually won't need to perform a Flow Rate Calibration unless you still see the listed defects after you have done other calibrations. For more details, please check out the wiki article."
+msgstr "流量比例校準測量預期擠出體積與實際擠出體積之間的比率。預設設定在Bambu Lab印表機和官方材料上表現良好，因為它們已經進行了預先校準和微調。對於普通的材料，通常情況下，您不需要執行流量比例校準，除非在完成其他校準後仍然看到上述列出的缺陷。如需更多詳細資訊，請查閱wiki文章。"
+
+msgid ""
+"Auto Flow Rate Calibration utilizes Bambu Lab's Micro-Lidar technology, directly measuring the calibration patterns. However, please be advised that the efficacy and accuracy of this method may be compromised with specific types of materials. Particularly, filaments that are transparent or semi-transparent, sparkling-particled, or have a high-reflective finish may not be suitable for this calibration and can produce less-than-desirable results.\n"
+"\n"
+"The calibration results may vary between each calibration or filament. We are still improving the accuracy and compatibility of this calibration through firmware updates over time.\n"
+"\n"
+"Caution: Flow Rate Calibration is an advanced process, to be attempted only by those who fully understand its purpose and implications. Incorrect usage can lead to sub-par prints or printer damage. Please make sure to carefully read and understand the process before doing it."
+msgstr ""
+"自動流量比例校準採用Bambu Lab的微型鐳射雷達技術，直接測量校準圖案。然而，請注意，這種方法的功效和準確性可能會因特定型別的材料而受影響。特別是透明或半透明、帶有閃光顆粒或具有高反射表面的材料可能不適合這種校準，並可能產生不理想的結果。\n"
+"\n"
+"校準結果可能因每次校準或材料的不同而有所不同。我們仍在透過韌體更新不斷提高這種校準的準確性和相容性。\n"
+"\n"
+"注意：流量比例校準是一項高階的過程，只有完全理解其目的和影響的人才應嘗試。錯誤的使用可能導致列印質量不佳或損壞印表機。請確保在執行之前仔細閱讀和理解此過程。"
+
+msgid "When you need Max Volumetric Speed Calibration"
+msgstr "當您需要最大體積速度校準時"
+
+msgid "Over-extrusion or under extrusion"
+msgstr "過度擠壓或擠壓不足"
+
+msgid "Max Volumetric Speed calibration is recommended when you print with:"
+msgstr "使用以下選項列印時，建議進行最大體積速度校準："
+
+msgid "material with significant thermal shrinkage/expansion, such as..."
+msgstr "具有顯著熱收縮/膨脹的材料，例如..."
+
+msgid "materials with inaccurate filament diameter"
+msgstr "耗材直徑不準確的材料"
+
+msgid "We found the best Flow Dynamics Calibration Factor"
+msgstr "我們找到了最佳的動態流量校準因子。"
+
+msgid "Part of the calibration failed! You may clean the plate and retry. The failed test result would be dropped."
+msgstr "部分校準失敗！您可以清潔列印平臺並重試。未透過的測試結果將被丟棄。"
+
+msgid "*We recommend you to add brand, material, type, and even humidity level in the Name"
+msgstr "*我們建議您在名稱中新增品牌、材料、型別，甚至溼度水平。"
+
+msgid "Failed"
+msgstr "失敗"
+
+msgid "Please enter the name you want to save to printer."
+msgstr "請輸入要儲存到印表機的名稱。"
+
+msgid "The name cannot exceed 40 characters."
+msgstr "名稱不能超過40個字元。"
+
+msgid "Nozzle ID"
+msgstr "噴嘴 ID"
+
+msgid "Standard Flow"
+msgstr "標準流量"
+
+msgid "Please find the best line on your plate"
+msgstr "請在您的列印板上找到最佳線條"
+
+msgid "Please find the corner with perfect degree of extrusion"
+msgstr "請找到具有完美擠出度的角落"
+
+msgid "Input Value"
+msgstr "輸入值"
+
+msgid "Save to Filament Preset"
+msgstr "儲存到材料預設"
+
+msgid "Preset"
+msgstr "預設"
+
+msgid "Record Factor"
+msgstr "記錄係數"
+
+msgid "We found the best flow ratio for you"
+msgstr "我們為您找到了最佳流量比"
+
+msgid "Flow Ratio"
+msgstr "流量比"
+
+msgid "Please input a valid value (0.0 < flow ratio < 2.0)"
+msgstr "請輸入一個有效值（0.0<流量比<2.0）"
+
+msgid "Please enter the name of the preset you want to save."
+msgstr "請輸入要儲存的預設的名稱。"
+
+msgid "Calibration1"
+msgstr "校準1"
+
+msgid "Calibration2"
+msgstr "校準2"
+
+msgid "Please find the best object on your plate"
+msgstr "請在您的盤裡找到最好的物件"
+
+msgid "Fill in the value above the block with smoothest top surface"
+msgstr "用最光滑的頂面填充塊上方的值"
+
+msgid "Skip Calibration2"
+msgstr "跳過校準2"
+
+#, c-format, boost-format
+msgid "flow ratio : %s "
+msgstr "流量比：%s "
+
+msgid "Please choose a block with smoothest top surface"
+msgstr "請選擇頂部表面最光滑的塊"
+
+msgid "Please choose a block with smoothest top surface."
+msgstr "請選擇頂部表面最光滑的塊。"
+
+msgid "Please input a valid value (0 <= Max Volumetric Speed <= 60)"
+msgstr "請輸入一個有效值（0<=最大容積速度<=60）"
+
+msgid "Calibration Type"
+msgstr "校準型別"
+
+msgid "Complete Calibration"
+msgstr "完整校準"
+
+msgid "Fine Calibration based on flow ratio"
+msgstr "基於流量比的精細校準"
+
+msgid "Title"
+msgstr "標題"
+
+msgid "A test model will be printed. Please clear the build plate and place it back to the hot bed before calibration."
+msgstr "將列印一份測試模型。在校準之前，請清理列印平臺並將其放回熱床上。"
+
+msgid "Printing Parameters"
+msgstr "列印引數"
+
+msgid "Synchronize nozzle and AMS information"
+msgstr "同步噴嘴和AMS資訊"
+
+msgid "Please connect the printer first before synchronizing."
+msgstr "同步前請先連線印表機"
+
+#, c-format, boost-format
+msgid "Printer %s nozzle information has not been set. Please configure it before proceeding with the calibration."
+msgstr "尚未設定印表機%s噴嘴資訊。請在進行校準之前對其進行配置。"
+
+msgid "AMS and nozzle information are synced"
+msgstr "AMS和噴嘴資訊已同步"
+
+msgid "Nozzle Flow"
+msgstr "噴嘴流量"
+
+msgid "Nozzle Info"
+msgstr "噴嘴資訊"
+
+msgid "Plate Type"
+msgstr "熱床型別"
+
+msgid "filament position"
+msgstr "耗材絲位置"
+
+msgid "Filament For Calibration"
+msgstr "校準用耗材"
+
+msgid ""
+"Tips for calibration material: \n"
+"- Materials that can share same hot bed temperature\n"
+"- Different filament brand and family(Brand = Bambu, Family = Basic, Matte)\n"
+msgstr ""
+"校準材料提示：\n"
+"- 可共享相同熱床溫度的材料\n"
+"- 不同耗材品牌和系列（品牌 = Bambu，系列 = Basic，啞光）\n"
+
+msgid "- Note: The hotend's number is tied to the holder. When the hotend is moved to a new holder, its number will update automatically.\n"
+msgstr "- 注意：熱端編號與刀架繫結。當熱端移動到新到架時，其編號將自動更新。\n"
+
+msgid ""
+"Tips for calibration material: \n"
+"- Materials that can share same hot bed temperature\n"
+"- Different filament brand and family(Brand = Bambu, Family = Basic, Matte)"
+msgstr ""
+"校準材料提示：\n"
+"-可以共享相同熱床溫度的材料\n"
+"-不同的耗材品牌和系列（Brand = Bambu, Family = Basic, Matte）"
+
+msgid "Pattern"
+msgstr "圖案"
+
+msgid "Method"
+msgstr "模式"
+
+#, c-format, boost-format
+msgid ""
+"Tip: Using a %.1fmm nozzle for auto dynamic flow calibration may have a high probability of failure.\n"
+"If it fails, it is recommended to use manual calibration."
+msgstr "提示：使用%.1fmm噴嘴進行自動流量校準可能會有較高的失敗機率，如果失敗，建議使用手動校準。"
+
+#, c-format, boost-format
+msgid ""
+"Tip: Using a %.1fmm nozzle for auto dynamic flow calibration may not get accurate calibration results.\n"
+"It is recommended to use manual calibration."
+msgstr "提示：使用%.1fmm噴嘴進行自動動態流量校準很可能無法獲得準確的校準結果，建議使用手動校準。"
+
+#, c-format, boost-format
+msgid "%s is not compatible with %s"
+msgstr "%s 與 %s 不相容"
+
+msgid "TPU is not supported for Flow Dynamics Auto-Calibration."
+msgstr "不支援TPU進行動態流量自動校準。"
+
+msgid "Can not print multiple filaments which have large difference of temperature together. Otherwise, the extruder and nozzle may be blocked or damaged during printing"
+msgstr "不能將溫度差異過大的材料一起列印。否則擠出機和噴嘴在列印中可能被堵塞或損壞"
+
+#, c-format, boost-format
+msgid ""
+"Tip: Calibrating foam filaments(%s) in X series printers may not get accurate results\n"
+"because their dynamic response is much different from that of ordinary filaments, and there is a high risk of oozing when printing calibration lines."
+msgstr ""
+"提示：X系列裝置校準發泡材料（%s）可能無法得到一個準確的校準值，\n"
+"因為它的動態響應和普通材料差距較大，且在列印校準線的時候有較大的漏料風險。"
+
+#, c-format, boost-format
+msgid ""
+"Tip: When using the A1/A1 mini printer, we do not recommend calibrating foam filaments(%s),\n"
+"as the results may be unstable and affect print quality."
+msgstr ""
+"提示：在使用A1/A1 mini機器時，不建議對發泡類材料（%s）進行校準，\n"
+"以免因效果不佳（校準結果不穩定）而影響列印質量。"
+
+msgid "Sync AMS and nozzle information"
+msgstr "同步AMS和噴嘴資訊"
+
+msgid "Connecting to printer"
+msgstr "正在連線印表機"
+
+msgid "Calibration only supports cases where the left and right nozzle diameters are identical."
+msgstr "只支援左右噴嘴直徑相同的情況下發起校準。"
+
+msgid "From k Value"
+msgstr "起始k值"
+
+msgid "To k Value"
+msgstr "結束k值"
+
+msgid "Value step"
+msgstr "值步長"
+
+msgid "The nozzle diameter has been synchronized from the printer Settings"
+msgstr "噴嘴直徑已從印表機設定同步"
+
+msgid "From Volumetric Speed"
+msgstr "從體積速度"
+
+msgid "To Volumetric Speed"
+msgstr "至體積速度"
+
+msgid "Are you sure to stop printing?"
+msgstr "您確定要停止列印嗎？"
+
+msgid "0min"
+msgstr "0分"
+
+msgid "Flow Dynamics Calibration Result"
+msgstr "動態流量校準結果"
+
+msgid "New"
+msgstr "新建"
+
+msgid "No History Result"
+msgstr "無歷史結果"
+
+msgid "Success to get history result"
+msgstr "成功獲取歷史結果"
+
+msgid "Refreshing the historical Flow Dynamics Calibration records"
+msgstr "重新整理歷史動態流量校準記錄"
+
+msgid "Action"
+msgstr "操作"
+
+#, c-format, boost-format
+msgid "This machine type can only hold %d history results per nozzle."
+msgstr "該機型每個噴嘴最多隻能儲存%d個歷史結果"
+
+msgid "Edit Flow Dynamics Calibration"
+msgstr "編輯動態流量校準"
+
+#, c-format, boost-format
+msgid "Within the same extruder, the name '%s' must be unique when the filament type, nozzle diameter, and nozzle flow are identical. Please choose a different name."
+msgstr ""
+"在同一個擠出機內，當耗材型別、噴嘴直徑和噴嘴流量相同時，名稱 ‘%s’ 必須是唯一的。\n"
+"請使用不同的名稱。"
+
+msgid "New Flow Dynamic Calibration"
+msgstr "新建動態流量校準"
+
+msgid "Ok"
+msgstr "確認"
+
+msgid "The filament must be selected."
+msgstr "請選擇材料"
+
+msgid "The extruder must be selected."
+msgstr "必須選擇擠出機。"
+
+msgid "The nozzle must be selected."
+msgstr "必須選擇噴嘴。"
+
+msgid "PA Calibration"
+msgstr "PA標定"
+
+msgid "PA Tower"
+msgstr "PA塔"
+
+msgid "PA Line"
+msgstr "PA線"
+
+msgid "PA Pattern"
+msgstr "PA圖案"
+
+msgid "Start PA: "
+msgstr "起始PA值"
+
+msgid "End PA: "
+msgstr "結束PA值"
+
+msgid "PA step: "
+msgstr "PA值步長"
+
+msgid "Print numbers"
+msgstr "列印數字"
+
+msgid "Temperature calibration"
+msgstr "溫度標定"
+
+msgid "Filament type"
+msgstr "材料型別"
+
+msgid "Start temp: "
+msgstr "起始溫度值"
+
+msgid "End temp: "
+msgstr "結束溫度值"
+
+msgid "Temp step: "
+msgstr "溫度值步長"
+
+msgid "Supported range: 180°C - 350°C"
+msgstr "支援的範圍：180°C - 350°C"
+
+msgid ""
+"Please input valid values:\n"
+"Start temp: <= 350\n"
+"End temp: >= 180\n"
+"Start temp >= End temp + 5)"
+msgstr ""
+"請輸入有效值:\n"
+"起始溫度: <= 350\n"
+"結束溫度: >= 180\n"
+"起始溫度 >= 結束溫度 + 5"
+
+msgid "Max volumetric speed test"
+msgstr "最大體積流量速度測試"
+
+msgid "Start volumetric speed: "
+msgstr "起始流量速度"
+
+msgid "End volumetric speed: "
+msgstr "結束流量速度"
+
+msgid "step: "
+msgstr "值步長"
+
+msgid ""
+"Please input valid values:\n"
+"start > 0 step >= 0\n"
+"end >= start + step)"
+msgstr ""
+"請輸入有效值:\n"
+"起始值 > 0\n"
+"步長值>=0\n"
+"結束值 >= 起始值 + 步長值"
+
+msgid "VFA test"
+msgstr "VFA測試"
+
+msgid "Start speed: "
+msgstr "起始速度"
+
+msgid "End speed: "
+msgstr "結束速度"
+
+msgid ""
+"Please input valid values:\n"
+"start > 10 step >= 0\n"
+"end >= start + step)"
+msgstr ""
+"請輸入有效值:\n"
+"起始值 > 10\n"
+"步長值>=0\n"
+"結束值 >= 起始值 + 步長值"
+
+msgid "Start retraction length: "
+msgstr "起始回抽長度"
+
+msgid "End retraction length: "
+msgstr "結束回抽長度"
+
+msgid "Network lookup"
+msgstr "網路尋找"
+
+msgid "Address"
+msgstr "地址"
+
+msgid "Hostname"
+msgstr "主機名"
+
+msgid "Service name"
+msgstr "服務名"
+
+msgid "OctoPrint version"
+msgstr "OctoPrint版本"
+
+msgid "Searching for devices"
+msgstr "正在搜尋裝置"
+
+msgid "Send to print"
+msgstr "傳送列印"
+
+msgid "Upload to Printer Host with the following filename:"
+msgstr "使用以下檔名上傳到印表機主機："
+
+msgid "Use forward slashes ( / ) as a directory separator if needed."
+msgstr "如有需要，請使用正斜槓（/）作為目錄分隔符。"
+
+#, c-format, boost-format
+msgid "Upload filename doesn't end with \"%s\". Do you wish to continue?"
+msgstr "上傳的檔名不以 \"%s\" 結尾。您是否希望繼續？"
+
+msgid "Upload"
+msgstr "上傳"
+
+msgid "Simulate"
+msgstr "模擬"
+
+msgid "Print host upload queue"
+msgstr "列印主機上傳佇列"
+
+msgid "Progress"
+msgstr "進度"
+
+msgid "Host"
+msgstr "主機"
+
+msgctxt "OfFile"
+msgid "Size"
+msgstr "大小"
+
+msgid "Filename"
+msgstr "檔名"
+
+msgid "Error Message"
+msgstr "錯誤資訊"
+
+msgid "Cancel selected"
+msgstr "取消選中"
+
+msgid "Show error message"
+msgstr "顯示錯誤資訊"
+
+msgid "Enqueued"
+msgstr "已加入佇列"
+
+msgid "Uploading"
+msgstr "正在上傳"
+
+msgid "Cancelling"
+msgstr "取消中"
+
+msgid "Error uploading to print host:"
+msgstr "上傳到列印主機時出錯："
+
+msgid "Unable to perform boolean operation on selected parts."
+msgstr "無法對所選零件執行布林運算。"
+
+msgid "Operation Canceled."
+msgstr "操作已取消。"
+
+msgid "Operation Failed."
+msgstr "操作失敗。"
+
+msgid "Union operation requires at least two volumes."
+msgstr "並集操作需要至少兩個零件。"
+
+msgid "Intersection operation requires at least two volumes."
+msgstr "交集至少需要兩個零件。"
+
+msgid "Difference operation requires at least one volume in both A and B lists."
+msgstr "差集操作需要 A 和 B 列表中至少各有一個零件。"
+
+msgid "Union operation requires at least two objects."
+msgstr "並集操作需要至少兩個物件。"
+
+msgid "Intersection operation requires at least two objects."
+msgstr "交集操作需要至少兩個物件。"
+
+msgid "Difference operation requires at least one object in both A and B lists."
+msgstr "差集操作需要 A 和 B 列表中至少各有一個物件。"
+
+msgid "Failed to group parts by object. Please check for self-intersections, non-manifold geometry, or open meshes."
+msgstr "無法按物件分組零件。請檢查是否存在自相交、非流形幾何體或開放網格。"
+
+msgid "No overlapping region found. Boolean intersection failed."
+msgstr "未找到重疊區域，交集失敗。請確認列表中所有元素存在重疊。"
+
+msgid "Mesh preparation failed."
+msgstr "網格準備失敗。"
+
+msgid "Mesh Boolean"
+msgstr "布林運算"
+
+msgid "- Object mode: Please select at least two objects."
+msgstr "- 物件模式：請至少選擇兩個物件。"
+
+msgid "- Part mode: Please select one object with at least two meshes."
+msgstr "- 零件模式：請選擇一個包含至少兩個零件的物件。"
+
+msgid "Union"
+msgstr "並集"
+
+msgid "Difference"
+msgstr "差集"
+
+msgid "Intersection"
+msgstr "交集"
+
+msgid "Selected Objects"
+msgstr "已選擇的物件"
+
+msgid "Selected Parts"
+msgstr "已選擇的零件"
+
+msgid "Keep original models"
+msgstr "保留原模型"
+
+msgid "Execute"
+msgstr "執行"
+
+msgid "Entity Only"
+msgstr "僅實體"
+
+msgid "Perform Boolean operations on entities only."
+msgstr "僅對實體執行布林運算。"
+
+msgid "This object contains non-part components."
+msgstr "該物件包含非實體零件。"
+
+msgid "Preparing data..."
+msgstr "正在準備資料…"
+
+msgid "Computing..."
+msgstr "正在執行網格布林運算…"
+
+msgid "Applying result.."
+msgstr "正在應用結果…"
+
+msgid "Network Test"
+msgstr "網路測試"
+
+msgid "Start Test Multi-Thread"
+msgstr "多執行緒開始測試"
+
+msgid "Start Test Single-Thread"
+msgstr "單執行緒開始測試"
+
+msgid "Export Log"
+msgstr "輸出日誌"
+
+msgid "Studio Version:"
+msgstr "Studio 版本："
+
+msgid "System Version:"
+msgstr "系統版本："
+
+msgid "DNS Server:"
+msgstr "DNS服務："
+
+msgid "Test BambuLab"
+msgstr "測試 BambuLab"
+
+msgid "Test BambuLab:"
+msgstr "測試 BambuLab："
+
+msgid "Test Bing.com"
+msgstr "測試 Bing.com"
+
+msgid "Test bing.com:"
+msgstr "測試 Bing.com："
+
+msgid "Test HTTP"
+msgstr "測試 HTTP"
+
+msgid "Test HTTP Service:"
+msgstr "測試 HTTP 服務："
+
+msgid "Test storage"
+msgstr "測試儲存"
+
+msgid "Test Storage Upload:"
+msgstr "測試儲存上傳："
+
+msgid "Test storage upgrade"
+msgstr "測試儲存升級"
+
+msgid "Test Storage Upgrade:"
+msgstr "測試儲存升級："
+
+msgid "Test storage download"
+msgstr "測試儲存下載"
+
+msgid "Test Storage Download:"
+msgstr "測試儲存下載："
+
+msgid "Test plugin download"
+msgstr "測試外掛下載"
+
+msgid "Test Plugin Download:"
+msgstr "測試外掛下載:"
+
+msgid "Test Storage Upload"
+msgstr "測試儲存上傳"
+
+msgid "Log Info"
+msgstr "日誌資訊"
+
+msgid "Select filament preset"
+msgstr "選擇材料預設"
+
+msgid "Create Filament"
+msgstr "建立材料"
+
+msgid "Create Based on Current Filament"
+msgstr "基於當前材料建立"
+
+msgid "Copy Current Filament Preset "
+msgstr "複製當前材料預設"
+
+msgid "Basic Information"
+msgstr "基本資訊"
+
+msgid "Add Filament Preset under this filament"
+msgstr "新增該材料的材料預設"
+
+msgid "We could create the filament presets for your following printer:"
+msgstr "我們可以為您的以下印表機建立材料預設："
+
+msgid "Select Vendor"
+msgstr "選擇供應商"
+
+msgid "Input Custom Vendor"
+msgstr "輸入自定義供應商"
+
+msgid "Can't find vendor I want"
+msgstr "找不到我想要的供應商"
+
+msgid "Select Type"
+msgstr "選擇型別"
+
+msgid "Select Filament Preset"
+msgstr "選擇材料預設"
+
+msgid "Serial"
+msgstr "系列"
+
+msgid "e.g. Basic, Matte, Silk, Marble"
+msgstr "例如：Basic, Matte, Silk, Marble"
+
+msgid "Filament Preset"
+msgstr "材料預設"
+
+msgid "Create"
+msgstr "建立"
+
+msgid "Vendor is not selected, please reselect vendor."
+msgstr "未選擇供應商，請重新選擇供應商。"
+
+msgid "Custom vendor is not input, please input custom vendor."
+msgstr "未輸入自定義供應商，請輸入自定義供應商。"
+
+msgid "\"Bambu\" or \"Generic\" can not be used as a Vendor for custom filaments."
+msgstr "“Bambu”或者“Generic”不能用於自定義材料的廠商"
+
+msgid "Filament type is not selected, please reselect type."
+msgstr "未選擇材料型別，請重新選擇。"
+
+msgid "Filament serial is not inputed, please input serial."
+msgstr "未輸入材料系列，請輸入材料系列。"
+
+msgid "There may be escape characters in the vendor or serial input of filament. Please delete and re-enter."
+msgstr "材料的供應商或系列輸入中可能包含跳脫字元。請刪除並重新輸入。"
+
+msgid "All inputs in the custom vendor or serial are spaces. Please re-enter."
+msgstr "自定義供應商或系列中的所有輸入都是空格。請重新輸入。"
+
+msgid "The vendor can not be a number. Please re-enter."
+msgstr "自定義供應商不能是數字。請重新輸入。"
+
+msgid "You have not selected a printer or preset yet. Please select at least one."
+msgstr "您還沒有選擇印表機或預設。請至少選擇一個。"
+
+#, c-format, boost-format
+msgid ""
+"The Filament name %s you created already exists. \n"
+"If you continue creating, the preset created will be displayed with its full name. Do you want to continue?"
+msgstr ""
+"您建立的耗材絲名字%s已經存在。\n"
+"如果您繼續建立，您建立的預設將以全名顯示。您想繼續嗎？"
+
+msgid "Some existing presets have failed to be created, as follows:\n"
+msgstr "以下一些現有預設未能成功建立：\n"
+
+msgid ""
+"\n"
+"Do you want to rewrite it?"
+msgstr ""
+"\n"
+"您想重寫預設嗎"
+
+msgid ""
+"We would rename the presets as \"Vendor Type Serial @printer you selected\". \n"
+"To add preset for more prinetrs, Please go to printer selection"
+msgstr ""
+"我們會將預設重新命名為“供應商 型別 系列 @您選擇的印表機”。\n"
+"要為更多的印表機新增預設，請前往印表機選擇。"
+
+msgid "Create Printer/Nozzle"
+msgstr "建立印表機/噴嘴"
+
+msgid "Create Printer"
+msgstr "建立印表機"
+
+msgid "Create Nozzle for Existing Printer"
+msgstr "為現有印表機建立噴嘴"
+
+msgid "Create from Template"
+msgstr "基於模板建立"
+
+msgid "Create Based on Current Printer"
+msgstr "基於當前印表機建立"
+
+msgid "wiki"
+msgstr ""
+
+msgid "Import Preset"
+msgstr "匯入預設"
+
+msgid "Create Type"
+msgstr "建立型別"
+
+msgid "The model is not fond, place reselect vendor."
+msgstr "該模型未找到，請重新選擇供應商。"
+
+msgid "Select Printer"
+msgstr "選擇印表機"
+
+msgid "Select Model"
+msgstr "選擇型號"
+
+msgid "Input Custom Model"
+msgstr "輸入自定義型號"
+
+msgid "Can't find my printer model"
+msgstr "無法找到我的印表機型號"
+
+msgid "Input Custom Nozzle Diameter"
+msgstr "請輸入自定義噴嘴直徑"
+
+msgid "Can't find my nozzle diameter"
+msgstr "無法找到我的噴嘴直徑"
+
+msgid "Rectangle"
+msgstr "矩形"
+
+msgid "Printable Space"
+msgstr "可列印形狀"
+
+msgid "Hot Bed STL"
+msgstr "熱床STL模型"
+
+msgid "Load stl"
+msgstr "載入stl"
+
+msgid "Hot Bed SVG"
+msgstr "熱床SVG圖片"
+
+msgid "Load svg"
+msgstr "載入svg"
+
+msgid "Max Print Height"
+msgstr "最大列印高度"
+
+msgid "Preset path is not found, please reselect vendor."
+msgstr "預設路徑未找到，請重新選擇供應商。"
+
+msgid "The printer model was not found, please reselect."
+msgstr "未找到印表機型號，請重新選擇。"
+
+msgid "The nozzle diameter is not fond, place reselect."
+msgstr "未找到噴嘴直徑，請重新選擇。"
+
+msgid "The printer preset is not fond, place reselect."
+msgstr "印表機預設未找到，請重新選擇。"
+
+msgid "Printer Preset"
+msgstr "印表機預設"
+
+msgid "Filament Preset Template"
+msgstr "材料預設模板"
+
+msgid "Deselect All"
+msgstr "全部取消選中"
+
+msgid "Process Preset Template"
+msgstr "工藝預設模板"
+
+msgid "Back Page 1"
+msgstr "返回第一頁"
+
+msgid "You have not yet chosen which printer preset to create based on. Please choose the vendor and model of the printer"
+msgstr "您尚未選擇要基於哪個印表機預設來建立。請先選擇印表機的供應商和型號。"
+
+msgid "You have entered an illegal input in the printable area section on the first page. Please check before creating it."
+msgstr "您在第一頁的可列印區域部分輸入了非法輸入。請檢查後再建立。"
+
+msgid ""
+"The printer preset you created already has a preset with the same name. Do you want to overwrite it?\n"
+"\tYes: Overwrite the printer preset with the same name, and filament and process presets with the same preset name will be recreated \n"
+"and filament and process presets without the same preset name will be reserve.\n"
+"\tCancel: Do not create a preset, return to the creation interface."
+msgstr ""
+"\"您建立的印表機預設已經有一個同名的預設。您想要覆蓋它嗎？\n"
+"- 是：覆蓋同名的印表機預設，具有相同預設名稱的材料和工藝預設將被重新建立，沒有相同預設名稱的材料和工藝預設將被保留。\n"
+"- 取消：不建立預設，返回到建立介面。\""
+
+msgid "You need to select at least one filament preset."
+msgstr "您需要至少選擇一個材料預設。"
+
+msgid "You need to select at least one process preset."
+msgstr "您需要至少選擇一個工藝預設。"
+
+msgid "Create filament presets failed. As follows:\n"
+msgstr "建立材料預設失敗。如下：\n"
+
+msgid "Create process presets failed. As follows:\n"
+msgstr "建立工藝預設失敗。如下：\n"
+
+msgid "Vendor is not found, please reselect."
+msgstr "供應商未找到，請重新選擇。"
+
+msgid "Current vendor has no models, please reselect."
+msgstr "當前的供應商沒有模型，請重新選擇。"
+
+msgid "You have not selected the vendor and model or inputed the custom vendor and model."
+msgstr "您還沒有選擇供應商和模型，或者沒有輸入自定義供應商和模型。"
+
+msgid "There may be escape characters in the custom printer vendor or model. Please delete and re-enter."
+msgstr "自定義印表機供應商或型號中可能有跳脫字元。請刪除並重新輸入。"
+
+msgid "All inputs in the custom printer vendor or model are spaces. Please re-enter."
+msgstr "自定義印表機供應商或型號的所有輸入都是空格。請重新輸入。"
+
+msgid "Please check bed printable shape and origin input."
+msgstr "請檢查可列印區域和原點的輸入。"
+
+msgid "You have not yet selected the printer to replace the nozzle, please choose."
+msgstr "您尚未選擇要更換噴嘴的印表機，請進行選擇。"
+
+msgid "The entered nozzle diameter is invalid, please re-enter:\n"
+msgstr "輸入的噴嘴直徑無效，請重新輸入：\n"
+
+msgid ""
+"The system preset does not allow creation. \n"
+"Please re-enter the printer model or nozzle diameter."
+msgstr "不允許建立和系統預設重名的印表機。請重新輸入印表機型號或噴嘴直徑。"
+
+msgid "Create Printer Successful"
+msgstr "建立印表機成功"
+
+msgid "Create Filament Successful"
+msgstr "建立材料成功"
+
+msgid "Printer Created"
+msgstr "印表機已建立"
+
+msgid "Please go to printer settings to edit your presets"
+msgstr "請去印表機設定編輯您的預設"
+
+msgid "Filament Created"
+msgstr "材料已建立"
+
+msgid ""
+"Please go to filament setting to edit your presets if you need.\n"
+"Please note that nozzle temperature, hot bed temperature, and maximum volumetric speed has a significant impact on printing quality. Please set them carefully."
+msgstr ""
+"如果需要，請轉到耗材絲設定以編輯您的預設。\n"
+"請注意噴嘴溫度、熱床溫度和最大體積流量對列印質量有重大影響。請小心設定它們。"
+
+msgid ""
+"Studio has detected that your user presets synchronization function is not enabled, which may result in unsuccessful Filament settings on the Device page. \n"
+"Click \"Sync user presets\" to enable the synchronization function."
+msgstr ""
+"Studio 檢測到您的使用者預設同步功能未啟用，這可能導致在裝置頁面上設定耗材時不成功。 \n"
+" 點選“同步使用者預設”以啟用同步功能。"
+
+msgid "Printer Setting"
+msgstr "印表機設定"
+
+msgid "Printer preset bundle(.bbscfg)"
+msgstr "印表機預設包（.bbscfg）"
+
+msgid "Filament preset bundle(.bbsflmt)"
+msgstr "材料預設包（.bbsflmt）"
+
+msgid "Printer presets(.zip)"
+msgstr "印表機預設(.zip)"
+
+msgid "Filament presets(.zip)"
+msgstr "材料預設(.zip)"
+
+msgid "Process presets(.zip)"
+msgstr "工藝預設(.zip)"
+
+msgid "initialize fail"
+msgstr "初始化失敗"
+
+msgid "add file fail"
+msgstr "新增檔案失敗"
+
+msgid "add bundle structure file fail"
+msgstr "新增預設集結構檔案失敗"
+
+msgid "finalize fail"
+msgstr "寫入失敗"
+
+msgid "open zip written fail"
+msgstr "開啟zip寫入失敗"
+
+msgid "Export successful"
+msgstr "匯出成功"
+
+#, c-format, boost-format
+msgid ""
+"The '%s' folder already exists in the current directory. Do you want to clear it and rebuild it.\n"
+"If not, a time suffix will be added, and you can modify the name after creation."
+msgstr ""
+"當前目錄中已存在名為 '%s' 的資料夾。您要清除它並重新構建嗎？\n"
+"如果不清除，將會在資料夾名後新增時間字尾，您可以在建立後進行修改。"
+
+msgid ""
+"Printer and all the filament&process presets that belong to the printer. \n"
+"Can be shared with others."
+msgstr ""
+"印表機和屬於印表機的所有的材料和工藝預設。\n"
+"能與他人分享。"
+
+msgid ""
+"User's fillment preset set. \n"
+"Can be shared with others."
+msgstr ""
+"使用者材料預設集。\n"
+"能與他人分享。"
+
+msgid "Only display printer names with changes to printer, filament, and process presets."
+msgstr "僅顯示發生了更改的印表機、材料和工藝預設的印表機名稱。"
+
+msgid "Only display the filament names with changes to filament presets."
+msgstr "僅顯示發生了更改的材料預設的材料名稱。"
+
+msgid "Only printer names with user printer presets will be displayed, and each preset you choose will be exported as a zip."
+msgstr "只顯示帶有使用者印表機預設的印表機名稱，並且您選擇的每個預設都將匯出為一個ZIP檔案。"
+
+msgid ""
+"Only the filament names with user filament presets will be displayed, \n"
+"and all user filament presets in each filament name you select will be exported as a zip."
+msgstr "只顯示帶有使用者材料預設的材料名稱，您選擇的每個材料名稱中的所有使用者材料預設都將匯出為一個ZIP檔案。"
+
+msgid ""
+"Only printer names with changed process presets will be displayed, \n"
+"and all user process presets in each printer name you select will be exported as a zip."
+msgstr "只顯示帶有更改的工藝預設的印表機名稱，您選擇的每個印表機名稱中的所有使用者工藝預設都將匯出為一個ZIP檔案。"
+
+msgid "Please select at least one printer or filament."
+msgstr "請至少選擇一種印表機或耗材絲。"
+
+msgid "Please select a type you want to export"
+msgstr "請選擇一個您想匯出的型別"
+
+msgid "Failed to create temporary folder, please try Export Configs again."
+msgstr "無法建立臨時資料夾，請再次嘗試匯出配置。"
+
+msgid "Edit Filament"
+msgstr "編輯材料"
+
+msgid "Filament presets under this filament"
+msgstr "此材料下的所有材料預設"
+
+msgid "Note: If the only preset under this filament is deleted, the filament will be deleted after exiting the dialog."
+msgstr "注意：如果在該材料下僅有的預設被刪除，那麼在退出對話方塊後該材料將被刪除。"
+
+msgid "Presets inherited by other presets can not be deleted"
+msgstr "被其他預設繼承的預設不能被刪除。"
+
+msgid "The following presets inherits this preset."
+msgid_plural "The following preset inherits this preset."
+msgstr[0] "以下預設繼承此預設。"
+
+msgid "Delete Preset"
+msgstr "刪除預設"
+
+msgid "Are you sure to delete the selected preset?"
+msgstr "您確定要刪除所選預設？"
+
+msgid "Delete preset"
+msgstr "刪除預設"
+
+msgid "+ Add Preset"
+msgstr "+ 新增預設"
+
+msgid "Delete Filament"
+msgstr "刪除材料"
+
+msgid ""
+"All the filament presets belong to this filament would be deleted. \n"
+"If you are using this filament on your printer, please reset the filament information for that slot."
+msgstr ""
+"刪除材料之後，附屬的材料預設也會被一併刪除。\n"
+"如果該材料正在您的印表機上使用，請重新設定該槽位的材料資訊。"
+
+msgid "Delete filament"
+msgstr "刪除材料"
+
+msgid "Add Preset"
+msgstr "新增預設"
+
+msgid "Add preset for new printer"
+msgstr "為新印表機新增預設"
+
+msgid "Copy preset from filament"
+msgstr "從材料中複製預設"
+
+msgid "The filament choice not find filament preset, please reselect it"
+msgstr "您選擇的材料未找到材料預設，請重新選擇。"
+
+msgid "[Delete Required]"
+msgstr "[刪除請求]"
+
+msgid "Edit Preset"
+msgstr "編輯預設"
+
+msgid "For more information, please check out Wiki"
+msgstr "瞭解更多資訊，請參閱Wiki"
+
+msgid "Collapse"
+msgstr "收起"
+
+msgid "Daily Tips"
+msgstr "每日貼士"
+
+msgid ""
+"The printer nozzle information has not been set.\n"
+"Please configure it before proceeding with the calibration."
+msgstr "尚未設定印表機噴嘴資訊。請在進行校準之前對其進行配置。"
+
+msgid ""
+"The nozzle type does not match the actual printer nozzle type.\n"
+"Please click the Sync button above and restart the calibration."
+msgstr "噴嘴型別與印表機實際噴嘴型別不匹配， 請點選上方的同步按鈕，然後重新校準。"
+
+#, c-format, boost-format
+msgid ""
+"Please input valid values:\n"
+"Start value: >= %.1f\n"
+"End value: <= %.1f\n"
+"End value: > Start value\n"
+"Value step: >= %.3f)"
+msgstr ""
+"請輸入有效值:\n"
+"起始值: >= %.1f\n"
+"結束值: <= %.1f\n"
+"結束值: > 起始值\n"
+"值步長: >= %.3f"
+
+#, c-format, boost-format
+msgid "nozzle size in preset: %d"
+msgstr "預設噴嘴尺寸：%d"
+
+#, c-format, boost-format
+msgid "nozzle size memorized: %d"
+msgstr "儲存的噴嘴尺寸：%d"
+
+msgid "The size of nozzle type in preset is not consistent with memorized nozzle.Did you change your nozzle lately ? "
+msgstr "預設的噴嘴型別尺寸與記憶中的噴嘴不一致。您最近換噴嘴了嗎？"
+
+#, c-format, boost-format
+msgid "nozzle[%d] in preset: %.1f"
+msgstr "預設中的噴嘴[%d]：%.1f"
+
+#, c-format, boost-format
+msgid "nozzle[%d] memorized: %.1f"
+msgstr "儲存的噴嘴[%d]：%.1f"
+
+msgid "Your nozzle type in preset is not consistent with memorized nozzle.Did you change your nozzle lately ? "
+msgstr "預設中的噴嘴型別與記憶中的噴嘴型別不一致。您最近更換了噴嘴嗎？"
+
+#, c-format, boost-format
+msgid "Printing %1s material with %2s nozzle may cause nozzle damage."
+msgstr "%1s材料在使用%2s的噴嘴列印時,可能會導致噴嘴損壞。"
+
+msgid "Need select printer"
+msgstr "需要選擇印表機"
+
+msgid "The start, end or step is not valid value."
+msgstr "起始、結束或者步長輸入值無效。"
+
+msgid "The number of printer extruders and the printer selected for calibration does not match."
+msgstr ""
+
+#, c-format, boost-format
+msgid "The nozzle diameter of %sextruder is 0.2mm which does not support automatic Flow Dynamics calibration."
+msgstr "%s 擠出機的噴嘴直徑為0.2毫米，不支援自動流量校準。"
+
+#, c-format, boost-format
+msgid ""
+"The currently selected nozzle diameter of %s extruder does not match the actual nozzle diameter.\n"
+"Please click the Sync button above and restart the calibration."
+msgstr "當前選擇的%s噴嘴直徑與機器實際直徑不匹配， 請點選上方的同步按鈕，然後重新校準。"
+
+msgid ""
+"The nozzle diameter does not match the actual printer nozzle diameter.\n"
+"Please click the Sync button above and restart the calibration."
+msgstr "噴嘴直徑與機器實際直徑不匹配， 請點選上方的同步按鈕，然後重新校準。"
+
+#, c-format, boost-format
+msgid ""
+"The currently selected nozzle type of %s extruder does not match the actual printer nozzle type.\n"
+"Please click the Sync button above and restart the calibration."
+msgstr "當前選擇的%s噴嘴型別與機器實際噴嘴型別不匹配，請點選上方的同步按鈕，然後重新校準。"
+
+msgid "Flow calibration does not support multiple nozzle diameters at the same time. Please ensure that the nozzle diameter used by the filament being calibrated is consistent before starting the calibration again."
+msgstr "暫不支援同時對不同噴嘴直徑進行流量校準。請確保被校準耗材所對應的噴嘴直徑一致，再重新發起校準。"
+
+msgid "Unable to calibrate: maybe because the set calibration value range is too large, or the step is too small"
+msgstr "無法標定：可能是標定值範圍過大，或者是補償過小"
+
+msgid "Physical Printer"
+msgstr "物理印表機"
+
+msgid "Print Host upload"
+msgstr "列印主機上傳"
+
+msgid "Test"
+msgstr "測試"
+
+msgid "Could not get a valid Printer Host reference"
+msgstr "無法獲取有效的印表機主機引用"
+
+msgid "Success!"
+msgstr "成功！"
+
+msgid "Refresh Printers"
+msgstr "重新整理印表機"
+
+msgid "HTTPS CA file is optional. It is only needed if you use HTTPS with a self-signed certificate."
+msgstr "HTTPS CA檔案是可選的。只有在使用自簽名證書進行HTTPS連線時才需要。"
+
+msgid "Certificate files (*.crt, *.pem)|*.crt;*.pem|All files|*.*"
+msgstr ""
+
+msgid "Open CA certificate file"
+msgstr "開啟CA證書檔案"
+
+#, c-format, boost-format
+msgid "On this system, %s uses HTTPS certificates from the system Certificate Store or Keychain."
+msgstr "在此係統上，%s 使用來自系統證書儲存或金鑰鏈的HTTPS證書。"
+
+msgid "To use a custom CA file, please import your CA file into Certificate Store / Keychain."
+msgstr "要使用自定義 CA 檔案，請將您的 CA 檔案匯入到證書儲存 / 金鑰鏈中。"
+
+msgid "Connection to printers connected via the print host failed."
+msgstr "連線到透過列印主機連線的印表機失敗。"
+
+#, c-format, boost-format
+msgid "Mismatched type of print host: %s"
+msgstr "列印主機的型別不匹配：%s"
+
+msgid "Connection to AstroBox works correctly."
+msgstr "與 AstroBox 的連線正常。"
+
+msgid "Could not connect to AstroBox"
+msgstr "無法連線到 AstroBox。"
+
+msgid "Note: AstroBox version at least 1.1.0 is required."
+msgstr "請注意，需要至少 AstroBox 版本 1.1.0。"
+
+msgid "Connection to Duet works correctly."
+msgstr "成功連線到 Duet 控制器。"
+
+msgid "Could not connect to Duet"
+msgstr "無法連線到 Duet 控制器。"
+
+msgid "Unknown error occured"
+msgstr "發生了未知錯誤。"
+
+msgid "Wrong password"
+msgstr "密碼錯誤。"
+
+msgid "Could not get resources to create a new connection"
+msgstr "無法獲取資源以建立新連線。"
+
+msgid "Upload not enabled on FlashAir card."
+msgstr "FlashAir卡未啟用上傳。"
+
+msgid "Connection to FlashAir works correctly and upload is enabled."
+msgstr "FlashAir連線正常，並啟用了上傳。"
+
+msgid "Could not connect to FlashAir"
+msgstr "FlashAir 連線失敗。"
+
+msgid "Note: FlashAir with firmware 2.00.02 or newer and activated upload function is required."
+msgstr "需要 FlashAir 韌體版本為 2.00.02 或更高，並啟用上傳功能。"
+
+msgid "Connection to MKS works correctly."
+msgstr "MKS的連線正常。"
+
+msgid "Could not connect to MKS"
+msgstr "無法連線到MKS。"
+
+msgid "Connection to OctoPrint works correctly."
+msgstr "成功連線到 OctoPrint。"
+
+msgid "Could not connect to OctoPrint"
+msgstr "無法連線到OctoPrint"
+
+msgid "Note: OctoPrint version at least 1.1.0 is required."
+msgstr "注意：至少需要 OctoPrint 版本 1.1.0。"
+
+msgid "Connection to Prusa SL1 / SL1S works correctly."
+msgstr "與 Prusa SL1 / SL1S 的連線正常。"
+
+msgid "Could not connect to Prusa SLA"
+msgstr "無法連線到 Prusa SLA。"
+
+msgid "Connection to PrusaLink works correctly."
+msgstr "連線到 PrusaLink 的連線正常。"
+
+msgid "Could not connect to PrusaLink"
+msgstr "無法連線到 PrusaLink。"
+
+msgid "Connection to Repetier works correctly."
+msgstr "與 Repetier 的連線正常。"
+
+msgid "Could not connect to Repetier"
+msgstr "無法連線到Repetier"
+
+msgid "Note: Repetier version at least 0.90.0 is required."
+msgstr "注意：需要 Repetier 版本至少為 0.90.0。"
+
+#, boost-format
+msgid ""
+"HTTP status: %1%\n"
+"Message body: \"%2%\""
+msgstr ""
+"HTTP狀態：%1%\n"
+"訊息體：\"%2%\""
+
+#, boost-format
+msgid ""
+"Parsing of host response failed.\n"
+"Message body: \"%1%\"\n"
+"Error: \"%2%\""
+msgstr ""
+"主機響應解析失敗。\n"
+"訊息體：\"%1%\"錯誤：\"%2%\""
+
+#, boost-format
+msgid ""
+"Enumeration of host printers failed.\n"
+"Message body: \"%1%\"\n"
+"Error: \"%2%\""
+msgstr ""
+"主機印表機的列舉失敗。\n"
+"訊息體：\"%1%\"\n"
+"錯誤：\"%2%\""
+
+msgid "It has a small layer height, and results in almost negligible layer lines and high printing quality. It is suitable for most general printing cases."
+msgstr "0.2 mm 噴嘴的預設引數，層高小，層紋不明顯，列印質量高，適合大部分常規列印場景。"
+
+msgid "Compared with the default profile of a 0.2 mm nozzle, it has lower speeds and acceleration, and the sparse infill pattern is Gyroid. So, it results in much higher printing quality, but a much longer printing time."
+msgstr "此為高質量引數，相比於此噴嘴的預設引數，列印速度、加速度較低，稀疏填充圖案為螺旋體，列印質量更高，但耗時更長。"
+
+msgid "Compared with the default profile of a 0.2 mm nozzle, it has a slightly bigger layer height, and results in almost negligible layer lines, and slightly shorter printing time."
+msgstr "相比於此噴嘴的預設引數，層高較大，層紋不明顯，列印耗時稍短。"
+
+msgid "Compared with the default profile of a 0.2 mm nozzle, it has a bigger layer height, and results in slightly visible layer lines, but shorter printing time."
+msgstr "相比於此噴嘴的預設引數，層高較大，層紋稍顯現，列印耗時較短。"
+
+msgid "Compared with the default profile of a 0.2 mm nozzle, it has a smaller layer height, and results in almost invisible layer lines and higher printing quality, but shorter printing time."
+msgstr "相比於此噴嘴的預設引數，層高較小，幾乎不顯層紋，列印質量較高，但列印耗時較長。"
+
+msgid "Compared with the default profile of a 0.2 mm nozzle, it has a smaller layer lines, lower speeds and acceleration, and the sparse infill pattern is Gyroid. So, it results in almost invisible layer lines and much higher printing quality, but much longer printing time."
+msgstr "此為高質量引數，相比於此噴嘴的預設引數，層高較小，列印速度、加速度較低，稀疏填充圖案為螺旋體，幾乎不顯層紋，列印質量非常高，但列印耗時很長。"
+
+msgid "Compared with the default profile of 0.2 mm nozzle, it has a smaller layer height, and results in minimal layer lines and higher printing quality, but shorter printing time."
+msgstr "相比於此噴嘴的預設引數，層高較小，幾乎不顯層紋，列印質量較高，但列印耗時較長。"
+
+msgid "Compared with the default profile of a 0.2 mm nozzle, it has a smaller layer lines, lower speeds and acceleration, and the sparse infill pattern is Gyroid. So, it results in minimal layer lines and much higher printing quality, but much longer printing time."
+msgstr "此為高質量引數，相比於此噴嘴的預設引數，層高較小，列印速度、加速度較低，稀疏填充圖案為螺旋體，幾乎不顯層紋，列印質量非常高，但列印耗時很長。"
+
+msgid "It has a general layer height, and results in general layer lines and printing quality. It is suitable for most general printing cases."
+msgstr "0.4 mm 噴嘴的預設引數，層高常規，層紋一般，列印質量常規，適合大部分常規列印場景。"
+
+msgid "Compared with the default profile of a 0.4 mm nozzle, it has more wall loops and a higher sparse infill density. So, it results in higher strength of the prints, but more filament consumption and longer printing time."
+msgstr "此為強度引數，相比於此噴嘴的預設引數，牆層數較大，稀疏填充密度較高，列印件的強度更高，但耗材用量更大，耗時更長。"
+
+msgid "Compared with the default profile of a 0.4 mm nozzle, it has a bigger layer height, and results in more apparent layer lines and lower printing quality, but slightly shorter printing time."
+msgstr "相比於此噴嘴的預設引數，層高較大，層紋較明顯，列印質量較低，部分模型的列印耗時稍短。"
+
+msgid "Compared with the default profile of a 0.4 mm nozzle, it has a bigger layer height, and results in more apparent layer lines and lower printing quality, but shorter printing time."
+msgstr "相比於此噴嘴的預設引數，層高較大，層紋較明顯，列印質量較低，部分模型的列印耗時較短。"
+
+msgid "Compared with the default profile of a 0.4 mm nozzle, it has a smaller layer height, and results in less apparent layer lines and higher printing quality, but longer printing time."
+msgstr "相比於此噴嘴的預設引數，層高較小，層紋較不明顯，列印質量較高，但列印耗時較長。"
+
+msgid "Compared with the default profile of a 0.4 mm nozzle, it has a smaller layer height, lower speeds and acceleration, and the sparse infill pattern is Gyroid. So, it results in less apparent layer lines and much higher printing quality, but much longer printing time."
+msgstr "此為高質量引數，相比於此噴嘴的預設引數，層高較小，列印速度、加速度較低，稀疏填充圖案為螺旋體，層紋較不明顯，列印質量較高，但列印耗時很長。"
+
+msgid "Compared with the default profile of a 0.4 mm nozzle, it has a smaller layer height, and results in almost negligible layer lines and higher printing quality, but longer printing time."
+msgstr "相比於此噴嘴的預設引數，層高較小，層紋更不明顯，列印質量較高，但列印耗時較長。"
+
+msgid "Compared with the default profile of a 0.4 mm nozzle, it has a smaller layer height, lower speeds and acceleration, and the sparse infill pattern is Gyroid. So, it results in almost negligible layer lines and much higher printing quality, but much longer printing time."
+msgstr "此為高質量引數，相比於此噴嘴的預設引數，層高較小，列印速度、加速度較低，稀疏填充圖案為螺旋體，層紋更不明顯，列印質量很高，但列印耗時很長。"
+
+msgid "Compared with the default profile of a 0.4 mm nozzle, it has a smaller layer height, and results in almost negligible layer lines and longer printing time."
+msgstr "相比於此噴嘴的預設引數，層高較小，層紋更不明顯，列印質量較高，但列印耗時較長。"
+
+msgid "It has a big layer height, and results in apparent layer lines and ordinary printing quality and printing time."
+msgstr "0.6 mm 噴嘴的預設引數，層高較大，層紋明顯，列印質量一般，列印耗時一般。"
+
+msgid "Compared with the default profile of a 0.6 mm nozzle, it has more wall loops and a higher sparse infill density. So, it results in higher strength of the prints, but more filament consumption and longer printing time."
+msgstr "此為強度引數，相比於此噴嘴的預設引數，牆層數較大，稀疏填充密度較高，列印件的強度更高，但耗材用量更大，耗時更長。"
+
+msgid "Compared with the default profile of a 0.6 mm nozzle, it has a bigger layer height, and results in more apparent layer lines and lower printing quality, but shorter printing time in some printing cases."
+msgstr "相比於此噴嘴的預設引數，層高較大，層紋較明顯，列印質量較低，部分模型的列印耗時較短。"
+
+msgid "Compared with the default profile of a 0.6 mm nozzle, it has a bigger layer height, and results in much more apparent layer lines and much lower printing quality, but shorter printing time in some printing cases."
+msgstr "相比於此噴嘴的預設引數，層高較大，層紋很明顯，列印質量較低，部分模型的列印耗時較短。"
+
+msgid "Compared with the default profile of a 0.6 mm nozzle, it has a smaller layer height, and results in less apparent layer lines and slight higher printing quality, but longer printing time."
+msgstr "相比於此噴嘴的預設引數，層高較小，層紋較不明顯，列印質量稍微較高，部分模型的列印耗時較長。"
+
+msgid "Compared with the default profile of a 0.6 mm nozzle, it has a smaller layer height, and results in less apparent layer lines and higher printing quality, but longer printing time."
+msgstr "相比於此噴嘴的預設引數，層高較小，層紋較不明顯，列印質量較高，部分模型的列印耗時較長。"
+
+msgid "It has a very big layer height, and results in very apparent layer lines, low printing quality and general printing time."
+msgstr "0.8 mm 噴嘴的預設引數，層高較大，層紋很明顯，列印質量低，列印耗時一般。"
+
+msgid "Compared with the default profile of a 0.8 mm nozzle, it has a bigger layer height, and results in very apparent layer lines and much lower printing quality, but shorter printing time in some printing cases."
+msgstr "相比於此噴嘴的預設引數，層高更大，層紋非常明顯，列印質量較低，部分模型的列印耗時較短。"
+
+msgid "Compared with the default profile of a 0.8 mm nozzle, it has a much bigger layer height, and results in extremely apparent layer lines and much lower printing quality, but much shorter printing time in some printing cases."
+msgstr "相比於此噴嘴的預設引數，層高較大，層紋非常明顯，列印質量較低，部分模型的列印耗時較短。"
+
+msgid "Compared with the default profile of a 0.8 mm nozzle, it has a slightly smaller layer height, and results in slightly less but still apparent layer lines and slightly higher printing quality, but longer printing time in some printing cases."
+msgstr "相比於此噴嘴的預設引數，層高較小，層紋較不明顯，列印質量稍微較高，部分模型的列印耗時較長。"
+
+msgid "Compared with the default profile of a 0.8 mm nozzle, it has a smaller layer height, and results in less but still apparent layer lines and slightly higher printing quality, but longer printing time in some printing cases."
+msgstr "相比於此噴嘴的預設引數，層高較小，層紋較不明顯，列印質量較高，部分模型的列印耗時較長。"
+
+msgid "This is neither a commonly used filament, nor one of Bambu filaments, and it varies a lot from brand to brand. So, it's highly recommended to ask its vendor for suitable profile before printing and adjust some parameters according to its performances."
+msgstr "此耗材較為小眾，拓竹並未出售，且不同品牌的差異很大，故強烈建議列印前向廠家諮詢預設引數，並根據列印表現來調整列印引數。"
+
+msgid "When printing this filament, there's a risk of warping and low layer adhesion strength. To get better results, please refer to this wiki: Printing Tips for High Temp / Engineering materials."
+msgstr "此耗材列印時有翹曲、層間強度較低等風險。為獲得更好的列印效果，請查閱 wiki: 工程材料列印指南。"
+
+msgid "When printing this filament, there's a risk of nozzle clogging, oozing, warping and low layer adhesion strength. To get better results, please refer to this wiki: Printing Tips for High Temp / Engineering materials."
+msgstr "此耗材列印時有堵噴嘴、漏料、翹曲、層間強度較低等風險。為獲得更好的列印效果，請查閱 wiki: 工程材料列印指南。"
+
+msgid "To get better transparent or translucent results with the corresponding filament, please refer to this wiki: Printing tips for transparent PETG."
+msgstr "若要用此耗材的透明耗材列印透明效果很好的模型，請查閱 wiki: 透明 PETG 列印指南。"
+
+msgid "To make the prints get higher gloss, please dry the filament before use, and set the outer wall speed to be 40 to 60 mm/s when slicing."
+msgstr "為使列印件具有更高的光澤，請在列印前把耗材烘乾，並在切片時把模型的外牆速度調到 40 到 60 mm/s 之間。"
+
+msgid "This filament is only used to print models with a low density usually, and some special parameters are required. To get better printing quality, please refer to this wiki: Instructions for printing RC model with foaming PLA (PLA Aero)."
+msgstr "此耗材通常只用於列印低密度的模型，且必須使用特殊引數。為保證列印質量，請查閱 wiki: 發泡 PLA（PLA Aero）列印航模操作指南。"
+
+msgid "This filament is only used to print models with a low density usually, and some special parameters are required. To get better printing quality, please refer to this wiki: ASA Aero Printing Guide."
+msgstr "此耗材通常只用於列印低密度的模型，且必須使用特殊引數。為保證列印質量，請查閱 wiki: 發泡 ASA （ASA Aero）列印指南。"
+
+msgid "This filament is too soft and not compatible with the AMS. Printing it is of many requirements, and to get better printing quality, please refer to this wiki: TPU printing guide."
+msgstr "此耗材太軟，不適配 AMS。其使用要求較高，為保證列印質量，請查閱 wiki: TPU 列印建議。"
+
+msgid "This filament has high enough hardness (about 67D)  and is compatible with the AMS. Printing it is of many requirements, and to get better printing quality, please refer to this wiki: TPU printing guide."
+msgstr "此耗材的硬度較高（約 67D），可透過 AMS 列印。其使用要求較高，為保證列印質量，請查閱 wiki: TPU 列印建議。"
+
+msgid "If you are to print a kind of soft TPU, please don't slice with this profile, and it is only for TPU that has high enough hardness (not less than 55D) and is compatible with the AMS. To get better printing quality, please refer to this wiki: TPU printing guide."
+msgstr "若要列印的 TPU 硬度較低，請勿用此引數切片。此引數僅適配硬度較高的 TPU（硬度通常需 ≥ 55D），也即可透過 AMS 列印的 TPU。其使用要求較高，為保證列印質量，請查閱 wiki: TPU 列印建議。"
+
+msgid "This is a water-soluble support filament, and usually it is only for the support structure and not for the model body. Printing this filament is of many requirements, and to get better printing quality, please refer to this wiki: PVA Printing Guide."
+msgstr "此為水溶性支撐耗材，通常只能用於列印支撐結構，不能用於列印模型主體。其使用要求較高，為保證列印質量，請查閱 wiki: PVA 列印指南。"
+
+msgid "This is a non-water-soluble support filament, and usually it is only for the support structure and not for the model body. To get better printing quality, please refer to this wiki: Printing Tips for Support Filament and Support Function."
+msgstr "此為非水溶性支撐耗材，通常只能用於列印支撐結構，不能用於列印模型主體。為保證列印質量，請查閱 wiki: 支撐耗材與支撐功能的介紹。"
+
+msgid "The generic presets are conservatively tuned for compatibility with a wider range of filaments. For higher printing quality and speeds, please use Bambu filaments with Bambu presets."
+msgstr "Generic 引數為了相容更多種耗材而進行了較為保守的調校，使用拓竹原裝耗材配合拓竹專用引數可獲得更高的列印質量與更高的列印速度。"
+
+msgid "High quality profile for 0.2mm nozzle, prioritizing print quality."
+msgstr "0.2mm噴嘴的高質量列印引數，列印質量優先。"
+
+msgid "High quality profile for 0.16mm layer height, prioritizing print quality and strength."
+msgstr "0.16mm層高的高質量引數，列印質量和強度優先。"
+
+msgid "Standard profile for 0.16mm layer height, prioritizing speed."
+msgstr "0.16mm層高標準引數，速度優先。"
+
+msgid "High quality profile for 0.2mm layer height, prioritizing strength and print quality."
+msgstr "0.2mm層高的高質量引數，強度和列印質量優先。"
+
+msgid "Standard profile for 0.4mm nozzle, prioritizing speed."
+msgstr "0.4mm噴嘴預設引數，速度優先。"
+
+msgid "High quality profile for 0.6mm nozzle, prioritizing print quality and strength."
+msgstr "0.6mm噴嘴的高質量列印引數，列印質量優先。"
+
+msgid "Strength profile for 0.6mm nozzle, prioritizing strength."
+msgstr "0.6mm噴嘴的高強度列印引數，強度優先。"
+
+msgid "Standard profile for 0.6mm nozzle, prioritizing speed."
+msgstr "0.6mm噴嘴的預設引數，速度優先。"
+
+msgid "High quality profile for 0.8mm nozzle, prioritizing print quality."
+msgstr "0.8mm噴嘴的高質量列印引數，列印質量優先。"
+
+msgid "Strength profile for 0.8mm nozzle, prioritizing strength."
+msgstr "0.8mm噴嘴的高強度列印引數，強度優先。"
+
+msgid "Standard profile for 0.8mm nozzle, prioritizing speed."
+msgstr "0.8mm噴嘴的預設引數，速度優先。"
+
+msgid "Failed to create GCodeV2"
+msgstr "無法建立 GCode"
+
+msgid "Failed to parse response"
+msgstr "解析響應失敗"
+
+msgid "Helio simulation task failed"
+msgstr "Helio模擬任務失敗"
+
+msgid "Helio optimization task failed"
+msgstr "Helio 最佳化任務失敗"
+
+msgid "Helio API endpoint is empty, please check the configuration."
+msgstr "Helio API 端點為空，請檢查配置。"
+
+msgid "Personal assecc token is empty, please fill in the correct token."
+msgstr "個人訪問令牌為空，請填寫正確的令牌。"
+
+msgid "Helio: Presigned URL Created"
+msgstr "Helio：預簽名URL已建立"
+
+msgid "Helio: file succesfully uploaded"
+msgstr "Helio：檔案已成功上傳"
+
+msgid "Helio: file upload failed"
+msgstr "Helio：檔案上傳失敗"
+
+msgid "Please make sure you have the corrent API key set in preferences."
+msgstr "請確保您已在偏好設定中正確設定了 API 金鑰。"
+
+msgid "Helio: GCode created successfully"
+msgstr "Helio：G程式碼已成功建立"
+
+msgid "Helio: simulation successfully created"
+msgstr "Helio：模擬建立成功"
+
+msgid "Helio: simulation working"
+msgstr "Helio：模擬執行中"
+
+msgid "Helio: simulation failed"
+msgstr "Helio：模擬失敗"
+
+msgid "Helio: Simulation check failed"
+msgstr "Helio：模擬檢測失敗"
+
+msgid "Helio: Failed to create Simulation"
+msgstr "Helio: 建立模擬失敗"
+
+msgid "Helio: Failed to create GCode"
+msgstr "Helio: 建立GCode失敗"
+
+msgid "Helio: optimization successfully created"
+msgstr "Helio：最佳化建立成功"
+
+msgid "Helio: optimization working"
+msgstr "Helio：最佳化執行中"
+
+msgid "Helio: optimization failed"
+msgstr "Helio：最佳化失敗"
+
+msgid "Helio: Optimzaion check failed"
+msgstr "Helio：最佳化檢查失敗"
+
+msgid "Helio: Failed to create Optimization"
+msgstr "Helio: 建立最佳化失敗"
+
+msgid "Helio: GCode downloaded successfully"
+msgstr "Helio：G程式碼下載成功"
+
+msgid "Helio: GCode download failed"
+msgstr "Helio: GCode 下載失敗"
+
+msgid "No AMS"
+msgstr "沒有AMS"
+
+msgid "There is no device available to send printing."
+msgstr "沒有可用於傳送列印的裝置。"
+
+msgid "The number of printers in use simultaneously cannot be equal to 0."
+msgstr "同時使用的印表機數量不能等於0。"
+
+msgid "Use External Spool"
+msgstr "使用外掛料卷"
+
+msgid "Select Printers"
+msgstr "選擇印表機"
+
+msgid "Device Name"
+msgstr "裝置名"
+
+msgid "Device Status"
+msgstr "裝置狀態"
+
+msgid "Ams Status"
+msgstr "AMS狀態"
+
+msgid "Please select the devices you would like to manage here (up to 6 devices)"
+msgstr "請在此處選擇您想管理的裝置（最多6個裝置）。"
+
+msgid "Printing Options"
+msgstr "列印選項"
+
+msgid "Bed Leveling"
+msgstr "熱床調平"
+
+msgid "Send Options"
+msgstr "傳送選項"
+
+msgid "printers at the same time.(It depends on how many devices can undergo heating at the same time.)"
+msgstr "印表機在同一時間。（這取決於有多少裝置可以接受同時加熱。）"
+
+msgid "Wait"
+msgstr "等待"
+
+msgid "minute each batch.(It depends on how long it takes to complete the heating.)"
+msgstr "分鐘傳送一次。（這取決於完成加熱需要多長時間。）"
+
+msgid "Task Sending"
+msgstr "正在傳送的任務"
+
+msgid "Task Sent"
+msgstr "已傳送的任務"
+
+msgid "Edit multiple printers"
+msgstr "編輯多個印表機"
+
+msgid "Select connected printers (0/6)"
+msgstr "選擇已連線的印表機 (0/6)"
+
+#, c-format, boost-format
+msgid "Select Connected Printers (%d/6)"
+msgstr "選擇已連線的印表機 (%d/6)"
+
+#, c-format, boost-format
+msgid "The maximum number of printers that can be selected is %d"
+msgstr "可以選擇的印表機數量最多為 %d。"
+
+msgid "No task"
+msgstr "沒有任務"
+
+msgid "Edit Printers"
+msgstr "編輯印表機"
+
+msgid "Task Name"
+msgstr "任務名"
+
+msgid "Actions"
+msgstr "動作"
+
+msgid "Task Status"
+msgstr "任務狀態"
+
+msgid "Sent Time"
+msgstr "傳送時間"
+
+msgid "There are no tasks to be sent!"
+msgstr "沒有任務正在傳送！"
+
+msgid "No historical tasks!"
+msgstr "沒有歷史任務！"
+
+msgid "Upgrading"
+msgstr "升級中"
+
+msgid "syncing"
+msgstr "同步中"
+
+msgid "Printing Finish"
+msgstr "列印成功"
+
+msgid "Printing Failed"
+msgstr "列印失敗"
+
+msgid "Printing Pause"
+msgstr "列印暫停"
+
+msgid "Pending"
+msgstr "等待中"
+
+msgid "Sending"
+msgstr "傳送中"
+
+msgid "Sending Finish"
+msgstr "傳送成功"
+
+msgid "Sending Cancel"
+msgstr "取消傳送"
+
+msgid "Sending Failed"
+msgstr "傳送失敗"
+
+msgid "Print Success"
+msgstr "列印成功"
+
+msgid "Print Failed"
+msgstr "列印失敗"
+
+msgid "Removed"
+msgstr "移除"
+
+msgid "Management user presets"
+msgstr "管理使用者預設"
+
+msgid "No content"
+msgstr ""
+
+#, c-format, boost-format
+msgid "Printer presets (%d/%d)"
+msgstr "印表機預設 (%d/%d)"
+
+#, c-format, boost-format
+msgid "Filament presets (%d/%d)"
+msgstr "材料預設 (%d/%d)"
+
+#, c-format, boost-format
+msgid "Process presets (%d/%d)"
+msgstr "工藝預設 (%d/%d)"
+
+#, c-format, boost-format
+msgid "%u Selected"
+msgstr "已選擇 %u項"
+
+msgid "Please select the preset to be deleted"
+msgstr ""
+
+#, c-format, boost-format
+msgid "%d %s Preset will be deleted."
+msgstr "%d個%s預設將被刪除。"
+
+msgid "Filament grouping"
+msgstr "耗材分組"
+
+msgid "Don't remind me again"
+msgstr "不再提醒"
+
+msgid "No further pop-up will appear. You can reopen it in 'Preferences'"
+msgstr "不再彈窗提醒。您可以在“偏好設定”中重新開啟。"
+
+msgid "Filament-Saving Mode"
+msgstr "省料模式"
+
+msgid "Convenience Mode"
+msgstr "便捷模式"
+
+msgid "Custom Mode"
+msgstr "自定義模式"
+
+msgid "Generates filament grouping for the left and right nozzles based on the most filament-saving principles to minimize waste"
+msgstr "根據最節省耗材的原則，生成左右噴嘴的耗材分組方案，幫助減少耗材浪費"
+
+msgid "Generates filament grouping for the left and right nozzles based on the printer's actual filament status, reducing the need for manual filament adjustment"
+msgstr "根據印表機實際耗材狀態，生成左右噴嘴的耗材分組方案，幫助減少對實際耗材的手動調整操作"
+
+msgid "Manually assign filament to the left or right nozzle"
+msgstr "根據您的個人意願，切片前手動設定耗材的左右分組"
+
+msgid "Global settings"
+msgstr "全域性設定"
+
+msgid "Video tutorial"
+msgstr "影片指南"
+
+msgid "(Sync with printer)"
+msgstr "（請連線印表機）"
+
+#, c-format, boost-format
+msgid "Error: %s extruder has no available %s nozzle, current group result is invalid."
+msgstr "錯誤: %s 擠出機沒有可用的 %s 噴嘴，當前分組結果無效。"
+
+msgid "We will slice according to this grouping method:"
+msgstr "我們將基於當前分配方案切片："
+
+msgid "Tips: You can drag the filaments to reassign them to different nozzles."
+msgstr "提示：您可以拖動耗材以將其重新分配到不同的噴嘴。"
+
+msgid "Please adjust your grouping or click "
+msgstr "請調整您的分組或點選 "
+
+msgid " to set nozzle count"
+msgstr "設定噴嘴數量"
+
+#, c-format, boost-format
+msgid "Left Extruder(%d)"
+msgstr "左擠出機(%d)"
+
+#, c-format, boost-format
+msgid "Right Extruder(Std: %d, HF: %d)"
+msgstr "右擠出機(標準: %d，高流量: %d)"
+
+#, c-format, boost-format
+msgid "Right Extruder(%d)"
+msgstr "右擠出機(%d)"
+
+msgid "The filament grouping method for current plate is determined by the dropdown option at the slicing plate button."
+msgstr "當前盤的耗材分組方式由切片按鈕處的下拉選項決定。"
+
+msgid "Skip Objects"
+msgstr "零件跳過"
+
+msgid "Zoom Out"
+msgstr "縮小"
+
+msgid "100 %"
+msgstr ""
+
+msgid "Zoom In"
+msgstr "放大"
+
+msgid "Load skipping objects information failed. Please try again."
+msgstr "載入跳過零件資訊失敗。請重試。"
+
+#, c-format, boost-format
+msgid "%d%%"
+msgstr ""
+
+#, c-format, boost-format
+msgid "%d"
+msgstr ""
+
+#, c-format, boost-format
+msgid "/%d Selected"
+msgstr "/%d 已選擇"
+
+msgid "Nothing selected"
+msgstr "未選中任何內容"
+
+msgid "Over 64 objects in single plate"
+msgstr "單盤中有超過64個物體"
+
+msgid "The current print job cannot be skipped"
+msgstr "當前列印任務不可跳過"
+
+msgid "Skipping all objects."
+msgstr "跳過所有零件。"
+
+msgid "The printing job will be stopped. Continue?"
+msgstr "列印任務將停止。是否繼續？"
+
+#, c-format, boost-format
+msgid "Skipping %d objects."
+msgstr "跳過%d個零件"
+
+msgid "This action cannot be undone. Continue?"
+msgstr "此操作無法撤銷，是否繼續？"
+
+msgid "Skipping objects."
+msgstr ""
+
+msgid "Continue"
+msgstr "繼續"
+
+msgid "Null Color"
+msgstr ""
+
+msgid "Multiple Color"
+msgstr "多色"
+
+msgid "Official Filament"
+msgstr "官方材料"
+
+msgid "More Colors"
+msgstr "其他顏色"
+
+msgid "Please set nozzle count"
+msgstr "請設定噴嘴數量"
+
+msgid "Error: Can not set both nozzle count to zero."
+msgstr "錯誤：無法將兩個噴嘴數量都設定為零。"
+
+#, c-format, boost-format
+msgid "Error: Nozzle count can not exceed %d."
+msgstr "錯誤：噴嘴數量不可以超過%d。"
+
+msgid "Nozzle Selection"
+msgstr "噴嘴選擇"
+
+msgid "Available Nozzles"
+msgstr "可用噴嘴"
+
+msgid "Sync Nozzle status"
+msgstr "同步噴嘴狀態"
+
+msgid "Caution: Mixing nozzle diameters in one print is not supported. If the selected size is only on one extruder, single-extruder printing will be enforced."
+msgstr "注意：不支援在列印中混用不同直徑的噴嘴。如果所選尺寸僅存在於一個擠出機上，將強制使用單擠出機列印。"
+
+#, c-format, boost-format
+msgid "Refresh %d/%d..."
+msgstr "重新整理 %d/%d..."
+
+msgid "Unknown nozzle detected. Refresh to update info (unrefreshed nozzles will be excluded during slicing). Verify nozzle diameter & flow rate against displayed values."
+msgstr "檢測到未知噴嘴。請重新整理以更新資訊（未重新整理的噴嘴將在切片時被排除）。請核對噴嘴直徑和流量是否與顯示值一致。"
+
+msgid "Unknown nozzle detected. Refresh to update (unrefreshed nozzles will be skipped in slicing)."
+msgstr "檢測到未知噴嘴。請重新整理以更新資訊（未重新整理的噴嘴將在切片時被排除）。"
+
+msgid "Please confirm whether the required nozzle diameter and flow rate match the currently displayed values."
+msgstr "請核對噴嘴直徑和流量是否與顯示值一致。"
+
+msgid "Your printer has different nozzles installed. Please select a nozzle for this print."
+msgstr "您的印表機安裝了不同的噴嘴。請選擇一個噴嘴進行本次列印。"
+
+msgid "Purge Mode Settings"
+msgstr "沖刷模式"
+
+msgid "Standard Mode"
+msgstr "標準模式"
+
+msgid "Performs full priming for the best print quality. Requires more material and time."
+msgstr "執行完整的沖刷流程以獲得最佳列印質量，需要更多材料和時間。"
+
+msgid "Prime Saving"
+msgstr "省料模式"
+
+msgid "Reduces prime waste and prints faster. May cause slight color mixing or small surface defects."
+msgstr "減少衝刷量，加快列印速度，但可能出現輕微的顏色混合或表面瑕疵。"
+
+msgid "Learn more about prime mode"
+msgstr "瞭解更多衝刷模式資訊"
+
+msgid "AMS Dryness Control"
+msgstr "AMS烘乾"
+
+msgid "Filament Drying Settings"
+msgstr "耗材烘乾設定"
+
+msgid "Start"
+msgstr "開始"
+
+msgid "Unable to dry temporarily due to ..."
+msgstr "暫時無法烘乾，由於 ..."
+
+msgid "Drying Error"
+msgstr "烘乾錯誤"
+
+msgid "Please check the Assistant for troubleshooting"
+msgstr "請檢視助手以進行故障排除"
+
+msgid "Please remove and store the filament (as shown)."
+msgstr "請拔出並收起耗材（如圖）"
+
+msgid "The AMS can rotate the filament which is properly stored, providing better drying results."
+msgstr "AMS會自動旋轉耗材收起的槽位，會有更好的烘乾效果。"
+
+msgid "Rotate spool when drying"
+msgstr "烘乾時旋轉料盤"
+
+msgctxt "amsdrying"
+msgid "Back"
+msgstr "返回"
+
+msgid "Drying-Heating"
+msgstr "烘乾-加熱中"
+
+msgid "Drying-Dehumidifying"
+msgstr "烘乾-除溼中"
+
+msgid " maximum drying temperature is "
+msgstr " 最大烘乾溫度是 "
+
+msgid " minimum drying temperature is "
+msgstr " 最低烘乾溫度是 "
+
+msgid "This filament may not be completely dried."
+msgstr "該耗材可能無法完全烘乾。"
+
+msgid "This AMS is currently printing. To ensure print quality, the drying temperature cannot exceed the recommended drying temperature."
+msgstr "此AMS當前正在列印。為確保列印質量，烘乾溫度不得超過推薦的烘乾溫度。"
+
+msgid "The temperature shall not exceed the filament's heat distortion temperature"
+msgstr "溫度不得超過耗材的壓潰溫度"
+
+msgid "Minimum time value cannot be less than 1."
+msgstr "時間最小值不能小於 1。"
+
+msgid "Maximum time value cannot be greater than 24."
+msgstr "時間最大值不能大於 24。"
+
+msgid "Insufficient power"
+msgstr "功率不足"
+
+msgid "  Too many AMS drying simultaneously. Please plug in the power or stop other drying processes before starting."
+msgstr "  同時烘乾的機器過多，您可以插上電源，或者停止其他烘乾後再開始。"
+
+msgid "AMS is busy"
+msgstr "AMS正忙"
+
+msgid "  AMS is calibrating | reading RFID | loading/unloading material, please wait."
+msgstr "  AMS正在校準｜讀取RFID｜進退料，請稍等。"
+
+msgid "Filament in AMS outlet"
+msgstr "耗材在AMS出料口中"
+
+msgid "  The high drying temperature may cause AMS blockage, please unload first."
+msgstr "烘乾的高溫可能造成AMS堵塞，請先退料。"
+
+msgid "Initiating AMS drying"
+msgstr "啟動AMS烘乾"
+
+msgid "Not supported in 2D mode"
+msgstr "不支援 2D 模式"
+
+msgid "Task in progress"
+msgstr "任務佔用"
+
+msgid "  The AMS might be in use during Task."
+msgstr "  任務中可能會使用到該臺AMS。"
+
+msgid "  Firmware update in progress, please wait..."
+msgstr "  韌體更新正在進行中，請稍候……"
+
+msgid "  Please plug in the power and then use the drying function."
+msgstr "  請插上電源後使用烘乾功能。"
+
+msgid "System is busy"
+msgstr "系統正忙"
+
+msgid "  Initiating other drying processes, please wait a few seconds..."
+msgstr "  正在開啟其他烘乾，請稍等幾秒……"
+
+msgid "For better drying results, remove the filament and allow it to rotate."
+msgstr "拔出耗材並旋轉烘乾會有更好的效果。"
+
+msgid "The AMS will automatically rotate the stored filament slots to enhance the drying performance."
+msgstr "AMS會自動滾動已儲存的耗材槽以增強烘乾效果。"
+
+msgid "Alternatively, you can dry the filament without removing it."
+msgstr "或者，您可以在不取出耗材的情況下進行乾燥。"
+
+msgid "Unknown filaments will be treated as PLA."
+msgstr "*未知的耗材會被當作PLA處理。"
+
+msgid "Please store the filament marked with an exclamation mark."
+msgstr "請收起帶感嘆號的耗材。"
+
+msgid "Filament left in the feeder during drying may soften because the drying temperature exceeds the softening point of materials like PLA and TPU."
+msgstr "材料插在進料口中烘乾可能會軟化，這是因為烘乾溫度超出了耗材的軟化溫度，常見於PLA、TPU等易軟化的材料。"
+
+msgid "Starting: Checking adapter connection"
+msgstr "正在啟動：檢查介面卡連線"
+
+msgid "Starting: Checking filament status"
+msgstr "正在啟動：檢查耗材狀態"
+
+msgid "Starting: Checking drying presets"
+msgstr "正在啟動：檢查烘乾引數"
+
+msgid "Starting: Checking filament location"
+msgstr "正在啟動：檢查耗材位置"
+
+msgid "Starting: Checking air intake"
+msgstr "正在啟動：檢查進氣口"
+
+msgid "Starting: Checking air vent"
+msgstr "正在啟動：檢查出氣口"
+
+msgid "Terms of Bambu Lab User Experience Improvement Program"
+msgstr "拓竹使用者體驗改進計劃"
+
+msgid "Recent Helio Runs"
+msgstr "最近的 Helio 執行記錄"
+
+msgid "Showing recent completed optimizations and simulations"
+msgstr "顯示最近已完成的最佳化與模擬"
+
+msgid "Loading recent runs..."
+msgstr "正在載入最近的執行記錄……"
+
+msgid "No Recent Runs Found"
+msgstr "未找到最近的執行記錄"
+
+msgid "No completed simulations or optimizations found"
+msgstr "未找到已完成的模擬或最佳化"
+
+#, c-format, boost-format
+msgid "OPTIMIZATIONS (%d)"
+msgstr "最佳化（%d）"
+
+#, c-format, boost-format
+msgid "SIMULATIONS (%d)"
+msgstr "模擬（%d）"
+
+#, c-format, boost-format
+msgid "%d layers"
+msgstr "%d 層"
+
+#, c-format, boost-format
+msgid "Quality: %s | Consistency: %s"
+msgstr "質量：%s | 一致性：%s"
+
+msgid "Download GCode"
+msgstr "下載 GCode"
+
+msgid "View Results"
+msgstr "檢視結果"
+
+msgid "GCode URL is not available"
+msgstr "GCode URL 不可用"
+
+msgid "Download Error"
+msgstr "下載錯誤"
+
+msgid "Save GCode File"
+msgstr "儲存 GCode 檔案"
+
+#, c-format, boost-format
+msgid ""
+"GCode file downloaded successfully!\n"
+"\n"
+"Saved to: %s"
+msgstr ""
+"GCode 檔案下載成功！\n"
+"\n"
+"已儲存到：%s"
+
+msgid "Download Complete"
+msgstr "下載完成"
+
+#, c-format, boost-format
+msgid ""
+"Failed to open file for writing:\n"
+"%s"
+msgstr ""
+"無法開啟檔案進行寫入：\n"
+"%s"
+
+#, c-format, boost-format
+msgid "Error saving file: %s"
+msgstr "儲存檔案出錯：%s"
+
+#, c-format, boost-format
+msgid ""
+"Failed to download GCode file.\n"
+"\n"
+"Error: %s"
+msgstr ""
+"下載 GCode 檔案失敗。\n"
+"\n"
+"錯誤：%s"
+
+msgid "Optimization Details"
+msgstr "最佳化詳情"
+
+msgid "Simulation Details"
+msgstr "模擬詳情"
+
+#, c-format, boost-format
+msgid "%d seconds ago"
+msgstr "%d 秒前"
+
+#, c-format, boost-format
+msgid "%d minutes ago"
+msgstr "%d 分鐘前"
+
+#, c-format, boost-format
+msgid "%d hours ago"
+msgstr "%d 小時前"
+
+#, c-format, boost-format
+msgid "%d days ago"
+msgstr "%d 天前"
+
+msgid "Print Outcome: WILL_PRINT"
+msgstr "列印結果：WILL_PRINT"
+
+msgid "Print Outcome: MAY_PRINT"
+msgstr "列印結果：MAY_PRINT"
+
+msgid "Print Outcome: LIKELY_FAIL"
+msgstr "列印結果：LIKELY_FAIL"
+
+msgid "Print Outcome: "
+msgstr "列印結果： "
+
+#: resources/data/hints.ini: [hint:How to use keyboard shortcuts]
+msgid ""
+"How to use keyboard shortcuts\n"
+"Did you know that Bambu Studio offers a wide range of keyboard shortcuts and 3D scene operations."
+msgstr ""
+"快捷鍵操作\n"
+"您知道嗎？Bambu Studio提供了豐富的快捷鍵操作和3D場景操作。"
+
+#: resources/data/hints.ini: [hint:Cut Tool]
+msgid ""
+"Cut Tool\n"
+"Did you know that you can cut a model at any angle and position with the cutting tool?"
+msgstr ""
+"切割工具\n"
+"您知道嗎？您可以使用切割工具以任何角度和位置切割模型。"
+
+#: resources/data/hints.ini: [hint:Fix Model]
+msgid ""
+"Fix Model\n"
+"Did you know that you can fix a corrupted 3D model to avoid a lot of slicing problems on the Windows system?"
+msgstr ""
+"修復模型\n"
+"您知道嗎？在Windows系統上，您可以修復一個損壞的3D模型以避免諸多切片問題。"
+
+#: resources/data/hints.ini: [hint:Timelapse]
+msgid ""
+"Timelapse\n"
+"Did you know that you can generate a timelapse video during each print?"
+msgstr ""
+"延時攝影\n"
+"您知道嗎？您可以每次列印時生成一段延時攝影。"
+
+#: resources/data/hints.ini: [hint:Auto-Arrange]
+msgid ""
+"Auto-Arrange\n"
+"Did you know that you can auto-arrange all objects in your project?"
+msgstr ""
+"自動擺盤\n"
+"您知道嗎？您可以自動排列專案中的所有物件。"
+
+#: resources/data/hints.ini: [hint:Auto-Orient]
+msgid ""
+"Auto-Orient\n"
+"Did you know that you can rotate objects to an optimal orientation for printing by a simple click?"
+msgstr ""
+"自動朝向\n"
+"您知道嗎？您只需單擊滑鼠，即可將物件旋轉到適合的列印方向。"
+
+#: resources/data/hints.ini: [hint:Lay on Face]
+msgid ""
+"Lay on Face\n"
+"Did you know that you can quickly orient a model so that one of its faces sits on the print bed? Select the \"Place on face\" function or press the <b>F</b> key."
+msgstr ""
+"選擇底面\n"
+"您知道嗎？您可以快速指定模型的底面，使其位於列印床上。選擇“選擇底面”功能或按<b>F</b>鍵。"
+
+#: resources/data/hints.ini: [hint:Object List]
+msgid ""
+"Object List\n"
+"Did you know that you can view all objects/parts in a list and change settings for each object/part?"
+msgstr ""
+"物件列表\n"
+"您知道物件列表嗎？您可以在其中的檢視所有物件/部件，並更改每個物件/部件的設定。"
+
+#: resources/data/hints.ini: [hint:Simplify Model]
+msgid ""
+"Simplify Model\n"
+"Did you know that you can reduce the number of triangles in a mesh using the Simplify mesh feature? Right-click the model and select Simplify model. Read more in the documentation."
+msgstr ""
+"簡化模型\n"
+"您知道嗎？您可以使用“簡化模型”功能減少模型的三角形數。在模型上單擊滑鼠右鍵，然後選擇“簡化模型”。"
+
+#: resources/data/hints.ini: [hint:Slicing Parameter Table]
+msgid ""
+"Slicing Parameter Table\n"
+"Did you know that you can view all objects/parts on a table and change settings for each object/part?"
+msgstr ""
+"參數列格\n"
+"您知道嗎？您可以參數列格上的所有物件/部件，並更改每個物件/部件的設定。"
+
+#: resources/data/hints.ini: [hint:Split to Objects/Parts]
+msgid ""
+"Split to Objects/Parts\n"
+"Did you know that you can split a big object into small ones for easy colorizing or printing?"
+msgstr ""
+"分割成物件/零件\n"
+"您知道嗎？您可以把一個大物件分割成多個小物件/零件以便著色或列印。"
+
+#: resources/data/hints.ini: [hint:Subtract a Part]
+msgid ""
+"Subtract a Part\n"
+"Did you know that you can subtract one mesh from another using the Negative part modifier? That way you can, for example, create easily resizable holes directly in Bambu Studio. Read more in the documentation."
+msgstr ""
+"減去部分幾何體\n"
+"您知道嗎？您可以使用負零件從另一個幾何體中減去另一個幾何體。例如，可以直接在Bambu Studio中建立可輕鬆調整大小的孔。"
+
+#: resources/data/hints.ini: [hint:STEP]
+msgid ""
+"STEP\n"
+"Did you know that you can improve your print quality by slicing a STEP file instead of an STL?\n"
+"Bambu Studio supports slicing STEP files, providing smoother results than a lower resolution STL. Give it a try!"
+msgstr ""
+"STEP檔案\n"
+"您知道嗎？透過切片STEP檔案而不是STL檔案可以提高列印質量。\n"
+"Bambu Studio支援切片STEP檔案，可以獲得比低解析度STL更平滑的列印效果。試試看！"
+
+#: resources/data/hints.ini: [hint:Z seam location]
+msgid ""
+"Z seam location\n"
+"Did you know that you can customize the location of the Z seam, and even paint it on your print, to have it in a less visible location? This improves the overall look of your model. Check it out!"
+msgstr ""
+"Z接縫位置\n"
+"您知道嗎？您可以自定義Z接縫的位置，甚至可以手動繪製在模型的指定位置上，使其位於不太可見的位置。這樣可以改善模型的整體外觀。試試看！"
+
+#: resources/data/hints.ini: [hint:Fine-tuning for flow rate]
+msgid ""
+"Fine-tuning for flow rate\n"
+"Did you know that flow rate can be fine-tuned for even better-looking prints? Depending on the material, you can improve the overall finish of the printed model by doing some fine-tuning."
+msgstr ""
+"流量微調\n"
+"您知道嗎？您可以微調流量，以獲得更好看的列印效果。根據材料的不同，可以透過進行一些微調來提高列印模型的整體光潔度。"
+
+#: resources/data/hints.ini: [hint:Split your prints into plates]
+msgid ""
+"Split your prints into plates\n"
+"Did you know that you can split a model that has a lot of parts into individual plates ready to print? This will simplify the process of keeping track of all the parts."
+msgstr ""
+"分盤列印\n"
+"您知道嗎？您可以把一個有很多零件的模型安排到多個獨立的分盤，然後列印出來，這將簡化對所有零件的管理。"
+
+#: resources/data/hints.ini: [hint:Speed up your print with Adaptive Layer
+#: Height]
+msgid ""
+"Speed up your print with Adaptive Layer Height\n"
+"Did you know that you can print a model even faster, by using the Adaptive Layer Height option? Check it out!"
+msgstr ""
+"自適應層高度加速列印\n"
+"您知道嗎？您可以使用“自適應層高度”選項來更快地列印模型。試試看！"
+
+#: resources/data/hints.ini: [hint:Support painting]
+msgid ""
+"Support painting\n"
+"Did you know that you can paint the location of your supports? This feature makes it easy to place the support material only on the sections of the model that actually need it."
+msgstr ""
+"繪製支撐\n"
+"您知道嗎？您可以手動繪製新增/遮蔽支撐的位置，此功能使僅將支撐材料放置在實際需要的模型截面上變得容易。"
+
+#: resources/data/hints.ini: [hint:Different types of supports]
+msgid ""
+"Different types of supports\n"
+"Did you know that you can choose from multiple types of supports? Tree supports work great for organic models, while saving filament and improving print speed. Check them out!"
+msgstr ""
+"支撐型別\n"
+"您知道嗎？有多種可選的支撐型別，樹狀支撐非常適合人物/動物模型，同時可以節省耗材並提高列印速度。試試看！"
+
+#: resources/data/hints.ini: [hint:Printing Silk Filament]
+msgid ""
+"Printing Silk Filament\n"
+"Did you know that Silk filament needs special consideration to print it successfully? Higher temperature and lower speed are always recommended for the best results."
+msgstr ""
+"列印絲綢耗材\n"
+"您知道嗎？絲綢耗材列印時有一些特別的注意事項。為了獲得最佳效果，通常建議使用較高的溫度和較低的速度。"
+
+#: resources/data/hints.ini: [hint:Brim for better adhesion]
+msgid ""
+"Brim for better adhesion\n"
+"Did you know that when printing models have a small contact interface with the printing surface, it's recommended to use a brim?"
+msgstr ""
+"使用Brim\n"
+"您知道嗎？當模型與熱床表面的接觸面積較小時，建議使用brim以提高列印成功率。"
+
+#: resources/data/hints.ini: [hint:Set parameters for multiple objects]
+msgid ""
+"Set parameters for multiple objects\n"
+"Did you know that you can set slicing parameters for all selected objects at one time?"
+msgstr ""
+"為多個物件設定引數\n"
+"您知道嗎？可以同時為所有選定物件設定切片引數。"
+
+#: resources/data/hints.ini: [hint:Stack objects]
+msgid ""
+"Stack objects\n"
+"Did you know that you can stack objects as a whole one?"
+msgstr ""
+"組合物體\n"
+"您知道嗎？您可以把多個物件組合為一個整體。"
+
+#: resources/data/hints.ini: [hint:Flush into support/objects/infill]
+msgid ""
+"Flush into support/objects/infill\n"
+"Did you know that you can save the wasted filament by flushing them into support/objects/infill during filament change?"
+msgstr ""
+"沖刷到支援/物件/填充中\n"
+"您知道嗎？您可以在換料時將它們衝入支撐/物件/填充，以節省浪費的料絲。"
+
+#: resources/data/hints.ini: [hint:Improve strength]
+msgid ""
+"Improve strength\n"
+"Did you know that you can use more wall loops and higher sparse infill density to improve the strength of the model?"
+msgstr ""
+"提高強度\n"
+"您知道嗎？您可以使用更多的牆層數和更高的疏散填充密度來提高模型的強度。"
+
+#: resources/data/hints.ini: [hint:When need to print with the printer door
+#: opened]
+msgid ""
+"When need to print with the printer door opened\n"
+"Did you know that opening the printer door can reduce the probability of extruder/hotend clogging when printing lower temperature filament with a higher enclosure temperature. More info about this in the Wiki."
+msgstr ""
+"什麼時候需要開啟機箱門列印\n"
+"您知道嗎？在較高腔溫下列印低溫耗材，開啟機箱門可以減少擠出機/熱端堵塞的機率。有關此的更多資訊，請參閱Wiki。"
+
+#: resources/data/hints.ini: [hint:Avoid warping]
+msgid ""
+"Avoid warping\n"
+"Did you know that when printing materials that are prone to warping such as ABS, appropriately increasing the heatbed temperature can reduce the probability of warping."
+msgstr ""
+"避免翹曲\n"
+"您知道嗎？列印ABS這類易翹曲材料時，適當提高熱床溫度可以降低翹曲的機率。"
+
+#: resources/data/helio_hints.ini: [hint: Run Nylon & PC (and other advanced
+#: materials) Like a Pro]
+msgid ""
+"Run Nylon & PC (and other advanced materials) Like a Pro\n"
+"Printing Nylon 612 or Polycarbonate or other advanced materials? Helio helps you avoid the 'almost worked' failure."
+msgstr ""
+"像專業人士一樣列印尼龍與 PC（以及其他高階材料）\n"
+"在列印尼龍 612、聚碳酸酯（PC）或其他高階材料？Helio 幫你避免“差點成功但最終失敗”的情況。"
+
+#: resources/data/helio_hints.ini: [hint: Make Prints up to 30% Faster
+#: (Safely)]
+msgid ""
+"Make Prints up to 30% Faster (Safely)\n"
+"Get real throughput, not risky 'speed mode'. A print that normally takes 8 hours might drop to ~5.6 hours."
+msgstr ""
+"安全地讓列印速度最高提升 30%\n"
+"獲得真正的產出提升，而不是冒險的“速度模式”。原本 8 小時的列印可能降至約 5.6 小時。"
+
+#: resources/data/helio_hints.ini: [hint: Stop Wasting Precious Design Time on
+#: Tuning]
+msgid ""
+"Stop Wasting Precious Design Time on Tuning\n"
+"Fewer trial prints, faster dial-in. Instead of multiple test prints, detect issues and print first time right."
+msgstr ""
+"幫助你節省調參花費的時間\n"
+"更少的試打、更快的引數收斂。無需反覆測試列印，提前發現問題，一次就打對。"
+
+#: resources/data/helio_hints.ini: [hint: Cut Warping on ASA/ABS and other
+#: advanced materials]
+msgid ""
+"Cut Warping on ASA/ABS and other advanced materials\n"
+"Warping ruins long jobs. Helio shows where risk is highest before you print, and, with enhance, cuts the risk of warping to almost nil."
+msgstr ""
+"減少 ASA/ABS 等高階材料的翹曲\n"
+"翹曲會毀掉長時間作業。Helio 會在列印前指出風險最高的位置，並透過增強將翹曲風險降到幾乎為零。"
+
+#: resources/data/helio_hints.ini: [hint: Quality Check Before You Hit Print]
+msgid ""
+"Quality Check Before You Hit Print\n"
+"Think of it like a pre-flight check. Example: if a PC bracket shows low TQI in thin ribs, you'll know to adjust before committing to an overnight run."
+msgstr ""
+"點選列印前先做質量檢查\n"
+"把它當作“起飛前檢查”。例如：如果一個 PC 支架在薄肋處顯示較低的 TQI，你就能在通宵列印前先做調整。"
+
+#: resources/data/helio_hints.ini: [hint: Stronger Parts With One Click]
+msgid ""
+"Stronger Parts With One Click\n"
+"Better bonding, fewer brittle failures. Example: for Polycarbonate, results show ~+65% tensile strength after optimization."
+msgstr ""
+"一鍵獲得更強的零件\n"
+"層間粘結更好，更少脆裂失敗。例如：對聚碳酸酯（PC），最佳化後結果顯示抗拉強度約提升 +65%。"
+
+#: resources/data/helio_hints.ini: [hint: Save Money Every Run]
+msgid ""
+"Save Money Every Run\n"
+"Faster + fewer failures = real savings."
+msgstr ""
+"每次列印都能省錢\n"
+"更快 + 更少失敗 = 真正的成本節省。"
+
+#: resources/data/helio_hints.ini: [hint: First-Time-Right Reliability]
+msgid ""
+"First-Time-Right Reliability\n"
+"Less babysitting, more predictable output. Example: a small farm running PETG parts avoids 'fail at hour 6' surprises and keeps batches on schedule."
+msgstr ""
+"一次成功的可靠性\n"
+"更少盯機，更可預測的產出。例如：小型列印農場列印 PETG 零件可降低意外失敗的機率，讓批次按計劃推進。"
+
+#~ msgid "Copy or use any part of this product outside the authorized scope of Helio Additive and Bambu Lab;"
+#~ msgstr "在Helio Additive和拓竹授權範圍之外複製或使用本產品的任何一部分內容；"
+
+#~ msgid "Attempt to disrupt, bypass, alter, invalidate, or evade any Digital Rights Management system related to and/or an integral part of this product;"
+#~ msgstr "企圖破壞、繞過、改變、作廢或者逃避和本產品相關的以及/或者屬於本產品有機組成的一部分的任何數字版權管理系統；"
+
+#~ msgid "Using this software and services for any improper or illegal activities."
+#~ msgstr "利用本軟體和服務進行任何不當或違反法律的行為。"
+
+#~ msgid "Helio does not support using a number of materials greater than 1."
+#~ msgstr "Helio 只支援最多1種材料。"
+
+#~ msgid "Helio functions do not support the print sequence of \"ByObject\"."
+#~ msgstr "Helio 功能不支援“逐件”的列印順序。"
+
+#~ msgid "Third-party Extension"
+#~ msgstr "第三方擴充套件"
+
+#~ msgid "Stronger parts, less warping, faster prints - powered by fast physics-based FEM simulation"
+#~ msgstr "更堅固的零件、更少翹曲、更快列印—由高速物理FEM 模擬驅動"
+
+#~ msgid "Uninstall the Helio Additive extension"
+#~ msgstr "解除安裝 Helio Additive 擴充套件"
+
+#~ msgid "Use Immediately"
+#~ msgstr "立即使用"
+
+#~ msgid "Third-Party Extension"
+#~ msgstr "第三方擴充套件"
+
+#~ msgid "Helio Additive third - party software service feature has been successfully enabled!"
+#~ msgstr "Helio Additive 第三方軟體服務功能已成功啟用！"
+
+#~ msgid "Privacy Policy of Helio Additive"
+#~ msgstr "Helio Additive 隱私政策"
+
+#~ msgid "Terms of Use of Helio Additive"
+#~ msgstr "Helio Additive 使用條款"
+
+#~ msgid "Agree and proceed"
+#~ msgstr "同意並繼續"
+
+#~ msgid "Simulation"
+#~ msgstr "模擬"
+
+#~ msgid "Optimization"
+#~ msgstr "最佳化"
+
+#~ msgid "Note: Adjust the above temperature based on actual conditions. More accurate data ensures more precise analysis results."
+#~ msgstr "注意：以上溫度請根據實際情況調整。資料越準確，分析結果越精確。"
+
+#~ msgid "Monthly quota remaining: "
+#~ msgstr "每月剩餘配額： "
+
+#~ msgid "Add-ons available: "
+#~ msgstr "可用的配額："
+
+#~ msgid "Optimise Outer Walls"
+#~ msgstr "最佳化外牆"
+
+#~ msgid "Buy Now / Manage Account"
+#~ msgstr "立即購買 / 管理賬戶"
+
+#~ msgid "Start Simulation"
+#~ msgstr "開始模擬"
+
+#~ msgid "Start Optimization"
+#~ msgstr "開始最佳化"
+
+#~ msgid "Buy add-ons"
+#~ msgstr "購買配額"
+
+#~ msgid "Layers to Optimize "
+#~ msgstr "需要最佳化的層 "
+
+#~ msgid ""
+#~ "Single-Material Only\n"
+#~ "Helio currently simulates one material and one nozzle per job. Multi-material or multi-extruder G-code adds long pauses that break thermal continuity, so results wouldn’t be meaningful."
+#~ msgstr ""
+#~ "僅支援單一材料\n"
+#~ "Helio 當前每個作業只支援一種材料和一個噴嘴。多材料或多噴頭的 G-code 會加入長時間暫停，打斷熱連續性，從而導致模擬結果不準確。"
+
+#~ msgid ""
+#~ "One Plate per Job\n"
+#~ "Upload G-code with a single build plate—multi-plate projects aren’t yet supported, so only the first plate would run."
+#~ msgstr ""
+#~ "每個作業只支援一個構建板\n"
+#~ "請上傳只包含一個構建板的 G-code。多構建板的專案當前尚不支援，因此只會模擬第一個構建板。"
+
+#~ msgid ""
+#~ "What is the Thermal Quality Index?\n"
+#~ "The Thermal Quality Index (scale –100 to +100) shows how hot or cold each region prints—green (≈ 0) is the “just right” zone for strong, warp-free parts. Keep most of the part green for best results."
+#~ msgstr ""
+#~ "什麼是熱質量指數？\n"
+#~ "熱質量指數（範圍為 –100 到 +100）表示每個區域的列印溫度是偏熱還是偏冷。綠色（約等於 0）表示“剛剛好”的區域，可獲得強度高、無翹曲的零件。將大部分割槽域保持在綠色有助於獲得最佳效果。"
+
+#~ msgid ""
+#~ "Voxel-Level Accuracy\n"
+#~ "We predict temperature in every voxel at every time-step, and for standard jobs the forecast is typically within ±5–10 °C. Pauses, custom firmware or odd cooling can widen that margin."
+#~ msgstr ""
+#~ "體素級精度\n"
+#~ "我們在每一個時間步都預測每個體素的溫度，對於標準作業，預測誤差通常在 ±5–10 °C 之間。有暫停、自定義韌體或異常冷卻設定時，這一誤差可能會擴大。"
+
+#~ msgid ""
+#~ "Fan & Airflow Model\n"
+#~ "A simplified fan-and-room model shows how cooling settings change part temps without slow CFD maths—great for day-to-day tuning. Chamber vortices aren’t yet simulated so runs stay fast."
+#~ msgstr ""
+#~ "風扇與氣流模型\n"
+#~ "一個簡化的風扇與室內氣流模型可以展示冷卻設定如何影響零件溫度，而無需複雜的 CFD 計算——適合日常調優。目前尚未模擬腔體內的渦流，以保證執行速度。"
+
+#~ msgid ""
+#~ "TQI Limits Explained\n"
+#~ "-100 → too cold: tensile strength is ~50 % lower than parts printed at the ideal 0 (ASTM D638 dog-bone tests). +100 → too hot: layers stay molten and may sag or collapse. Keep regions near 0 for peak strength and accuracy."
+#~ msgstr ""
+#~ "熱質量指數極限說明\n"
+#~ "-100 → 太冷：拉伸強度約比理想值 0 的零件低 50%（根據 ASTM D638 骨型測試）。+100 → 太熱：層之間保持熔融狀態，可能下垂或坍塌。將區域保持在接近 0 的值，可獲得最佳強度與精度。"
+
+#~ msgid ""
+#~ "What Drives Runtime?\n"
+#~ "Extra layers, dense infill, lots of tiny arcs (small mesh elements) or very slow printing speeds all extend simulation time because the solver must step through more seconds. Multi-core CPUs or CUDA GPUs speed things up."
+#~ msgstr ""
+#~ "哪些因素影響執行時間？\n"
+#~ "額外的層、密集填充、大量小弧線（即細小網格元素）或非常慢的列印速度都會增加模擬時間，因為求解器需要處理更多時間步。多核 CPU 或 CUDA GPU 可加快模擬速度。"
+
+#~ msgid ""
+#~ "Nozzle Temp Range\n"
+#~ "Supported set-points are 190 – 320 °C; anything outside is clamped to keep physics realistic."
+#~ msgstr ""
+#~ "噴嘴溫度範圍\n"
+#~ "\n"
+#~ "支援的噴嘴設定溫度範圍為 190 – 320 °C；超出範圍的值將被限制，以確保物理模擬真實可靠。"
+
+#~ msgid ""
+#~ "Debugging Flowchart\n"
+#~ "Not sure why a result looks off? Follow our step-by-step debugging flowchart to trace settings, G-code and material issues in minutes."
+#~ msgstr ""
+#~ "除錯流程圖\n"
+#~ "不確定結果為何異常？只需幾分鐘，按照我們的逐步除錯流程圖檢查設定、G-code 和材料問題。"
+
+#~ msgid ""
+#~ "Why Cooling Varies\n"
+#~ "Outer walls and bridges cool fastest while thick interiors stay warmer—geometry, airflow and tool-path all play a part, and the simulation visualises these differences."
+#~ msgstr ""
+#~ "為什麼冷卻效果不同\n"
+#~ "外壁和橋接區域冷卻速度最快，而厚實的內部結構則保持更高溫度——幾何結構、氣流和路徑都會影響冷卻效果，模擬視覺化會呈現這些差異。"
+
+#~ msgid ""
+#~ "Extrusion Temp Model\n"
+#~ "Material properties shape the melt curve, but printer geometry decides how much heat the filament actually gains, so the model is material-specific and printer-calibrated."
+#~ msgstr ""
+#~ "擠出溫度模型\n"
+#~ "材料屬性決定熔化曲線，而印表機結構決定材料實際吸收的熱量，因此該模型既與材料相關，也需針對印表機進行校準。"
+
+#~ msgid ""
+#~ "Nozzle setting of 190 °C vs 320 °C?\n"
+#~ "A 100 °C nozzle change only nudges the thermal index because extrusion temp, flow rate and post-deposition cooling dominate the part’s heat history."
+#~ msgstr ""
+#~ "噴嘴設定為 190 °C 與 320 °C 有何區別？\n"
+#~ "噴嘴溫度變化 100 °C 對熱指數的影響較小，因為擠出溫度、流速和沉積後的冷卻過程才是決定零件熱歷史的主要因素。"
+
+#~ msgid ""
+#~ "Bed Temperature influence\n"
+#~ "Only the first-layer bed temp feeds the model right now; later bed changes aren’t yet captured."
+#~ msgstr ""
+#~ "熱床溫度的影響\n"
+#~ "目前模型只考慮第一層的熱床溫度；後續層的床溫變化尚未納入模擬。"
+
+#~ msgid ""
+#~ "Actual Tool-Path\n"
+#~ "Yes—your exact G-code path, speeds and fan commands are simulated."
+#~ msgstr ""
+#~ "實際工具路徑\n"
+#~ "是的——我們會模擬您的完整 G-code 路徑、列印速度和風扇指令。"
+
+#~ msgid ""
+#~ "Mesh Resolution\n"
+#~ "The voxel grid is finer than the G-code line spacing, capturing layer-by-layer detail without wasting compute."
+#~ msgstr ""
+#~ "網格解析度\n"
+#~ "體素網格的解析度比 G-code 的線間距更高，能夠逐層捕捉細節，同時不會浪費計算資源。"
+
+#~ msgid ""
+#~ "Shrinkage, Warping & Stress\n"
+#~ "By controlling the thermal index you can remove the heat-driven causes of warp and stress."
+#~ msgstr ""
+#~ "收縮、翹曲與應力\n"
+#~ "透過控制熱指數，可以消除由熱引起的翹曲和應力根源。"
+
+#~ msgid "Use 12-hour time format"
+#~ msgstr "使用12小時制時間格式"
+
+#~ msgid "Display time in 12-hour format with AM/PM instead of 24-hour format"
+#~ msgstr "以12小時制(AM/PM)顯示時間，而不是24小時制"
+
+#, c-format, boost-format
+#~ msgid "The hardness of current material (%s) exceeds the hardness of %s(%s). It may cause nozzle wear, leading to material leakage and unstable flow. Please exercise caution when using it."
+#~ msgstr "當前材料（%s）的硬度高於 %s（%s）的硬度，可能導致噴嘴磨損，進而造成材料洩漏和流動不穩定。使用時請務必小心。"
+
+#~ msgid "Join Customer Experience Improvement Program."
+#~ msgstr "加入使用者體驗改進計劃。"
+
+#~ msgid "What data would be collected?"
+#~ msgstr "將收集哪些資料？"
+
+#~ msgid ""
+#~ "This filament may not be completely dried.\n"
+#~ "\n"
+#~ msgstr ""
+#~ "該耗材可能無法完全烘乾。\n"
+#~ "\n"
+
+#~ msgid "This AMS is currently printing. To ensure print quality, the drying temperature cannot exceed the recommended drying temperature.\n"
+#~ msgstr "此AMS當前正在列印。為確保列印質量，烘乾溫度不得超過推薦的烘乾溫度。\n"
+
+#~ msgid "The temperature shall not exceed the heat distortion temperature("
+#~ msgstr "溫度不得超過耗材的壓潰溫度（"
+
+#~ msgid "°C) of the filament.\n"
+#~ msgstr "°C)。\n"
+
+#~ msgid "Minimum time value cannot be less than 1.\n"
+#~ msgstr "時間最小值不能小於 1。\n"
+
+#~ msgid "Maximum time value cannot be greater than 24.\n"
+#~ msgstr "時間最大值不能大於 24。\n"
+
+#~ msgid "*Insufficient power\n"
+#~ msgstr "*功率不足\n"
+
+#~ msgid "  Too many AMS drying simultaneously. Please plug in the power or stop other drying processes before starting.\n"
+#~ msgstr "  同時烘乾的機器過多，您可以插上電源，或者停止其他烘乾後再開始。\n"
+
+#~ msgid "*AMS is busy\n"
+#~ msgstr "*AMS正忙\n"
+
+#~ msgid "  AMS is calibrating | reading RFID | loading/unloading material, please wait.\n"
+#~ msgstr "  AMS正在校準｜讀取RFID｜進退料，請稍等。\n"
+
+#~ msgid "*Filament in AMS outlet\n"
+#~ msgstr "*耗材在AMS出料口中\n"
+
+#~ msgid "*Initiating AMS drying\n"
+#~ msgstr "*啟動AMS烘乾\n"
+
+#~ msgid "*Not supported in 2D mode\n"
+#~ msgstr "*不支援 2D 模式\n"
+
+#~ msgid "*Task in progress\n"
+#~ msgstr "*任務佔用\n"
+
+#~ msgid "  The AMS might be in use during Task.\n"
+#~ msgstr "  任務中可能會使用到該臺AMS。\n"
+
+#~ msgid "*Upgrading\n"
+#~ msgstr "*正在升級\n"
+
+#~ msgid "  Firmware update in progress, please wait...\n"
+#~ msgstr "  韌體更新正在進行中，請稍候……\n"
+
+#~ msgid "  Please plug in the power and then use the drying function.\n"
+#~ msgstr "  請插上電源後使用烘乾功能。\n"
+
+#~ msgid "*System is busy\n"
+#~ msgstr "*系統正忙\n"
+
+#~ msgid "  Initiating other drying processes, please wait a few seconds...\n"
+#~ msgstr "  正在開啟其他烘乾，請稍等幾秒...\n"
+
+#~ msgid "Performs full purging for the best print quality. Requires more material and time."
+#~ msgstr "執行完整的沖刷流程以獲得最佳列印質量，需要更多材料和時間。"
+
+#~ msgid "Purge Saving"
+#~ msgstr "省料模式"
+
+#~ msgid "Reduces purge waste and prints faster. May cause slight color mixing or small surface defects."
+#~ msgstr "減少衝刷量，加快列印速度，但可能出現輕微的顏色混合或表面瑕疵。"
+
+#~ msgid "Learn more about purge mode"
+#~ msgstr "瞭解更多衝刷模式資訊"
+
+#~ msgid "When using ABS/ASA/PETG HF on the right extruder, it can only be used as support material."
+#~ msgstr "ABS/ASA/PETG HF在右擠出機列印時，僅能作為支撐材料使用。"
+
+#~ msgid "CF/GF filaments are hard and brittle, It's easy to break or get stuck in AMS, please use with caution."
+#~ msgstr "CF/GF耗材絲又硬又脆，在AMS中很容易斷裂或卡住，請謹慎使用。"
+
+#~ msgid "4-slot AMS"
+#~ msgstr "4槽AMS"
+
+#~ msgid "1-slot AMS"
+#~ msgstr "單槽AMS"
+
+#~ msgid "Remove this AMS"
+#~ msgstr "移除此AMS"
+
+#~ msgid "There are no nozzles under current diameter. Continuing switching will automatically change diameters of all nozzles"
+#~ msgstr "當前直徑下無噴嘴。繼續切換將自動更改所有噴嘴的直徑。"
+
+#~ msgid "Confirm Diameter Switch"
+#~ msgstr "確認直徑切換"
+
+#~ msgid "(Unavailable for right extruder)"
+#~ msgstr "（右側擠出機不可用）"
+
+#~ msgid "The TPU High Flow nozzle doesn't support auto filament switching, so only one filament can be assigned.\n"
+#~ msgstr "TPU 高流量噴嘴不支援自動切換耗材，因此只能分配一種耗材。\n"
+
+#~ msgid " filaments are assigned to the TPU High Flow nozzle"
+#~ msgstr " 耗材被分配到 TPU 高流量噴嘴上"
+
+#~ msgid "1. Filaments of different types cannot be matched."
+#~ msgstr "1. 不同型別的耗材不能混用。"
+
+#~ msgid "2. Left nozzle filaments do not match the right nozzle."
+#~ msgstr "2. 左噴嘴的耗材與右噴嘴不匹配。"
+
+#~ msgid "To proceed, go to the Preparation page to change the filament or nozzle assignment, then slice again. Please refer to Wiki before use->"
+#~ msgstr "若要繼續，請轉到準備頁面更改耗材或噴嘴分配，然後重新切片。請使用前參考Wiki ->"
+
+#~ msgid "Cooling heatbed"
+#~ msgstr "熱床降溫中"
+
+#~ msgid "Micro lidar calibration"
+#~ msgstr "微型鐳射雷達校準"
+
+#~ msgid "Bed leveling"
+#~ msgstr "熱床調平"
+
+#~ msgid "High-temperature Heatbed Calibration"
+#~ msgstr "高溫熱床校準"
+
+#~ msgid "Nozzle clumping detection Calibration"
+#~ msgstr "噴嘴裹頭檢測位置校準"
+
+#~ msgid ""
+#~ "The color has been selected, you can choose OK \n"
+#~ " to continue or manually adjust it."
+#~ msgstr ""
+#~ "顏色已經選好了，您可以選中確認 \n"
+#~ " 繼續或手動修改它。"
+
+#, c-format, boost-format
+#~ msgid "Note: the filament type(%s) does not match with the filament type(%s) in the slicing file. If you want to use this slot, you can install %s instead of %s and change slot information on the 'Device' page."
+#~ msgstr "提示: 此耗材型別(%s)與切片檔案中的耗材型別(%s)不匹配。如果您想使用這個槽位，請安裝%s耗材替換掉%s耗材，然後在''裝置'頁面設定槽位資訊。"
+
+#, c-format, boost-format
+#~ msgid "Note: the slot is empty or undefined. If you want to use this slot, you can install %s and change slot information on the 'Device' page."
+#~ msgstr "提示: 此槽位是空的或者未定義的。如果您想使用這個槽位，請安裝%s，然後在''裝置'頁面設定槽位資訊。"
+
+#~ msgid "Note: Only filament-loaded slots can be selected."
+#~ msgstr "提示：僅允許選擇放置有耗材的槽位。"
+
+#~ msgid "Surround projection by char"
+#~ msgstr "按字元環繞投影"
+
+#~ msgid "Horizonal"
+#~ msgstr "水平"
+
+#~ msgid "Embeded depth"
+#~ msgstr "內嵌深度"
+
+#~ msgid "AMS ID will be reset. If you want a specific ID sequence, disconnect all AMS before resetting and connect them in the desired order after resetting."
+#~ msgstr "已連線AMS的ID將被重置。如果你想要一個特定的ID順序，在重置後斷開所有AMS的連線，重置後按所需順序連線。"
+
+#~ msgid ""
+#~ "Support ironing will not work with sparse support interface.\n"
+#~ "Do you want to disable the support ironing?\n"
+#~ "Yes: disable the support ironing.\n"
+#~ "No: make the support interface solid."
+#~ msgstr ""
+#~ "支撐熨燙無法在稀疏的支撐介面上使用。\n"
+#~ "是否需要關閉支撐熨燙選項？\n"
+#~ "是：關閉支撐熨燙。\n"
+#~ "否：調整支撐介面設定使其實心。"
+
+#~ msgid " Preparing Hotend"
+#~ msgstr " 熱端準備中"
+
+#~ msgid "This calibration does not support the currently selected nozzle diameter"
+#~ msgstr "該標定不支援當前選中噴嘴直徑"
+
+#~ msgid "Current flowrate cali param is invalid"
+#~ msgstr "當前流量標定引數非法"
+
+#~ msgid "Selected diameter and machine diameter do not match"
+#~ msgstr "選擇的直徑和機器直徑不匹配"
+
+#~ msgid "Failed to generate cali gcode"
+#~ msgstr "生成標定GCode失敗"
+
+#~ msgid "Calibration error"
+#~ msgstr "校準錯誤"
+
+#~ msgid "Allow Prompt Sound"
+#~ msgstr "支援提示音"
+
+#, c-format, boost-format
+#~ msgid "The hardness of current material (%s) exceeds the hardness of %s(%s). Please verify the nozzle or material settings and try again."
+#~ msgstr "當前材料(%s) 所需噴嘴的硬度 高於 %s(%s)的硬度，請確認噴嘴或材料屬性後重試。"
+
+#~ msgid "Grouping error: "
+#~ msgstr "分組錯誤："
+
+#~ msgid "Set special cooling fan for the first certain layers. Cooling fan of the first layer used to be closed to get better build plate adhesion and used for auto cooling function"
+#~ msgstr "為前幾層設定輔助風扇的數值。首層的輔助風扇通常關閉，以獲得更好的列印平臺附著力，同時用於自動冷卻功能。同時，會關閉部件風扇"
+
+#~ msgid "Special cooling fan speed for the first certain layers"
+#~ msgstr "在前幾層使用特殊的冷卻風扇速度"
+
+#~ msgid "The filament may require slicing parameter adjustments."
+#~ msgstr "該材料可能需要調整切片引數。"
+
+#~ msgid "Smooth mesh"
+#~ msgstr "平滑網格"
+
+#~ msgid "The rough surface of PLA Glow can accelerate wear on the AMS system, particularly on the internal components of the AMS Lite."
+#~ msgstr "PLA Glow的粗糙表面可能加速AMS系統的磨損，尤其是AMS Lite的內部部件。"
+
+#~ msgid "Scale to build volume"
+#~ msgstr "縮放到構建空間大小"
+
+#~ msgid "Scale an object to fit the build volume"
+#~ msgstr "縮放物件以適應構建空間大小"
+
+#~ msgid "Cooling mode is suitable for printing PLA/PETG/TPU materials."
+#~ msgstr "冷卻模式適合列印PLA/PETG/TPU材質"
+
+#, c-format, boost-format
+#~ msgid "[ %s ] requires printing in a high-temperature environment.Please close the door."
+#~ msgstr "[ %s ] 需要在高溫環境下列印。請關上門。"
+
+#~ msgid "High chamber temperature is required. Please close the door."
+#~ msgstr "需高腔溫列印，請關門。"
+
+#~ msgid "Log in failed. Please check the Pin Code."
+#~ msgstr "登入失敗，請檢查Pin碼。"
+
+#~ msgid "Auto turn off filter on overheat"
+#~ msgstr "開啟自動關閉過濾"
+
+#~ msgid "Spacing of interface lines. Zero means solid interface"
+#~ msgstr "接觸面的線距。0代表實心接觸面。"
+
+#~ msgid "This is  the number of layers of top bottom penetration."
+#~ msgstr "頂部塗色滲透的層數"
+
+#~ msgid "Distribute along Y axis"
+#~ msgstr "在包圍盒Y軸上均勻分佈"
+
+#~ msgid "Distribute along X axis"
+#~ msgstr "在包圍盒X軸上均勻分佈"
+
+#~ msgid "Distribute along Z axis"
+#~ msgstr "在包圍盒Z軸上均勻分佈"
+
+#~ msgid "Align to Y Max"
+#~ msgstr "對齊到包圍盒Y軸最大位置"
+
+#~ msgid "Align to Y Min"
+#~ msgstr "對齊到包圍盒Y軸最小位置"
+
+#~ msgid "Align to Y Center"
+#~ msgstr "對齊到包圍盒Y軸中心位置"
+
+#~ msgid "Align to X Max"
+#~ msgstr "對齊到包圍盒X軸最大位置"
+
+#~ msgid "Align to X Min"
+#~ msgstr "對齊到包圍盒Y軸最小位置"
+
+#~ msgid "Align to X Center"
+#~ msgstr "對齊到包圍盒X軸中心位置"
+
+#~ msgid "Align to Z Max"
+#~ msgstr "對齊到包圍盒Z軸最大位置"
+
+#~ msgid "Align to Z Min"
+#~ msgstr "對齊到包圍盒Z軸最小位置"
+
+#~ msgid "Align to Z Center"
+#~ msgstr "對齊到包圍盒Z軸中心位置"
+
+#~ msgctxt "NozzleVolumeType"
+#~ msgid "SF"
+#~ msgstr "標準流量"
+
+#~ msgctxt "NozzleVolumeType"
+#~ msgid "HF"
+#~ msgstr "高流量"
+
+#~ msgid "The current filament doesn't support the high-flow nozzle and can't be used."
+#~ msgstr "當前材料不支援高流量噴嘴，無法使用。"
+
+#~ msgid "Align objects to the minimum X position"
+#~ msgstr "將物件或零件對齊到包圍盒X軸最小位置"
+
+#~ msgid "Align objects to the center X position"
+#~ msgstr "將物件或零件對齊到包圍盒X軸中心位置"
+
+#~ msgid "Align objects to the maximum X position"
+#~ msgstr "將物件或零件對齊到包圍盒X軸最大位置"
+
+#~ msgid "Distribute objects evenly along X axis"
+#~ msgstr "將物件或零件均勻分佈在包圍盒X 軸上"
+
+#~ msgid "Align objects to the maximum Y position"
+#~ msgstr "將物件或零件對齊到包圍盒Y軸最大位置"
+
+#~ msgid "Align objects to the center Y position"
+#~ msgstr "將物件或零件對齊到包圍盒Y軸中心位置"
+
+#~ msgid "Align objects to the minimum Y position"
+#~ msgstr "將物件或零件對齊到包圍盒Y軸最小位置"
+
+#~ msgid "Distribute objects evenly along Y axis"
+#~ msgstr "將物件或零件均勻分佈在包圍盒Y 軸上"
+
+#~ msgid "Align objects to the minimum Z position"
+#~ msgstr "將零件對齊到包圍盒Z軸最小位置"
+
+#~ msgid "Please select at least 2 parts and do not select entire object"
+#~ msgstr "請選擇至少2個零件，且不要選擇整個物件"
+
+#~ msgid "Align objects to the center Z position"
+#~ msgstr "將零件對齊到包圍盒Z軸中心位置"
+
+#~ msgid "Align objects to the maximum Z position"
+#~ msgstr "將零件對齊到包圍盒Z軸最大位置"
+
+#~ msgid "Distribute objects evenly along Z axis"
+#~ msgstr "將物件或零件均勻分佈在包圍盒Z 軸上"
+
+#~ msgid "Please select at least 3 parts and do not select entire object"
+#~ msgstr "請選擇至少3個零件，且不要選擇整個物件"
+
+#~ msgid "Pauses printing when the detected build plate type does not mhatch the selected one."
+#~ msgstr "檢測到列印板型別與所選型別不匹配時，暫停列印。"
+
+#~ msgid ""
+#~ "This is your first time slicing with the H2D machine.\n"
+#~ "Would you like to watch a quick tutorial video?"
+#~ msgstr ""
+#~ "這是您第一次使用 H2D 機器進行切片操作。\n"
+#~ "您需要觀看一個簡短的指導影片嗎？"
+
+#~ msgid ""
+#~ "This is your first time printing tpu filaments with the H2D machine.\n"
+#~ "Would you like to watch a quick tutorial video?"
+#~ msgstr ""
+#~ "這是您第一次使用H2D機器列印TPU耗材。\n"
+#~ "您需要觀看一個簡短的指導影片嗎？"
+
+#~ msgid "'Process'-'Others'-'Special Mode'-'Timelapsed'"
+#~ msgstr "“工藝”-”其他“-”特殊模式“-”延時攝影“"
+
+#~ msgid ""
+#~ "When using PLA to support TPU, We recommend the following settings:\n"
+#~ "0 top z distance, 0 interface spacing, 0 support/object xy distance, interlaced rectilinear pattern, enable Z \n"
+#~ "overrides XY, disable independent support layer height and use PLA for both support interface and support base"
+#~ msgstr ""
+#~ "當使用PLA作為支撐材料支撐TPU時，我們推薦以下設定：\n"
+#~ "0頂部z距離，0接觸面間距，0支撐/模型 xy 間距，交疊直線圖案，啟用Z覆蓋XY，禁用支撐獨立層高，並將PLA同時用於支撐介面和支撐主體"
+
+#~ msgid ""
+#~ "When using soluble material for the support, We recommend the following settings:\n"
+#~ "0 top z distance, 0 interface spacing, 0 support/object xy distance, interlaced rectilinear pattern, enable Z \n"
+#~ "overrides XY, disable independent support layer height and use soluble materials for both support interface \n"
+#~ "and support base"
+#~ msgstr ""
+#~ "當使用可溶性材料作為支撐時，我們推薦以下設定：\n"
+#~ "0頂部z距離，0接觸面間距，0支撐/模型 xy 間距，交疊直線圖案，啟用Z覆蓋XY，禁用獨立支撐層高，並將可溶性材料同時用於支撐介面和支撐主體"
+
+#~ msgid ""
+#~ "When using support material for the support interface, We recommend the following settings:\n"
+#~ "0 top z distance, 0 interface spacing, interlaced rectilinear pattern, enable Z overrides XY and disable \n"
+#~ "independent support layer height"
+#~ msgstr ""
+#~ "當支撐介面使用支撐材料時，我們推薦以下設定：\n"
+#~ "0頂部z距離，0接觸面間距，交疊直線圖案，啟用Z覆蓋XY，並且禁用獨立支撐層高"
+
+#~ msgid ""
+#~ "When using soluble material for the support interface, We recommend the following settings:\n"
+#~ "0 top z distance, 0 interface spacing, 0 support/object xy distance, interlaced rectilinear pattern, enable Z \n"
+#~ "overrides XY, disable independent support layer height and use soluble materials for both support interface \n"
+#~ "and support base"
+#~ msgstr ""
+#~ "當使用可溶性材料作為支撐介面時，我們推薦以下設定：\n"
+#~ "0頂部z距離，0接觸面間距，0支撐/模型 xy 間距，交疊直線圖案，啟用Z覆蓋 XY，禁用獨立支撐層高，並將可溶性材料同時用於支撐介面和支撐主體"
+
+#~ msgid "Advanced Settings"
+#~ msgstr "高階設定"
+
+#~ msgid "Buy Now"
+#~ msgstr "立即購買"
+
+#~ msgid "Smoothing outwall speed in z direction to get better surface quality. Print time will increases. It is not work on spiral vase mode."
+#~ msgstr "平滑 Z 方向外牆速度以獲得更好的表面質量。該功能會增加列印時間，同時無法在旋轉花瓶模式下生效。"
+
+#~ msgid "length when change nozzle"
+#~ msgstr "換噴嘴時回抽量"
+
+#~ msgid "When this retraction value is modified, it will be used as the amount of filament retracted inside the nozzle before changing nozzles."
+#~ msgstr "當調整此回抽值時，它將作為更換噴嘴前噴嘴內耗材的回抽量。"
+
+#~ msgid "When top z distance overrides support/object xy distance, give priority to ensuring that supports are generated beneath overhangs, and a gap of the same size as top z distance is leaved with the model. Whereas in the opposite case, the gap between supports and the model follows support/object xy distance all the time"
+#~ msgstr "當頂部z距離覆蓋支撐/模型 xy 間距時，優先確保在懸垂下方生成支撐，並與模型保持與頂部z距離大小相同的間隙；反之，支撐與模型之間的間隙始終遵循支撐/模型 xy 間距"
+
+#~ msgid "Detect spaghetti failure(scattered lose filament)."
+#~ msgstr "檢測到炒麵（散落的耗材絲）。"
+
+#~ msgid "Monitor if the waste is piled up in the purge chute."
+#~ msgstr "監控沖刷料是否在垃圾桶中發生堆積。"
+
+#~ msgid "Check if the nozzle is clumping by filaments or other foreign objects."
+#~ msgstr "檢查噴嘴是否被耗材或其他異物堵塞。"
+
+#~ msgid "Check if the nozzle is clumping by filament or other foreign objects."
+#~ msgstr "檢查噴嘴是否被耗材絲或其他異物裹住"
+
+#~ msgid "Idel Heating Protection"
+#~ msgstr "空閒加熱保護"
+
+#~ msgid "Failed to group and merge parts by object. Please check for self-intersections, non-manifold geometry, or open meshes."
+#~ msgstr "無法按物件分組，及合併零件。請檢查是否存在自相交、非流形幾何體或開放網格。"
+
+#~ msgid "Debug Info"
+#~ msgstr "除錯資訊"
+
+#~ msgid "Turn it Off"
+#~ msgstr "關閉"
+
+#, c-format, boost-format
+#~ msgid "Left: %s"
+#~ msgstr "左: %s"
+
+#, c-format, boost-format
+#~ msgid "Right: %s"
+#~ msgstr "右: %s"
+
+#~ msgid "(Modified)"
+#~ msgstr "(待修改）"
+
+#, c-format, boost-format
+#~ msgid "Remaining time: %s"
+#~ msgstr "剩餘時間 ： %s"
+
+#, c-format, boost-format
+#~ msgid "The nozzle diameter of %s extruder is 0.2mm which does not support automatic Flow Dynamics calibration."
+#~ msgstr "%s 擠出機的噴嘴直徑為0.2毫米，不支援自動流量校準。"
+
+#~ msgid "No available external storage was obtained. Please confirm and try again."
+#~ msgstr "沒有可用的外部儲存介質。請確認後重試。"
+
+#~ msgid "Media capability acquisition timeout, please check if the firmware version supports it."
+#~ msgstr "媒體能力獲取超時，請檢查韌體版本是否支援它。"
+
+#~ msgid "Filter out gaps smaller than the threshold specified. This setting won't affact top/bottom layers"
+#~ msgstr "過濾掉小於指定閾值的間隙。此設定不會影響頂部/底部圖層。"
+
+#~ msgid "Unable to perform boolean operation on selected parts"
+#~ msgstr "無法對所選部件執行布林運算"
+
+#~ msgid "Performed boolean intersection fails because the selected parts have no intersection"
+#~ msgstr "因選中的物體無交集，布林交集計算失敗"
+
+#~ msgid ""
+#~ "Please add at least one more object and select them together,\n"
+#~ "then right click to assembly these objects."
+#~ msgstr ""
+#~ "請增加至少一個物件並一起選中它們，\n"
+#~ "然後右鍵組合這些物件。"
+
+#~ msgid "Please right click to assembly these objects."
+#~ msgstr "請右鍵組合這些物件"
+
+#~ msgid "Source Volume"
+#~ msgstr "源體積"
+
+#~ msgid "Tool Volume"
+#~ msgstr "工具體積"
+
+#~ msgid "selected"
+#~ msgstr "已選中"
+
+#~ msgid "Part 1"
+#~ msgstr "零件 1"
+
+#~ msgid "Subtract from"
+#~ msgstr "從中減去"
+
+#~ msgid "Part 2"
+#~ msgstr "零件 2"
+
+#~ msgid "Subtract with"
+#~ msgstr "與之相減"
+
+#~ msgid "Delete input"
+#~ msgstr "刪除輸入"
+
+#~ msgid "Helio: Failed to create Simulation\n"
+#~ msgstr "Helio: 建立模擬失敗\n"
+
+#~ msgid "Helio: Failed to create GCode\n"
+#~ msgstr "Helio：建立G程式碼失敗\n"
+
+#~ msgid "Helio: Failed to create Optimization\n"
+#~ msgstr "Helio：建立最佳化失敗\n"
+
+#~ msgid "Helio: GCode download failed\n"
+#~ msgstr "Helio：GCode 下載失敗\n"
+
+#~ msgid "Automatic calibration only supports cases where the left and right nozzle diameters are identical."
+#~ msgstr "自動標定僅支援左右噴嘴直徑完全相同的情況。"
+
+#~ msgid "Helio Action"
+#~ msgstr "Helio功能"
+
+#~ msgid "Helio Options"
+#~ msgstr "Helio 選項"
+
+#~ msgid "Enable Helio"
+#~ msgstr "開啟 Helio"
+
+#~ msgid "About Helio"
+#~ msgstr "關於 Helio"
+
+#~ msgid "Helio Privacy Policy"
+#~ msgstr "Helio 隱私政策"
+
+#~ msgid "Terms of Service"
+#~ msgstr "服務條款"
+
+#~ msgid "You are about to enable a third-party software service feature from Helio Additive! Before confirming the use of this feature, please carefully read the following statements."
+#~ msgstr "您正準備開啟一個來自Helio Additive的第三方軟體服務功能！在確認使用此功能前，請仔細閱讀以下宣告。"
+
+#~ msgid "Unless otherwise specified, Bambu Lab only provides support for the software features officially provided. The slicing evaluation and slicing optimization features based on Helio Additive's cloud service in this software will be developed, operated, provided, and maintained by Helio Additive. Helio Additive is responsible for the effectiveness and availability of this service. The optimization feature of this service may modify the default print commands, posing a risk of printer damage. These features will collect necessary user information and data to achieve relevant service functions. Subscriptions and payments may be involved. Please visit Helio Additive and refer to the Helio Additive Privacy Agreement and the Helio Additive User Agreement for detailed information."
+#~ msgstr "除非特殊說明，拓竹科技僅對官方提供的軟體功能提供支援。本軟體中基於Helio Additive雲端服務的切片評估和切片最佳化功能由Helio Additive負責開發、維護以及對外提供服務，其服務效果和可用性由Helio Additive負責.本服務的最佳化功能可能修改預設的列印指令，存在印表機損壞的風險。同時這些功能將收集必要的使用者資訊和資料以實現相關服務功能，並可能涉及訂閱與付費，請訪問Helio Addtive和參考Helio Additive隱私協議 和Helio Addtive 使用者使用協議獲取詳細資訊。"
+
+#~ msgid "Meanwhile, you understand that this product is provided to you \"as is\" based on Helio Additive's services, and Bambu makes no express or implied warranties of any kind, nor can it control the service effects. To the fullest extent permitted by applicable law, Bambu or its licensors/affiliates do not provide any express or implied representations or warranties, including but not limited to warranties regarding merchantability, satisfactory quality, fitness for a particular purpose, accuracy, confidentiality, and non-infringement of third-party rights. Due to the nature of network services, Bambu cannot guarantee that the service will be available at all times, and Bambu reserves the right to terminate the service based on relevant circumstances."
+#~ msgstr "同時，您理解本產品是基於Helio Additive的服務“按原樣”向您提供，拓竹不存在任何形式的明示或暗示擔保，也無法控制服務效果，並且在適用法律允許的最大範圍內，拓竹、其許可方/附屬公司均不提供任何明示或暗示的陳述或保證，包括但不限於有關適銷性、滿意質量、適用於特定目的、準確性、保密權以及不侵犯第三方權利的保證。基於網路服務的特性，拓竹無法保證該服務隨時可達，並且拓竹有權根據相關情況終止該服務。"
+
+#~ msgid "You agree not to use this product and its related updates to engage in the following activities:"
+#~ msgstr "您同意不使用本產品及相關更新內容從事以下行為："
+
+#~ msgid "1.Copy or use any part of this product outside the authorized scope of Helio Additive and Bambu."
+#~ msgstr "1. 在Helio Additive和拓竹授權範圍之外複製或使用本產品的任何一部分內容。"
+
+#~ msgid "2.Attempt to disrupt, bypass, alter, invalidate, or evade any Digital Rights Management system related to and/or an integral part of this product."
+#~ msgstr "2. 企圖破壞、繞過、改變、作廢或者逃避和本產品相關的以及/或者屬於本產品有機組成的一部分的任何數字版權管理系統。"
+
+#~ msgid "3.Using this software and services for any improper or illegal activities."
+#~ msgstr "3. 利用本軟體和服務進行任何不當或違反法律的行為。"
+
+#~ msgid "Agree"
+#~ msgstr "同意"
+
+#~ msgid "No cooling for the first"
+#~ msgstr "關閉冷卻對前"
+
+#~ msgid "Close all cooling fan for the first certain layers. Cooling fan of the first layer used to be closed to get better build plate adhesion"
+#~ msgstr "對開始的一些層關閉所有的部件冷卻風扇。通常關閉首層冷卻用來獲得更好的熱床粘接"
+
+#~ msgid "Custom filaments"
+#~ msgstr "自定義材料"
+
+#~ msgid "Helio Simulation"
+#~ msgstr "Helio 模擬"
+
+#~ msgid "Note: Please set the above temperature according to the actual situation. The more accurate the data is, the more precise the analysis results will be."
+#~ msgstr "注意：請根據實際情況設定上述溫度。資料越準確，分析結果越精確。"
+
+#~ msgid "How to use Helio"
+#~ msgstr "如何使用 Helio"
+
+#~ msgid "Helio: Process Started"
+#~ msgstr "Helio：處理已開始"
+
+#~ msgctxt "air_duct"
+#~ msgid "Right"
+#~ msgstr "右邊"
+
+#~ msgid "The printer has been logged out and cannot connect."
+#~ msgstr "印表機已登出，無法連線。"
+
+#, c-format, boost-format
+#~ msgid "Printer not connected. Please go to the device page to connect an %s printer before syncing."
+#~ msgstr "未連線印表機，請前往裝置頁連線一臺 %s 後再同步。"
+
+#, c-format, boost-format
+#~ msgid "The currently connected printer on the device page is not an %s. Please switch to an %s before syncing."
+#~ msgstr "裝置頁當前連線的印表機不是 %s ，無法同步，請切換成 %s 後再同步。"
+
+#~ msgid "enable_wrapping_detection"
+#~ msgstr "啟用觸碰裹頭檢測"
+
+#~ msgid "enable_prime_tower"
+#~ msgstr "啟用擦拭塔"
+
+#, c-format, boost-format
+#~ msgid "Printer not connected. Please go to the device page to connect %s printer before syncing."
+#~ msgstr "未連線印表機，請前往裝置頁連線一臺 %s 印表機後再同步。"
+
+#~ msgid "Parameter recommendation: In the process preset, under Others-Advanced, check Enable clumping detection by probing. This feature generates a small wipe tower and performs probing detection to identify clumping issues early in the print and stop printing, preventing print failures or printer damage.\n"
+#~ msgstr "在工藝預設的【其他-高階】中勾選“啟用觸碰裹頭檢測”選項。該功能將透過生成小型料塔和觸碰檢測，可在列印早期發現裹頭問題並終止列印，避免列印失敗或印表機損傷。\n"
+
+#~ msgid "Open Preferences."
+#~ msgstr "開啟首選項"
+
+#~ msgid "Open next tip."
+#~ msgstr "開啟下一條提示。"
+
+#~ msgid "Open Documentation in web browser."
+#~ msgstr "在web瀏覽器中開啟文件。"
+
+#~ msgid "Spiral mode only works when wall loops is 1, support is disabled, top shell layers is 0, sparse infill density is 0, timelapse type is traditional and smoothing wall speed in z direction is false."
+#~ msgstr "花瓶模式僅在以下條件下可用：牆壁環數設定為 1，支撐禁用，頂殼層數為 0，稀疏填充密度為 0，延時攝影型別為傳統，並且 Z 方向牆速度平滑不啟用。"
+
+#~ msgid "Fatal"
+#~ msgstr "致命"
+
+#~ msgid "Serious"
+#~ msgstr "嚴重"
+
+#~ msgid "Common"
+#~ msgstr "普通"
+
+#~ msgid "Stop Buzzer"
+#~ msgstr "關閉蜂鳴器"
+
+#~ msgid "Helio settings"
+#~ msgstr "Helio 設定"
+
+#~ msgid "Small perimter threshold"
+#~ msgstr "小輪廓閾值"
+
+#~ msgid "Unless otherwise specified, Bambu Lab only provides support for the software features officially provided. The slicing evaluation and slicing optimization features based on Helio Additive's cloud service in this software will be developed, operated, provided, and maintained by Helio Additive. The effectiveness and availability of this service will be managed by Helio Additive.These features will collect necessary user information and data to achieve relevant service functions. Subscriptions and payments may be involved. Please visit Helio Additive and refer to the Helio Additive Privacy Agreement and the Helio Additive User Agreement for detailed information."
+#~ msgstr "除非特殊說明，拓竹科技僅對官方提供的軟體功能提供支援。本軟體中基於Helio Additive雲端服務的切片評估和切片最佳化功能將由Helio Additive負責開發、維護以及對外提供服務，其服務效果和可用性由Helio Additive管理。同時這些功能將收集必要的使用者資訊和資料以實現相關服務功能，並可能涉及訂閱與付費，請訪問Helio Addtive和參考Helio Additive隱私協議 和Helio Addtive 使用者使用協議獲取詳細資訊。"
+
+#~ msgid "When enabled, the last used color scheme (e.g., Line Type, Speed) will be automatically applied on next startup.."
+#~ msgstr "啟用後，將在下次啟動Studio後切片自動應用上次切片時使用的顏色方案（如走線型別、速度）。"
+
+#~ msgid "Layer Time (s)"
+#~ msgstr "層時間（s）"
+
+#~ msgid "Turning off the lights during the task will cause the failure of AI monitoring, like spaghetti dectection. Please choose carefully."
+#~ msgstr "任務過程中關燈可能導致炒麵檢測等AI監控失效, 請謹慎選擇。"
+
+#~ msgid "Open Door Dectection"
+#~ msgstr "開門檢測"
+
+#~ msgid "Previous unsaved project detected, do you want to restore it?"
+#~ msgstr "檢測到有未儲存的專案，是否恢復此專案？"
+
+#~ msgid "Paused due to filament runout"
+#~ msgstr "斷料暫停"
+
+#~ msgid "Heating hotend"
+#~ msgstr "加熱熱端"
+
+#~ msgid "Calibrating extrusion"
+#~ msgstr "動態流量校準"
+
+#~ msgid "Printing was paused by the user"
+#~ msgstr "使用者暫停"
+
+#~ msgid "Pause of front cover falling"
+#~ msgstr "工具頭前蓋掉落暫停"
+
+#~ msgid "Calibrating extrusion flow"
+#~ msgstr "擠出絕對流量校準"
+
+#~ msgid "Paused due to nozzle temperature malfunction"
+#~ msgstr "熱端溫控異常暫停"
+
+#~ msgid "Paused due to heat bed temperature malfunction"
+#~ msgstr "熱床溫控異常暫停"
+
+#~ msgid "Skip step pause"
+#~ msgstr "丟步暫停"
+
+#~ msgid "Paused due to AMS lost"
+#~ msgstr "因為AMS連線丟失而暫停"
+
+#~ msgid "Paused due to low speed of the heat break fan"
+#~ msgstr "因熱斷路風扇速度過低而暫停"
+
+#~ msgid "Paused due to chamber temperature control error"
+#~ msgstr "因腔溫錯誤而暫停"
+
+#~ msgid "Paused by the Gcode inserted by user"
+#~ msgstr "由使用者插入的Gcode指令導致暫停"
+
+#~ msgid "Nozzle filament covered detected pause"
+#~ msgstr "裹頭暫停"
+
+#~ msgid "Cutter error pause"
+#~ msgstr "切刀異常暫停"
+
+#~ msgid "First layer error pause"
+#~ msgstr "首層掃描異常暫停"
+
+#~ msgid "Nozzle clog pause"
+#~ msgstr "堵頭暫停"
+
+#~ msgid "Check printer absolute accuracy before calibration"
+#~ msgstr "校準前檢測印表機絕對精度"
+
+#~ msgid "Absolute accuracy calibration"
+#~ msgstr "校準前檢測印表機絕對精度"
+
+#~ msgid "Check printer absolute accuracy after calibration"
+#~ msgstr "校準後檢測印表機絕對精度"
+
+#~ msgid "Confirming birdeye camera position"
+#~ msgstr "俯視相機位置確認中"
+
+#~ msgid "Calibrating birdeye camera"
+#~ msgstr "俯視相機標定中"
+
+#~ msgid "Heated bed cooling"
+#~ msgstr "熱床降溫中"
+
+#~ msgid "skin infill pattern"
+#~ msgstr "表皮填充圖案"
+
+#~ msgid "skeleton infill pattern"
+#~ msgstr "骨架填充圖案"
+
+#, c-format, boost-format
+#~ msgid "Printer presets(%d/%d)"
+#~ msgstr "印表機預設 (%d/%d)"
+
+#, c-format, boost-format
+#~ msgid "Filament presets(%d/%d)"
+#~ msgstr "材料預設 (%d/%d)"
+
+#, c-format, boost-format
+#~ msgid "Process presets(%d/%d)"
+#~ msgstr "工藝預設 (%d/%d)"
+
+#~ msgid "Connecting to the printer. Unable to cancel during the connection process."
+#~ msgstr "正在連線印表機。連線過程中無法取消。"
+
+#~ msgid "Note: Only the AMS slots loaded with the same material type can be selected."
+#~ msgstr "僅允許選擇相同材質型別的耗材"
+
+#~ msgid "Shift + Mouse move up or down"
+#~ msgstr "Shift + 滑鼠上移或下移"
+
+#~ msgid "Rotate text"
+#~ msgstr "旋轉文字"
+
+#~ msgid "Embeded"
+#~ msgstr "嵌入的"
+
+#~ msgid ""
+#~ "Embeded\r\n"
+#~ "depth"
+#~ msgstr "內嵌深度"
+
+#~ msgid "Warning:Input cannot be empty!"
+#~ msgstr "警告：輸入不能為空！"
+
+#~ msgid ""
+#~ "Warning:Because current text does indeed use surround algorithm,\n"
+#~ "if continue to edit, text has to regenerated according to new location."
+#~ msgstr ""
+#~ "警告：因為當前文字確實使用了環繞演算法，\n"
+#~ "如果繼續編輯，文字必須根據新位置重新生成。"
+
+#~ msgid ""
+#~ "Warning:old matrix has at least two parameters: mirroring, scaling, and rotation. \n"
+#~ "If you continue editing, it may not be correct. \n"
+#~ "Please dragging text or cancel using current pose, \n"
+#~ "save and reedit again."
+#~ msgstr ""
+#~ "警告：舊矩陣至少有兩個引數：映象、縮放和旋轉。\n"
+#~ "如果繼續編輯，則可能不正確。 \n"
+#~ "請拖動文字或取消使用當前位姿，\n"
+#~ "儲存並重新編輯。"
+
+#~ msgid ""
+#~ "Error:Detecting an incorrect mesh id or an unknown error, \n"
+#~ "regenerating text may result in incorrect outcomes.\n"
+#~ "Please drag text,save it then reedit it again."
+#~ msgstr ""
+#~ "錯誤：檢測到不正確的網格id或未知錯誤，\n"
+#~ "重新生成文字可能會導致不正確的結果。\n"
+#~ "請拖動文字，儲存，然後重新編輯。"
+
+#~ msgid ""
+#~ "Warning:Due to functional upgrade, rotation information \n"
+#~ "cannot be restored. Please drag or modify text,\n"
+#~ " save it and reedit it will ok."
+#~ msgstr ""
+#~ "警告：由於功能升級，無法恢復旋轉資訊。\n"
+#~ "請拖動或修改文字，\n"
+#~ "儲存並重新編輯即可。"
+
+#~ msgid "Use opened text pose"
+#~ msgstr "使用開啟時的文字位姿"
+
+#~ msgid "Surface"
+#~ msgstr "附著曲面"
+
+#~ msgid "Horizontal text"
+#~ msgstr "水平文字"
+
+#~ msgid "Num"
+#~ msgstr "數量"
+
+#~ msgid "Finish Time: N/A"
+#~ msgstr "完成時間：N/A"
+
+#~ msgid "Finish Time: "
+#~ msgstr "完成時間："
+
+#~ msgid "Sensitivity of pausing is"
+#~ msgstr "暫停的靈敏度為"
+
+#~ msgid "Expand the first raft or support layer to improve bed plate adhesion"
+#~ msgstr "擴充套件筏和支撐的首層可以改善和熱床的粘接。"
+
+#~ msgid ""
+#~ "Please input valid values:\n"
+#~ "Start PA: >= 0.0\n"
+#~ "End PA: > Start PA\n"
+#~ "PA step: >= 0.001)"
+#~ msgstr ""
+#~ "請輸入有效值:\n"
+#~ "起始PA值: >= 0.0\n"
+#~ "結束PA值: > Start PA\n"
+#~ "PA值步長: >= 0.001)"
+
+#~ msgid ""
+#~ "Please input valid values:\n"
+#~ "Start temp: <= 350\n"
+#~ "End temp: >= 180\n"
+#~ "Start temp > End temp + 5)"
+#~ msgstr ""
+#~ "請輸入有效值:\n"
+#~ "起始溫度值: <= 350\n"
+#~ "結束溫度值: >= 180\n"
+#~ "起始值 > 結束值 + 5)"
+
+#~ msgid ""
+#~ "Please input valid values:\n"
+#~ "start > 0 step >= 0\n"
+#~ "end > start + step)"
+#~ msgstr ""
+#~ "請輸入有效值：\n"
+#~ "起始值 > 0 且 步長 >= 0\n"
+#~ "終止值 > 起始值 + 步長）"
+
+#~ msgid ""
+#~ "Please input valid values:\n"
+#~ "start > 10 step >= 0\n"
+#~ "end > start + step)"
+#~ msgstr ""
+#~ "請輸入有效值：\n"
+#~ "起始值 > 10 且 步長 >= 0\n"
+#~ "終止值 > 起始值 + 步長）"
+
+#~ msgid "Heating mode is suitable for printeing ABS/ASA/PC/PA materials and circulates filters the chamber air."
+#~ msgstr "腔溫保持模式適合列印ABS/ASA/PC/PA材質，在機箱內部迴圈過濾腔內空氣"
+
+#~ msgid "Bambu PET-CF/PA6-CF/PPA-CF/PPS-CF is not supported by AMS."
+#~ msgstr "Bambu PET-CF/PA6-CF/PPA-CF/PPS-CF暫不支援在AMS中使用。"
+
+#~ msgid "Temporarily closed because there is no operating for a long time."
+#~ msgstr "因長時間沒有操作，暫時關閉。"
+
+#~ msgid ""
+#~ "When using soluble material for the support, We recommend the following settings:\n"
+#~ "0 top z distance, 0 interface spacing, interlaced rectilinear pattern, disable independent support layer height \n"
+#~ "and use soluble materials for both support interface and support base"
+#~ msgstr ""
+#~ "當使用可溶性材料作為支撐時，我們推薦以下設定：\n"
+#~ "0頂層z距離，0接觸層間距，交疊直線圖案，禁用獨立支撐層高\n"
+#~ "並將可溶性材料同時用於支撐介面和支撐主體"
+
+#~ msgid ""
+#~ "When using soluble material for the support interface, We recommend the following settings:\n"
+#~ "0 top z distance, 0 interface spacing, interlaced rectilinear pattern, disable independent support layer height \n"
+#~ "and use soluble materials for both support interface and support base"
+#~ msgstr ""
+#~ "當使用支撐介面的可溶性支撐材料時，我們推薦以下設定：\n"
+#~ "0頂層z距離，0接觸層間距，交疊直線圖案，禁用獨立支撐層高\n"
+#~ "並將可溶性材料同時用於支撐介面和支撐主體"
+
+#~ msgid "This setting specifies the count of support walls in the range of [0,2]. 0 means auto."
+#~ msgstr "此設定指定[0,2]範圍內的支撐牆層數。0表示自動。"
+
+#, c-format, boost-format
+#~ msgid "TPU is not supported by %s extruder for this printer."
+#~ msgstr "此印表機的 %s 擠出機不支援TPU。"
+
+#~ msgid "The prime tower extends beyond the plate boundary, which may cause part of the prime tower to lie outside the printable area after slicing."
+#~ msgstr "料塔超出了列印板邊界，可能導致切片後料塔部分位於可列印區域之外。"
+
+#, c-format, boost-format
+#~ msgid ""
+#~ "The currently connected printer, %s, is a %s model.\n"
+#~ "To use this printer for printing, please switch the printer model of project file to %s."
+#~ msgstr ""
+#~ "當前連線的印表機 %s 為 %s機型。\n"
+#~ "如果使用該印表機列印，請將專案檔案中的機型切換為 %s。"
+
+#, c-format, boost-format
+#~ msgid ""
+#~ "The currently connected printer, %s, is a %s model but not consistent with preset in project file.\n"
+#~ "To use this printer for printing, please switch the preset first."
+#~ msgstr "當前連線的印表機%s是%s型號，但與專案檔案中的預設不一致。若要使用此印表機進行列印，請先切換預設。"
+
+#~ msgid "TPU is incompatible with AMS and must be printed seperately in the "
+#~ msgstr "TPU材料與AMS不相容，必須單獨分組且僅限"
+
+#~ msgid ""
+#~ " nozzle.\n"
+#~ "Please adjust the filament group accordingly."
+#~ msgstr ""
+#~ "噴嘴列印。\n"
+#~ "請重新分組。"
+
+#~ msgid "Only supports up to one TPU filament."
+#~ msgstr "最多僅支援1個TPU材料"
+
+#~ msgid "Still unload"
+#~ msgstr "繼續退料"
+
+#~ msgid "Still load"
+#~ msgstr "繼續進料"
+
+#~ msgid ""
+#~ "Are you sure you want to store original SVGs with their local paths into the 3MF file?\n"
+#~ "If you hit 'NO', all SVGs in the project will not be editable any more."
+#~ msgstr ""
+#~ "您確定要將原始SVG及其本地路徑儲存到3MF檔案中嗎？\n"
+#~ "如果點選“否”，專案中的所有SVG將不再可編輯。"
+
+#~ msgid "Private protection"
+#~ msgstr "個人保護"
+
+#~ msgid "If the transparency of the mapping changes, this thumbnail is for reference only."
+#~ msgstr "若對映的透明度發生變化，此縮圖僅供參考"
+
+#~ msgid "Some faces not define color."
+#~ msgstr "有些面片未定義顏色。"
+
+#~ msgid "For PVA filaments, it is strongly recommended to use normal support to avoid print failures."
+#~ msgstr "對於PVA耗材，強烈建議使用普通支撐，以避免列印失敗。"
+
+#~ msgid "Change these settings automatically? \n"
+#~ msgstr "是否自動更改這些設定？\n"
+
+#~ msgid "Click here if you can't connect to the printer ->"
+#~ msgstr "如果您無法連線印表機，請點選這裡 ->"
+
+#~ msgid "Unprintable filament type"
+#~ msgstr "不可列印的材料型別"
+
+#~ msgid "isometric"
+#~ msgstr "等距"
+
+#~ msgid "top_front"
+#~ msgstr "上前方"
+
+#~ msgid "top"
+#~ msgstr "頂部"
+
+#~ msgid "bottom"
+#~ msgstr "底部"
+
+#~ msgid "front"
+#~ msgstr "前方"
+
+#~ msgid "rear"
+#~ msgstr "後方"
+
+#, c-format, boost-format
+#~ msgid "Filament %s exceeds the number of AMS slots. Please update the printer firmware to support AMS slot assignment."
+#~ msgstr "材料編號%s超出AMS槽位數量，請更新印表機韌體以支援AMS槽位對映功能"
+
+#~ msgid "Filament exceeds the number of AMS slots. Please update the printer firmware to support AMS slot assignment."
+#~ msgstr "材料編號超出AMS槽位數量，請更新印表機韌體以支援AMS槽位對映功能"
+
+#~ msgid "The printer firmware only supports sequential mapping of filament => AMS slot."
+#~ msgstr "已自動建立 “耗材絲列表=>AMS槽位” 的對映關係。 可點選上方具體的耗材絲手動設定其所對應的AMS槽位"
+
+#~ msgid "Resume Printing(defects acceptable)"
+#~ msgstr "繼續列印（缺陷可接受）"
+
+#~ msgid "Resume Printing(problem solved)"
+#~ msgstr "繼續列印（問題已解決）"
+
+#~ msgid "Changing fan speed during pringing may affect print quality, please choose carefully."
+#~ msgstr "在列印過程中改變風扇速度可能會影響列印質量，請謹慎選擇。"
+
+#~ msgid "Changed fan speed during pringing may affect print quality, please choose carefully."
+#~ msgstr "在列印過程中改變風扇速度可能會影響列印質量，請謹慎選擇"
+
+#~ msgid "Timelapse is not supported while the SD card does not exist."
+#~ msgstr "沒有外接儲存卡，故無法啟用延時攝影"
+
+#~ msgid "Timelapse is not supported while the SD card is unavailable."
+#~ msgstr "外接儲存卡不可用，故無法啟用延時攝影"
+
+#~ msgid "Timelapse is not supported while the SD card is readonly."
+#~ msgstr "外接儲存卡當前是隻讀的，故無法啟用延時攝影"
+
+#, c-format, boost-format
+#~ msgid "Printing high temperature material(%s) with %s nozzle may cause nozzle damage, please check the type of nozzle"
+#~ msgstr "高溫材料（%s）若透過%s噴嘴列印，可能會導致噴嘴損壞。請檢查噴嘴型別"
+
+#~ msgid "Camera Angle - Left side"
+#~ msgstr "攝像機視角 - 左面"
+
+#~ msgid "Camera Angle - Right side"
+#~ msgstr "攝像機視角 - 右面"
+
+#~ msgid "Prefer to use high performance GPU (Effective after manual restart Bambu Studio)"
+#~ msgstr "優先使用高效能顯示卡 （手動重啟 Bambu Studio 後生效）"
+
+#~ msgid "If enabled, this feature can improve rendering performance to some extent. However, it may cause flickering on multi-GPU systems, so it is recommended to disable it."
+#~ msgstr "啟用後，該功能可在一定程度上提升渲染效能。但在多顯示卡裝置上可能會導致閃爍，則建議關閉。"
+
+#~ msgid "To map to AMS, enable 'Use AMS' in 'Advanced Options'."
+#~ msgstr "若要對映至AMS，請在'高階選項'開啟'使用AMS'"
+
+#~ msgid ""
+#~ "Waring:The count of newly added and \n"
+#~ " current extruders exceeds 16."
+#~ msgstr ""
+#~ "警告：新增追加耗材絲數量 \n"
+#~ " 和已有耗材絲數量超過了16."
+
+#~ msgid "The wall of prime tower will add four ribs"
+#~ msgstr "擦料塔外牆增加4個斜肋"
+
+#, c-format, boost-format
+#~ msgid ""
+#~ "Arrangement ignored the following objects which can't fit into a single bed:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "自動擺放會忽略以下無法放入單盤的零件：\n"
+#~ "%s"
+
+#~ msgid "Currently only External Spool is available, color mapping is prohibited, and control pop-up drop-down boxes are also prohibited."
+#~ msgstr "目前僅有外掛料槽，顏色對映被禁止，並且控制彈出下拉框也被禁止"
+
+#, boost-format
+#~ msgid "Copying of file %1% to %2% failed: %3%"
+#~ msgstr "從%1%複製檔案到%2%失敗：%3%"
+
+#, boost-format
+#~ msgid "Copying directory %1% to %2% failed: %3%"
+#~ msgstr "從%1%複製目錄到%2%失敗：%3%"
+
+#~ msgid "If you want to have tighter or looser assemble, you can set this value."
+#~ msgstr "如果你需要更緊或者更松的配合，請調整這個引數"
+
+#~ msgid "External Spool"
+#~ msgstr "外部線軸"
+
+#~ msgid "There are some unknown or uncompatible filaments mapped to generic preset. Please update Bambu Studio or restart Bambu Studio to check if there is an update to system presets."
+#~ msgstr "有一些未知或不相容的耗材對映到通用預設中。請更新Bambu Studio或重新啟動Bambu Studio，以檢查是否有系統預設的更新。"
+
+#~ msgid "Enable gamma correct in imported obj"
+#~ msgstr "在obj匯入中啟用gamma校正"
+
+#, c-format, boost-format
+#~ msgid "Printing high temperature material(%s material) with %s may cause nozzle damage"
+#~ msgstr "用%s列印高溫材料（%s材料）可能會導致噴嘴損壞"
+
+#~ msgid "Filament circle compensation setting"
+#~ msgstr "材料軸孔補償設定"
+
+#, c-format, boost-format
+#~ msgid "Filament %d is placed in the %s, but the generated G-code path exceeds the printable range of the %s."
+#~ msgstr "材料%d放置在%s，但是生成的G-code超出了%s的可列印區域。"
+
+#, c-format, boost-format
+#~ msgid "Filaments %d is placed in the %s, but the generated G-code path exceeds the printable range of the %s."
+#~ msgstr "材料%d放置在%s中，但生成的G程式碼路徑超出了%s的可列印範圍。"
+
+#, c-format, boost-format
+#~ msgid "Filament %d is placed in the %s, but the generated G-code path exceeds the printable height of the %s."
+#~ msgstr "材料%d放置在%s中，但生成的G程式碼路徑超過了%s的可列印高度"
+
+#, c-format, boost-format
+#~ msgid "Filaments %d is placed in the %s, but the generated G-code path exceeds the printable height of the %s."
+#~ msgstr "材料%d放置在%s中，但生成的G程式碼路徑超過了%s的可列印高度"
+
+#, c-format, boost-format
+#~ msgid "The color count should be in range [%d, %d]."
+#~ msgstr "顏色數量範圍應該是[%d, %d]。"
+
+#~ msgid "Add consumable extruder after existing extruders."
+#~ msgstr "近似的顏色匹配。"
+
+#~ msgid "New Value"
+#~ msgstr "新值"
+
+#~ msgid "Laser 10w"
+#~ msgstr "鐳射10W"
+
+#~ msgid "Laser 40w"
+#~ msgstr "鐳射40W"
+
+#~ msgid "Arranging..."
+#~ msgstr "自動擺放中..."
+
+#, boost-format
+#~ msgid "Cost %1%g filament and %2% changes more than optimal grouping."
+#~ msgstr "如果使用最優分組可多節省%1%g耗材和%2%次換料。"
+
+#, boost-format
+#~ msgid "Save %1%g filament and %2% changes than one-nozzle printer."
+#~ msgstr "相較於單頭印表機可節省%1%g耗材和%2%次換料。"
+
+#~ msgid "Copied the following parameters to the left nozzle:"
+#~ msgstr "複製了下列引數到左噴嘴名下："
+
+#~ msgid "Copied the following parameters to the right nozzle:"
+#~ msgstr "複製了下列引數到右噴嘴名下："
+
+#~ msgid ""
+#~ "Find the best coefficient for dynamic flow calibration to enhance print quality.\n"
+#~ "*Automatic mode: Skip if the filament was calibrated recently."
+#~ msgstr ""
+#~ "找到動態流量校準的最佳係數，以提高列印質量。\n"
+#~ "*自動模式：如果耗材絲最近校準過，則跳過。"
+
+#~ msgid "Attention"
+#~ msgstr "注意"
+
+#~ msgid "Unused AMS filaments should also be added to the filament list."
+#~ msgstr "未使用的AMS耗材也新增到耗材列表。"
+
+#~ msgid "Unprintable filament map to extruder"
+#~ msgstr "不可列印的耗材絲匹配至擠出機"
+
+#~ msgid ""
+#~ "Performed boolean intersection fails \n"
+#~ " because the selected parts have no intersection"
+#~ msgstr "因選中的物體無交集，布林交集計算失敗"
+
+#~ msgid "Filaments to AMS slots mappings have been established. You can click a filament above to change its mapping AMS slot"
+#~ msgstr "已自動建立 \"耗材絲列表=>AMS槽位\" 的對映關係。 可點選上方具體的耗材絲手動設定其所對應的AMS槽位"
+
+#~ msgid "Please click each filament above to specify its mapping AMS slot before sending the print job"
+#~ msgstr "請在傳送列印前點選上方各個耗材絲，指定其所對應的AMS槽位"
+
+#~ msgid "Step 1. Please confirm Bambu Studio and your printer are in the same LAN."
+#~ msgstr "步驟1，請確認Bambu Studio和您的印表機位於同一區域網中。"
+
+#~ msgid "Step 2. If the IP and Access Code below are different from the actual values on your printer, please correct them."
+#~ msgstr "步驟2，如果下面的IP和訪問程式碼與印表機上的實際值不同，請重新輸入。"
+
+#~ msgid "Step 3. Please obtain the device SN from the printer side; it is usually found in the device information on the printer screen."
+#~ msgstr "步驟3，請從印表機端獲取裝置序列號，它通常位於印表機螢幕上的裝置資訊中。"
+
+#, c-format, boost-format
+#~ msgid "%d Hours"
+#~ msgstr "%d小時"
+
+#~ msgid "\"Fix Model\" feature is currently only on Windows. Please use a third-party tool to repair the model before importing it into Bambu Studio, such as "
+#~ msgstr "\"修復模型\"功能目前僅適用於Windows。請使用第三方工具修復模型後再匯入Bambu Studio，如"
+
+#, boost-format
+#~ msgid "SVG file does NOT contain a single path to be embossed (%1%)."
+#~ msgstr "SVG檔案不包含要浮雕的單個路徑（%1%）。"
+
+#~ msgid ""
+#~ "Tip:If you want to place svg file on another part surface,\n"
+#~ "you should select part first, and then drag svg file to the part surface."
+#~ msgstr ""
+#~ "提示：如果要將svg檔案放置在另一個零件表面上，\n"
+#~ "您應該先選擇零件，然後將svg檔案拖動到零件表面。"
+
+#~ msgid "width:"
+#~ msgstr "寬"
+
+#~ msgid "height:"
+#~ msgstr "高"
+
+#, c-format, boost-format
+#~ msgid "Left nozzle: X:%.0f-%.0f, Y:%.0f-%.0f, Z:%.0f-%.0f\n"
+#~ msgstr "左噴嘴：X:%.0f-%.0f, Y:%.0f-%.0f, Z:%.0f-%.0f\n"
+
+#, c-format, boost-format
+#~ msgid "Right nozzle: X:%.0f-%.0f, Y:%.0f-%.0f, Z:%.0f-%.0f"
+#~ msgstr "右噴嘴：X:%.0f-%.0f, Y:%.0f-%.0f, Z:%.0f-%.0f"
+
+#~ msgid ""
+#~ "Printing with multiple filaments that have a large temperature difference can cause the extruder and nozzle to be blocked or dameged during printing.\n"
+#~ "Please enable with caution."
+#~ msgstr ""
+#~ "溫度差異過大的材料一起列印可能導致擠出機和噴嘴在列印中堵塞或損壞。\n"
+#~ "請謹慎啟用。"
+
+#~ msgid "Auto-Calc"
+#~ msgstr "自動計算"
+
+#~ msgid "unloaded"
+#~ msgstr "解除安裝"
+
+#~ msgid "loaded"
+#~ msgstr "裝載"
+
+#~ msgid "Filament #"
+#~ msgstr "耗材絲#"
+
+#~ msgid "From"
+#~ msgstr "從"
+
+#~ msgid "To"
+#~ msgstr "到"
+
+#~ msgid "Flushing volumes: Auto-calculate every time when the color is changed."
+#~ msgstr "沖刷體積：每一次更換顏色時自動計算。"
+
+#~ msgid "If enabled, auto-calculate every time when the color is changed."
+#~ msgstr "如果啟用，會在每一次更換顏色時自動計算。"
+
+#~ msgid "Flushing volumes: Auto-calculate every time when the filament is changed."
+#~ msgstr "沖刷體積：每一次更換材料時自動計算。"
+
+#~ msgid "If enabled, auto-calculate every time when filament is changed"
+#~ msgstr "如果啟用，會在每一次更換材料時自動計算。"
+
+#~ msgid "Clear my choice on the unsaved presets."
+#~ msgstr "清除我對未儲存的預置的選擇。"
+
+#~ msgid ""
+#~ "The selected filament's nozzle diameter or type does not match the actual printer configuration.\n"
+#~ "Please click the Sync button above and restart the calibration."
+#~ msgstr "當前選擇的噴頭噴嘴型別與實際印表機的噴嘴型別不匹配。請點選上方的同步按鈕並重新開始校準。"
+
+#~ msgid "Printer not connected. Please connect or choose a printer on the Device page and try again."
+#~ msgstr "印表機未連線。請在“裝置”頁面上連線或選擇印表機，然後重試。"
+
+#~ msgid "Merge all identical filaments."
+#~ msgstr "合併完全相同的耗材"
+
+#, c-format, boost-format
+#~ msgid "nozzle in preset: %.1f %s"
+#~ msgstr "預設中的噴嘴：%.1f %s"
+
+#, c-format, boost-format
+#~ msgid "nozzle memorized: %.1f %s"
+#~ msgstr "記憶中的噴嘴：%.1f %s"
+
+#~ msgid "Your nozzle diameter in sliced file is not consistent with memorized nozzle. If you changed your nozzle lately, please go to Device > Printer Parts to change settings."
+#~ msgstr "切片檔案中的噴嘴直徑與記憶的噴嘴不一致。如果您最近更換了噴嘴，請前往裝置 > 印表機零件進行更改設定。"
+
+#~ msgid "Auto Circle Holes-contour Compensation"
+#~ msgstr "自動圓形孔洞和輪廓補償"
+
+#~ msgid "Recommends filament grouping for the left and right nozzles based on the most filament-saving principles to minimize waste"
+#~ msgstr "根據最節省耗材的原則，推薦左右噴嘴的耗材分組方案，幫助減少耗材浪費"
+
+#~ msgid "Recommends filament grouping for the left and right nozzles based on the printer's actual filament status, reducing the need for manual filament adjustment"
+#~ msgstr "根據印表機實際耗材狀態，推薦左右噴嘴的耗材分組方案，幫助減少對實際耗材的手動調整操作"
+
+#~ msgid "Advanced settings >"
+#~ msgstr "高階設定 >"
+
+#~ msgid "Smoothing wall speed in z direction(experimental)"
+#~ msgstr "平滑z方向外牆速度（實驗）"
+
+#~ msgid "This parameter adds a slight rotation to each layer of infill to create a cross cross texture."
+#~ msgstr "這個引數給每層填充新增輕微旋轉以塑造交錯花紋"
+
+#~ msgid "Line pattern of support interface. Default pattern for non-soluble support interface is Rectilinear, while default pattern for soluble support interface is Concentric"
+#~ msgstr "支撐接觸面的走線圖案。非可溶支撐接觸面的預設圖案為直線，可溶支撐接觸面的預設圖案為同心。"
+
+#~ msgid ""
+#~ "Style and shape of the support. For normal support, projecting the supports into a regular grid will create more stable supports (default), while snug support towers will save material and reduce object scarring.\n"
+#~ "For tree support, slim style will merge branches more aggressively and save a lot of material, strong style will make larger and stronger support structure and use more materials, while hybrid style is the combination of slim tree and normal support with normal nodes under large flat overhangs. Organic style will produce more organic shaped tree structure and less interfaces which makes it easer to be removed. The default style is organic tree for most cases, and hybrid tree if adaptive layer height is enabled."
+#~ msgstr ""
+#~ "支撐的樣式和形狀。對於普通支撐，將支撐投射到一個規則的網格中，將建立更穩定的支撐（預設），而緊貼的支撐塔將節省材料並減少物體的瑕疵。\n"
+#~ "對於樹形支撐，苗條樹將更激進地合併樹枝，並節省大量的材料；粗壯樹會產生更大更強壯的支撐結構，但用料更多；而混合樹是苗條樹和普通支撐的結合，它會在大的平面懸垂下建立與正常支撐類似的結構；有機樹將產生更有機的樹狀結構，並且減少介面層，這使得它們更容易被移除。多數情況下，預設風格是有機樹，如果啟用了自適應層高，則為混合樹。"
+
+#~ msgid "rib wall"
+#~ msgstr "斜肋外牆"
+
+#~ msgid "fillet wall"
+#~ msgstr "外牆倒圓角"
+
+#~ msgid "Rearrange filaments of the left and right nozzles ->"
+#~ msgstr "重新分配左右頭耗材並切片->"
+
+#, c-format, boost-format
+#~ msgid "The current nozzle diameter (Left: %.1fmm  Right: %.1fmm) doesn't match with the slicing file (%.1fmm). Please make sure the nozzle installed matches with settings in printer, then set the corresponding printer preset when slicing."
+#~ msgstr "當前噴嘴直徑（左: %.1fmm  右: %.1fmm）和切片檔案（%.1fmm）不一致，無法發起列印。請確保印表機上安裝噴嘴直徑和機器設定中一致，並在切片時設定對應的噴嘴直徑。"
+
+#, c-format, boost-format
+#~ msgid "The nozzle flow setting of %snozzle(%s) doesn't match with the slicing file(%s). Please make sure the nozzle installed matches with settings in printer, then set the corresponding printer preset while slicing."
+#~ msgstr "%s噴嘴的流量設定（%s）和切片檔案（%s）不一致，無法發起列印。請確保印表機上安裝噴嘴型別和機器設定中一致，並在切片時設定對應的噴嘴型別。"
+
+#~ msgid "Enable to apply scarf seam on the circle to have better assemble."
+#~ msgstr "在圓形上應用斜拼接縫以獲得更好的裝配。"
+
+#~ msgid "When replacing the extruder, it is recommended to extrude a certain length of filament from the original extruder. This helps minimize nozzle oozing."
+#~ msgstr "更換擠出機時，建議從原擠出機中擠出一定長度的耗材絲。這有助於最大限度地減少噴嘴漏料。"
+
+#~ msgid "the ramming length of this filament when changing extruder"
+#~ msgstr "更換擠出機時該材料所需的衝壓長度"
+
+#~ msgid "BambuStudio configuration file may be corrupted and is not able to be parsed.Please delete the file and try again."
+#~ msgstr "Bambu Studio配置檔案可能已損壞而無法解析。請刪除此檔案並重新啟動BambuStudio。"
+
+#~ msgid "Change opengl multi instance rendering requires application restart."
+#~ msgstr "改變opengl多例項渲染要求軟體重啟。"
+
+#~ msgid "Enable opengl multi instance rendering"
+#~ msgstr "開啟opengl多例項渲染"
+
+#~ msgid "Enable multi instance rendering by opengl"
+#~ msgstr "開啟opengl多例項渲染"
+
+#~ msgid "If enabled, it can improve certain rendering performance. But for some graphics cards, it may not be applicable, please turn it off."
+#~ msgstr "如果啟用，它可以提高一定的渲染效能。但對於某些圖形卡，它可能不適用，請將其關閉。"
+
+#~ msgid "Category"
+#~ msgstr "類別"
+
+#~ msgid "The smaller the number, the longer the speed transition path."
+#~ msgstr "數值越小，平滑區域越長"
+
+#~ msgid "Brim width of wipe tower, -1 means auto calculated width based on the height of wipe tower."
+#~ msgstr "料塔的Brim寬度，-1表示基於料塔高度自動計算寬度"
+
+#~ msgid ""
+#~ "Style and shape of the support. For normal support, projecting the supports into a regular grid will create more stable supports (default), while snug support towers will save material and reduce object scarring.\n"
+#~ "For tree support, slim style will merge branches more aggressively and save a lot of material, strong style will make larger and stronger support structure and use more materials, while hybrid style is the combination of slim tree and normal support with normal nodes under large flat overhangs (default)."
+#~ msgstr ""
+#~ "支撐的樣式和形狀。對於普通支撐，將支撐投射到一個規則的網格中，將建立更穩定的支撐（預設），而緊貼的支撐塔將節省材料並減少物體的瑕疵。\n"
+#~ "對於樹形支撐，苗條樹將更激進地合併樹枝，並節省大量的材料；粗壯樹會產生更大更強壯的支撐結構，但用料更多；而混合樹是苗條樹和普通支撐的結合，它會在大的平面懸垂下建立與正常支撐類似的結構；有機樹將產生更有機的樹狀結構，並且減少介面層，這使得它們更容易被移除。多數情況下，預設風格是有機樹，如果啟用了自適應層高，則為混合樹。"
+
+#~ msgid "Material and color information have been synchronized, but slot information is not included."
+#~ msgstr "材料和顏色資訊已同步，但不包括槽位資訊。"
+
+#~ msgid "Please select a printer in 'Device' page first."
+#~ msgstr "請先在 \"裝置 \"頁面選擇印表機。"
+
+#~ msgid "The currently connected printer does not have two extruders."
+#~ msgstr "當前連線的印表機沒有兩個擠出機。"
+
+#~ msgid "The currently selected machine preset is inconsistent with the connected printer type.Please change device or currently selected machine.\n"
+#~ msgstr "當前選擇的機器預設與連線的印表機型別不一致。請更改裝置或當前選擇的機器。\n"
+
+#~ msgid "The project's filament list will be directly replaced with the information of all filaments from the printer. This action cannot be undone."
+#~ msgstr "專案耗材列表將直接被來自印表機的所有的耗材資訊替換。此操作不可撤銷。"
+
+#, c-format, boost-format
+#~ msgid "Only the %s with external filament spool can print TPU"
+#~ msgstr "只能使用%s的外掛料列印TPU"
+
+#~ msgid "Some models are"
+#~ msgstr "一些模型"
+
+#, c-format, boost-format
+#~ msgid "The model %s is"
+#~ msgstr "模型%s"
+
+#, c-format, boost-format
+#~ msgid ""
+#~ " located within the %s only area, making it impossible to print with the filaments assigned to %s.\n"
+#~ "Please move the model out of the %s only area or adjust the filament grouping.\n"
+#~ msgstr ""
+#~ "位於僅%s列印區域，無法使用對映到%s的耗材列印。\n"
+#~ "請將模型移出僅%s可列印區域，或者調整耗材左右分組。\n"
+
+#, c-format, boost-format
+#~ msgid "After completing your operation, %s project will be closed and create a new project. Do you want to continue?"
+#~ msgstr "執行完成該操作後，%s 專案將會被關閉並建立一個新專案。是否繼續？"
+
+#, c-format, boost-format
+#~ msgid ""
+#~ "The currently connected printer, %s, is a %s model.\n"
+#~ "To use this printer for printing, please switch the printer model of the project file to %s,\n"
+#~ "and sync the nozzle type and AMS quantity information from the connected printer."
+#~ msgstr ""
+#~ "當前連線的印表機 %s 為 %s機型。\n"
+#~ "如果使用該印表機列印，請將專案檔案中的機型切換為 %s，\n"
+#~ "並從連線的印表機同步噴嘴型別和AMS數量資訊。"
+
+#~ msgid "Prime volume"
+#~ msgstr "清理量"
+
+#~ msgid "Bambu PET-CF/PA6-CF is not supported by AMS."
+#~ msgstr "AMS不支援Bambu PET-CF/PA6-CF。"
+
+#~ msgid "Extruder change length"
+#~ msgstr "擠出機改變長度"
+
+#~ msgid "Outer first"
+#~ msgstr "外牆優先"
+
+#~ msgid "The prime tower print outer first"
+#~ msgstr "料塔優先列印外牆"
+
+#~ msgid "Convenient Mode"
+#~ msgstr "便捷模式"
+
+#~ msgid "Calculate the best filament grouping to minimize filament waste. Need to manually place filaments on the printer based on slicing results."
+#~ msgstr "以最小化耗材浪費為目標，切片時自動規劃耗材左右分組。需根據切片結果在印表機上調整耗材位置"
+
+#~ msgid "Calculate the filament grouping based on the printer's filaments, reducing the need for adjusting filaments at the printer."
+#~ msgstr "為了減少去印表機手動調整耗材位置，切片時根據當前印表機的耗材擺放自動規劃耗材的左右分組，但可能會有更多的耗材浪費"
+
+#~ msgid "Manually assign filament to the left or right nozzle."
+#~ msgstr "根據您的個人意願，切片前手動設定耗材的左右分組"
+
+#~ msgid ""
+#~ "When the current filament runs out, the printer will use identical filament to continue printing.\n"
+#~ "Identical filament: same brand, type and color."
+#~ msgstr ""
+#~ "當前耗材用完時，印表機將使用相同的耗材繼續列印。\n"
+#~ "相同的耗材：相同的品牌、型別和顏色。"
+
+#~ msgid ""
+#~ "If there are two identical filaments in AMS, AMS filament backup will be enabled. \n"
+#~ "(Currently supporting automatic supply of consumables with the same brand, material type, and color)"
+#~ msgstr ""
+#~ "如果AMS中有兩卷相同的耗材，將啟用自動續料。\n"
+#~ "（目前，自動續料支援同品牌、同材料種類、同顏色的耗材）"
+
+#~ msgid "The AMS will estimate Bambu filament's remaining capacity after the filament info is updated. During printing, remaining capacity will be updated automatically."
+#~ msgstr "AMS讀取Bambu Lab耗材絲資訊同時推算料卷的剩餘容量。在列印過程中，剩餘容量會自動更新。"
+
+#~ msgid "Project's filaments"
+#~ msgstr "專案耗材列表"
+
+#~ msgid "The filament grouping for current plate follows the global settings."
+#~ msgstr "當前盤的耗材分組方案遵循全域性設定。"
+
+#~ msgid "The current chamber temperature or the target chamber temperature exceeds 45\\u2103.In order to avoid extruder clogging,low temperature filament(PLA/PETG/TPU) is not allowed to be loaded."
+#~ msgstr "當前腔溫或目標腔溫超過了45度。為了避免擠出機堵塞，不允許載入低溫度的列印材料（如PLA/PETG/TPU）"
+
+#~ msgid "When you set the chamber temperature below 40\\u2103, the chamber temperature control will not be activated. And the target chamber temperature will automatically be set to 0\\u2103."
+#~ msgstr "當您設定的腔溫低於40度時，腔溫控制將不會啟動。並且目標腔溫將自動設定為0度"
+
+#~ msgid "Filament Grouping Recommendation"
+#~ msgstr "耗材分組推薦"
+
+#~ msgid "Current grouping of slice result is optimal."
+#~ msgstr "當前分組為最優結果。"
+
+#~ msgid "Please place the filaments on the printer as recommended."
+#~ msgstr "請按照推薦分組去印表機放置耗材。"
+
+#~ msgid ""
+#~ "Tips: You can drag the filaments to reassign them to different nozzles.\n"
+#~ "But your filament grouping may not be the most efficient for filament usage."
+#~ msgstr ""
+#~ "提示：您可以拖動耗材以將其重新分配到不同的噴嘴。\n"
+#~ "請注意，當前的分組可能並不是最節省耗材的方案。"
+
+#~ msgid "Your filament grouping method is not optimal."
+#~ msgstr "當前材料分組不是最優結果。"
+
+#~ msgid "Parameters related to the extruder model will be discarded because the extruder model list for the front and rear printers is inconsistent."
+#~ msgstr "與擠出機型號相關的引數將被丟棄，因為前後印表機的擠出機型號列表不一致。"
+
+#~ msgctxt "SideBar"
+#~ msgid "Filaments"
+#~ msgstr "耗材列表"
+
+#~ msgid "The software does not support using different diameter of nozzles for one  print. If the left and right nozzles are inconsistent, we can only proceed with single-head printing. Please confirm which nozzle you would like to use for this project."
+#~ msgstr "軟體暫不支援使用兩種不同直徑的噴嘴同時列印，由於你設定的左右噴嘴不一致，我們只能採用單頭列印。 請確認使用哪個噴嘴列印當前專案。"
+
+#~ msgid "After sync, all currently configured filament presets and colors will be discarded."
+#~ msgstr "同步後將丟棄所有當前配置的耗材預設、顏色。"
+
+#~ msgid "Are you sure to directly override current filaments?"
+#~ msgstr "確定要直接覆蓋當前耗材嗎？"
+
+#~ msgid "Sync AMS filament"
+#~ msgstr "繼續同步AMS耗材"
+
+#~ msgid ""
+#~ " located within the %s only area, making it impossible to print with the filaments assigned to %s.\n"
+#~ "Please move the model out of the %s only area or adjust the filament assignment.\n"
+#~ msgstr ""
+#~ "位於僅%s列印區域，無法使用對映到%s的耗材列印。\n"
+#~ "請將模型移出僅%s可列印區域，或者調整材料對映。\n"
+
+#~ msgid "Successfully synchronized color and type of filament in AMS."
+#~ msgstr "AMS耗材顏色和材質同步成功。"
+
+#~ msgid "It is not recommended to use AMS and external filaments simultaneously on the same nozzle. Otherwise, you will need to manually change filaments %d times for this print."
+#~ msgstr "不推薦在同一個噴嘴上同時使用AMS和外掛料，否則此次列印你需要手動換料%d次。"
+
+#~ msgid "It is not recommended to use AMS and external filaments simultaneously. Otherwise, you will need to manually change filaments %d times for this print."
+#~ msgstr "不推薦同時使用AMS和外掛料，否則此次列印你需要手動換料%d次。"
+
+#~ msgid ""
+#~ "An object is laid on the left/right nozzle only area.\n"
+#~ "Please make sure the filaments used by this object on this area are not mapped to the other nozzles."
+#~ msgstr ""
+#~ "一個模型放置在僅左/右噴嘴可列印區域。\n"
+#~ "請確保該模型在該區域內使用的材料沒有對映到其他噴嘴。"
+
+#~ msgid "When you click \"Synchronize now\" button,it will append unmapped color."
+#~ msgstr "當您單擊\"立即同步\"按鈕時，它將附加未匹配的顏色。"
+
+#~ msgid "When you click \"Synchronize now\" button,it will merge same ams to only one color."
+#~ msgstr "當您點選\"立即同步\"按鈕時，它會將相同的ams合併為一種顏色。"
+
+#~ msgid "When you click ok button,it will append unmapped color."
+#~ msgstr "當您單擊ok按鈕時，它將附加未匹配的顏色。"
+
+#~ msgid "When you click ok button,it will merge same ams to only one color."
+#~ msgstr "當你們點選“確定”按鈕時，它會將相同的ams合併為一種顏色。"
+
+#~ msgid ""
+#~ "Up: Original\n"
+#~ "Down: filament in AMS\n"
+#~ "And you can click it to modify it."
+#~ msgstr ""
+#~ "下拉框的上半部分：原始\n"
+#~ "下拉框的下半部分：AMS的材料\n"
+#~ "您可以單擊它進行修改"
+
+#~ msgid "Send print job to"
+#~ msgstr "傳送列印任務至"
+
+#~ msgid "Please set the number of ams installed on the this extrusion head."
+#~ msgstr "請設定該擠壓頭上安裝的 ams 數量。"
+
+#~ msgid "AMS(4 colors)"
+#~ msgstr "AMS(4個顏色)"
+
+#~ msgid "AMS(single color)"
+#~ msgstr "AMS(單個顏色)"
+
+#~ msgid "Sync filaments with AMS successfully."
+#~ msgstr "完成AMS的耗材同步。"
+
+#~ msgid "Currently, the object configuration form cannot be used with multiple extruders."
+#~ msgstr "目前，物件配置表單不能用於多臺擠出機。"
+
+#~ msgid "Ams filaments synchronization"
+#~ msgstr "AMS耗材同步"
+
+#~ msgid "(Inconsistent)"
+#~ msgstr "(不一致)"
+
+#~ msgid "The device printer and the currently selected printer are not consistent. It is recommended to be consistent."
+#~ msgstr "裝置印表機和當前選擇的印表機不一致。建議保持一致。"
+
+#~ msgid "Automatically re-slice according to the optimal filament arrangement, and the arrangement results will be displayed after slicing."
+#~ msgstr "將會自動根據最優材料分組重新切片，分組結果將會在切片後展示。"
+
+#~ msgid "Color Arrangement Recommendation"
+#~ msgstr "耗材擺放推薦"
+
+#~ msgid "Color Arrangement"
+#~ msgstr "耗材擺放"
+
+#~ msgid "This arrangement would be optimal."
+#~ msgstr "當前材料擺放為最優結果"
+
+#~ msgid "Save %1%g filament and %2% changes than one-extruder printer."
+#~ msgstr "相較於單頭印表機可節省%1%g耗材和%2%次換料。"
+
+#~ msgid "This arrangement is not optimal."
+#~ msgstr "當前材料擺放不是最優結果"
+
+#~ msgid "Cost %1%g filament and %2% changes more than optimal arrangement."
+#~ msgstr "如果使用最優擺放可多節省%1%g耗材和%2%次換料。"
+
+#~ msgid "Rearrange filament"
+#~ msgstr "材料分組"
+
+#~ msgid ""
+#~ " located within the %s only area, making it impossible to print with the filaments assigned to %s.\n"
+#~ "Please move the model out of the %s only area or adjust the filament assignment."
+#~ msgstr ""
+#~ "位於僅%s列印區域，無法使用對映到%s的耗材列印。\n"
+#~ "請將模型移出僅%s可列印區域，或者調整材料對映。"
+
+#~ msgid "Filament Arrange"
+#~ msgstr "材料分配"
+
+#~ msgid "Pop up to select filament arrangement mode"
+#~ msgstr "彈窗以選擇材料分配模式"
+
+#~ msgid "Filament arrangement"
+#~ msgstr "材料分配"
+
+#~ msgid "Manual Mode"
+#~ msgstr "手動模式"
+
+#~ msgid "Calculate the best filament arrangement to minimize usage. Need to manually arrange filaments on the printer based on slicing results."
+#~ msgstr "透過計算最佳分配方案來減少材料消耗。需要根據切片結果去印表機調整材料"
+
+#~ msgid "Use AMS filaments to automatically assign filament to the left or right nozzle."
+#~ msgstr "根據AMS中的材料，將材料分配到左/右噴嘴"
+
+#~ msgid ""
+#~ "Tips: You can drag the filaments to reassign them to different nozzles.\n"
+#~ "But your filament arrangement may not be the most efficient for filament usage."
+#~ msgstr ""
+#~ "提示：您可以拖動材料以將其重新分配到不同的噴嘴。\n"
+#~ "請注意，當前的分配可能並不是最節省材料的方案。"
+
+#~ msgid "The filament arrangement for current plate follows the global settings."
+#~ msgstr "當前盤的材料分配方案遵循全域性設定。"
+
+#~ msgid "The nozzle diameter (%.1fmm) in slice file is unconsistent withthe left nozzle diameter (%.1fmm) or right nozzle diameter (%.1fmm)set on your print."
+#~ msgstr "切片檔案中設定的噴嘴直徑（%.1fmm），與機器上設定的左噴嘴直徑（%.1fmm）和右噴嘴（%.1fmm）均不一致。需要保持跟可用噴嘴一致後，才能繼續列印"
+
+#~ msgid "The nozzle diameter (%.1fmm) in slice file is unconsistent with the nozzle diameter (%.1fmm) set on your print.You can't send to print until they are consistent."
+#~ msgstr "切片檔案中設定的噴嘴直徑（%.1fmm），與機器上設定的噴嘴直徑（%.1fmm）不一致。保持一致後，才能繼續列印"
+
+#~ msgid ""
+#~ "Top half of combobox: Original\n"
+#~ "Down half of combobox: Filament of AMS\n"
+#~ "And you can click it to modify"
+#~ msgstr ""
+#~ "下拉框的上半部分：原始\n"
+#~ "下拉框的下半部分：AMS的材料\n"
+#~ "您可以單擊它進行修改"
+
+#~ msgid "Delete then replace with"
+#~ msgstr "刪除後替換為"
+
+#~ msgid ""
+#~ " located within the %s only area, making it impossible to print with the filaments assigned to %s.\n"
+#~ "Please move the model out of the %s only area or adjust the filament assignment\n"
+#~ msgstr ""
+#~ "位於僅%s列印區域，無法使用對映到%s的耗材列印。\n"
+#~ "請將模型移出僅%s可以列印區域，或者調整材料對映\n"
+
+#~ msgid "Connected printer is %s. It must match the project preset for printing.\n"
+#~ msgstr "當前連線的印表機為 %s，需要和專案預設匹配才能列印。\n"
+
+#~ msgid "Do you want to sync the printer information and automatically switch the preset?"
+#~ msgstr "是否從印表機同步資訊並自動切換專案預設？"
+
+#~ msgid ""
+#~ "It is detected that you have not synchronized the nozzle and AMS information.\n"
+#~ "If you synchronize it before slicing, the filament arrangement will be more reasonable.\n"
+#~ "Do you need to synchronize it ?"
+#~ msgstr ""
+#~ "檢測到您沒有同步噴嘴和AMS資訊。\n"
+#~ "如果在切片前同步，耗材絲排列會更整齊合理。\n"
+#~ "需要同步嗎？"
+
+#~ msgid "Out of sync"
+#~ msgstr "不同步"
+
+#~ msgid "Save Modified Value"
+#~ msgstr "儲存修改值"
+
+#~ msgid "You have changed some settings of preset \"%1%\". "
+#~ msgstr "您已更改了預設 “%1%” 的一些設定。"
+
+#~ msgid ""
+#~ "\n"
+#~ "You can save or discard the preset values you have modified."
+#~ msgstr ""
+#~ "\n"
+#~ "您可以儲存或丟棄已經修改的預設值。"
+
+#~ msgid ""
+#~ "\n"
+#~ "You can save or discard the preset values you have modified, or choose to continue using the values you have modified on the new preset."
+#~ msgstr ""
+#~ "\n"
+#~ "您可以丟棄修改過的預設值，或選擇在新專案中繼續使用修改後的值。"
+
+#~ msgid "You have previously modified your settings."
+#~ msgstr "您已經修改了預設引數。"
+
+#~ msgid ""
+#~ "\n"
+#~ "You can discard the preset values you have modified, or choose to continue using the modified values in the new project"
+#~ msgstr ""
+#~ "\n"
+#~ "您可以丟棄修改過的預設值，或選擇在新專案中繼續使用修改後的值"
+
+#~ msgid "Left Ams"
+#~ msgstr "左側Ams"
+
+#~ msgid "Right Ams"
+#~ msgstr "右側Ams"
+
+#~ msgid "Print with filaments in ams"
+#~ msgstr "採用AMS裡的材料列印"
+
+#~ msgid "Please do not mix-use the Ext with Ams"
+#~ msgstr "請勿將Ext與Ams混用"
+
+#~ msgid "Original"
+#~ msgstr "原始"
+
+#~ msgid "Only synchronize filament type and color, not included AMS slot info."
+#~ msgstr "僅同步耗材型別和顏色，不包含AMS槽位資訊。"
+
+#~ msgid "over 100% wall (not bridge)"
+#~ msgstr "完全懸垂牆（非架橋牆）"
+
+#~ msgid "Calibrating the micro lida"
+#~ msgstr "輪廓儀鐳射校準"
+
+#~ msgid "All of your configured filament presets and colors will discarded after sync."
+#~ msgstr "同步後，所有配置的材料預設和顏色都將被丟棄。"
+
+#~ msgid "In the Filament auto-matching mode, Filament "
+#~ msgstr "在耗材自動匹配模式下，耗材"
+
+#~ msgid "Please solve the problem by moving them within the build volume.\n"
+#~ msgstr "請透過將它們移動到可構建範圍內來解決問題。\n"
+
+#~ msgid "In the Filament manual-matching mode, Following filament->extruder maps: \n"
+#~ msgstr "在耗材手動匹配模式下，以下耗材->擠出機圖：\n"
+
+#~ msgid "Are you sure to synchronize according to the current effect?"
+#~ msgstr "根據當前效果，您確定同步嗎？"
+
+#~ msgid "Maping"
+#~ msgstr "匹配"
+
+#~ msgid "The mapping only influences filament type and color,without AMS slot information."
+#~ msgstr "對映僅影響材料型別和顏色，不影響AMS插槽資訊。"
+
+#~ msgid "Unmatched AMS filaments should also be synchronized into thhe filaments list"
+#~ msgstr "未匹配到的AMS材料也同步到材料列表中"
+
+#~ msgid "Automatically merge the same colors in the model after matching"
+#~ msgstr "匹配後自動合併模型中的相同顏色"
+
+#~ msgid "Are you sure to synchronize the filament?"
+#~ msgstr "您確定要同步材料嗎？"
+
+#~ msgid "Change to"
+#~ msgstr "更改為"
+
+#~ msgid "Calculate the best filament arrangement to minimize usage. Manually arrange filaments on the printer based on slicing results."
+#~ msgstr "透過計算最佳分配方案來減少材料消耗。需要根據切片結果去印表機手動調整材料"
+
+#~ msgid ""
+#~ "An object is laid on the left/right extruder only area.\n"
+#~ "Please make sure the filaments used by this object on this area are not mapped to the other extruders."
+#~ msgstr ""
+#~ "一個模型放置在僅左/右擠出機可列印區域。\n"
+#~ "請確保該模型在該區域內使用的材料沒有對映到其他擠出機。"
+
+#~ msgid "Multiple TPU filaments are not allowed to print at the same time, and the TPU filament must be placed in the virtual slot of %s."
+#~ msgstr "不允許同時列印多根TPU耗材，並且TPU耗材必須放置在%s的虛擬插槽中。"
+
+#~ msgid "Filament %s cannot be placed in the %s extruder for printing."
+#~ msgstr "材料 %s 不能放置在 %s 擠出機中進行列印。"
+
+#~ msgid ""
+#~ "The printer you are currently bound to is %s,\n"
+#~ "The printer preset for your current file is %s,\n"
+#~ msgstr ""
+#~ "您當前繫結的印表機是%s，\n"
+#~ "當前檔案的印表機預設為%s，\n"
+
+#~ msgid "Do you want to sync printer presets, ams and nozzle information immediately?"
+#~ msgstr "您想立即同步印表機預設、ams和噴嘴資訊嗎"
+
+#~ msgid "Do you want to sync printer presets immediately?"
+#~ msgstr "您想立即同步印表機預設嗎？"
+
+#~ msgid "Disregrad the filaments in AMS. Optimize filament usage by calculating the best arrangement for the left and right nozzles. Arrange the filaments on the printer based on the slicing results."
+#~ msgstr "忽略AMS中的材料，透過計算最佳分配方案來減少材料消耗。需要根據切片結果去印表機調整材料"
+
+#~ msgid "Based on the current filaments in the AMS, arrange the filaments to the left and right nozzles."
+#~ msgstr "根據AMS中的材料，將材料分配到左右噴嘴"
+
+#~ msgid "Mannully arrange the filaments for the left and right nozzles."
+#~ msgstr "無需推薦，切片時手動設定左右噴嘴的材料分配"
+
+#~ msgid "(Arrange after slicing)"
+#~ msgstr "（先切片後襬料）"
+
+#~ msgid "(Arrange before slicing)"
+#~ msgstr "（先擺料後切片）"
+
+#~ msgid "(Please sync printer)"
+#~ msgstr "（請連線印表機）"
+
+#~ msgid "More info on wiki"
+#~ msgstr "更多資訊檢視wiki"
+
+#~ msgid "Axis go home"
+#~ msgstr "Axis回Home點"
+
+#~ msgid "Are you sure you want to home now?"
+#~ msgstr "你確定現在要回Home點嗎？"
+
+#~ msgid "Home"
+#~ msgstr "首頁"
+
+#~ msgid "TPU is not supported by deputy extruder."
+#~ msgstr "副擠出機不支援TPU。"
+
+#~ msgid "Sweeping XY mech mode"
+#~ msgstr "掃描XY軸機械模態"
+
+#~ msgid "Motor noise calibration"
+#~ msgstr "電機噪音標定"
+
+#~ msgid ""
+#~ "You can find it in \"Settings > Network > Connection code\"\n"
+#~ "on the printer, as shown in the figure:"
+#~ msgstr ""
+#~ "你可以在印表機“設定->網路->連線->訪問碼\"\n"
+#~ "檢視，如下圖所示："
+
+#~ msgid "Normal flow"
+#~ msgstr "普通流量"
+
+#~ msgid "The selected diameter is inconsistent with the printer diameter."
+#~ msgstr "所選直徑與印表機直徑不一致。"
+
+#~ msgid "No AMS filaments. Please select a printer in 'Device' page to load AMS info."
+#~ msgstr "沒有發現AMS材料。請在“裝置”頁面選擇印表機，將載入 AMS 資訊。"
+
+#~ msgid "Sync filaments with AMS will drop all current selected filament presets and colors. Do you want to continue?"
+#~ msgstr "同步到 AMS 的材料列表將丟棄所有當前配置的材料預設、顏色。是否繼續？"
+
+#~ msgid "Already did a synchronization, do you want to sync only changes or resync all?"
+#~ msgstr "已經同步過，你希望僅同步改變的材料還是重新同步所有材料？"
+
+#~ msgid "Sync"
+#~ msgstr "同步"
+
+#~ msgid "Resync"
+#~ msgstr "重新同步"
+
+#~ msgid "Spiral mode only works when wall loops is 1, support is disabled, top shell layers is 0, sparse infill density is 0 and timelapse type is traditional."
+#~ msgstr "旋轉模式只能在外牆層數為1，關閉支撐，頂層層數為0，稀疏填充密度為0，傳統延時攝影時有效。"
+
+#~ msgid "The custom printer or model is not inputed, place input."
+#~ msgstr "自定義印表機或型號未輸入，請輸入。"
+
+#~ msgid "*Printing %s material with %s may cause nozzle damage"
+#~ msgstr "*使用 %s 材料和 %s 列印可能會導致噴嘴損壞"
+
+#~ msgid "Low temperature filament(PLA/PETG/TPU) is loaded in the extruder.In order to avoid extruder clogging,it is not allowed to set the chamber temperature above 45℃."
+#~ msgstr "擠出機中載入了低溫度的列印材料（如PLA/PETG/TPU）。為了避免擠出機堵塞，不允許將腔溫設定高於45℃。"
+
+#~ msgid "See BambuLab Wiki"
+#~ msgstr "檢視BambuLab Wiki"
+
+#~ msgid "Current filament colors:"
+#~ msgstr "當前耗材絲顏色:"
+
+#~ msgid "Quick set:"
+#~ msgstr "快捷設定:"
+
+#~ msgid "Cluster colors"
+#~ msgstr "重置匹配的耗材絲"
+
+#~ msgid "Map Filament"
+#~ msgstr "匹配耗材絲"
+
+#~ msgid ""
+#~ "Note:The color has been selected, you can choose OK \n"
+#~ " to continue or manually adjust it."
+#~ msgstr ""
+#~ "注意：顏色已經選好了，您可以選中確認 \n"
+#~ " 繼續或手動修改它。"
+
+#~ msgid "An SD card needs to be inserted before printing via LAN."
+#~ msgstr "需要插入SD卡後方可傳送區域網列印"
+
+#~ msgid "An SD card needs to be inserted before sending to printer."
+#~ msgstr "需要插入SD卡後方可傳送到印表機。"
+
+#~ msgid "Browsing file in SD card is not supported in current firmware. Please update the printer firmware."
+#~ msgstr "當前韌體暫不支援檢視SD卡中檔案。請更新印表機韌體後重試。"
+
+#~ msgid ""
+#~ "Please check if the SD card is inserted into the printer.\n"
+#~ "If it still cannot be read, you can try formatting the SD card."
+#~ msgstr "請檢查印表機中SD卡是否已經插入，如果仍然不能讀取，您可嘗試格式化SD卡。"
+
+#~ msgid "Browsing file in SD card is not supported in LAN Only Mode."
+#~ msgstr "區域網模式下暫不支援檢視SD卡內檔案。"
+
+#~ msgid "Can't start this without SD card."
+#~ msgstr "沒有SD卡無法開始任務。"
+
+#~ msgid "An SD card needs to be inserted before printing."
+#~ msgstr "請在發起列印前插入SD卡"
+
+#~ msgid "An SD card needs to be inserted to record timelapse."
+#~ msgstr "開啟延遲攝影功能需要插入SD卡"
+
+#~ msgid "Send to Printer SD card"
+#~ msgstr "傳送到印表機的SD卡"
+
+#~ msgid "An SD card needs to be inserted before send to printer SD card."
+#~ msgstr "傳送到印表機需要插入SD卡"
+
+#~ msgid "The printer does not support sending to printer SD card."
+#~ msgstr "該印表機不支援傳送到印表機SD卡。"
+
+#~ msgid "enable multi instance rendering by opengl"
+#~ msgstr "開啟opengl多例項渲染"
+
+#~ msgid "Set the brim type to \"painted\""
+#~ msgstr "將Brim型別設定為繪製模式"
+
+#~ msgid "?"
+#~ msgstr "?"
+
+#~ msgid "AMS not connected"
+#~ msgstr "AMS未連線"
+
+#~ msgid "Ext Spool"
+#~ msgstr "外掛料卷"
+
+#~ msgid "Guide"
+#~ msgstr "引導"
+
+#~ msgid "Calibrating AMS..."
+#~ msgstr "正在校準AMS..."
+
+#~ msgid "A problem occurred during calibration. Click to view the solution."
+#~ msgstr "校準過程遇到問題。點選檢視解決方案。"
+
+#~ msgid "Calibrate again"
+#~ msgstr "重新校準"
+
+#~ msgid "Cancel calibration"
+#~ msgstr "取消校準"
+
+#~ msgid "Feed Filament"
+#~ msgstr "進料"
+
+#~ msgid "SD Card"
+#~ msgstr "SD卡"
+
+#~ msgid "Cham"
+#~ msgstr "機箱"
+
+#~ msgid "No SD Card"
+#~ msgstr "無SD卡"
+
+#~ msgid "SD Card Abnormal"
+#~ msgstr "SD卡異常"
+
+#~ msgid "Unable to perform boolean operation on model meshes. Only positive parts will be kept. You may fix the meshes and try agian."
+#~ msgstr "無法對模型網格執行布林運算。只保留正體積部分。您可以修復網格後再試一次。"
+
+#~ msgid "nozzle in preset: %s %s"
+#~ msgstr "預設中的噴嘴：%s %s"
+
+#~ msgid "Caution to use! Flow calibration on Textured PEI Plate may fail due to the scattered surface."
+#~ msgstr "小心使用！紋理PEI板上的流量校準可能會因表面散射而失敗。"
+
+#~ msgid "Automatic flow calibration using Micro Lidar"
+#~ msgstr "使用微型鐳射雷達進行自動流量校準"
+
+#~ msgid "Direct drive"
+#~ msgstr "直接驅動"
+
+#~ msgid "Only one of the results with the same name will be saved. Are you sure you want to override the other results?"
+#~ msgstr "相同名稱的結果只會儲存一個。您確定要覆蓋其他結果嗎？"
+
+#~ msgid "Your nozzle diameter in preset is not consistent with memorized nozzle diameter. Did you change your nozzle lately?"
+#~ msgstr "預設中的噴嘴直徑與記憶的噴嘴直徑不一致。您最近更換了噴嘴嗎？"
+
+#~ msgid "The wipe speed is determined by speed of current extrusion role. e.g if a wip action is executed immediately following an outer wall extrusion, the speed of the outer wall extrusion will be utilized for the wipe action."
+#~ msgstr "擦拭速度由當前擠出型別的速度決定。例如，如果擦拭動作緊隨外牆，擦拭速度將使用外牆速度。"
+
+#~ msgid "Rough"
+#~ msgstr "粗糙"
+
+#~ msgid "Reduce Linear"
+#~ msgstr "減少線偏轉值"
+
+#~ msgid "Reduce Angle"
+#~ msgstr "減少角偏轉值"
+
+#~ msgid "More faces"
+#~ msgstr "更多三角面"
+
+#~ msgid "Fewer faces"
+#~ msgstr "更少三角面"
+
+#~ msgid "Printing high temperature material(%1s material) with %2s may cause nozzle damage"
+#~ msgstr "用%2s列印高溫材料（%1s材料）可能會導致噴嘴損壞"
+
+#~ msgid "Unknow error."
+#~ msgstr "未知錯誤"
+
+#~ msgid "Printing high temperature material(%1 material) with %2 may cause nozzle damage"
+#~ msgstr "用%2列印高溫材料（%1材料）可能會導致噴嘴損壞"
+
+#~ msgid "We would use Lidar to read the calibration result"
+#~ msgstr "我們將使用鐳射雷達來讀取校準結果。"
+
+#~ msgid "Are you sure you want to cancel this print?"
+#~ msgstr "你確定要取消這次列印嗎？"
+
+#~ msgid ""
+#~ "Tip: When using the A1/A1 mini machine, we do not recommend calibrating foam filaments(%s),\n"
+#~ "as the results may be unstable and affect print quality."
+#~ msgstr ""
+#~ "提示：在使用A1/A1 mini機器時，不建議對發泡類材料（%s）進行校準，\n"
+#~ "以免因效果不佳（校準結果不穩定）而影響列印質量。"
+
+#~ msgid "filaments %s cannot be printed directly on the surface of this plate"
+#~ msgstr "材料 %s 不能在直接在當前列印板上列印"
+
+#~ msgid "Remove all points"
+#~ msgstr "刪除所有點"
+
+#~ msgid "(Set the brim type to \"painted\")"
+#~ msgstr "將Brim型別設定為繪製模式"
+
+#~ msgid "Conditional scarf joint"
+#~ msgstr "選擇性應用斜拼接縫"
+
+#~ msgid "Conditional angle threshold"
+#~ msgstr "角度閾值"
+
+#~ msgid "Role base wipe speed"
+#~ msgstr "自動擦拭速度"
+
+#~ msgid "Jump to layer"
+#~ msgstr "跳轉到層"
+
+#~ msgid "PLA Plate"
+#~ msgstr "PLA列印板"
+
+#~ msgid "Cool Plate / PLA Plate"
+#~ msgstr "低溫列印板 / PLA列印板"
+
+#~ msgid "Step 1, please confirm Bambu Studio and your printer are in the same LAN."
+#~ msgstr "第1步，請確認Bambu Studio和您的印表機在同一個LAN上。"
+
+#~ msgid "Step 2, if the IP and Access Code below are different from the actual values on your printer, please correct them."
+#~ msgstr "第2步，如果下方的IP和訪問程式碼與印表機上的實際值不同,請更正。"
+
+#~ msgid "Step 3: Ping the IP address to check for packet loss and latency."
+#~ msgstr "步驟3，請ping印表機的IP地址，以此檢查丟包和延遲。"
+
+#~ msgid "The device does not support using IP and Access Code for connection."
+#~ msgstr "該裝置不支援使用IP和訪問程式碼進行連線。"
+
+#~ msgid "Please check the custom G-code or use the default custom G-code."
+#~ msgstr "請檢查自定義G-code，或者使用預設的。"
+
+#~ msgid "Clearance radius around extruder. Used for collision avoidance in by-object printing."
+#~ msgstr "擠出機四周的避讓半徑。用於在逐件列印中避免碰撞。"
+
+#~ msgid "Warning: The brim type is not set to manual,"
+#~ msgstr "警告：Brim型別未設定為手動，"
+
+#~ msgid "the brim ears will not take effect !"
+#~ msgstr "Brim圓盤不會生效！"
+
+#~ msgid "(set)"
+#~ msgstr "（設定）"
+
+#~ msgid "Object will be raised by this number of support layers. Use this function to avoid wrapping when print ABS"
+#~ msgstr "模型會在相應層數的支撐上抬高進行列印。使用該功能通常用於列印ABS時翹曲。"
+
+#~ msgid "Printer binding successful. The dialog will close later"
+#~ msgstr "印表機繫結成功。稍後將關閉對話方塊。"
+
+#~ msgid "User Sync"
+#~ msgstr "使用者同步"
+
+#~ msgid "Update built-in Presets automatically."
+#~ msgstr "自動更新系統預設。"
+
+#~ msgid "System Sync"
+#~ msgstr "系統同步"
+
+#~ msgid "Brim ears"
+#~ msgstr "Brim圓盤"
+
+#~ msgid "Draw brim"
+#~ msgstr "繪製brim"
+
+#~ msgid "Please input a valid value (0.001 < angle deflection < 0.1)"
+#~ msgstr "請輸入有效值（0.001<線偏轉值<0.1）"
+
+#~ msgid ""
+#~ "Too small scarf start height.\n"
+#~ "Reset to 50%"
+#~ msgstr "斜拼接縫起始高度過小，重設為50%。"
+
+#~ msgid ""
+#~ "Too big scarf start height.\n"
+#~ "Reset to 50%"
+#~ msgstr "斜拼接縫起始高度過大，重設為50%。"
+
+#~ msgid "Linear Deflection:"
+#~ msgstr "線偏轉值"
+
+#~ msgid "Angle Deflection:"
+#~ msgstr "角偏轉值"
+
+#~ msgid "Number of triangular facets: "
+#~ msgstr "三角面數量"
+
+#~ msgid "Scarf joint seam (experimental)"
+#~ msgstr "斜拼接縫（實驗）"
+
+#~ msgid "Use scarf joint to minimize seam visibility and increase seam strength."
+#~ msgstr "使用斜拼接縫來最小化接縫的可見性並增加接縫的強度。"
+
+#~ msgid ""
+#~ "Start height of the scarf.\n"
+#~ "This amount can be specified in millimeters or as a percentage of the current layer height. The default value for this parameter is 0."
+#~ msgstr ""
+#~ "斜拼接縫的起始高度。\n"
+#~ "這個數值可以用毫米或者當前層高的百分比表示。預設值為0。"
+
+#~ msgid "Slop gap"
+#~ msgstr "斜面接縫"
+
+#~ msgid "Set Position"
+#~ msgstr "設定位置"
+
+#~ msgid "Stopped."
+#~ msgstr "已經停止。"
+
+#~ msgid "\"Fix Model\" feature is currently only on Windows. Please repair the model on Bambu Studio(windows) or CAD softwares."
+#~ msgstr "\"修復模型\"功能目前僅適用於Windows。請在Bambu Studio(windows)或CAD軟體上修復模型。"
+
+#~ msgid ""
+#~ "We have added an experimental style \"Tree Slim\" that features smaller support volume but weaker strength.\n"
+#~ "We recommend using it with: 0 interface layers, 0 top distance, 2 walls."
+#~ msgstr ""
+#~ "我們增加了一種實驗性的風格 \"苗條樹\"，它的特點是支撐體積較小，但強度較弱。\n"
+#~ "因此我們推薦以下引數：接觸層數為0，頂部Z距離為0，牆層數為2。"
+
+#~ msgid "For \"Tree Strong\" and \"Tree Hybrid\" styles, we recommend the following settings: at least 2 interface layers, at least 0.1mm top z distance or using support materials on interface."
+#~ msgstr "對於 \"強壯樹 \"和 \"混合樹 \"風格，我們推薦以下設定：至少2層介面層，至少0.1毫米的頂部z距離或在介面上使用支撐材料。"
+
+#~ msgid "LAN Connection Failed (Sending print file)"
+#~ msgstr "LAN連線失敗(傳送列印檔案)"
+
+#~ msgid "This setting specifies the count of walls around support"
+#~ msgstr "此設定指定了支撐的外牆層數"
+
+#~ msgid "China"
+#~ msgstr "中國"
+
+#~ msgid "Tree support brim width"
+#~ msgstr "樹狀支撐裙邊寬度"
+
+#~ msgid "The brim width around tree support. 0 means auto."
+#~ msgstr "圍繞樹狀支撐的裙邊寬度。0表示自動。"
+
+#~ msgid "Show &Labels"
+#~ msgstr "顯示名稱"
+
+#~ msgid "*We recommend you to add brand, materia, type, and even humidity level in the Name"
+#~ msgstr "*我們建議您在名稱中新增品牌、材料、型別，甚至溼度水平。"
+
+#~ msgid "Alt + Mouse wheel"
+#~ msgstr "Alt + 滑鼠滾輪"
+
+#~ msgid "Move: press to snap by 1mm"
+#~ msgstr "移動：以1mm為步進移動"
+
+#~ msgid "⌘+Mouse wheel"
+#~ msgstr "⌘+滑鼠滾輪"
+
+#~ msgid "⌥+Mouse wheel"
+#~ msgstr "⌥+滑鼠滾輪"
+
+#~ msgid "Alt+Mouse wheel"
+#~ msgstr "Alt+滑鼠滾輪"
+
+#~ msgid ""
+#~ "Please find the details of Flow Dynamics Calibration from our wiki.\n"
+#~ "\n"
+#~ "Usually the calibration is unnecessary. When you start a single color/material print, with the \"flow dynamics calibration\" option checked in the print start menu, the printer will follow the old way, calibrate the filament before the print; When you start a multi color/material print, the printer will use the default compensation parameter for the filament during every filament switch which will have a good result in most cases.\n"
+#~ "\n"
+#~ "Please note there are a few cases that will make the calibration result not reliable: using a texture plate to do the calibration; the build plate does not have good adhesion (please wash the build plate or apply gluestick!) ...You can find more from our wiki.\n"
+#~ "\n"
+#~ "The calibration results have about 10 percent jitter in our test, which may cause the result not exactly the same in each calibration. We are still investigating the root cause to do improvements with new updates."
+#~ msgstr ""
+#~ "請從我們的wiki中找到動態流量校準的詳細資訊。\n"
+#~ "\n"
+#~ "通常情況下，校準是不必要的。當您開始單色/單材料列印，並在列印開始選單中勾選了“動態流量校準”選項時，印表機將按照舊的方式，在列印前校準絲料；當您開始多色/多材料列印時，印表機將在每次換絲料時使用預設的補償引數，這在大多數情況下會產生良好的效果。\n"
+#~ "\n"
+#~ "請注意，有幾種情況會導致校準結果不可靠：使用紋理板進行校準；建模平臺粘附效果不好（請清洗建模平臺或塗抹膠棒）... 您可以在我們的wiki中找到更多資訊。\n"
+#~ "\n"
+#~ "在我們的測試中，校準結果有約10%的波動，這可能導致每次校準的結果略有不同。我們仍在調查根本原因，並透過新的更新進行改進。"
+
+#~ msgid "Select Connected Printetrs (%d/6)"
+#~ msgstr "選擇已連線的印表機 (%d/6)"
+
+#~ msgid "Select connected printetrs (0/6)"
+#~ msgstr "選擇已連線的印表機 (0/6)"
+
+#~ msgid "Please input a valid value (K in 0~0.3)"
+#~ msgstr "請輸入有效的數值 (K的範圍為0~0.3)"
+
+#~ msgid "Please input a valid value (K in 0~0.3, N in 0.6~2.0)"
+#~ msgstr "請輸入有效的數值 (K的範圍為0~0.3，N的範圍為0.6~2.0)"
+
+#~ msgid "Low temperature filament(PLA/PETG/TPU) is loaded in the extruder.In order to avoid extruder clogging,it is not allowed to set the chamber temperature above 45\\u2103."
+#~ msgstr "擠出機中載入了低溫度的列印材料（如PLA/PETG/TPU）。為了避免擠出機堵塞，不允許將腔溫設定高於45度。"
+
+#~ msgid "Printer local connection failed, please try again."
+#~ msgstr "印表機區域網連線失敗，請重試。"
+
+#~ msgid ""
+#~ "Please input valid values:\n"
+#~ "start > 0 \\step >= 0\n"
+#~ "end > start + step)"
+#~ msgstr ""
+#~ "請輸入有效值:\n"
+#~ "起始值 > 0 \\值步長 >= 0\n"
+#~ "結束值 > 起始值 + 值步長)"
+
+#~ msgid ""
+#~ "Please input valid values:\n"
+#~ "start > 10 \\step >= 0\n"
+#~ "end > start + step)"
+#~ msgstr ""
+#~ "請輸入有效值:\n"
+#~ "起始值 > 0 \\值步長 >= 0\n"
+#~ "結束值 > 起始值 + 值步長)"
+
+#~ msgid "Over 4 studio/handy are using remote access, you can close some and try again."
+#~ msgstr "超過4個Studio和App在遠端連線印表機，請關閉部分後重試。"
+
+#~ msgid ""
+#~ "Due to ensuer_on_bed, assembly between \n"
+#~ "different objects may not be correct in 3D view.\n"
+#~ " It is recommended to assemble them together."
+#~ msgstr ""
+#~ "由於物件必須在熱床上，不同物件之間的 \n"
+#~ "裝配在3D檢視也許不正確。推薦將它們組合在一起。"
+
+#~ msgid "Combinate"
+#~ msgstr "組合"
+
+#~ msgid "Export &Configs"
+#~ msgstr "匯出預設"
+
+#~ msgid ""
+#~ "Failed to save the project.\n"
+#~ "Please check whether the folder exists online or if other programs open the project file."
+#~ msgstr "儲存檔案失敗。請檢查目錄是否存在，以及是否有其他程式開啟了該專案檔案。"
+
+#~ msgid "Line pattern of internal solid infill. if the detect nattow internal solid infill be enabled, the concentric pattern will be used for the small area."
+#~ msgstr "內部實心填充的線型圖案。如果啟用了檢測狹窄的內部實心填充，將使用同心圓圖案來填充小區域。"
+
+#~ msgid "Export Configs"
+#~ msgstr "匯出預設"
+
+#~ msgid "Printer config bundle(.bbscfg)"
+#~ msgstr "印表機預設集(.bbscfg)"
+
+#~ msgid "Filament bundle(.bbsflmt)"
+#~ msgstr "材料預設集(.bbsflmt)"
+
+#~ msgid "Unconnected device"
+#~ msgstr "未連線裝置"
+
+#~ msgid ""
+#~ "Select 2 faces on objects and \n"
+#~ " make the objects assemble together."
+#~ msgstr ""
+#~ "在兩個物體上選擇兩個面 \n"
+#~ "並將物體組合在一起。"
+
+#~ msgid "Featue 2"
+#~ msgstr "特徵2"
+
+#~ msgid "Not Extruded Yet,Retry"
+#~ msgstr "耗材未擠出，重試"
+
+#~ msgid "active"
+#~ msgstr "活動的"
+
+#~ msgid "Unload Filament"
+#~ msgstr "退料"
+
+#~ msgid "Studio would re-calculate your flushing volumes everytime the filaments color changed. You could disable the auto-calculate in Bambu Studio > Preferences"
+#~ msgstr "Studio 將會在每一次更換耗材顏色時重新計算你的沖刷體積， 你可以在 Bambu Studio > 偏好設定 中關閉自動計算"
+
+#~ msgid "MoveInMeasure"
+#~ msgstr "在測量中平移"
+
+#~ msgid "Experimental feature: Retracting and cutting off the filament at a greater distance during filament changes to minimize flush.Although it can notably reduce flush, it may also elevate the risk of nozzle clogs or other printing complications."
+#~ msgstr "實驗性選項。在更換耗材絲時，將耗材絲回抽一段距離後再切斷以最小化沖刷。雖然這可以顯著減少衝刷，但也可能增加噴嘴堵塞或其他列印問題的風險。"
+
+#~ msgid "Generating supports"
+#~ msgstr "生成支撐"
+
+#~ msgid "Use Modified Value of Printer"
+#~ msgstr "使用機器預設的修改值"
+
+#~ msgid "Scarf joint seam (beta)"
+#~ msgstr "斜拼接縫（試驗）"
+
+#~ msgid "Filament Extruded,Continue"
+#~ msgstr "耗材已擠出，繼續"
+
+#~ msgid "Finished,Continue"
+#~ msgstr "已完成，繼續"
+
+#~ msgid "Load Filament "
+#~ msgstr "進料並前往進料頁面"
+
+#~ msgid "OK "
+#~ msgstr "我知道了"
+
+#~ msgid "Translate (relative) [World]"
+#~ msgstr "平移（相對）[世界]"
+
+#~ msgid "Adsorbed onto the surface"
+#~ msgstr "吸附到表面"
+
+#~ msgid "modify x distance between objects"
+#~ msgstr "修改物體間x距離"
+
+#~ msgid "modify y distance between objects"
+#~ msgstr "修改物體間y距離"
+
+#~ msgid "Actions For Unsaved Changes"
+#~ msgstr "未儲存更改的操作"
+
+#~ msgid "Preset Value"
+#~ msgstr "預設值"
+
+#~ msgid "Modified Value"
+#~ msgstr "修改值"
+
+#~ msgid "Transfer Modified Value"
+#~ msgstr "遷移修改值"
+
+#~ msgid "Use Preset Value"
+#~ msgstr "使用預設值"
+
+#~ msgid ""
+#~ "\n"
+#~ "Would you like to save these changed settings(modified value)?"
+#~ msgstr ""
+#~ "\n"
+#~ "您想儲存這些更改的設定（修改後的值）嗎？"
+
+#~ msgid ""
+#~ "\n"
+#~ "Would you like to keep these changed settings(modified value) after switching preset?"
+#~ msgstr ""
+#~ "\n"
+#~ "您想在切換預設後保留這些更改的設定（修改後的值）嗎？"
+
+#~ msgid "You have previously modified your settings and are about to overwrite them with new ones."
+#~ msgstr "您之前修改過您的設定，即將用新的設定覆蓋它們。"
+
+#~ msgid ""
+#~ "\n"
+#~ "Do you want to keep your current modified settings, or use preset settings?"
+#~ msgstr ""
+#~ "\n"
+#~ "您想保留當前修改過的設定，還是使用預設的設定？"
+
+#~ msgid ""
+#~ "\n"
+#~ "Do you want to save your current modified settings?"
+#~ msgstr ""
+#~ "\n"
+#~ "您要儲存當前修改的設定嗎？"
+
+#~ msgid "Support: generate toolpath at layer %d"
+#~ msgstr "支撐：正在生成層%d的走線路徑"
+
+#~ msgid "Support: detect overhangs"
+#~ msgstr "支撐：正在檢測懸空面"
+
+#~ msgid "Support: precalculate avoidance"
+#~ msgstr "支援：預計算避讓區域"
+
+#~ msgid "Support: generate contact points"
+#~ msgstr "支撐：正在生成接觸點"
+
+#~ msgid "Support: propagate branches"
+#~ msgstr "支撐：正在生長樹枝"
+
+#~ msgid "Support: draw polygons"
+#~ msgstr "支撐：正在生成多邊形"
+
+#~ msgid "Support: generate toolpath"
+#~ msgstr "支撐：正在生成走線路徑"
+
+#~ msgid "Support: generate polygons at layer %d"
+#~ msgstr "支撐：正在生成層%d的多邊形"
+
+#~ msgid "Support: fix holes at layer %d"
+#~ msgstr "支撐：正在修補層%d的空洞"
+
+#~ msgid "Support: propagate branches at layer %d"
+#~ msgstr "支撐：正在生長層%d的樹枝"
+
+#~ msgid "Switch table page"
+#~ msgstr "切換標籤頁"
+
+#~ msgid "Upload Pictrues"
+#~ msgstr "上傳圖片"
+
+#~ msgid "Succeed to export G-code to %1%"
+#~ msgstr "成功匯出G-code至 %1%"
+
+#~ msgid "Total Time Estimation"
+#~ msgstr "總時間預估"
+
+#~ msgid "Share"
+#~ msgstr "分享"
+
+#~ msgid "Transfer or discard changes"
+#~ msgstr "遷移或者丟棄更改"
+
+#~ msgid "Old Value"
+#~ msgstr "舊值"
+
+#~ msgid "Transfer"
+#~ msgstr "遷移"
+
+#~ msgid "Discard"
+#~ msgstr "放棄"
+
+#~ msgid ""
+#~ "You have changed some settings of preset \"%1%\". \n"
+#~ "Would you like to keep these changed settings (new value) after switching preset?"
+#~ msgstr "您已經更改了預設 \"%1%\"，是否在切換後要保留這些更改的預設引數？"
+
+#~ msgid ""
+#~ "You have changed some preset settings. \n"
+#~ "Would you like to keep these changed settings (new value) after switching preset?"
+#~ msgstr "您已經更改了預設引數，是否在切換後要保留這些更改的預設引數？"
+
+#~ msgid " is too close to others, there may be collisions when printing."
+#~ msgstr "太靠近其他物體，列印時可能會有碰撞。"
+
+#~ msgid "Please update the printer firmware and try again."
+#~ msgstr "請更新印表機韌體，然後重試。"
+
+#~ msgid "No files [%d]"
+#~ msgstr "檔案列表為空[%d]"
+
+#~ msgid "Load failed [%d]"
+#~ msgstr "載入失敗 [%d]"
+
+#~ msgid "Cabin humidity"
+#~ msgstr "艙內溼度"
+
+#~ msgid "Green means that AMS humidity is normal, orange represents humidity is high, red represents humidity is too high.(Hygrometer: lower the better.)"
+#~ msgstr "綠色表示 AMS 溼度正常，橙色表示溼度高，紅色表示溼度過高。(溼度計：越低越好。)"
+
+#~ msgid "Desiccant status"
+#~ msgstr "乾燥劑狀態"
+
+#~ msgid "A desiccant status lower than two bars indicates that desiccant may be inactive. Please change the desiccant.(The bars: higher the better.)"
+#~ msgstr "乾燥劑狀態低於兩格表示乾燥劑可能不活躍。請更換乾燥劑。(槓：越高越好)。"
+
+#~ msgid "Note: When the lid is open or the desiccant pack is changed, it can take hours or a night to absorb the moisture. Low temperatures also slow down the process. During this time, the indicator may not represent the chamber accurately."
+#~ msgstr "注意：當蓋子開啟或更換乾燥劑包裝時，可能需要數小時或一晚才能吸收水分，低溫也會減慢這一過程。在此期間，指示器的數值可能並不準確。"
+
+#~ msgid "Unable to perform boolean operation on model meshes. Only positive parts will be exported."
+#~ msgstr "無法對模型網格執行布林運算。只有正面部分將被匯出。"
+
+#~ msgid "Auto Bed Type"
+#~ msgstr "自動列印板型別"
+
+#~ msgid "non-mainifold edges be caused by cut tool, do you want to fix it now?"
+#~ msgstr "因切割產生了非流形邊，您是否想現在修復？"
+
+#~ msgid ""
+#~ "Invalid state. \n"
+#~ "No one part is selected for keep after cut"
+#~ msgstr ""
+#~ "無效狀態。\n"
+#~ "切割後沒有選中要保留的部分"
+
+#~ msgid "Can't apply when proccess preview."
+#~ msgstr "處理預覽的過程中無法應用。"
+
+#~ msgid "Shift + Mouse move up or dowm"
+#~ msgstr "Shift + 滑鼠上移或下移"
+
+#~ msgid "BambuStudio configuration file may be corrupted and is not abled to be parsed.Please delete the file and try again."
+#~ msgstr "Bambu Studio配置檔案可能已損壞而無法解析。請刪除此檔案並重新啟動BambuStudio。"
+
+#~ msgid "You can keep the modifield presets to the new project, discard or save changes as new presets."
+#~ msgstr "您可以保留未儲存修改的預設應用到新專案中，或者選擇忽略。"
+
+#~ msgid "Fatal error, exception catched: %1%"
+#~ msgstr "致命錯誤，捕獲到異常：%1%"
+
+#~ msgid "Split the selected object into mutiple objects"
+#~ msgstr "拆分所選物件為多個物件"
+
+#~ msgid "Split the selected object into mutiple parts"
+#~ msgstr "拆分所選物件為多個零件"
+
+#~ msgid ""
+#~ "This action will break a cut correspondence.\n"
+#~ "After that model consistency can't be guaranteed .\n"
+#~ "\n"
+#~ "To manipulate with solid parts or negative volumes you have to invalidate cut infornation first."
+#~ msgstr ""
+#~ "該行為將破壞切割關係，在此之後將無法保證模型一致性。\n"
+#~ "\n"
+#~ "如果要操作子部件或者負零件，需要先解除切割關係。"
+
+#~ msgid "The target object contains only one part and can not be splited."
+#~ msgstr "目標物件僅包含一個零件，無法被拆分。"
+
+#~ msgid "If first selected item is an object, the second one should also be object."
+#~ msgstr "如果第一個選擇的是物件，那麼第二個選擇的也必須是物件。"
+
+#~ msgid "If first selected item is a part, the second one should be part in the same object."
+#~ msgstr "如果第一個選擇的是零件，那麼第二個選擇的也必須是同一個物件中的零件。"
+
+#~ msgid "Failed to repair folowing model object"
+#~ msgid_plural "Failed to repair folowing model objects"
+#~ msgstr[0] "以下模型对象修复失败"
+
+#~ msgid "A problem occured during calibration. Click to view the solution."
+#~ msgstr "校準過程遇到問題。點選檢視解決方案。"
+
+#~ msgid "Choose an AMS slot then press \"Load\" or \"Unload\" button to automatically load or unload filiament."
+#~ msgstr "選擇1個AMS槽位，然後點選進料/退料按鈕以自動進料/退料。"
+
+#~ msgid "No arrangable objects are selected."
+#~ msgstr "沒有可擺盤的物件被選中。"
+
+#~ msgid "Unkown Error."
+#~ msgstr "未知錯誤。"
+
+#~ msgid "Green means that AMS humidity is normal, orange represent humidity is high, red represent humidity is too high.(Hygrometer: lower the better.)"
+#~ msgstr "綠色表示 AMS 溼度正常，橙色表示溼度高，紅色表示溼度過高。(溼度計：越低越好。)"
+
+#~ msgid "Note: if new filament is inserted during  printing, the AMS will not automatically read any information until printing is completed."
+#~ msgstr "注意：如果是在列印過程中插入新的耗材絲，AMS會在列印結束後自動讀取此耗材絲資訊。"
+
+#~ msgid "A error occurred. Maybe memory of system is not enough or it's a bug of the program"
+#~ msgstr "發生錯誤。可能系統記憶體不足或者程式存在bug。"
+
+#~ msgid ""
+#~ "Nozzle may be blocked when the temperature is out of recommended range.\n"
+#~ "Please make sure whether to use the temperature to print.\n"
+#~ "\n"
+#~ msgstr ""
+#~ "當溫度超過建議的範圍時，噴嘴可能會堵塞。\n"
+#~ "請確認是否使用該溫度列印\n"
+#~ "\n"
+
+#~ msgid ""
+#~ "This setting is only used for model size tunning with small value in some cases.\n"
+#~ "For example, when model size has small error and hard to be assembled.\n"
+#~ "For large size tuning, please use model scale function.\n"
+#~ "\n"
+#~ "The value will be reset to 0."
+#~ msgstr ""
+#~ "這個設定僅用於在特定場景下微調模型尺寸。\n"
+#~ "例如，當模型尺寸有小誤差，難以裝配。\n"
+#~ "對於大尺寸的調整，請使用模型縮放功能。\n"
+#~ "\n"
+#~ "這個數值將被重置為0。"
+
+#~ msgid ""
+#~ "Too large elefant foot compensation is unreasonable.\n"
+#~ "If really have serious elephant foot effect, please check other settings.\n"
+#~ "For example, whether bed temperature is too high.\n"
+#~ "\n"
+#~ "The value will be reset to 0."
+#~ msgstr ""
+#~ "過大的象腳補償是不合理的。\n"
+#~ "如果確實有嚴重的象腳效應，請檢查其他設定。\n"
+#~ "例如，是否設定了過高的床溫。\n"
+#~ "\n"
+#~ "這個數值將被重置為0。"
+
+#~ msgid ""
+#~ "Switch to rectilinear pattern?\n"
+#~ "Yes - switch to rectilinear pattern automaticlly\n"
+#~ "No  - reset density to default non 100% value automaticlly"
+#~ msgstr ""
+#~ "切換到直線圖案？\n"
+#~ "是 - 自動切換到直線圖案\n"
+#~ "否 - 自動將密度重置為預設的非100%值"
+
+#~ msgid "Only the object being edit is visible."
+#~ msgstr "只有正在編輯的物件是可見的。"
+
+#~ msgid "Initialize failed (No Device)!"
+#~ msgstr "初始化失敗（沒有裝置）！"
+
+#~ msgid "Initialize failed (Device connection not ready)!"
+#~ msgstr "初始化失敗（裝置未連線）"
+
+#~ msgid "Initialize failed (No Camera Device)!"
+#~ msgstr "初始化失敗（沒有攝像頭）"
+
+#~ msgid "Printer is busy downloading, Please wait for the downloading to finish."
+#~ msgstr "印表機正在下載，請等待下載結束。"
+
+#~ msgid "Initialize failed (Not supported on the current printer version)!"
+#~ msgstr "初始化失敗（當前印表機的版本不支援）！"
+
+#~ msgid "Initialize failed (Not accessible in LAN-only mode)!"
+#~ msgstr "初始化失敗（在區域網模式中不可訪問）！"
+
+#~ msgid "Initialize failed (Missing LAN ip of printer)!"
+#~ msgstr "初始化失敗（未找到印表機的區域網地址）！"
+
+#~ msgid "Initialize failed (%s)!"
+#~ msgstr "初始化失敗（%s）!"
+
+#~ msgid "Stopped [%d]!"
+#~ msgstr "已停止 [%d]!"
+
+#~ msgid "Load failed [%d]!"
+#~ msgstr "載入失敗 [%d]！"
+
+#~ msgid "Connect failed [%d]!"
+#~ msgstr "連線失敗 [%d]！"
+
+#~ msgid "Initialize failed (Storage unavailable, insert SD card.)!"
+#~ msgstr "初始化失敗（儲存不可用，請插入 SD 卡）！"
+
+#~ msgid "Failed to fetching model infomations from printer."
+#~ msgstr "無法從印表機獲取模型資訊。"
+
+#~ msgid "Failed to parse model infomations."
+#~ msgstr "解析模型資訊失敗。"
+
+#~ msgid "The .gcode.3mf file contains no G-code data.Please slice it whthBambu Studio and export a new .gcode.3mf file."
+#~ msgstr ".gcode.3mf檔案中不包含G-code資料。請使用Bambu Studio進行切片並匯出新的.gcode.3mf檔案。"
+
+#~ msgid "Connection lost. Please retry."
+#~ msgstr "連線丟失。請重試。"
+
+#~ msgid "File not exists."
+#~ msgstr "檔案不存在"
+
+#~ msgid "Storage unavailable, insert SD card."
+#~ msgstr "儲存不可用，請插入SD卡。"
+
+#~ msgid " upload config prase failed\n"
+#~ msgstr "上傳配置解析失敗\n"
+
+#~ msgid "%1$d Object has custom supports."
+#~ msgid_plural "%1$d Objects have custom supports."
+#~ msgstr[0] "%1$d 模型有自定义支撑。"
+
+#~ msgid "Flushing volumes: Auto-calculate everytime the color changed."
+#~ msgstr "沖刷體積：每一次更換顏色時自動計算。"
+
+#~ msgid "If enabled, auto-calculate everytime the color changed."
+#~ msgstr "如果啟用，會在每一次更換顏色時自動計算。"
+
+#~ msgid "Note: The preparation may takes several minutes. Please be patiant."
+#~ msgstr "提示：釋出前需要一些準備時間，請耐心等待。"
+
+#~ msgid "Thank you for purchasing a Bambu Lab device.Before using your Bambu Lab device, please read the termsand conditions.By clicking to agree to use your Bambu Lab device, you agree to abide by the Privacy Policyand Terms of Use(collectively, the \"Terms\"). If you do not comply with or agree to the Bambu Lab Privacy Policy, please do not use Bambu Lab equipment and services."
+#~ msgstr "感謝您購買Bambu Lab裝置，使用Bambu Lab裝置前，請閱讀一下條款，單擊同意使用您的Bambu Lab裝置即表示您同意遵守隱私政策以及使用條款（統稱為“條款”）。如果您不符合或不同意Bambu Lab隱私政策，請不要使用Bambu Lab裝置和服務。"
+
+#~ msgid "The configuration package is changed in previous Config Guide"
+#~ msgstr "引數配置包在之前的配置嚮導中發生了變更"
+
+#~ msgid "The following object(s) have empty initial layer and can't be printed. Please Cut the bottom or enable supports."
+#~ msgstr "模型出現空層無法列印。請切掉底部或開啟支撐。"
+
+#~ msgid "The prime tower requires that support has the same layer height with object."
+#~ msgstr "擦拭塔要求支撐和物件採用同樣的層高。"
+
+#~ msgid "Detour and avoid to travel across wall which may cause blob on surface"
+#~ msgstr "空駛時繞過外牆以避免在模型外觀面產生斑點"
+
+#~ msgid "Maximum detour distance for avoiding crossing wall. Don't detour if the detour distance is large than this value. Detour length could be specified either as an absolute value or as percentage (for example 50%) of a direct travel path. Zero to disable"
+#~ msgstr "避免跨越外牆時的最大繞行距離。當繞行距離比這個數值大時，此次空駛不繞行。繞行距離可表達為絕對值，或者相對直線空駛長度的百分比(例如50%)。0表示禁用"
+
+#~ msgid "The number of bottom solid layers is increased when slicing if the thickness calculated by bottom shell layers is thinner than this value. This can avoid having too thin shell when layer height is small. 0 means that this setting is disabled and thickness of bottom shell is absolutely determained by bottom shell layers"
+#~ msgstr "如果由底部殼體層數算出的厚度小於這個數值，那麼切片時將自動增加底部殼體層數。這能夠避免當層高很小時，底部殼體過薄。0表示關閉這個設定，同時底部殼體的厚度完全由底部殼體層數決定"
+
+#~ msgid "Force part cooling fan to be this speed when printing bridge or overhang wall which has large overhang degree. Forcing cooling for overhang and bridge can get better quality for these part"
+#~ msgstr "當列印橋接和超過設定閾值的懸垂時，強制部件冷卻風扇為設定的速度值。強制冷卻能夠使懸垂和橋接獲得更好的列印質量"
+
+#~ msgid "Use only one wall on flat top surface, to give more space to the top infill pattern. Could be applyed on topmost surface or all top surface."
+#~ msgstr "頂面只使用單層牆，從而更多的空間能夠使用頂部填充圖案。可以應用於最頂部表面或所有頂部表面。"
+
+#~ msgid "Enable this option to slow printing speed down to make the final layer time not shorter than the layer time threshold in \"Max fan speed threshold\", so that layer can be cooled for longer time. This can improve the cooling quality for needle and small details"
+#~ msgstr "勾選這個選項，將降低列印速度，使得最終的層列印時間不小於\"最大風扇速度閾值\"裡的層時間閾值，從而使得該層獲得更久的冷卻。這能夠改善尖頂和小細節的冷卻效果"
+
+#~ msgid "Speed of exhuast fan during printing.This speed will overwrite the speed in filament custom gcode"
+#~ msgstr "列印過程中排風扇的速度。此速度將覆蓋材料的自定義G程式碼中的速度。"
+
+#~ msgid "Don't support the whole bridge area which make support very large. Bridge usually can be printing directly without support if not very long"
+#~ msgstr "不對整個橋接面進行支撐，否則支撐體會很大。不是很長的橋接通常可以無支撐直接列印。"
+
+#~ msgid "If enabled, Studio will generate support loops under the contours of internal bridges.These support loops could prevent internal bridges from extruding over the air and improve the top surface quality, especially when the sparse infill density is low.This value determines the thickness of the support loops. 0 means disable this feature"
+#~ msgstr "如果開啟，Studio會沿著內部橋接的邊沿在其下方生成支撐輪廓。這些支撐輪廓可以防止懸空地列印內部橋接並提高頂面質量，特別是在填充密度較低的情況下。這個設定用於調整支撐輪廓的厚度，0表示關閉此特性。"
+
+#~ msgid "If enable this setting, part cooling fan will never be stoped and will run at least at minimum speed to reduce the frequency of starting and stoping"
+#~ msgstr "如果勾選這個選項，部件冷卻風扇將永遠不會停止，並且會至少執行在最小風扇轉速值以減少風扇的啟停頻次"
+
+#~ msgid "Height of initial layer. Making initial layer height to be thick slightly can improve build plate adhension"
+#~ msgstr "首層層高"
+
+#~ msgid "The average diatance between the random points introducded on each line segment"
+#~ msgstr "產生絨毛表面時，插入的隨機點之間的平均距離"
+
+#~ msgid "Enable this to get a G-code file which has G2 and G3 moves. And the fitting tolerance is same with resolution"
+#~ msgstr "開啟這個設定，匯出的G-code將包含G2 G3指令。圓弧擬合的容許值和精度相同。"
+
+#~ msgid "The largest printable layer height for extruder. Used tp limits the maximum layer hight when enable adaptive layer height"
+#~ msgstr "擠出頭最大可列印的層高。用於限制開啟自適應層高時的最大層高。"
+
+#~ msgid "Speed of auxiliary part cooling fan. Auxiliary fan will run at this speed during printing except the first several layers which is defined by no cooling layers"
+#~ msgstr "輔助部件冷卻風扇的轉速。輔助部件冷卻風扇將一直執行在該速度，除了設定的無需冷卻的前若干層"
+
+#~ msgid "The lowest printable layer height for extruder. Used tp limits the minimum layer hight when enable adaptive layer height"
+#~ msgstr "擠出頭最小可列印的層高。用於限制開啟自適應層高時的最小層高。"
+
+#~ msgid "The start and end points which is from cutter area to garbage can."
+#~ msgstr "從切割區域到垃圾桶的起始和結束點。"
+
+#~ msgid "G-code path is genereated after simplifing the contour of model to avoid too much points and gcode lines in gcode file. Smaller value means higher resolution and more time to slice"
+#~ msgstr "為了避免G-code檔案中過密集的點和走線，G-code走線通常是在簡化模型的外輪廓之後生成。越小的數值代表更高的解析度，同時需要更長的切片時間。"
+
+#~ msgid "Whenever the retraction is done, the nozzle is lifted a little to create clearance between nozzle and the print. It prevents nozzle from hitting the print when travel move. Using spiral line to lift z can prevent stringing"
+#~ msgstr "回抽完成之後，噴嘴輕微抬升，和列印件之間產生一定間隙。這能夠避免空駛時噴嘴和列印件剮蹭和碰撞。使用螺旋線抬升z能夠減少拉絲。"
+
+#~ msgid "Speed for reloading filament into extruder. Zero means same speed with retraction"
+#~ msgstr "耗材絲裝填的速度，0表示和回抽速度一致。"
+
+#~ msgid "This setting specify the count of walls around support"
+#~ msgstr "此設定指定了支撐的外牆層數"
+
+#~ msgid "Move nozzle along the last extrusion path when retracting to clean leaked material on nozzle. This can minimize blob when print new part after travel"
+#~ msgstr "當回抽時，讓噴嘴沿著前面的走線方向繼續移動，清除掉噴嘴上的漏料。這能夠避免空駛結束列印新的區域時產生斑點。"
+
+#~ msgid "Discribe how long the nozzle will move along the last path when retracting"
+#~ msgstr "表示回抽時擦拭的移動距離。"
+
+#~ msgid "Only one of the results with the same name will be saved. Are you sure you want to overrides the other results?"
+#~ msgstr "相同名稱的結果只會儲存一個。您確定要覆蓋其他結果嗎？"
+
+#~ msgid "There is already a historical calibration result with the same name: %s. Only one of the results with the same name is saved. Are you sure you want to overrides the historical result?"
+#~ msgstr "已經存在一個具有相同名稱的歷史校準結果：%s。相同名稱的結果只會儲存一個。您確定要覆蓋歷史結果嗎？"
+
+#~ msgid "Please find the cornor with perfect degree of extrusion"
+#~ msgstr "請找到具有完美擠出度的角落"
+
+#~ msgid "Preset path is not find, please reselect vendor."
+#~ msgstr "預設路徑未找到，請重新選擇供應商。"
+
+#~ msgid "Vendor is not find, please reselect."
+#~ msgstr "供應商未找到，請重新選擇。"
+
+#~ msgid ""
+#~ "Please go to filament setting to edit your presets if you need.\n"
+#~ "Please note that nozzle temperature, hot bed temperature, and maximum volumetric speed have a significant impact on printing quality. Please set them carefully."
+#~ msgstr ""
+#~ "如果需要，請轉到材料設定以編輯您的預設。\n"
+#~ "請注意噴嘴溫度、熱床溫度和最大體積流量對列印質量有重大影響。請小心設定它們。"
+
+#~ msgid ""
+#~ "Printer and all the filament&process presets that belongs to the printer. \n"
+#~ "Can be shared with others."
+#~ msgstr ""
+#~ "印表機和屬於印表機的所有的材料和工藝預設。\n"
+#~ "能與他人分享。"
+
+#~ msgid "Support air filtration"
+#~ msgstr "支援空氣過濾增強"
+
+#~ msgid "Enable this if printer support air filtration"
+#~ msgstr "如果印表機支援空氣過濾，請啟用此選項"
+
+#~ msgid "This slicer file version %s is newer than %s's version:"
+#~ msgstr "此切片軟體檔案版本 %s 較新，高於 %s 的版本："
+
+#~ msgid "Would you like to update your Bambu Studio software to enable all functionality in this slicer file?\n"
+#~ msgstr "您是否想要更新您的Bambu Studio軟體，以啟用此切片軟體檔案中的所有功能？\n"
+
+#~ msgid "you can always update Bambu Studio at your convenience. The slicer file will now be loaded without full functionality."
+#~ msgstr "您隨時可以方便地更新Bambu Studio。切片軟體檔案將載入，但功能可能不完整。"
+
+#~ msgid ""
+#~ "This slicer file version %s is newer than %s's version.\n"
+#~ "\n"
+#~ "Would you like to update your Bambu Studio software to enable all functionality in this slicer file?"
+#~ msgstr ""
+#~ "此切片軟體檔案版本 %s 較新，高於 %s 的版本。\n"
+#~ "\n"
+#~ "您是否想要更新您的Bambu Studio軟體，以啟用此切片軟體檔案中的所有功能？"
+
+#~ msgid "MainBoard"
+#~ msgstr "主機板"
+
+#~ msgid "⌘+Any arrow"
+#~ msgstr "⌘+方向鍵"
+
+#~ msgid "⌥+Left mouse button"
+#~ msgstr "⌥+滑鼠左鍵"
+
+#~ msgid "⌘+Left mouse button"
+#~ msgstr "⌘+滑鼠左鍵"
+
+#~ msgid "Ctrl+Any arrow"
+#~ msgstr "Ctrl+方向鍵"
+
+#~ msgid "Alt+Left mouse button"
+#~ msgstr "Alt+滑鼠左鍵"
+
+#~ msgid "Ctrl+Left mouse button"
+#~ msgstr "Ctrl+滑鼠左鍵"
+
+#~ msgid "The beginning of the vendor can not be a number. Please re-enter."
+#~ msgstr "自定義供應商的開頭不能是數字。請重新輸入。"
+
+#~ msgid "The printer timed out while receiving a print job. Please check if the network is functioning properly and send the print again."
+#~ msgstr "印表機接收列印任務超時，請檢查網路正常後再次傳送列印。"
+
+#~ msgid "Fliament Tangle Detect"
+#~ msgstr "纏料檢測"
+
+#~ msgid "Project Inside Preset"
+#~ msgstr "專案預設"
+
+#~ msgid "Discard or Keep changes"
+#~ msgstr "放棄或保留更改"
+
+#~ msgid "Reduce interface filament for base"
+#~ msgstr "介面材料不用於主體"
+
+#~ msgid "Avoid using support interface filament to print support base"
+#~ msgstr "避免使用支撐介面材料列印支撐主體"
+
+#~ msgid "Improt Preset"
+#~ msgstr "匯入預設"
+
+#~ msgid ""
+#~ "Delete filament?\n"
+#~ "Delete filament would deleted all the attatched filament presets"
+#~ msgstr ""
+#~ "刪除材料？\n"
+#~ "刪除材料將刪除所有附屬的材料預設。"
+
+#~ msgid "No interface filament for body"
+#~ msgstr "介面材料不用於主體"
+
+#~ msgid "Don't use support interface filament to print support body"
+#~ msgstr "不使用支撐介面材料列印支撐主體"
+
+#~ msgid "Filling bed "
+#~ msgstr "填充熱床"
+
+#~ msgid "Please heat the nozzle to above 170 degree before loading filament."
+#~ msgstr "請在進料前把噴嘴升溫到170℃。"
+
+#~ msgid "Create based on current filamet"
+#~ msgstr "基於當前材料建立"
+
+#~ msgid "Copy current filament preset "
+#~ msgstr "複製當前材料預設"
+
+#~ msgid "Input custom vendor"
+#~ msgstr "輸入自定義供應商"
+
+#~ msgid "Filament preset"
+#~ msgstr "材料預設"
+
+#~ msgid "Select vendor"
+#~ msgstr "選擇供應商"
+
+#~ msgid "Select model"
+#~ msgstr "選擇型號"
+
+#~ msgid "Select printer"
+#~ msgstr "選擇印表機"
+
+#~ msgid "Input custom model"
+#~ msgstr "輸入自定義型號"
+
+#~ msgid "Max print height"
+#~ msgstr "最大列印高度"
+
+#~ msgid "Printer preset"
+#~ msgstr "印表機預設"
+
+#~ msgid "Filament preset template"
+#~ msgstr "材料預設模板"
+
+#~ msgid "Process preset template"
+#~ msgstr "工藝預設模板"
+
+#~ msgid "Creat Filament"
+#~ msgstr "建立材料"
+
+#~ msgid "Create Nozzle for existing printer"
+#~ msgstr "為現存的印表機建立噴嘴"
+
+#~ msgid "Create from template"
+#~ msgstr "從模板中建立"
+
+#~ msgid "Create based on current printer"
+#~ msgstr "基於當前印表機建立"
+
+#~ msgid "Layer height cannot exceed the limit in Printer Settings -> Extruder -> Layer height limits"
+#~ msgstr "層高不能超過印表機設定->擠出機->層高限制中的限制"
+
+#~ msgid ""
+#~ "Style and shape of the support. For normal support, projecting the supports into a regular grid will create more stable supports (default), while snug support towers will save material and reduce object scarring.\n"
+#~ "For tree support, slim style will merge branches more aggressively and save a lot of material (default), while hybrid style will create similar structure to normal support under large flat overhangs."
+#~ msgstr ""
+#~ "支撐物的樣式和形狀。對於普通支撐，將支撐投射到一個規則的網格中，將建立更穩定的支撐（預設），而緊貼的支撐塔將節省材料並減少物體的瑕疵。\n"
+#~ "對於樹形支撐，苗條板的風格將更積極地合併樹枝，並節省大量的材料（預設），而混合風格將在大的平面懸垂下建立與正常支撐類似的結構。"
+
+#~ msgid " search results"
+#~ msgstr " 搜尋結果"
+
+#~ msgid "Closing in %ds"
+#~ msgstr "%d秒內關閉"
+
+#~ msgid "Upper part"
+#~ msgstr "上半部分"
+
+#~ msgid "Lower part"
+#~ msgstr "下半部分"
+
+#~ msgid "Please check bed shape input."
+#~ msgstr "請檢查熱床形狀輸入。"
+
+#~ msgid "Please go to filament setting to edit your presets if you need"
+#~ msgstr "如有需要，請去材料設定編輯您的預設"
+
+#~ msgid "There may be escape characters in the custom printer or model. Please delete and re-enter."
+#~ msgstr "自定義印表機或型號中可能有跳脫字元。請刪除並重新輸入。"
+
+#~ msgid "Presets inherited by other presets cannot be deleted"
+#~ msgstr "不能刪除被其他預設繼承的預設"
+
+#~ msgid "Your nozzle diameter in preset is not consistent with memorized nozzle.Did you change your nozzle lately ? "
+#~ msgstr "預設中的噴嘴直徑與記憶中的噴嘴直徑不一致。您最近更換了噴嘴嗎？"
+
+#~ msgid "Improt Presets"
+#~ msgstr "匯入預設"
+
+#~ msgid ""
+#~ "Printer and all the filament&process presets that belongs to the printer. \n"
+#~ "Can be share in MakerWorld."
+#~ msgstr "印表機以及屬於該印表機的所有材料和工藝預設。可以在MakerWorld中共享。"
+
+#~ msgid ""
+#~ "User's fillment preset set. \n"
+#~ "Can be share in MakerWorld."
+#~ msgstr ""
+#~ "使用者的材料預設集。\n"
+#~ "可以在MakerWorld中共享。"
+
+#~ msgid "Only display printer names with changes to printer, filament, and process presets for uploading to the model mall."
+#~ msgstr "僅顯示對印表機、材料和工藝預設進行了更改的印表機名稱，以上傳到模型商城。"
+
+#~ msgid "Only display the filament names with changes to filament presets for uploading to the model mall."
+#~ msgstr "僅顯示對材料預設進行了更改的填充名稱，以上傳到模型商城。"
+
+#~ msgid ""
+#~ "How to use keyboard shortcuts\n"
+#~ "BambuStudio offers a wide range of keyboard shortcuts and 3D scene operations."
+#~ msgstr ""
+#~ "快捷鍵操作\n"
+#~ "BambuStudio提供了豐富的快捷鍵操作和3D場景操作"
+
+#~ msgid ""
+#~ "When need to print with the printer door opened\n"
+#~ "Opening the printer door can reduce the probability of extruder/hotend clogging when printing lower temperature filament with a higher enclosure temperature. More info about this in the Wiki."
+#~ msgstr ""
+#~ "什麼時候需要開啟機箱門列印\n"
+#~ "在較高腔溫下列印低溫耗材，開啟機箱門可以減少擠出機/熱端堵塞的機率。有關此的更多資訊，請參閱Wiki。"
+
+#~ msgid ""
+#~ "Avoid warping\n"
+#~ "When printing materials that are prone to warping such as ABS, appropriately increasing the heatbed temperature can reduce the probability of warping."
+#~ msgstr ""
+#~ "避免翹曲\n"
+#~ "列印ABS這類易翹曲材料時，適當提高熱床溫度可以降低翹曲的機率"
+
+#~ msgid "When print by object, machines with I3 structure will not generate timelapse videos."
+#~ msgstr "當按物件列印時，具有I3結構的機器將不會生成延時影片。"
+
+#~ msgid ""
+#~ "The preset you created already has a preset with the same name. Do you want to overwrite it?\n"
+#~ "\tYes: Overwrite the printer preset with the same name, and filament and process presets with the same preset name will not be recreated.\n"
+#~ "\tCancel: Do not create a preset, return to the creation interface."
+#~ msgstr ""
+#~ "您建立的預設已經存在相同名稱的預設。您要覆蓋它嗎？\n"
+#~ "\t是：覆蓋具有相同名稱的印表機預設，具有相同預設名稱的填充物和工藝預設將不會被重新建立。\n"
+#~ "\t取消：不建立預設，返回建立介面。"
+
+#~ msgid "The version of Bambu studio is too low and needs to be updated to the latest version before it can be used normally"
+#~ msgstr "Bambu Studio版本過低，需要更新到最新版本方可正常使用"
+
+#~ msgid ""
+#~ "An error occurred when uploading user presets, affecting the synchronization of user presets on other devices.\n"
+#~ "Error message: %s"
+#~ msgstr ""
+#~ "上傳使用者預設時發生錯誤，影響了在其他裝置上的使用者預設同步。\n"
+#~ "錯誤訊息：%s"
+
+#~ msgid "No vendor I want"
+#~ msgstr "沒有我想要的供應商"
+
+#~ msgid "Show \"Tip of the day\" notification after start"
+#~ msgstr "啟動後顯示“每日小貼士”通知"
+
+#~ msgid "If enabled, useful hints are displayed at startup."
+#~ msgstr "如果啟用，將在啟動時顯示有用的提示。"
+
+#~ msgid "test"
+#~ msgstr "測試"
+
+#~ msgid "Export 3MF"
+#~ msgstr "匯出3MF"
+
+#~ msgid "Export project as 3MF."
+#~ msgstr "匯出專案為3MF。"
+
+#~ msgid "Export slicing data"
+#~ msgstr "匯出切片資料"
+
+#~ msgid "Export slicing data to a folder."
+#~ msgstr "匯出切片資料到目錄"
+
+#~ msgid "Load slicing data"
+#~ msgstr "匯入切片資料"
+
+#~ msgid "Load cached slicing data from directory"
+#~ msgstr "從目錄匯入快取的切片資料"
+
+#~ msgid "Export STL"
+#~ msgstr "匯出STL檔案"
+
+#~ msgid "Export the objects as multiple STL."
+#~ msgstr "將物件匯出為多個STL檔案"
+
+#~ msgid "Slice"
+#~ msgstr "切片"
+
+#~ msgid "Slice the plates: 0-all plates, i-plate i, others-invalid"
+#~ msgstr "切片平臺：0-所有平臺，i-第i個平臺，其他-無效"
+
+#~ msgid "Show command help."
+#~ msgstr "顯示命令列幫助。"
+
+#~ msgid "Update the configs values of 3mf to latest."
+#~ msgstr "將3mf的配置值更新為最新值。"
+
+#~ msgid "Load default filaments"
+#~ msgstr "載入預設列印材料"
+
+#~ msgid "Load first filament as default for those not loaded"
+#~ msgstr "載入第一個列印材料為預設材料"
+
+#~ msgid "Minimum save"
+#~ msgstr "最小儲存"
+
+#~ msgid "export 3mf with minimum size."
+#~ msgstr "以最小大小匯出3mf檔案。"
+
+#~ msgid "max triangle count per plate for slicing."
+#~ msgstr "切片時每個盤的最大三角形數。"
+
+#~ msgid "max slicing time per plate in seconds."
+#~ msgstr "每個盤的最大切片時間（秒）。"
+
+#~ msgid "Normative check"
+#~ msgstr "規範性檢查"
+
+#~ msgid "Check the normative items."
+#~ msgstr "檢查規範性專案。"
+
+#~ msgid "Output Model Info"
+#~ msgstr "輸出模型資訊"
+
+#~ msgid "Output the model's information."
+#~ msgstr "輸出模型的資訊。"
+
+#~ msgid "Export Settings"
+#~ msgstr "匯出配置"
+
+#~ msgid "Export settings to a file."
+#~ msgstr "匯出配置到檔案。"
+
+#~ msgid "Send progress to pipe"
+#~ msgstr "將進度傳送到管道"
+
+#~ msgid "Send progress to pipe."
+#~ msgstr "將進度傳送到管道。"
+
+#~ msgid "Arrange Options"
+#~ msgstr "擺放選項"
+
+#~ msgid "Arrange options: 0-disable, 1-enable, others-auto"
+#~ msgstr "擺放選項：0-關閉，1-開啟，其他-自動"
+
+#~ msgid "Repetions count"
+#~ msgstr "重複次數"
+
+#~ msgid "Repetions count of the whole model"
+#~ msgstr "整個模型的重複次數"
+
+#~ msgid "Ensure on bed"
+#~ msgstr "確保在熱床上"
+
+#~ msgid "Lift the object above the bed when it is partially below. Disabled by default"
+#~ msgstr "當物件部分位於床下時，將物件抬離床。預設情況下禁用。"
+
+#~ msgid "Convert Unit"
+#~ msgstr "轉換單位"
+
+#~ msgid "Convert the units of model"
+#~ msgstr "轉換模型的單位"
+
+#~ msgid "Orient Options"
+#~ msgstr "方向選項"
+
+#~ msgid "Orient options: 0-disable, 1-enable, others-auto"
+#~ msgstr "方向選項：0-禁用，1-啟用，其他-自動"
+
+#~ msgid "Rotation angle around the Z axis in degrees."
+#~ msgstr "繞Z軸的旋轉角度，以度為單位。"
+
+#~ msgid "Rotate around X"
+#~ msgstr "繞X軸旋轉"
+
+#~ msgid "Rotation angle around the X axis in degrees."
+#~ msgstr "繞X軸的旋轉角度，以度為單位。"
+
+#~ msgid "Rotate around Y"
+#~ msgstr "繞Y軸旋轉"
+
+#~ msgid "Rotation angle around the Y axis in degrees."
+#~ msgstr "繞Y軸的旋轉角度，以度為單位。"
+
+#~ msgid "Scale the model by a float factor"
+#~ msgstr "根據因子縮放模型"
+
+#~ msgid "Load General Settings"
+#~ msgstr "載入通用設定"
+
+#~ msgid "Load process/machine settings from the specified file"
+#~ msgstr "從指定檔案載入工藝/印表機設定"
+
+#~ msgid "Load Filament Settings"
+#~ msgstr "載入耗材絲設定"
+
+#~ msgid "Load filament settings from the specified file list"
+#~ msgstr "從指定檔案載入耗材絲設定"
+
+#~ msgid "Skip some objects in this print"
+#~ msgstr "列印過程中跳過一些零件"
+
+#~ msgid "load uptodate process/machine settings when using uptodate"
+#~ msgstr "在使用最新設定時載入最新的程序/機器設定"
+
+#~ msgid "load uptodate process/machine settings from the specified file when using uptodate"
+#~ msgstr "在使用最新設定時，從指定的檔案中載入最新的程序/機器設定。"
+
+#~ msgid "Output directory"
+#~ msgstr "輸出路徑"
+
+#~ msgid "Output directory for the exported files."
+#~ msgstr "匯出檔案的輸出路徑。"
+
+#~ msgid "Debug level"
+#~ msgstr "除錯等級"
+
+#~ msgid "Sets debug logging level. 0:fatal, 1:error, 2:warning, 3:info, 4:debug, 5:trace\n"
+#~ msgstr "設定除錯日誌等級。0:fatal， 1:error， 2:warning， 3:info， 4:debug， 5:trace\n"
+
+#~ msgid "Load custom gcode"
+#~ msgstr "載入自定義 gcode"
+
+#~ msgid "Load custom gcode from json"
+#~ msgstr "從 json 中載入自定義 gcode"
+
+#~ msgid ""
+#~ "3D Scene Operations\n"
+#~ "Did you know how to control view and object/part selection with mouse and touchpanel in the 3D scene?"
+#~ msgstr ""
+#~ "3D場景操作\n"
+#~ "如何在3D場景中使用滑鼠和觸控面板進行視角控制和物件/部件選擇"
+
+#~ msgid ""
+#~ "Fix Model\n"
+#~ "Did you know that you can fix a corrupted 3D model to avoid a lot of slicing problems?"
+#~ msgstr ""
+#~ "修復模型\n"
+#~ "您知道嗎？您可以修復一個損壞的3D模型以避免諸多切片問題。"
+
+#~ msgid "%s is not supported by AMS."
+#~ msgstr "%s 不受AMS支援。"
+
+#~ msgid "The printer preset you selected does not have a name, please reselect it"
+#~ msgstr "您選擇的印表機預設沒有名稱，請重新選擇。"
+
+#~ msgid "Export as STL"
+#~ msgstr "匯出為 STL"
+
+#~ msgid "Check cloud service status"
+#~ msgstr "檢查雲服務狀態"
+
+#~ msgid "Export all objects as STL"
+#~ msgstr "匯出所有物件為STL"
+
+#~ msgid "Keep"
+#~ msgstr "保持"
+
+#~ msgid "Order of inner wall/outer wall/infil"
+#~ msgstr "內牆/外牆/填充的順序"
+
+#~ msgid "Print sequence of inner wall, outer wall and infill. "
+#~ msgstr "內圈牆/外圈牆/填充的列印順序"
+
+#~ msgid "inner/outer/infill"
+#~ msgstr "內牆/外牆/填充"
+
+#~ msgid "outer/inner/infill"
+#~ msgstr "外牆/內牆/填充"
+
+#~ msgid "infill/inner/outer"
+#~ msgstr "填充/內牆/外牆"
+
+#~ msgid "infill/outer/inner"
+#~ msgstr "填充/外牆/內牆"
+
+#~ msgid "inner-outer-inner/infill"
+#~ msgstr "內牆/外牆/內牆/填充"
+
+#~ msgid "Input Printer Vendor and Model"
+#~ msgstr "輸入印表機供應商和模型"
+
+#~ msgid "The custom printer and model are not inputed, place return page 1 to input."
+#~ msgstr "自定義印表機和模型還沒有輸入，請返回第一頁去輸入。"
+
+#~ msgid ""
+#~ "Printer and all the filament&process presets that belongs to the printer. \n"
+#~ "Can be share in makerworld."
+#~ msgstr ""
+#~ "印表機以及所有屬於該印表機的材料和工藝預設。\n"
+#~ "可以在 MakerWorld 中共享。"
+
+#~ msgid "You have not selected a filament preset, please choose."
+#~ msgstr "你還沒選擇材料預設，請選擇。"
+
+#~ msgid "You have not upload bed texture."
+#~ msgstr "您還沒有上傳熱床紋理。"
+
+#~ msgid "You have not upload bed model."
+#~ msgstr "您還沒有上傳熱床模型。"
+
+#~ msgid "The current hot bed temperature is relatively high.The nozzle may be clogged when printing this filament in a closed enclosure.Please open the front door and/or remove the upper glass."
+#~ msgstr "當前熱床溫度相對較高。在封閉式外殼中列印這種絲可能會導致噴嘴堵塞。請開啟前門和/或取下上部玻璃。"
+
+#~ msgid ""
+#~ "You have completed printing the mall model, but the synchronization of rating information has failed. \n"
+#~ "If you need to resynchronize, please reselect the printer."
+#~ msgstr ""
+#~ "您已完成列印商城模型，但評分資訊的同步失敗了。\n"
+#~ "如果需要重新同步，請重新選擇印表機。"
+
+#~ msgid "The bed temperature exceeds filament's vitrification temperature. Please open the front door of printer before printing to avoid nozzle clog."
+#~ msgstr "熱床溫度超過了材料的軟化溫度。請在列印前開啟印表機前門以防堵頭。"
+
+#~ msgid "The 3mf is not compatible, load geometry data only!"
+#~ msgstr "該3mf檔案與軟體不相容，將只載入幾何資料。"
+
+#~ msgid "Incompatible 3mf"
+#~ msgstr "不相容的3mf"
+
+#~ msgid "Temperature of vitrificaiton"
+#~ msgstr "軟化溫度"
+
+#~ msgid "Material becomes soft at this temperature. Thus the heatbed cannot be hotter than this tempature"
+#~ msgstr "材料在這個溫度開始變軟。因此熱床溫度不能超過這個溫度。"
+
+#~ msgid "Create Printer/Filament Successful"
+#~ msgstr "建立印表機/材料成功"
+
+#~ msgid ""
+#~ "\n"
+#~ "\n"
+#~ "Would you like to redirect to the webpage for storing?"
+#~ msgstr ""
+#~ "\n"
+#~ "\n"
+#~ "您是否想要重定向到評分網頁？"
+
+#~ msgid ""
+#~ "Embeded\n"
+#~ "depth"
+#~ msgstr "內嵌深度"
+
+#~ msgid "Add/Remove printers"
+#~ msgstr "新增/刪除印表機"
+
+#~ msgid "Spiral Vase"
+#~ msgstr "旋轉花瓶"
+
+#~ msgid "Search plater, object and part."
+#~ msgstr "搜尋盤，模型和零件。"
+
+#~ msgid ""
+#~ "There are currently no identical spare consumables available, and automatic replenishment is currently not possible. \n"
+#~ "(Currently supporting automatic supply of consumables with the same brand, material type, and color)"
+#~ msgstr ""
+#~ "當前無相同的備用耗材，暫時無法自動補給。\n"
+#~ "（目前支援品牌、材料種類、顏色相同的耗材的自動補給）"
+
+#~ msgid "Load shape from STL..."
+#~ msgstr "從STL檔案載入形狀..."
+
+#~ msgid "Invalid nozzle diameter"
+#~ msgstr "非法噴嘴口徑"
+
+#~ msgid "Immediately score"
+#~ msgstr "立即打分"
+
+#~ msgid "Error: IP or Access Code are not correct"
+#~ msgstr "錯誤:IP或訪問程式碼不正確"
+
+#~ msgid "Can't connect to the printer"
+#~ msgstr "無法連線印表機"
+
+#~ msgid "Motor noise"
+#~ msgstr "電機降噪"
+
+#~ msgid ""
+#~ "Bed temperature of other layer is lower than bed temperature of initial layer for more than %d degree centigrade.\n"
+#~ "This may cause model broken free from build plate during printing"
+#~ msgstr ""
+#~ "其它層的熱床溫度比首層熱床溫度低太多，超過了%d 攝氏度。\n"
+#~ "這可能導致列印中模型從熱床脫落"
+
+#~ msgid ""
+#~ "Bed temperature is higher than vitrification temperature of this filament.\n"
+#~ "This may cause nozzle blocked and printing failure\n"
+#~ "Please keep the printer open during the printing process to ensure air circulation or reduce the temperature of the hot bed"
+#~ msgstr ""
+#~ "熱床溫度超過了耗材絲的軟化溫度，材料軟化可能造成噴頭堵塞。\n"
+#~ "請保持印表機在列印過程中敞開，保證空氣流通或降低熱床溫度"
+
+#~ msgid "Resonance frequency identification"
+#~ msgstr "共振頻率辨識"
+
+#~ msgid "Recommended temperature range"
+#~ msgstr "建議溫度範圍"
+
+#~ msgid "Bed temperature difference"
+#~ msgstr "熱床溫差"
+
+#~ msgid "Do not recommend bed temperature of other layer to be lower than initial layer for more than this threshold. Too low bed temperature of other layer may cause the model broken free from build plate"
+#~ msgstr "不建議其它層熱床溫度比首層的熱床溫度低於這個值。太低的其它層熱床溫度可能導致列印過程中模型從列印板脫落。"
+
+#~ msgid "Orient the model"
+#~ msgstr "旋轉模型"
+
+#~ msgid "Bamabu High Temperature Plate"
+#~ msgstr "高溫列印板"
+
+#~ msgid "High Temp Plate"
+#~ msgstr "高溫列印板"
+
+#~ msgid "Bed temperature when high temperature plate is installed. Value 0 means the filament does not support to print on the High Temp Plate"
+#~ msgstr "安裝高溫列印熱床時的熱床溫度。0值表示這個耗材絲不支援高溫列印熱床"
+
+#~ msgid "Don't remind me of this version again"
+#~ msgstr "此版本不再提示"
+
+#~ msgid "Cali"
+#~ msgstr "校準"
+
+#~ msgid "Calibration of extrusion"
+#~ msgstr "擠出校準"
+
+#~ msgid "Push new filament into the extruder"
+#~ msgstr "將新的耗材絲推入擠出機"
+
+#~ msgid "Please give a score for your favorite Bambu Market model."
+#~ msgstr "請為您喜歡的 Bambu 商城模型打分。"
+
+#~ msgid "Score"
+#~ msgstr "打分"
+
+#~ msgid "Target chamber temperature"
+#~ msgstr "目標腔體溫度"
+
+#~ msgid "The failed test result has been droped."
+#~ msgstr "測試失敗的結果已被刪除。"
+
+#~ msgid "Part of the calibration failed! You may clean the plate and retry. The failed test result would be droped."
+#~ msgstr "部分校準失敗！您可以清潔列印平臺並重試。未透過的測試結果將被丟棄。"
+
+#~ msgid "The 3mf's version %s is newer than %s's version %s, Found following keys unrecognized:"
+#~ msgstr "該3mf的版本%s比%s的版本%s新，發現以下引數鍵值無法識別:"
+
+#~ msgid "You'd better upgrade your software.\n"
+#~ msgstr "建議升級您的軟體版本。\n"
+
+#~ msgid "The 3mf's version %s is newer than %s's version %s, Suggest to upgrade your software."
+#~ msgstr "該3mf的版本%s比%s的版本%s要新，建議升級你的軟體。"
+
+#~ msgid "The selected preset: %1% is not found."
+#~ msgstr "未找到選定的預設：%1%。"
+
+#~ msgid "Only one wall type"
+#~ msgstr "頂面單層牆"
+
+#~ msgid "Use only one wall on flat top surface, to give more space to the top infill pattern"
+#~ msgstr "頂面只使用單層牆，從而更多的空間能夠使用頂部填充圖案"
+
+#~ msgid "Nozzle HRC"
+#~ msgstr "噴嘴洛氏硬度"
+
+#~ msgid "The nozzle's hardness. Zero means no checking for nozzle's hardness during slicing."
+#~ msgstr "噴嘴硬度。零值表示在切片時不檢查噴嘴硬度。"
+
+#~ msgid "HRC"
+#~ msgstr "洛氏硬度"
+
+#~ msgid "Detect the overhang percentage relative to line width and use different speed to print. For 100%% overhang, bridge speed is used."
+#~ msgstr "檢測懸空相對於線寬的百分比，並應用不同的速度列印。100%%的懸空將使用橋接速度。"
+
+#~ msgid "Bottom surface flow ratio"
+#~ msgstr "底部表面流量比例"
+
+#~ msgid "This factor affects the amount of material for bottom solid infill"
+#~ msgstr "這個因素影響底部實心填充的材料用量"
+
+#~ msgid "When you need to use Flow Rate Calibration"
+#~ msgstr "在什麼情況下需要進行流量比例校準"
+
+#~ msgid "Record"
+#~ msgstr "記錄"
+
+#~ msgid "Please select the nozzle diameter of your printer"
+#~ msgstr "請選擇印表機的噴嘴直徑"
+
+#~ msgid "Please select the plate type of your printer"
+#~ msgstr "請選擇印表機的印版型別"
+
+#~ msgid "Pause Print"
+#~ msgstr "暫停列印"
+
+#~ msgid "Edit Pause Print Message"
+#~ msgstr "編輯暫停列印資訊"
+
+#~ msgid "Delete Pause Print"
+#~ msgstr "刪除暫停列印"
+
+#~ msgid "The selected preset has been deleted."
+#~ msgstr "所選預設已被刪除。"
+
+#~ msgid "Factors of dynamic flow cali"
+#~ msgstr "動態流量標定係數"
+
+#~ msgid "Flow Calibration"
+#~ msgstr "流量校準"
+
+#~ msgid "uneven extrusion"
+#~ msgstr "不均勻擠出"
+
+#~ msgid "After calibration, the linear compensation factor(K) will be recorded and applied to printing. This factor would be different if device, degree of usage, material, and material family type are different"
+#~ msgstr "校準完成後，線性補償係數(K) 將被記錄並應用於列印中。如果裝置、使用程度、材料和材料型別不同，這個係數也會有所不同。"
+
+#~ msgid "When you need Flow Rate Calibration"
+#~ msgstr "當您需要流量比例校準時"
+
+#~ msgid "Flow Rate calibration is recommended when you print with:"
+#~ msgstr "當使用以下內容列印時，建議進行流速校準："
+
+#~ msgid "Dynamic Pressure Control Calibration"
+#~ msgstr "動態壓力控制校準"
+
+#~ msgid "Maual Calibration"
+#~ msgstr "手動校準"
+
+#~ msgid "Dynamic Pressure Control"
+#~ msgstr "動態壓力控制"
+
+#~ msgid "Dynamic Pressure Control calibration result has been saved to the printer"
+#~ msgstr "動態壓力控制校準結果已儲存到印表機。"
+
+#~ msgid "When you need Dynamic Pressure Control Calibration"
+#~ msgstr "當您需要動態壓力控制校準時"
+
+#~ msgid "We found the best Dynamic Pressure Control Factor"
+#~ msgstr "我們找到了最佳的動態壓力控制係數"
+
+#~ msgid "Brand Name"
+#~ msgstr "品牌名稱"
+
+#~ msgid "The name cannot exceed 20 characters."
+#~ msgstr "名稱不能超過20個字元。"
+
+#~ msgid "Printing List"
+#~ msgstr "專案切片"
+
+#~ msgid "Pressure Adavance"
+#~ msgstr "壓力提升"
+
+#~ msgid "Filament From"
+#~ msgstr "耗材絲來源"
+
+#~ msgid "Please select same type of material, because plate temperature might not be compatible with different type of material"
+#~ msgstr "請選擇相同型別的材料，因為熱床溫度可能與不同型別的材料不相容。"
+
+#~ msgid "Restart"
+#~ msgstr "重新開始"
+
+#~ msgid "Re-Calibrate"
+#~ msgstr "重新校準"
+
+#~ msgid "Is in printing. Please wait for printing to complete"
+#~ msgstr "正在列印中，請等待列印完成。"
+
+#~ msgid "It will restart to get the results. Do you confirm to re-calibrate?"
+#~ msgstr "將重新啟動以獲取結果。您確定要重新校準嗎？"
+
+#~ msgid "It will restart to get the results. Do you confirm to restart?"
+#~ msgstr "將重新啟動以獲取結果。您確定要重新啟動嗎？"
+
+#~ msgid "Please select a printer and nozzle for calibration."
+#~ msgstr "請選擇用於校準的印表機和噴嘴。"
+
+#~ msgid "No print preset"
+#~ msgstr "沒有列印預設。"
+
+#~ msgid "Please select filament for calibration."
+#~ msgstr "請選擇用於校準的列印材料。"
+
+#~ msgid "The printing parameters is empty, please reselect nozzle and plate type."
+#~ msgstr "列印引數為空，請重新選擇噴嘴和列印板型別。"
+
+#~ msgid "Saved success."
+#~ msgstr "儲存成功"
+
+#~ msgid "Are you sure you want to cancel this calibration? It will return to start page"
+#~ msgstr "您確定要取消此次校準嗎？這將返回到開始頁面。"
+
+#~ msgid "Unable to print %s and %s together. Filaments have large bed temperature difference"
+#~ msgstr "無法同時列印 %s 和 %s。列印材料的列印床溫度差異較大。"
+
+#~ msgid "No AMS filaments. Please select a printer to load AMS info."
+#~ msgstr "沒有 AMS 材料。請先選擇一個印表機以載入 AMS 資訊。"
+
+#~ msgid "We found the best Pressure Advance Factor"
+#~ msgstr "我們找到了最佳的壓力提升因子"
+
+#~ msgid "When you need Pressure Advance Calibration"
+#~ msgstr "當您需要進行壓力提升校準時"
+
+#~ msgid "Pressure Advance"
+#~ msgstr "壓力提升"
+
+#~ msgid "Material"
+#~ msgstr "材料"
+
+#~ msgid "Edit plate settings"
+#~ msgstr "編輯盤設定"
+
+#~ msgid "Ams filament backup"
+#~ msgstr "AMS自動續料"
+
+#~ msgid "Filaments Auto refill"
+#~ msgstr "耗材絲自動續料"
+
+#~ msgid "Auto refill"
+#~ msgstr "自動補給"
+
+#~ msgid "3D Models"
+#~ msgstr "3D模型"
+
+#~ msgid "Number of currently selected: %1%\n"
+#~ msgstr "當前選擇的零件數量: %1%\n"
+
+#~ msgid "Assemble the selected parts to a single part"
+#~ msgstr "組合所選零件為單個零件"
+
+#~ msgid "Initialize failed (Not supported with LAN-only mode)!"
+#~ msgstr "初始化失敗（不支援區域網模式的影片連線）"
+
+#~ msgid "Damp %s will become flexible and get stuck inside AMS,please take care to dry it before use."
+#~ msgstr "潮溼的%s會變軟並卡在AMS內，請在使用前保持乾燥。"
+
+#~ msgid "%s filaments are hard and brittle, It's easy to break or get stuck in AMS, please use with caution."
+#~ msgstr "%s耗材絲又硬又脆，很容易斷裂或卡在AMS中，請謹慎使用。"
+
+#~ msgid "Top Solid Layers"
+#~ msgstr "頂部實心層"
+
+#~ msgid "Top Minimum Shell Thickness"
+#~ msgstr "頂部外殼最小厚度"
+
+#~ msgid "Bottom Solid Layers"
+#~ msgstr "底部實心層"
+
+#~ msgid "Bottom Minimum Shell Thickness"
+#~ msgstr "底部外殼最小厚度"
+
+#~ msgid "Not supported by this model of printer!"
+#~ msgstr "該型號的印表機不支援該功能！"
+
+#~ msgid "Disconnected from printer [%s] due to LAN mode disabled.Please reconnect the printer by logging in with your user account."
+#~ msgstr "由於LAN模式被禁用，已與印表機[%s]斷開連線。請使用您的使用者帳戶登入以重新連線印表機。"
+
+#~ msgid "Disconnected from printer [%s] due to LAN mode enabled.Please reconnect the printer by inputting Access Code which can be gotten from printer screen."
+#~ msgstr "由於啟用了LAN模式，已與印表機[%s]斷開連線。請透過輸入訪問碼重新連線印表機，訪問碼可從印表機螢幕上獲取。"
+
+#~ msgid " plate %1%:"
+#~ msgstr "盤%1%："
+
+#~ msgid "Set Unprintable"
+#~ msgstr "設定不可列印"
+
+#~ msgid "Set Printable"
+#~ msgstr "設定可列印"
+
+#~ msgid "Edit plate setitngs"
+#~ msgstr "編輯盤設定"
+
+#~ msgid "Feed new filament from external spool"
+#~ msgstr "從外部料盤送入新的耗材絲"
+
+#~ msgid "Confirm whether the filament has been extruded"
+#~ msgstr "確認耗材絲是否已被擠出"
+
+#~ msgid "Initialize failed (Not supported by printer)!"
+#~ msgstr "初始化失敗（印表機不支援該功能）！"
+
+#~ msgid "There are some unknown filaments mapped to generic preset. Please update Bambu Studio or restart Bambu Studio to check if there is an update to system presets."
+#~ msgstr "有一些未知型號的材料，對映到通用預設。請更新或者重啟 Bambu Studio，以檢查系統預設有沒有更新。"
+
+#~ msgid "Extrusion compensation calibration is not supported when using Textured PEI Plate"
+#~ msgstr "使用帶紋理的PEI板時不支援擠出補償校準"
+
+#~ msgid "The region parameter is incorrrect"
+#~ msgstr "區域設定不正確"
+
+#~ msgid "Failure of printer login"
+#~ msgstr "登入裝置失敗"
+
+#~ msgid "Failed to get ticket"
+#~ msgstr "獲取Ticket失敗"
+
+#~ msgid "User authorization timeout"
+#~ msgstr "使用者鑑權超時"
+
+#~ msgid "Failure of bind"
+#~ msgstr "裝置登入失敗"
+
+#~ msgid "Upload task timed out. Please check the network problem and try again"
+#~ msgstr "上傳任務超時，請排查網路問題後重試"
+
+#~ msgid "Print file not found, please slice again"
+#~ msgstr "未找到列印檔案，請重新切片"
+
+#~ msgid "The print file exceeds the maximum allowable size (1GB). Please simplify the model and slice again"
+#~ msgstr "列印檔案超過最大允許大小（1GB），請簡化模型後重新切片"
+
+#~ msgid "Failed uploading print file"
+#~ msgstr "列印任務上傳失敗"
+
+#~ msgid "Wrong Access code"
+#~ msgstr "訪問碼錯誤"
+
+#~ msgid "Send to Printer failed. Please try again."
+#~ msgstr "傳送到印表機失敗。請重試。"
+
+#~ msgid "No space left on Printer SD card"
+#~ msgstr "印表機SD卡上沒有剩餘空間"
+
+#~ msgid "Sending gcode file through cloud service"
+#~ msgstr "透過雲服務傳送gcode檔案"
+
+#~ msgid "Please log out and login to the printer again."
+#~ msgstr "請先退出登入然後再重新登入印表機。"
+
+#~ msgid "Other color"
+#~ msgstr "其他顏色"
+
+#~ msgid "Not accessible in LAN-only mode!"
+#~ msgstr "在區域網模式中不可訪問！"
+
+#~ msgid "Missing LAN ip of printer!"
+#~ msgstr "未找到印表機的區域網地址！"
+
+#~ msgid "You are going to delete %u files. Are you sure to continue?"
+#~ msgstr "你正在刪除%u個檔案，你確定嗎？"
+
+#~ msgid "Dump video"
+#~ msgstr "下載影片"
+
+#~ msgid "Cool plate"
+#~ msgstr "低溫列印板"
+
+#~ msgid "Engineering plate"
+#~ msgstr "工程材料列印板"
+
+#~ msgid "One object has empty initial layer and can't be printed. Please Cut the bottom or enable supports."
+#~ msgstr "模型出現空層無法列印。請切掉底部或開啟支撐。"
+
+#~ msgid "Conflicts of gcode paths have been found at layer %d, z = %.2lf mm. Please separate the conflicted objects farther (%s <-> %s)."
+#~ msgstr "發現gcode路徑在層%d，高為%.2lf mm處的衝突。請將有衝突的物件分離得更遠(%s <-> %s)。"
+
+#~ msgid "ERROR:"
+#~ msgstr "錯誤："
+
+#~ msgid "Conflicts of gcode paths have been found. Please separate the conflicted objects farther (%s <-> %s)."
+#~ msgstr "發現gcode路徑的衝突。請將有衝突的物件分離得更遠(%s <-> %s)。"
+
+#~ msgid "Please check the following infomation and click Confirm to continue sending print:"
+#~ msgstr "請檢查以下資訊，點選確認後繼續傳送列印："
+
+#~ msgid "The printer type used to generate G-code is not the same type as the currently selected physical printer. It is recommend to re-slice by selecting the same printer type."
+#~ msgstr "生成該G-code的印表機型別與當前選中的印表機型別不同。建議選擇相同的印表機型別後重新切片。"
+
+#~ msgid "Failed uploading print file. Please enter ip address again."
+#~ msgstr "上傳列印檔案失敗，請重新輸入IP地址。"
+
+#~ msgid "This controls the generation of the brim at outer side of models. Auto means the brim width is analysed and calculated automatically."
+#~ msgstr "設定外牆brim的生成方式，選擇自動意味著brim的寬度會被自動分析計算。"
+
+#~ msgid "AMS settings are not supported for external spool"
+#~ msgstr "AMS設定對外接料盤無效"
+
+#~ msgid "Auto sync system presets(Printer/Filament/Process)"
+#~ msgstr "自動同步預設（印表機/耗材絲/工藝）"
+
+#~ msgid ""
+#~ "Arachne engine only works when overhang slowing down is disabled.\n"
+#~ "This may cause decline in the quality of overhang surface when print fastly"
+#~ msgstr ""
+#~ "Arachne引擎只在關閉懸垂降速時起作用。\n"
+#~ "這可能會導致高速列印時懸垂表面質量的下降。"
+
+#~ msgid ""
+#~ "Disable overhang slowing down automatically? \n"
+#~ "Yes - Enable arachne and disable overhang slowing down\n"
+#~ "No  - Give up using arachne this time"
+#~ msgstr ""
+#~ "自動關閉懸垂降速？\n"
+#~ "是 - 使用arachne並關閉懸垂降速\n"
+#~ "否 - 此次放棄使用arachne"
+
+#~ msgid "Add/Edit connectors"
+#~ msgstr "新增/編輯連線件"
+
+#~ msgid "Shortcut key %1%"
+#~ msgstr "快捷鍵 %1%"
+
+#~ msgid "Backup"
+#~ msgstr "備份"
+
+#~ msgid "Backup interval"
+#~ msgstr "備份間隔時長"
+
+#~ msgid "The %s filament is too soft to be used with the AMS"
+#~ msgstr "%s耗材太軟，無法與AMS一起使用"
+
+#~ msgid "It seems object %s has completely floating regions. Please re-orient the object or enable support generation."
+#~ msgstr "似乎物件%s有完全浮空的區域。請調整朝向或開啟支撐生成。"
+
+#~ msgid "It seems object %s has large overhangs. Please enable support generation."
+#~ msgstr "似乎物件%s有很大面積的懸垂面。請開啟支撐生成。"
+
+#~ msgid "Spiral mode only works when wall loops is 1, support is disabled, top shell layers is 0, sparse infill density is 0 and timelapse type is traditional"
+#~ msgstr "旋轉模式只能在外牆層數為1，關閉支撐，頂層層數為0，稀疏填充密度為0，傳統延時攝影時有效"
+
+#~ msgid "Keep upper part"
+#~ msgstr "保留上半部分"
+
+#~ msgid "Keep lower part"
+#~ msgstr "保留下半部分"
+
+#~ msgid "AMS auto switch filament"
+#~ msgstr "AMS自動續料"
+
+#~ msgid "All Plates"
+#~ msgstr "所有盤"
+
+#~ msgid ""
+#~ "When using support material for the support interface, We recommend the following settings:\n"
+#~ "0 top z distance, 0 interface spacing, concentric pattern."
+#~ msgstr ""
+#~ "當使用支撐材料的支撐介面時，我們推薦以下設定。\n"
+#~ "0頂層z距離，0介面層間距，同心圖案。"
+
+#~ msgid "The P1P printer does not support smooth timelapse, use traditional timelapse instead."
+#~ msgstr "P1P印表機不支援平滑模式的延時攝影，請改用傳統模式。"
+
+#~ msgid "Support base"
+#~ msgstr "支撐主體"
+
+#~ msgid "Support layer uses layer height independent with object layer. This is to support customizing z-gap and save print time."
+#~ msgstr "支撐使用不同於物件的層高。這樣可以支援自定義Z方向間隙並節省列印時間。"
+
+#~ msgid "This controls brim position including outer side of models, inner side of holes or both. Auto means both the brim position and brim width is analysed and calculated automatically"
+#~ msgstr "設定brim生成位置，包括模型往外的外側,模型的孔的內側和內外側都生成。選擇自動意味著brim的位置和寬度都會自動分析計算生成。"
+
+#~ msgid "Export G-Code."
+#~ msgstr "匯出G-Code."
+
+#~ msgid "Export."
+#~ msgstr "匯出。"
+
+#~ msgid "Modify"
+#~ msgstr "修改"
+
+#~ msgid " will be closed before creating a new model. Do you want to continue?"
+#~ msgstr "將會被關閉以建立新模型。是否繼續？"
+
+#~ msgid "Layer Time (log)"
+#~ msgstr "層時間（log）"
+
+#~ msgid "Layer Time(log): "
+#~ msgstr "層時間（log）："
+
+#~ msgid "Layer Time (log) (s)"
+#~ msgstr "層時間（log）（s）"
+
+#~ msgid "Select Bed Type"
+#~ msgstr "選擇熱床型別"
+
+#~ msgid "Import geometry data from STL/STEP/3MF/OBJ/AMF files."
+#~ msgstr "從STL/STEP/3MF/OBJ/AMF檔案中匯入幾何資料"
+
+#~ msgid "Plate %d: %s does not support filament %s (%s)."
+#~ msgstr "盤%d：%s不支援耗材絲%s（%s）。"
+
+#~ msgid "NO AMS"
+#~ msgstr "無AMS"
+
+#~ msgid "Calibration completed. Please select the factors according to the left figure and fill them in the input boxes."
+#~ msgstr "標定完成。請按照左圖展示的方式選擇流量補償係數，並填寫到輸入框中。"
+
+#~ msgid "Clean"
+#~ msgstr "清除"
+
+#~ msgid "Actual Volume = Flushing Volume * Multiplier"
+#~ msgstr "實際沖刷量 = 沖刷體積 * 乘數"
+
+#~ msgid "Suggestion: Actual Volume in range [%d, %d]"
+#~ msgstr "建議：實際沖刷量設定在[%d, %d]範圍內"
+
+#~ msgid "Loading user presets..."
+#~ msgstr "正在載入使用者預設..."
+
+#~ msgid "Click the pencil icon to edit the filament."
+#~ msgstr "點選鉛筆圖示編輯耗材絲。"
+
+#~ msgid ""
+#~ "Arachne engine only works when overhang slowing down is disabled.\n"
+#~ "This may cause decline in the quality of overhang surface when print fastly\n"
+#~ msgstr ""
+#~ "Arachne引擎只在關閉懸垂降速時起作用。\n"
+#~ "這可能會導致高速列印時懸垂表面質量的下降\n"
+
+#~ msgid ""
+#~ "Switch to rectilinear pattern?\n"
+#~ "Yes - switch to rectilinear pattern automaticlly\n"
+#~ "No  - reset density to default non 100% value automaticlly\n"
+#~ msgstr ""
+#~ "切換到直線圖案？\n"
+#~ "是 - 自動切換到直線圖案\n"
+#~ "否 - 自動重置為非100%填充密度\n"
+
+#~ msgid ""
+#~ "Do you want to synchronize your personal data from Bambu Cloud? \n"
+#~ "It contains the following information:\n"
+#~ "1. The Process presets\n"
+#~ "2. The Filament presets\n"
+#~ "3. The Printer presets\n"
+#~ msgstr ""
+#~ "想從Bambu 雲同步你的個人資料嗎?\n"
+#~ "包含如下資訊:\n"
+#~ "1. 工藝預設\n"
+#~ "2. 耗材絲預設\n"
+#~ "3. 印表機預設\n"
+
+#~ msgid "The 3mf's version %s is newer than %s's version %s, Found following keys unrecognized:\n"
+#~ msgstr "該3mf的版本%s比%s的版本%s新，發現以下引數鍵值無法識別；\n"
+
+#~ msgid "The 3mf's version %s is newer than %s's version %s, Suggest to upgrade your software.\n"
+#~ msgstr "該3mf檔案的版本%s 比%s的版本%s更新，建議升級您的軟體。\n"
+
+#~ msgid "Plate %d: %s does not support filament %s (%s).\n"
+#~ msgstr "盤%d：%s不支援耗材絲%s (%s)。\n"
+
+#~ msgid "Please check the following infomation and click Confirm to continue sending print:\n"
+#~ msgstr "請檢查以下資訊，點選確認後繼續傳送列印：\n"
+
+#~ msgid "The printer type used to generate G-code is not the same type as the currently selected physical printer. It is recommend to re-slice by selecting the same printer type.\n"
+#~ msgstr "用於生成G-code的印表機型別與當前選定的物理印表機型別不同，建議選擇相同的印表機型別重新切片。\n"
+
+#~ msgid ""
+#~ "When recording timelapse without toolhead, it is recommended to add a \"Timelapse Wipe Tower\" \n"
+#~ "by right-click the empty position of build plate and choose \"Add Primitive\"->\"Timelapse Wipe Tower\".\n"
+#~ msgstr ""
+#~ "在錄製無工具頭延時攝影影片時，建議新增“延時攝影擦料塔”\n"
+#~ "右鍵單擊列印板的空白位置，選擇“新增標準模型”->“延時攝影擦料塔”。\n"
+
+#~ msgid " is too close to others, there may be collisions when printing.\n"
+#~ msgstr "到其他物件的距離太近了，可能在列印過程中發生碰撞。\n"
+
+#~ msgid " is too close to exclusion area, there may be collisions when printing.\n"
+#~ msgstr "到遮蔽區域的距離太近了，可能在列印過程中發生碰撞。\n"
+
+#~ msgid "Plate %d: %s does not support filament %s\n"
+#~ msgstr "盤%d: %s 不支援耗材絲 %s\n"
+
+#~ msgid ""
+#~ "We have added an experimental style \"Tree Slim\" that features smaller support volume but weaker strength.\n"
+#~ "We recommand using it with: 0 interface layers, 0 top distance, 2 walls."
+#~ msgstr ""
+#~ "我們加入一個新的實驗性風格\\\"苗條樹\\\"，它使用更少的支撐體積，但強度可能較弱。\n"
+#~ "\"因此我們推薦以下引數：接觸層數為0，頂部Z距離為0，牆層數為2。"
+
+#~ msgid ""
+#~ "When using support material for the support interface, We recommand the following settings:\n"
+#~ "0 top distance, 0 interface spacing, concentric pattern."
+#~ msgstr ""
+#~ "當使用支撐材料作為支撐面，我們推薦以下設定：\n"
+#~ "頂部Z距離為0， 支撐面線距為0，接觸面圖案為同。"
+
+#~ msgid "Do not recommand bed temperature of other layer to be lower than initial layer for more than this threshold. Too low bed temperature of other layer may cause the model broken free from build plate"
+#~ msgstr "不建議其它層熱床溫度比首層的熱床溫度低於這個值。太低的其它層熱床溫度可能導致列印過程中模型從列印板脫落"
+
+#~ msgid "normal(auto) and tree(auto) is used to generate support automatically. If normal or tree is selected, only support enforcers are generated"
+#~ msgstr "普通（自動）和樹狀（自動）用於自動生成支撐體。如果選擇普通或樹狀，僅會在支撐強制面上生成支撐。"
+
+#~ msgid "hybrid(auto)"
+#~ msgstr "混合(自動)"
+
+#~ msgid "Filament to print support and raft. \"Default\" means no specific filament for support and current filament is used"
+#~ msgstr "列印支撐和筏層的耗材絲。\"預設\"代表不指定特定的耗材絲，並使用當前耗材"
+
+#~ msgid ""
+#~ "Spiral mode only works when wall loops is 1, \n"
+#~ "support is disabled, top shell layers is 0 and sparse infill density is 0\n"
+#~ msgstr "旋轉模式只能在外牆層數為1，關閉支撐，頂層層數為0，稀疏填充密度為0時有效。\n"
+
+#~ msgid "When sparse infill density is low, the internal solid infill or internal bridge may have no archor at the end of line. This cause falling and bad quality when printing internal solid infill. When enable this feature, loop paths will be added to the sparse fill of the lower layers for specific thickness, so that better archor can be provided for internal bridge. 0 means disable this feature"
+#~ msgstr "當稀疏填充密度很低時，內部實心填充或內部橋接可能在走線轉角處沒有鉚接。這導致內部實心填充列印失敗或者列印質量差。開啟這個設定時，將會在低層的稀疏填充中列印指定厚度的環形走線，為內部橋接提供更好的鉚接。0值代表關閉該功能。"
+
+#~ msgid "If enabled, Studio will generate support loops under the contours of internal bridges.These support loops could prevent internal bridges from extruding over the air and improve the top surface quality, expecially with a low infill density.This value determins the thickness of the support loops."
+#~ msgstr "如果開啟，Studio沿著內部橋接的邊緣在其下方生成支撐輪廓。這些支撐輪廓可以防止懸空列印內部橋接並提高頂面質量，特別是在填充密度較低的情況下。這個設定用於調整支撐輪廓的厚度。"
+
+#~ msgid "Choose one or more files (3mf/step/stl/obj/amf):"
+#~ msgstr "選擇一個或多個檔案（3mf/step/stl/obj/amf）："
+
+#~ msgid "Import 3MF/STL/STEP/OBJ/AMF"
+#~ msgstr "匯入 3MF/STL/STEP/OBJ/AMF"
+
+#~ msgid "Virtual Camera"
+#~ msgstr "虛擬攝像頭"
+
+#~ msgid "Part Cooling"
+#~ msgstr "部件冷卻"
+
+#~ msgid "Aux Cooling"
+#~ msgstr "輔助冷卻"
+
+#~ msgid "Same as global bed type"
+#~ msgstr "跟隨全域性熱床型別設定"
+
+#~ msgid "Filament to print support and skirt. 0 means no specific filament for support and current filament is used"
+#~ msgstr "列印支撐和skirt的耗材絲。0代表不指定特定的耗材絲，並使用當前耗材"
+
+#~ msgid "Filament to print support interface. 0 means no specific filament for support interface and current filament is used"
+#~ msgstr "列印支撐接觸面的耗材絲。0代表不指定特定的耗材絲，並使用當前耗材"
+
+#~ msgid "Repair"
+#~ msgstr "修復"
+
+#~ msgid "Repair the model's meshes if it is non-manifold mesh"
+#~ msgstr "修復模型網格"
+
+#~ msgid "Heat the nozzle to target temperature"
+#~ msgstr "加熱噴嘴"
+
+#~ msgid "Show 'Streaming Video' guide page."
+#~ msgstr "展示 'Streaming Video' 引導頁"
+
+#~ msgid "Successfully sent. Will automatically jump to the device page in %s s"
+#~ msgstr "已傳送完成，即將自動跳轉到裝置頁面（%s秒）"
+
+#~ msgid "AMS switches to the same type of filament automatically when the current filament runs out."
+#~ msgstr "AMS料材耗盡後將自動切換相同型別的料材。"
+
+#~ msgid "Monitoring Recording"
+#~ msgstr "監控錄影"
+
+#~ msgid ""
+#~ "Failed to save the project.\n"
+#~ "Please check whether the project file is opened by other programs."
+#~ msgstr ""
+#~ "儲存專案失敗。\n"
+#~ "請檢查專案檔案是否被其他程式開啟。"
+
+#~ msgid "Go to layer"
+#~ msgstr "跳轉到層"
+
+#~ msgid "Layer number"
+#~ msgstr "層數"
+
+#~ msgid "Edit Object Process"
+#~ msgstr "編輯物件工藝"
+
+#~ msgid "Switch to per-object setting mode to edit object process."
+#~ msgstr "切換到物件模式以編輯物件的工藝。"
+
+#~ msgid "The flush volume is less than the minimum value and will be automatically set to the minimum value."
+#~ msgstr "沖刷體積小於最小值，將被自動設定為最小值"
+
+#~ msgid "Perimeter transitioning threshold angle"
+#~ msgstr "牆過渡閾值角度"
+
+#~ msgid "Perimeter distribution count"
+#~ msgstr "牆分佈計數"
+
+#~ msgid "Layers and Perimeters"
+#~ msgstr "層和牆"
+
+#~ msgid "Send to Printer"
+#~ msgstr "傳送到印表機"
+
+#~ msgid ""
+#~ "Virtual camera is started.\n"
+#~ "Press 'OK' to navigate the guide page of 'Streaming video of Bambu Printer'."
+#~ msgstr "虛擬攝像頭已經啟動。點選“確認”開啟相關幫助頁面：'Streaming video of Bambu Printer'。"
+
+#~ msgid "Tree support with infill"
+#~ msgstr "樹狀支撐生成填充"
+
+#~ msgid "This setting specifies whether to add infill inside large hollows of tree support"
+#~ msgstr "這個設定決定是否為樹狀支撐內部的空腔生成填充。"
+
+#~ msgid "Entering Seam painting"
+#~ msgstr "進入Z縫繪製"
+
+#~ msgid "Leaving Seam painting"
+#~ msgstr "退出Z縫繪製"
+
+#~ msgid "Paint-on seam editing"
+#~ msgstr "編輯手繪填縫"
+
+#~ msgid "Export ok."
+#~ msgstr "匯出成功."
+
+#~ msgid "Plate %d: %s does not support filament %s.\n"
+#~ msgstr "盤%d：%s不支援耗材絲%s\n"
+
+#~ msgid "Not supported."
+#~ msgstr "不支援"
+
+#~ msgid "Spaghetti and Excess Chute Pileup Detection"
+#~ msgstr "炒麵與堆料檢查"
+
+#~ msgid "Stop printing when Spaghetti or Excess Chute Pileup is detected"
+#~ msgstr "當發生炒麵或廢料口堆料時停止列印"
+
+#~ msgid "Sync material list from AMS"
+#~ msgstr "同步到 AMS 的材料列表"
+
+#~ msgid "Filament N XX"
+#~ msgstr "耗材絲 N XX"
+
+#~ msgid "Color Print"
+#~ msgstr "彩色列印"
+
+#~ msgid "Comsumption"
+#~ msgstr "消耗"
+
+#~ msgid "Filament 1"
+#~ msgstr "耗材絲 1"
+
+#~ msgid "Flushed filament"
+#~ msgstr "換料沖刷消耗"
+
+#~ msgid "Initialize failed (Not supported without remote video tunnel)!"
+#~ msgstr "初始化失敗（不支援遠端影片連線）"
+
+#~ msgid "Adaptive layer height"
+#~ msgstr "自適應層高"
+
+#~ msgid ""
+#~ "Enabling this option means the height of every layer except the first will be automatically calculated during slicing according to the slope of the model’s surface.\n"
+#~ "Note that this option only takes effect if no prime tower is generated in current plate."
+#~ msgstr ""
+#~ "開啟這個選項，程式會在切片的過程中根據模型表面的傾斜度自動計算每層的層高，首層除外。\n"
+#~ "注意這個選項僅在當前盤不存在擦拭塔的情況下生效。"
+
+#~ msgid "normal"
+#~ msgstr "普通"
+
+#~ msgid "tree"
+#~ msgstr "樹狀"
+
+#~ msgid " Object:"
+#~ msgstr " 物件："
+
+#~ msgid "Please check the following infomation:\n"
+#~ msgstr "請確認以下資訊後傳送列印：\n"
+
+#~ msgid ""
+#~ "You have changed some preset settings. \n"
+#~ "Would you like to keep these changed settings after switching preset?"
+#~ msgstr ""
+#~ "您有一些修改過的設定。\n"
+#~ "切換預設後，是否要保留這些更改過的設定？"
+
+#~ msgid "Export sliced file"
+#~ msgstr "匯出切片檔案"
+
+#~ msgid "Export Sliced File"
+#~ msgstr "匯出切片檔案"
+
+#~ msgid "Add Custom Printer"
+#~ msgstr "新增自定義印表機"
+
+#~ msgid "Show Log"
+#~ msgstr "顯示日誌"
+
+#~ msgid "Export current Sliced file"
+#~ msgstr "匯出當前已切片的檔案"
+
+#~ msgid "Publish Project"
+#~ msgstr "釋出專案"
+
+#~ msgid "Force cooling fan to be specific speed when overhang degree of printed part exceeds this value. Expressed as percentage which indicides how much width of the line without support from lower layer"
+#~ msgstr "當列印部分的懸垂程度超出設定值，強制冷卻風扇為設定的速度。懸垂程度表示為未被低層支撐的部分佔線寬的百分比"
+
+#~ msgid "Distance of the nozzle tip to the lower rod. Used as input of auto-arranging to avoid collision when printing by object"
+#~ msgstr "擠出頭尖端到下方滑桿的距離。用於逐件列印的自動擺盤"
+
+#~ msgid "Distance of the nozzle tip to the lid. Used as input of auto-arranging to avoid collision when printing by object"
+#~ msgstr "擠出頭尖端到頂蓋的距離。用於逐件列印的自動擺盤。"
+
+#~ msgid "Clearance radius around extruder. Used as input of auto-arranging to avoid collision when printing by object"
+#~ msgstr "擠出機的避讓半徑。用於逐件列印的自動擺盤"
+
+#~ msgid "Send and Print"
+#~ msgstr "傳送並列印"
+
+#~ msgid "Upgrade firmware"
+#~ msgstr "升級韌體"
+
+#~ msgid "Upgrading failed"
+#~ msgstr "升級失敗"
+
+#~ msgid "Upgrading successful"
+#~ msgstr "升級成功"
+
+#~ msgid "Show &Wireframe"
+#~ msgstr "顯示線框"
+
+#~ msgid "Show wireframes in 3D scene"
+#~ msgstr "在3D場景中顯示線框"
+
+#~ msgid "Erase painting"
+#~ msgstr "擦除繪製"
+
+#~ msgid "Set pen size"
+#~ msgstr "設定畫筆大小"
+
+#~ msgid "Rotation:"
+#~ msgstr "旋轉："
+
+#~ msgid "Height:"
+#~ msgstr "高度："
+
+#~ msgid "Initialize failed [%d]!"
+#~ msgstr "初始化失敗 [%d]！"
+
+#~ msgid "Management"
+#~ msgstr "管理"
+
+#~ msgid "Choose save directory"
+#~ msgstr "選擇儲存目錄"
+
+#~ msgid "preparing, export 3mf failed!"
+#~ msgstr "正在準備中，匯出 3mf 失敗！"
+
+#~ msgid "Prime tower is required by timeplase. Are you sure you want to disable both of them?"
+#~ msgstr "延時攝影需要使用擦拭塔，是否同時禁用？"
+
+#~ msgid "Prime tower is required by timelapse. Do you want to enable both of them?"
+#~ msgstr "延時攝影需要使用擦拭塔，是否同時啟用？"
+
+#~ msgid "%1% is too close to exclusion area, there will be collisions when printing."
+#~ msgstr "%1%離不可列印區域太近，會造成列印時出現碰撞。"
+
+#~ msgid ""
+#~ "\n"
+#~ "%1% is too close to exclusion area, there will be collisions when printing."
+#~ msgstr ""
+#~ "\n"
+#~ "%1%離不可列印區域太近，會造成列印時出現碰撞。"
+
+#~ msgid " is too close to others, there will be collisions when printing.\n"
+#~ msgstr "離其它物件太近，會造成列印時出現碰撞。\n"
+
+#~ msgid " is too close to exclusion area, there will be collisions when printing.\n"
+#~ msgstr "離不可列印區域太近，會造成列印時出現碰撞。\n"
+
+#~ msgid "Avoid crossing wall when travel"
+#~ msgstr "空駛時避免跨越外牆"
+
+#~ msgid "Max travel detour distance"
+#~ msgstr "最大繞行距離"
+
+#~ msgid "Maximum detour distance for avoiding crossing wall. Don't detour if the detour distance is large than this value"
+#~ msgstr "避免跨越外牆時的最大繞行距離。如果繞行距離大於這個閾值，則不再繞行。"
+
+#~ msgid "Height of the clearance cylinder around extruder. Used as input of auto-arrange to avoid collision when print object by object"
+#~ msgstr "擠出機的淨空高度。作為自動擺放的輸入資訊，避免逐件列印時發生碰撞。"
+
+#~ msgid "Clearance radius around extruder. Used as input of auto-arrange to avoid collision when print object by object"
+#~ msgstr "擠出機的淨空半徑。作為自動擺放的輸入資訊，避免逐件列印時發生碰撞。"
+
+#~ msgid "Error at line %1%:\n"
+#~ msgstr "錯誤在行%1%：\n"
+
+#~ msgid "Reduce Triangles"
+#~ msgstr "簡化三角形"
+
+#~ msgid "Stop printing when spaghetti detected"
+#~ msgstr "當發生炒麵時停止列印"
+
+#~ msgid ""
+#~ "Switch to zig-zag pattern?\n"
+#~ "Yes - switch to zig-zag pattern automaticlly\n"
+#~ "No  - reset density to default non 100% value automaticlly\n"
+#~ msgstr ""
+#~ "切換到鋸齒圖案？\n"
+#~ "是 - 自動切換到鋸齒圖案\n"
+#~ "否 - 自動重置為非100%填充密度\n"
+
+#~ msgid "Extruder position"
+#~ msgstr "擠出機位置"
+
+#~ msgid "Zig zag"
+#~ msgstr "鋸齒"
+
+#~ msgid ""
+#~ "Bed temperature is higher than vitrification temperature of this filament.\n"
+#~ "This may cause nozzle blocked and printing failure"
+#~ msgstr ""
+#~ "熱床溫度已高於這個耗材的軟化溫度。\n"
+#~ "這可能導致堵頭和列印失敗"
+
+#~ msgid "Waiting"
+#~ msgstr "等待中"
+
+#~ msgid "Per object edit"
+#~ msgstr "編輯單個物件"
+
+#~ msgid "Inner wall speed"
+#~ msgstr "內牆速度"
+
+#~ msgid "Clipping of view"
+#~ msgstr "剪下檢視"
+
+#~ msgid "the 3mf is not compatible, load geometry data only!"
+#~ msgstr "該3mf檔案不相容，僅載入幾何資料！"
+
+#~ msgid "Save configuration as:"
+#~ msgstr "預設另存為："
+
+#~ msgid "Line type"
+#~ msgstr "走線型別"
+
+#~ msgid "Designer"
+#~ msgstr "設計師"
+
+#~ msgid "Report"
+#~ msgstr "報告"
+
+#~ msgid "0%"
+#~ msgstr "0%"
+
+#~ msgid "Timelapse Wipe Tower"
+#~ msgstr "延時攝影擦料塔"
+
+#~ msgid "Device:"
+#~ msgstr "裝置："
+
+#~ msgid "Translation"
+#~ msgstr "翻譯"
+
+#~ msgid "It seems object %s needs support to print. Please enable support generation."
+#~ msgstr "物件“%s”可能需要新增支撐才能列印。建議開啟支撐生成。"
+
+#~ msgid "The model has overlapping or self-intersecting facets. I tried to repair it, however you might want to check the results or repair the input file and retry."
+#~ msgstr "模型有重疊或自交的面片。已嘗試修復，請檢查結果是否正確，或修復輸入檔案後重試。"
+
+#~ msgid "Auto orientates selected objects or all objects.If there are selected objects, it just orientates the selected ones.Otherwise, it will orientates all objects in the project."
+#~ msgstr ""
+#~ "自動調整選定零件/所有零件的方向,\n"
+#~ "有選定零件時調整選定零件的朝向,沒有選擇零件時調整所有零件的朝向"
+
+#~ msgid "The Config is not compatible and can not be loaded."
+#~ msgstr "該配置不相容，無法被載入。"
+
+#~ msgid "default value"
+#~ msgstr "預設值"
+
+#~ msgid "The filament index exceeds the AMS's slot count and cannot send the print job."
+#~ msgstr "印表機韌體僅支援材料=>AMS槽位的順序對映。材料編號超過AMS的槽位數量，無法傳送列印任務。"
+
+#~ msgid "Timelapse without toolhead"
+#~ msgstr "無工具頭延時攝影"
+
+#~ msgid "Downloading Bambu Network plug-in"
+#~ msgstr "正在下載Bambu網路外掛"
+
+#~ msgid "Creating"
+#~ msgstr "正在建立"
+
+#~ msgid "Please fill report first."
+#~ msgstr "請先填寫報告。"
+
+#~ msgid "Unable to create zip file"
+#~ msgstr "無法建立zip壓縮檔案"
+
+#~ msgid "Printer firmware does not support material = >ams slot mapping."
+#~ msgstr "印表機韌體不支援材料=>AMS槽位對映"
+
+#~ msgid "Filaments Selection"
+#~ msgstr "材料選擇"
+
+#~ msgid "Printer Selection"
+#~ msgstr "印表機選擇"
+
+#~ msgid "Auto arrange"
+#~ msgstr "自動擺盤"
+
+#~ msgid "Spiral mode"
+#~ msgstr "旋轉模式"
+
+#~ msgid "Unprintable area in XY plane. For example, X1 Series printers use the front left corner to cut filament in multi-material printing. The area is expressed as polygon by points in following format: \"XxY, XxY, ...\""
+#~ msgstr "XY平面上的不可列印區域。例如，X1系列印表機在換料過程中，會使用左前角區域來切斷耗材絲。這個多邊形區域由以下格式的點表示：“XxY，XxY，…”"
+
+#~ msgid "Connect %s[SN:%s] failed!"
+#~ msgstr "連線 %s[SN:%s]失敗."
+
+#~ msgid "Fragment area"
+#~ msgstr "碎片面積閾值"
+
+#~ msgid "Clear all"
+#~ msgstr "清除所有"
+
+#~ msgid "Monitoring"
+#~ msgstr "實時影片"
+
+#~ msgid "Record monitor video"
+#~ msgstr "錄製監控影片"
+
+#~ msgid "Fragment filter"
+#~ msgstr "碎片過濾器"
+
+#~ msgid "Fragment Filter"
+#~ msgstr "碎片過濾器"
+
+#~ msgid "Position:"
+#~ msgstr "位置："
+
+#~ msgid "Updating Bambu Network plug-in"
+#~ msgstr "正在更新Bambu網路外掛"
+
+#~ msgid ""
+#~ "An object is layed over the boundary of plate.\n"
+#~ "Please solve the problem by moving it totally inside or outside plate."
+#~ msgstr ""
+#~ "檢測到有物件放置在盤的邊界。\n"
+#~ "請把它整體移動到盤內或盤外以解決此問題。"
+
+#~ msgid "Show Model Mesh(TODO)"
+#~ msgstr "顯示模型網格"
+
+#~ msgid "Display triangles of models"
+#~ msgstr "顯示模型面片"
+
+#~ msgid "Show Model Shadow(TODO)"
+#~ msgstr "顯示模型陰影"
+
+#~ msgid "Display shadow of objects"
+#~ msgstr "顯示物件陰影"
+
+#~ msgid "Show Printable Box(TODO)"
+#~ msgstr "顯示列印區邊界"
+
+#~ msgid "Display printable box"
+#~ msgstr "顯示列印區邊界"
+
+#~ msgid ""
+#~ "Do you want to synchronize your personal data from Bambu Cloud? \n"
+#~ "It ontains the following information:\n"
+#~ "1. The Process presets\n"
+#~ "2. The Filament presets\n"
+#~ "3. The Printer presets\n"
+#~ msgstr ""
+#~ "想從Bambu 雲同步你的個人資料嗎?\n"
+#~ "包含如下資訊:\n"
+#~ "1. 工藝預設\n"
+#~ "2. 耗材絲預設\n"
+#~ "3. 印表機預設\n"
+
+#~ msgid "Fix model through cloud"
+#~ msgstr "透過雲端修復模型"
+
+#~ msgid "Fix model locally"
+#~ msgstr "本地修復模型"
+
+#~ msgid "Module"
+#~ msgstr "模組"
+
+#~ msgid ""
+#~ "Heat the nozzle to target \n"
+#~ "temperature"
+#~ msgstr "加熱噴嘴到目標溫度"
+
+#~ msgid ""
+#~ "Push new filament \n"
+#~ "into extruder"
+#~ msgstr "送出新的耗材絲到擠出機"
+
+#~ msgid "Successfully sent.Will automatically jump to the device page in %s s"
+#~ msgstr "已傳送完成，即將自動跳轉到裝置頁面 (%s 秒）"
+
+#~ msgid ""
+#~ "Do you want to synchronize your personal data from Bambu Cloud? \n"
+#~ "Contains the following information:\n"
+#~ "1. The Process presets\n"
+#~ "2. The Filament presets\n"
+#~ "3. The Printer presets\n"
+#~ msgstr ""
+#~ "是否從Bambu雲同步您的個人資料？\n"
+#~ "包含以下資訊：\n"
+#~ "1. 工藝預設\n"
+#~ "2. 耗材絲預設\n"
+#~ "3. 印表機預設\n"
+
+#~ msgid "Please upgrade your printer first"
+#~ msgstr "請先升級印表機韌體"
+
+#~ msgid "Swith cloud environment, Please login again!"
+#~ msgstr "切換雲環境，請重新登入!"
+
+#~ msgid "The firmware versions of printer and AMS are too low.Please update to the latest version before sending the print job"
+#~ msgstr "印表機和AMS韌體版本過低，請更新到最新版本方可傳送列印"
+
+#~ msgid "Output file"
+#~ msgstr "輸出檔案"
+
+#~ msgid "Don't retract when the travel is in infill area absolutely. That means the oozing can't been seen"
+#~ msgstr "當完全在填充區域內部空駛時不會抽，即便滲出滴料也是不可見的。"
+
+#~ msgid "sdfsadf Any arrow"
+#~ msgstr "方向鍵"
+
+#~ msgid "Ctrl + Left mouse button"
+#~ msgstr "Ctrl + 滑鼠左鍵"
+
+#~ msgid "Shift + Any arrow"
+#~ msgstr "Shift + 方向鍵"
+
+#~ msgid "Ctrl + Any arrow"
+#~ msgstr "Ctrl + 方向鍵"
+
+#~ msgid "Shift + Mouse wheel"
+#~ msgstr "Shift + 滑鼠滾輪"
+
+#~ msgid "User pause"
+#~ msgstr "使用者暫停"
+
+#~ msgid "Pause(toolhead shell off)"
+#~ msgstr "工具頭前蓋掉落暫停"
+
+#~ msgid "In the calibration of laser scanner"
+#~ msgstr "輪廓儀鐳射標定"
+
+#~ msgid "In the calibration of extrusion flow"
+#~ msgstr "擠出絕對流量標定"
+
+#~ msgid "Pause(hotend temperature error)"
+#~ msgstr "熱端溫控異常暫停"
+
+#~ msgid "Pause(heated bed temperature error)"
+#~ msgstr "熱床溫控異常暫停"
+
+#~ msgid "Beginner's Tutorial"
+#~ msgstr "新手引導"
+
+#~ msgid "Render statistics debugging box"
+#~ msgstr "渲染統計資料除錯框"
+
+#~ msgid "Pause(hotend temperature error"
+#~ msgstr "熱端溫控異常暫停"
+
+#~ msgid "Pause(heated bed temperature error"
+#~ msgstr "熱床溫控異常暫停"
+
+#~ msgid "The bed is auto leveling"
+#~ msgstr "熱床正在自動調平"
+
+#~ msgid "The hot bed is preheating"
+#~ msgstr "熱床正在預加熱"
+
+#~ msgid "Frequncy sweeping"
+#~ msgstr "機器正在進行掃頻"
+
+#~ msgid "Change the filament"
+#~ msgstr "更改材料"
+
+#~ msgid "Pause(M400)"
+#~ msgstr "暫停（M400）"
+
+#~ msgid "Pause(Lack of filament)"
+#~ msgstr "缺料暫停"
+
+#~ msgid "The nozzle is preheating"
+#~ msgstr "噴頭正在預加熱"
+
+#~ msgid "Extruder compensation scanning"
+#~ msgstr "正在進行擠出補償掃描"
+
+#~ msgid "Bed surface scanning"
+#~ msgstr "正在進行熱床表面掃描"
+
+#~ msgid "First layer scanning"
+#~ msgstr "正在進行首層掃描"
+
+#~ msgid "In the calibration of extrinsic parameters"
+#~ msgstr "輪廓儀外參標定中"
+
+#~ msgid "In the calibration of temperature protection"
+#~ msgstr "擠出頭溫度保護標定"
+
+#~ msgid "Silent Mode"
+#~ msgstr "靜音模式"
+
+#~ msgid "Show Edges(TODO)"
+#~ msgstr "顯示模型邊緣"
+
+#~ msgid "Show Edges"
+#~ msgstr "顯示模型邊緣"
+
+#~ msgid "Associate .step files to BambuStudio"
+#~ msgstr "使用Bambu Studio開啟.step檔案"
+
+#~ msgid "Vibration Calibration"
+#~ msgstr "振動校準"
+
+#~ msgid "Please select a printer first."
+#~ msgstr "請先選擇一臺印表機。"
+
+#~ msgid "The printer is updating firmware. Please send it after the update is completed"
+#~ msgstr "印表機正在更新韌體，請在更新完成後傳送"
+
+#~ msgid "Enable spaghetti detector"
+#~ msgstr "炒麵檢測"
+
+#~ msgid "Enable the camera on printer to check spaghetti"
+#~ msgstr "開啟印表機的攝像頭檢查是否發生炒麵。"
+
+#~ msgid ""
+#~ "The calibration program detects the status of your device automatically to minimize deviation.\n"
+#~ " It keeps the device performing optimally."
+#~ msgstr ""
+#~ "校準程式會自動檢測裝置以最小化裝置誤差。\n"
+#~ "它可以讓裝置保持最佳效能。"
+
+#~ msgid "The calibration program detects the status of your device automatically to minimize deviation. It keeps the device performing optimally."
+#~ msgstr "校準程式會自動檢測裝置以最小化裝置誤差。它可以讓裝置保持最佳效能。"
+
+#~ msgid "Reading printer info timed out"
+#~ msgstr "讀取印表機資訊超時"
+
+#~ msgid "Per Object Setting"
+#~ msgstr "物件設定"
+
+#~ msgid "Reset All"
+#~ msgstr "重置所有"
+
+#~ msgid "Waiting for login"
+#~ msgstr "正在登入中"
+
+#~ msgid "Internal error, no gcode file to upload."
+#~ msgstr "內部錯誤，沒有可上傳的gcode檔案"
+
+#~ msgid "Print job was cancelled."
+#~ msgstr "列印任務已取消。"
+
+#~ msgid "Failed to create the print job. Please try agian."
+#~ msgstr "無法建立列印任務，請重試。"
+
+#~ msgid "Failed to upload the print job. Please try agian."
+#~ msgstr "未能上傳列印任務，請重試。"
+
+#~ msgid "Uploading print job timed out. Please try again."
+#~ msgstr "上傳列印任務超時，請重試。"
+
+#~ msgid "Sending print task timed out. Please try again."
+#~ msgstr "傳送列印任務超時，請重試。"
+
+#~ msgid "Try to upload project over lan"
+#~ msgstr "嘗試透過區域網上傳專案"
+
+#~ msgid "Try to send project over cloud"
+#~ msgstr "嘗試透過雲服務傳送專案"
+
+#~ msgid "Ams Mappling failed, please select filament"
+#~ msgstr "AMS 對映失敗，請手動選擇耗材絲"
+
+#~ msgid "Plese select the filament in ams"
+#~ msgstr "請手動選擇耗材絲"
+
+#~ msgid "The printer is being updated. Please try again after the update."
+#~ msgstr "印表機正在更新。 請更新後重試。"
+
+#~ msgid "Exporting 3mf..."
+#~ msgstr "正在匯出3mf..."
+
+#~ msgid "Internal error."
+#~ msgstr "內部錯誤。"
+
+#~ msgid "Exporting 3mf failed, please slice again."
+#~ msgstr "匯出3mf失敗，請重新切片。"
+
+#~ msgid "No printer available"
+#~ msgstr "沒有可用的印表機"
+
+#~ msgid "Current printer is busy"
+#~ msgstr "當前印表機正忙"
+
+#~ msgid "Current printer is printing now"
+#~ msgstr "當前印表機正在列印中"
+
+#~ msgid "YES"
+#~ msgstr "是"
+
+#~ msgid "NO"
+#~ msgstr "否"
+
+#~ msgid "Reading printer information..."
+#~ msgstr "正在讀取印表機資訊"
+
+#~ msgid ""
+#~ "Do you want to synchronize your personal data from Bambu Cloud? \n"
+#~ "Contains the following information:\n"
+#~ "1. The Process presets\n"
+#~ "2. The Filament presets\n"
+#~ "3. The Machine presets\n"
+#~ msgstr ""
+#~ "想從Bambu 雲同步你的個人資料嗎?\n"
+#~ "包含如下資訊:\n"
+#~ "1. 工藝預設\n"
+#~ "2. 耗材絲預設\n"
+#~ "3. 印表機預設\n"
+
+#~ msgid "Machine Control"
+#~ msgstr "控制"
+
+#~ msgid "General settings"
+#~ msgstr "常規設定"
+
+#~ msgid "Bed temperature when cool plate is installed"
+#~ msgstr "安裝低溫列印熱床時的熱床溫度"
+
+#~ msgid "Bed temperature when engineering plate is installed"
+#~ msgstr "安裝工程材料熱床時的熱床溫度"
+
+#~ msgid "Bed temperature when high temperature plate is installed"
+#~ msgstr "安裝高溫列印熱床時的熱床溫度"
+
+#~ msgid "Record Timelapse"
+#~ msgstr "錄製Timelapse"
+
+#~ msgid "bed temperature for layers except the initial one"
+#~ msgstr "除了首層之外的熱床溫度"
+
+#~ msgid "Bed temperature of the initial layer"
+#~ msgstr "首層床溫"
+
+#~ msgid "Tiny patch filter"
+#~ msgstr "碎片過濾器"
+
+#~ msgid "Filter tiny patch"
+#~ msgstr "濾除碎片"
+
+#~ msgid "Try to send project over lan"
+#~ msgstr "嘗試透過區域網傳送專案"
+
+#~ msgid "Filament Retraction"
+#~ msgstr "材料回抽"
+
+#~ msgid "%1% is too close to others, there will be collisions when printing."
+#~ msgstr "%1%離其它物件太近，會造成列印時出現碰撞。"
+
+#~ msgid ""
+#~ "\n"
+#~ "%1% is too close to others, there will be collisions when printing."
+#~ msgstr ""
+#~ "\n"
+#~ "%1%離其它物件太近，會造成列印時出現碰撞。"
+
+#~ msgid "%1% is too tall, there will be collisions when printing."
+#~ msgstr "%1%的高度過高，會造成列印時出現碰撞。"
+
+#~ msgid ""
+#~ "\n"
+#~ "%1% is too tall, there will be collisions when printing."
+#~ msgstr ""
+#~ "\n"
+#~ "%1%的高度過高，會造成列印時出現碰撞。"
+
+#~ msgid "Login with your Account"
+#~ msgstr "使用您的賬號登入"
+
+#~ msgid "Logout"
+#~ msgstr "登出"
+
+#~ msgid "Publish Model/Profile"
+#~ msgstr "釋出模型/配置"
+
+#~ msgid "Please slice all plates before upload"
+#~ msgstr "請在上傳之前將所有盤切片"
+
+#~ msgid "Chinese (Simplified)"
+#~ msgstr "中文(簡體)"
+
+#~ msgid "Purging after filament change will be done inside objects' infills. This may lower the amount of waste"
+#~ msgstr "換料後的過渡料將被擠出到物件的填充中。這樣可以減少材料的浪費"
+
+#~ msgid "GUI"
+#~ msgstr "介面"
+
+#~ msgid "Shortcuts"
+#~ msgstr "快捷鍵"
+
+#~ msgid "Smart"
+#~ msgstr "自動"
+
+#~ msgid "Total Size:"
+#~ msgstr "總尺寸："
+
+#~ msgid "Show daily tips"
+#~ msgstr "顯示每日小貼士"
+
+#~ msgid "Choose Filaments"
+#~ msgstr "選擇耗材絲"
+
+#~ msgid "Bind Dialog"
+#~ msgstr "繫結對話方塊"
+
+#~ msgid "Temperature and Axis Control"
+#~ msgstr "溫度和軸移動控制"
+
+#~ msgid "Current printer is busy. Please select another one."
+#~ msgstr "當前印表機正忙，請選擇另一臺印表機。"
+
+#~ msgid "Bambu Studio initialization failed"
+#~ msgstr "Bambu Studio初始化失敗"
+
+#~ msgid "Object %s has zero size and can't be arranged."
+#~ msgstr "物件%s的尺寸為0，無法被自動擺放。"
+
+#~ msgid "Import project failed, Please try again!"
+#~ msgstr "載入專案失敗，請重試！"
+
+#~ msgid "Failed to publish your project. Please try agian!"
+#~ msgstr "專案釋出失敗。請重試！"
+
+#~ msgid "Preparing to upload your project..."
+#~ msgstr "正在準備上傳專案..."
+
+#~ msgid "Uploading..."
+#~ msgstr "上傳中"
+
+#~ msgid "Upload has been canceled."
+#~ msgstr "上傳已被取消。"
+
+#~ msgid "Failed to publish. Please try again!"
+#~ msgstr "釋出失敗，請重試！"
+
+#~ msgid "Uploading is timed out. Please try again!"
+#~ msgstr "上傳已超時，請重試！"
+
+#~ msgid "Design id is empty."
+#~ msgstr "獲取設計id失敗。"
+
+#~ msgid "Unable to get system certificate."
+#~ msgstr "無法獲取系統證書。"
+
+#~ msgid "use system SSL certificate: %1%"
+#~ msgstr "使用系統的SSL證書：%1%"
+
+#~ msgid "CURL initialization failed. See the log for additional details."
+#~ msgstr "CURL初始化失敗。檢視日誌以獲取詳細資訊。"
+
+#~ msgid "print project cancelled."
+#~ msgstr "列印任務已取消。"
+
+#~ msgid "Creating a print job..."
+#~ msgstr "建立列印任務..."
+
+#~ msgid "Uploading the print job..."
+#~ msgstr "上傳列印任務..."
+
+#~ msgid "Wait for the job to be sent."
+#~ msgstr "等待任務傳送完成。"
+
+#~ msgid "The print job has been sent to your printer."
+#~ msgstr "列印任務已傳送至印表機。"
+
+#~ msgid "Invalid plate index %d"
+#~ msgstr "無效的盤索引 %d"
+
+#~ msgid "Plate %d"
+#~ msgstr "盤 %d"
+
+#~ msgid "Start printing..."
+#~ msgstr "開始列印..."
+
+#~ msgid "Process %1% / 100"
+#~ msgstr "處理 %1% / 100"
+
+#~ msgid "Auto brim"
+#~ msgstr "自動brim"
+
+#~ msgid "No brim"
+#~ msgstr "無"
+
+#~ msgid "X/Y Axis"
+#~ msgstr "X/Y 軸"
+
+#~ msgid ""
+#~ "Nozzle may be blocked when the temperature is out of recommanded range.\n"
+#~ "Please make sure whether to use the temperature to print.\n"
+#~ "\n"
+#~ msgstr ""
+#~ "當溫度超出推薦範圍時，噴嘴可能堵塞。\n"
+#~ "請檢查是否使用該溫度列印。\n"
+
+#~ msgid "Recommanded nozzle temperature of this filament type is [%d, %d] degree centigrade"
+#~ msgstr "該型別材料的建議噴嘴溫度是[%d, %d]攝氏度"
+
+#~ msgid "Recommanded temperature range"
+#~ msgstr "建議溫度範圍"
+
+#~ msgid "Bed temperature of different bed type when printing"
+#~ msgstr "列印時不同型別熱床的溫度"
+
+#~ msgid "Bed temperature for layers except the initial one"
+#~ msgstr "列印除首層外的其它層時的床溫"
+
+#~ msgid "BBL private bed temperature"
+#~ msgstr "BBL自定義床溫"
+
+#~ msgid "Use BBL private temperature gcode instead of standard M140/M190"
+#~ msgstr "使用BBL自定義的私有溫度控制G程式碼替代標準的M140/M190。"
+
+#~ msgid "Processing model '%1%' with more than 1M triangles could be slow. It is highly recommended to reduce the amount of triangles."
+#~ msgstr "處理超出1M個三角形面片的模型“%1%”可能會很慢。強烈建議減少模型的三角形面片數量。"
+
+#~ msgid "The bed is auto leveling..."
+#~ msgstr "熱床正在自動調平..."
+
+#~ msgid "The hot bed is preheating..."
+#~ msgstr "熱床預熱中..."
+
+#~ msgid "Frequncy sweeping..."
+#~ msgstr "機械模態掃頻中..."
+
+#~ msgid "Change the filament..."
+#~ msgstr "換料中..."
+
+#~ msgid "The nozzle is preheating..."
+#~ msgstr "熱端預熱中..."
+
+#~ msgid "Extruder compensation scanning..."
+#~ msgstr "擠出補償掃描中..."
+
+#~ msgid "Bed surface scanning..."
+#~ msgstr "床面掃描中..."
+
+#~ msgid "First layer scanning..."
+#~ msgstr "首層掃描中..."
+
+#~ msgid "Bed surface is auto identifying..."
+#~ msgstr "床面型別識別中..."
+
+#~ msgid "The tool head is homing..."
+#~ msgstr "工具頭回中"
+
+#~ msgid "Nozzle cleaning..."
+#~ msgstr "擠出頭端面清理中..."
+
+#~ msgid "Material for support"
+#~ msgstr "支撐材料"
+
+#~ msgid "Filament to print support and skirt."
+#~ msgstr "列印支撐和skirt的耗材絲"
+
+#~ msgid "Filament to print support interface"
+#~ msgstr "列印支撐接觸面的耗材絲"
+
+#~ msgid "Import STL/OBJ/AMF/3MF without config, keep plater"
+#~ msgstr "匯入STL/OBJ/AMF/3MF"
+
+#~ msgid "Overall"
+#~ msgstr "全域性"
+
+#~ msgid "Build plate"
+#~ msgstr "列印板"
+
+#~ msgid "Object list"
+#~ msgstr "物件列表"
+
+#~ msgid "Camera view. - Default"
+#~ msgstr "攝像機視角 - 預設"
+
+#~ msgid "Camera view. - Top"
+#~ msgstr "攝像機視角 - 頂部"
+
+#~ msgid "Camera view. - Bottom"
+#~ msgstr "攝像機視角 - 底部"
+
+#~ msgid "Camera view. - Front"
+#~ msgstr "攝像機視角 - 前面"
+
+#~ msgid "Camera view. - Behind"
+#~ msgstr "攝像機視角 - 後面"
+
+#~ msgid "Camera Angle. - Left side"
+#~ msgstr "攝像機視角 - 左面"
+
+#~ msgid "Camera Angle. - Right side"
+#~ msgstr "攝像機視角 - 右面"
+
+#~ msgid "1-9 Set part consumable wire"
+#~ msgstr "1-9 設定零件耗材絲"
+
+#~ msgid "overall_shortcuts"
+#~ msgstr "全域性快捷鍵"
+
+#~ msgid "Arrange all parts"
+#~ msgstr "全域性整理"
+
+#~ msgid ""
+#~ "Automatically adjust the orientation of selected parts/all parts,\n"
+#~ "            When there are selected parts - adjust selected parts orientation,\n"
+#~ "            When no part is selected - adjust the orientation of all parts"
+#~ msgstr "自動調整選定零件/所有零件的方向,有選定零件時-調整選定零件的朝向,沒有選擇零件時-調整所有零件的朝向"
+
+#~ msgid "Box selection of multiple parts"
+#~ msgstr "框選多個零件"
+
+#~ msgid "Gizmo move: Press to snap by 1mm"
+#~ msgstr "Gizmo 移動:按下1mm"
+
+#~ msgid "Gizmo/Supports/Gizmo Color/Painting: Adjust brush radius"
+#~ msgstr "調節畫筆半徑"
+
+#~ msgid "Gizmo/Supports/Gizmo Color/Painting:Position of regulated section"
+#~ msgstr "調節剖面位置"
+
+#~ msgid "Unhandled exception: %1%"
+#~ msgstr "未處理的異常：%1%"
+
+#~ msgid "AMS Control"
+#~ msgstr "AMS 控制"
+
+#~ msgid "Printing..."
+#~ msgstr "列印中..."
+
+#~ msgid "Objects being edited are not visible."
+#~ msgstr "正在編輯的物件是不可見的。"
+
+#~ msgid "%d%% uploaded..."
+#~ msgstr "已上傳 %d%%"
+
+#~ msgid "Set to cover"
+#~ msgstr "設定為封面"
+
+#~ msgid "No errors"
+#~ msgstr "無錯誤"
+
+#~ msgid "Auxiliary"
+#~ msgstr "附件"
+
+#~ msgid "Eject drive"
+#~ msgstr "彈出裝置"
+
+#~ msgid "Triangles: %1%, "
+#~ msgstr "三角形數： %1%, "
+
+#~ msgid "The bed type that correspond to the following temperatures"
+#~ msgstr "與下列溫度對應的熱床型別"
+
+#~ msgid "%1$d open edge"
+#~ msgid_plural "%1$d open edges"
+#~ msgstr[0] "%1$d条非闭合边"
+
+#~ msgid "Custom supports, seams and color painting were removed after repairing."
+#~ msgstr "修復後自定義支撐、接縫、上色配置會被刪除。"
+
+#~ msgid "No objects to export."
+#~ msgstr "沒有可匯出的物件。"
+
+#~ msgid "Event"
+#~ msgstr "事件"
+
+#~ msgid "Remaining time"
+#~ msgstr "剩餘時間"
+
+#~ msgid "Duration"
+#~ msgstr "持續時間"
+
+#~ msgid "Part cooling fan speed will start to run at min speed when the estimated layer time is no longer than the layer time in setting"
+#~ msgstr "當預估的層時間不大於設定的數值時，部件冷卻風扇將開始執行在最小速度"
+
+#~ msgid "Auxiliary part cooling fan speed"
+#~ msgstr "輔助部件冷卻風扇的轉速"
+
+#~ msgid "Max fan speed"
+#~ msgstr "最大風扇轉速"
+
+#~ msgid "Min fan speed"
+#~ msgstr "最小風扇轉速"
+
+#~ msgid "Part cooling fan speed for overhang"
+#~ msgstr "懸垂風扇轉速"
+
+#~ msgid "Fan settings"
+#~ msgstr "風扇設定"
+
+#~ msgid "Max fan speed and min fan speed"
+#~ msgstr "最大和最小風扇轉速"
+
+#~ msgid "Cooling thresholds"
+#~ msgstr "冷卻閾值"
+
+#~ msgid "Overhang fan speed"
+#~ msgstr "冷卻懸空風扇轉速"
+
+#~ msgid "Fan speed when printing bridge and overhang wall"
+#~ msgstr "列印橋接和懸空牆的風扇轉速"
+
+#~ msgid "Force cooling fan speed to be overhang_fan_speed when overhang degree of printed part exceeds this value. Expressed as percentage which indicides how many width of the line without support from lower layer"
+#~ msgstr "當列印部分的走線懸空程度超過這個值時，強制冷卻風扇的轉速為“冷卻懸空風扇轉速”。懸空程度使用無低層支撐部分的寬度相對線寬的百分比表示。"
+
+#~ msgid "Enable auto cooling"
+#~ msgstr "開啟自動冷卻"
+
+#~ msgid "Enable auto cooling to adjust printing speed and fan speed according to layer printing time automatically"
+#~ msgstr "開啟自動冷卻後，風扇轉速和列印速度都會根據每一層的預估列印時間自動調整。"
+
+#~ msgid "Disable fan for the first"
+#~ msgstr "關閉風扇對開始的"
+
+#~ msgid "Close cooling fan for the first certain layers. We usually close fan for the initial layer to get better build plate adhesion"
+#~ msgstr "對開始的一些層關閉冷卻風扇。通常關閉首層的冷卻風扇來獲得更好的熱床粘接。"
+
+#~ msgid "Starting fan from stop state usually costs lots's of time. If enable this setting, fan will never be stoped and will run at least at minimum speed to reduce the frequency of starting and stoping"
+#~ msgstr "風扇的啟停需要消耗較長時間。如果開啟這個設定，那麼風扇就不會停下。至少維持在最小轉速執行，來避免頻繁啟停。"
+
+#~ msgid "Enable fan if layer print time is below"
+#~ msgstr "開啟風扇當層時間小於"
+
+#~ msgid "Cooling fan will be enabled for layers of which estimated time is shorter than this value. Fan speed is interpolated between the minimum and maximum fan speeds according to layer printing time"
+#~ msgstr "當層預估列印時間小於這個閾值時，冷卻風扇將被開啟。風扇轉速會根據層時間的長短做線性插值。"
+
+#~ msgid "Auxiliary fan"
+#~ msgstr "輔助風扇"
+
+#~ msgid "Enable this option if machine has auxiliary fan"
+#~ msgstr "當機器有輔助風扇時開啟這個選項"
+
+#~ msgid "Maximum fan speed for cooling"
+#~ msgstr "冷卻風扇最大速度"
+
+#~ msgid "Minimum fan speed for cooling"
+#~ msgstr "冷卻風扇最小轉速"
+
+#~ msgid "Additional cooling fan speed"
+#~ msgstr "增強冷卻風扇轉速"
+
+#~ msgid "Speed of additional cooling fan"
+#~ msgstr "增強冷卻風扇轉速"
+
+#~ msgid "Slow down if layer print time is below"
+#~ msgstr "降速當層時間小於"
+
+#~ msgid " plate %1% :"
+#~ msgstr "盤%1%:"
+
+#~ msgid "Speed for different overhang degree. Overhang degree is expressed as percentage of line width"
+#~ msgstr "不同懸垂程度的列印速度。懸垂程度使用相對於線寬的百分表示"
+
+#~ msgid "Log in Printer"
+#~ msgstr "登入印表機"
+
+#~ msgid "Log out failed."
+#~ msgstr "登出失敗。"
+
+#~ msgid "Would you like to log in the current account from this printer?"
+#~ msgstr "你想使用當前賬號登入印表機嗎?"
+
+#~ msgid "Log in success."
+#~ msgstr "登入成功。"
+
+#~ msgid "Log out Printer"
+#~ msgstr "登出印表機"
+
+#~ msgid "Would you like to log out the current account from this printer?"
+#~ msgstr "你想使用當前賬號登出印表機嗎?"
+
+#~ msgid "Log out success."
+#~ msgstr "登出成功。"
+
+#~ msgid "Invalid printer. Please select a printer."
+#~ msgstr "無效的印表機。 請選擇一臺印表機。"
+
+#~ msgid "Plese select an action"
+#~ msgstr "請選擇處理方式"
+
+#~ msgid "Click the pencil icon to edit the filament"
+#~ msgstr "點選鉛筆圖示編輯耗材絲"
+
+#~ msgid "Send Task to"
+#~ msgstr "傳送任務至"
+
+#~ msgid "Selected a printer"
+#~ msgstr "選擇印表機"
+
+#~ msgid "Please select a printer first!"
+#~ msgstr "請先選擇印表機!"
+
+#~ msgid "Please fill report first!"
+#~ msgstr "請先填寫報告！"
+
+#~ msgid "Extrusion width value is too low."
+#~ msgstr "擠出寬度太小。"
+
+#~ msgid "Extrusion width value is too high."
+#~ msgstr "擠出寬度太大。"
+
+#~ msgid "Line width of outer wall. It's relative to nozzle diameter if expressed as percentage"
+#~ msgstr "外牆的線寬。如果表示為百分數，則基數為噴嘴直徑。"
+
+#~ msgid "Line width of initial layer. It's relative to nozzle diameter if expressed as percentage"
+#~ msgstr "首層的線寬。如果表示為百分數，則基數為噴嘴直徑。"
+
+#~ msgid "Line width of internal sparse infill. It's relative to nozzle diameter if expressed as percentage"
+#~ msgstr "內部稀疏填充的線寬。如果表示為百分數，則基數為噴嘴直徑。"
+
+#~ msgid "Line width of inner wall. It's relative to nozzle diameter if expressed as percentage"
+#~ msgstr "內圈牆的線寬。如果表示為百分數，則基數為噴嘴直徑。"
+
+#~ msgid "Line width of internal solid infill. It's relative to nozzle diameter if expressed as percentage"
+#~ msgstr "內部實心填充的線寬。如果表示為百分數，則基數為噴嘴直徑。"
+
+#~ msgid "Used to set line width for support. It's relative to nozzle diameter if expressed as percentage"
+#~ msgstr "支撐的線寬。如果表示為百分比，則基數為噴嘴直徑。"
+
+#~ msgid "Used to set line width for support transition. It's relative to nozzle diameter if expressed as percentage"
+#~ msgstr "支撐面轉換層的線寬。如果表示為百分比，則基數為噴嘴直徑。"
+
+#~ msgid "Speed for printing support transition layers in which support infill direction is changed"
+#~ msgstr "列印支撐轉換層的速度，支撐填充的方向會在此層發生變化。"
+
+#~ msgid "Used to set line width for top surfaces. It's relative to nozzle diameter if expressed as percentage"
+#~ msgstr "頂面填充的線寬。如果用百分比表示，則基數為噴嘴直徑。"
+
+#~ msgid "Slicing plate %1%"
+#~ msgstr "正在切片盤 %1%"
+
+#~ msgid "Slicing Plate %1% "
+#~ msgstr "正在切片盤 %1% "
+
+#~ msgid "Slicing Plate %1%"
+#~ msgstr "正在切片盤 %1%"
+
+#~ msgid "Generating G-code: layer %d"
+#~ msgstr "正在生成G-code：層 %d"
+
+#~ msgid "Generating G-code: layer "
+#~ msgstr "正在生成G-code：層 "
+
+#~ msgid "Generating infills"
+#~ msgstr "正在生成填充"
+
+#~ msgid "Generating infill"
+#~ msgstr "生成填充"
+
+#~ msgid "Optimize extrusion path"
+#~ msgstr "最佳化擠出走線"
+
+#~ msgid "The number of solid layers of top shell, including top surface layer. When the thickness calculated by this value is thinner than top shell thickness, the top shell layers number will be increased when slicing"
+#~ msgstr "頂部殼體實心層層數，包括頂面。當由該層數計算的厚度小於頂部殼體厚度時，在切片時會增加頂部殼體的層數。"
+
+#~ msgid "The number of solid layers of bottom shell, including bottom surface layer. When the thickness calculated by this value is thinner than bottom shell thickness, the bottom shell layers number will be increased when slicing."
+#~ msgstr "底部殼體實心層層數，包括底面。當由該層數計算的厚度小於底部殼體厚度時，在切片時會增加底部殼體的層數。"
+
+#~ msgid "The number of bottom solid layers is increased when slicing if the thickness calculated by bottom_shell_layers is thinner than this value. This can avoid too thin shell when layer height is small"
+#~ msgstr "如果由底部殼體實心層層數確定的厚度小於底部殼體厚度，那麼切片時將增加底部殼體實心層層數。這樣可以避免層高過小時產生過薄的殼體。"
+
+#~ msgid "The number of top solid layers is increased when slicing if the thickness calculated by top_shell_layers is thinner than this value. This can avoid too thin shell when layer height is small"
+#~ msgstr "如果有頂部殼體層數算出的厚度小於這個數值，那麼切片時將自動增加頂部殼體層數。這能夠避免當層高很小時，頂部殼體過薄。"
+
+#~ msgid "Merge the selected objects to an object with multiple parts"
+#~ msgstr "合併所選物件為一個多零件物件"
+
+#~ msgid "Merge the selected objects to an object with single part"
+#~ msgstr "合併所選物件為一個單零件物件"
+
+#~ msgid "Merge the selected parts to a single part"
+#~ msgstr "合併所選零件為單個零件"
+
+#~ msgid "Merged"
+#~ msgstr "已合併"
+
+#~ msgid "Internal Error. design id is empty."
+#~ msgstr "內部錯誤。獲取design id失敗。"
+
+#~ msgid "Internal Error. Exporting 3mf failed, please slice again."
+#~ msgstr "內部錯誤。匯出3mf失敗，請重新切片。"
+
+#~ msgid "Detect the overhang percentage relative to line width and use different speed to print. For 100%% overhang, bridge speed is used"
+#~ msgstr "檢測懸空相對於線寬的百分比，並應用不同的速度列印。100%%的懸空將使用橋接速度"
+
+#~ msgid "print project cancelled"
+#~ msgstr "列印專案取消"
+
+#~ msgid "Failed to create the printing task. Please try again"
+#~ msgstr "無法建立列印任務。請再試一次"
+
+#~ msgid "Failed to upload the printing task. Please try again"
+#~ msgstr "無法上傳列印任務。請再試一次"
+
+#~ msgid "Uploading printing task timed out. Please try again"
+#~ msgstr "上傳列印任務超時。請再試一次"
+
+#~ msgid "Failed to send the printing task. Please try again"
+#~ msgstr "無法傳送列印任務。請再試一次"
+
+#~ msgid "Sending the printing task has timed out. Please try again"
+#~ msgstr "傳送列印任務已超時。請再試一次"
+
+#~ msgid "Creating a print project..."
+#~ msgstr "建立列印專案..."
+
+#~ msgid "Uploading the print task..."
+#~ msgstr "上傳列印任務中..."
+
+#~ msgid "The printing project is being sent..."
+#~ msgstr "正在傳送列印專案..."
+
+#~ msgid "The printing task was sent successfully"
+#~ msgstr "列印任務已成功傳送"
+
+#~ msgid "Filament N"
+#~ msgstr "耗材絲 N"
+
+#~ msgid "Unable to connect server"
+#~ msgstr "無法連線到伺服器"
+
+#~ msgid "Unable to get printer status"
+#~ msgstr "無法獲取印表機狀態"
+
+#~ msgid "Tip: Click the button to edit your filament"
+#~ msgstr "提示：點選此按鈕以編輯耗材絲"
+
+#~ msgid "Before loading, please make sure the filament is pushed into toolhead."
+#~ msgstr "載入前，請確保耗材絲已送入到工具頭內。"
+
+#~ msgid "Remove frequency sweep gcode"
+#~ msgstr "跳過掃頻"
+
+#~ msgid "Enable this to skip frequency sweep when start printing"
+#~ msgstr "開啟這個設定將跳過開始列印時的掃頻階段。"
+
+#~ msgid "Remove bed leveling gcode"
+#~ msgstr "跳過調平"
+
+#~ msgid "Enable this to skip bed leveling when start printing"
+#~ msgstr "開啟這個設定將跳過開始列印時的調平階段。"
+
+#~ msgid "Remove extrusion calibration gcode"
+#~ msgstr "跳過擠出標定"
+
+#~ msgid "Enable this to skip extrusion calibration when start printing"
+#~ msgstr "開啟這個設定將跳過開始列印時的擠出標定。"
+
+#~ msgid "Monitor"
+#~ msgstr "印表機"
+
+#~ msgid "Modifications to the preset have been saved"
+#~ msgid_plural "Modifications to the presets have been saved"
+#~ msgstr[0] "对预设的修改已被保存"
+
+#~ msgid "All modifications will be discarded for new project."
+#~ msgstr "在新專案中所有修改都會被丟棄。"
+
+#~ msgid ""
+#~ "Do you want to synchronize your personal data from Bambu Cloud? \n"
+#~ "Contains the following information:\n"
+#~ "1. The Process presets;\n"
+#~ "2. The Filament presets;\n"
+#~ "3. The Machine presets;\n"
+#~ msgstr ""
+#~ "是否從Bambu 雲端同步您的使用者資料？\n"
+#~ "包含以下資訊：\n"
+#~ "1. 工藝預設；\n"
+#~ "2. 耗材絲預設；\n"
+#~ "3. 印表機預設；\n"
+
+#~ msgid "Current bed type do not support filament "
+#~ msgstr "當前熱床不支援耗材絲"
+
+#~ msgid "Load from disk"
+#~ msgstr "從硬碟載入"
+
+#~ msgid "Import presets only"
+#~ msgstr "僅匯入預設"
+
+#~ msgid "Slice the models."
+#~ msgstr "對模型切片。"
+
+#~ msgid ""
+#~ "All the selected objects are on the locked plate,\n"
+#~ "We can not do auto-arrange on these objects!"
+#~ msgstr ""
+#~ "所有選中的物件都處於被鎖定的盤上，\n"
+#~ "無法對這些物件做自動擺盤。"
+
+#~ msgid "Arrange failed. Found some exceptions when processing object Geometries"
+#~ msgstr "自動擺放失敗，處理物件幾何資料時遇到異常。"
+
+#~ msgid "Arranging is done but there are unpacked items! Reduce spacing and try again!"
+#~ msgstr "已完成自動擺放，但是有未被擺到盤內的項，可在減小間距後重試。"
+
+#~ msgid "The Config is not compatible, can not load!"
+#~ msgstr "該配置不相容，無法被載入"
+
+#~ msgid "One object has empty initial layer and can't be printed."
+#~ msgstr "模型出現空層無法列印。"
+
+#~ msgid "Prime Tower is too close to others, there will be collisions when printing."
+#~ msgstr "擦拭塔和其他物件捱得太近，會造成列印時出現碰撞。"
+
+#~ msgid "Cancel Calibration"
+#~ msgstr "取消校準"
+
+#~ msgid "Overhang"
+#~ msgstr "懸垂"
+
+#~ msgid ""
+#~ "Nozzle may be blocked when the temperature is out of recommanded range.\n"
+#~ "Please make sure whether to use the temperature to print"
+#~ msgstr ""
+#~ "當噴嘴溫度高於推薦溫度範圍，列印時可能會發生堵塞。\n"
+#~ "請確認是否使用該溫度列印"
+
+#~ msgid ""
+#~ "Bed temperature of other layer is lower too much than bed temperature of initial layer. \n"
+#~ "This may cause model broken free from build plate during printing. \n"
+#~ "Please check the bed temperature and make sure whether to use the value"
+#~ msgstr ""
+#~ "其它層熱床溫度比首層熱床溫度低太多。\n"
+#~ "這可能導致列印中模型從列印板脫落。\n"
+#~ "請檢查熱床溫度並確認是否用相應數值"
+
+#~ msgid "Nozzle temperature range"
+#~ msgstr "噴嘴溫度範圍"
+
+#~ msgid "Recommanded nozzle temperature range"
+#~ msgstr "建議噴嘴溫度範圍"
+
+#~ msgid "Highest"
+#~ msgstr "最高"
+
+#~ msgid "The lowest recommanded nozzle temperature when print with this filament"
+#~ msgstr "使用該材料列印時建議的噴嘴溫度的最低值"
+
+#~ msgid "Lowest"
+#~ msgstr "最低"
+
+#~ msgid "The highest recommanded nozzle temperature when print with this filament"
+#~ msgstr "使用該材料列印時建議的噴嘴溫度的最高值"
+
+#~ msgid "Gizmo-Move"
+#~ msgstr "Gizmo-移動"
+
+#~ msgid "Gizmo-Scale"
+#~ msgstr "縮放工具"
+
+#~ msgid "Gizmo-Rotate"
+#~ msgstr "Gizmo-旋轉"
+
+#~ msgid "Bmabu Cool Plate"
+#~ msgstr "低溫列印熱床"
+
+#~ msgid "Bmabu Engineering Plate"
+#~ msgstr "工程材料熱床"
+
+#~ msgid "Bmabu High Temperature Plate"
+#~ msgstr "高溫列印熱床"
+
+#~ msgid "Bed style"
+#~ msgstr "熱床型別"
+
+#~ msgid "current printer is busy! please select another!"
+#~ msgstr "當前印表機繁忙! 請選擇另一個!"
+
+#~ msgid ""
+#~ "This plate is locked,\n"
+#~ "We can not do auto-arrange on this plate!"
+#~ msgstr ""
+#~ "該盤處於鎖定狀態，\n"
+#~ "無法對其進行自動擺盤"
+
+#~ msgid "Object %s has zero size and can't be arranged!"
+#~ msgstr "物件%s的尺寸為0，無法被自動擺放。"
+
+#~ msgid "Arrange failed! Found some exceptions when processing object Geometries"
+#~ msgstr "自動擺放失敗，處理物件幾何資料時遇到異常。"
+
+#~ msgid ""
+#~ "All the selected objects are on the locked plate,\n"
+#~ "We can not do auto-orient on these objects!"
+#~ msgstr ""
+#~ "所有選中的物件都處於被鎖定的盤上，\n"
+#~ "無法對這些物件做自動朝向。"
+
+#~ msgid ""
+#~ "This plate is locked,\n"
+#~ "We can not do auto-orient on this plate!"
+#~ msgstr ""
+#~ "該盤處於鎖定狀態，\n"
+#~ "無法對其進行自動朝向"
+
+#~ msgid "Choose the position"
+#~ msgstr "選擇AMS料倉"
+
+#~ msgid "Click the load below"
+#~ msgstr "點選載入"
+
+#~ msgid "Heat the extruder"
+#~ msgstr "熱端升溫"
+
+#~ msgid "Complete"
+#~ msgstr "完成"
+
+#~ msgid "Feed"
+#~ msgstr "上料"
+
+#~ msgid "Ams Settings"
+#~ msgstr "AMS 設定"
+
+#~ msgid "Whether to synchronize cloud user data?\n"
+#~ msgstr "是否同步您的雲端資料？\n"
+
+#~ msgid "Ensure"
+#~ msgstr "確認"
+
+#~ msgid "Box"
+#~ msgstr "盒子"
+
+#~ msgid "Click the icon to reset printable property of the object"
+#~ msgstr "點選此圖示可重置物件的可列印屬性"
+
+#~ msgid "Holes of object will be grown or shrunk in XY plane by the configured value. Negative value makes holes bigger. Positive value makes holes smaller. This function is used to adjust size when the object has assembling issue"
+#~ msgstr "模型的孔洞會在XY平面上被拓展或者收縮特定值。負值代表擴大孔洞。正值代表收縮孔洞。此功能一般用於調整有裝配問題的模型。"
+
+#~ msgid "Contour of object will be grown or shrunk in XY plane by the configured value. Positive value makes contour bigger. Negative value makes contour smaller. This function is used to adjust size when the object has assembling issue"
+#~ msgstr "模型的外輪廓會在XY平面上被拓展或者收縮特定值。正值代表擴大。負值代表收縮。此功能一般用於調整有裝配問題的模型。"
+
+#~ msgid "To click download new version in default browser: %s"
+#~ msgstr "在瀏覽器中下載最新版本: %s"
+
+#~ msgid "click download new version in default browser: %s"
+#~ msgstr "在瀏覽器中下載最新版本: %s"
+
+#~ msgid "New Version of BambuStudio"
+#~ msgstr "新版本的BambuStudio"
+
+#~ msgid "Switching Presets: Unsaved Changes"
+#~ msgstr "切換預設:未儲存的更改"
+
+#~ msgid "Save the selected options to preset \"%1%\"."
+#~ msgstr "儲存所選項到預設\"%1%\"。"
+
+#~ msgid "Transfer the selected options to the newly selected preset \"%1%\"."
+#~ msgstr "將所選項遷移到新的預設 \"%1%\"。"
+
+#~ msgid "The following preset was modified"
+#~ msgid_plural "The following presets were modified"
+#~ msgstr[0] "修改了以下预设"
+
+#~ msgid "Explosion"
+#~ msgstr "爆炸圖"
+
+#~ msgid "Ratio"
+#~ msgstr "比例"
+
+#~ msgid "Show daily tip on startup"
+#~ msgstr "啟動時顯示每日小貼士"
+
+#~ msgid "The selected plate is empty."
+#~ msgstr "所選盤是空的。"
+
+#~ msgid "XY separation between an object and its support. It's relative to outer wall line width if expressed as percentage"
+#~ msgstr "模型和支撐之間的XY間距。如果表示為百分數，則基數為外圈牆的線寬。"
+
+#~ msgid ""
+#~ "Failed to save gcode file\n"
+#~ "Error message: %1%"
+#~ msgstr "儲存G-code檔案失敗，錯誤資訊：%1%"
+
+#~ msgid "Please login first!"
+#~ msgstr "請先登入賬戶！"
+
+#~ msgid "From height"
+#~ msgstr "從高度"
+
+#~ msgid "To height"
+#~ msgstr "到高度"
+
+#~ msgid "Local coordinates"
+#~ msgstr "本地座標"
+
+#~ msgid "Drop to bed"
+#~ msgstr "放到床上"
+
+#~ msgid "Inches"
+#~ msgstr "英寸"
+
+#~ msgid "Non-uniform scaling is only supported for single object/part selection"
+#~ msgstr "不等比例縮放僅支援在選中單個物件/零件時進行"
+
+#~ msgid "Speed of outer wall which is outermost and visible. It's expressed as percentage relative to inner wall speed. It's used to be slower than inner wall speed to get better quality"
+#~ msgstr "可見的最外圈的牆的列印速度。表示為相對於內層牆速度的百分數。通常設定比內牆速度慢一些進而獲得更好的質量。"
+
+#~ msgid "The number of solid layers of bottom shell, including bottom surface layer. When the thickness calculated by this value is thinner than bottom_shell_thickness, the top shell layers number will be increased when slicing"
+#~ msgstr "底部殼體實心層的層數，包括底面。如果由這個層數確定的厚度小於底部殼體厚度時，切片時將增加底部層數"
+
+#~ msgid "Filament to print support, raft and skirt"
+#~ msgstr "列印支撐，筏層和skirt時使用的耗材絲"
+
+#~ msgid ""
+#~ "Zero tree support branch distance is invalid.\n"
+#~ "Reset to 1"
+#~ msgstr "樹狀支撐分支間距不可為0。將重置為1"
+
+#~ msgid ""
+#~ "Zero tree support branch diameter is invalid.\n"
+#~ "Reset to 5"
+#~ msgstr "樹狀支撐分支直徑不可為0。將重置為5"
+
+#~ msgid ""
+#~ "Zero tree support collision resolution is invalid.\n"
+#~ "Reset to 0.2"
+#~ msgstr "樹狀支撐碰撞解析度不可為0。將重置為0.2"
+
+#~ msgid "Add..."
+#~ msgstr "新增..."
+
+#~ msgid "Project Slicing: "
+#~ msgstr "專案切片："
+
+#~ msgid "Single Plate Slicing: "
+#~ msgstr "單盤切片："
+
+#~ msgid "Upload and publish your project"
+#~ msgstr "上傳和釋出專案"
+
+#~ msgid "preparing your project"
+#~ msgstr "正在準備您的專案"
+
+#~ msgid "uploading..."
+#~ msgstr "上傳中..."
+
+#~ msgid "Precise of control"
+#~ msgstr "精確控制"
+
+#~ msgid "Add support for sharp tails"
+#~ msgstr "支撐尖尾"
+
+#~ msgid "Remove support for small overhangs"
+#~ msgstr "不支援小懸空"
+
+#~ msgid "Enable this option and height of every layer except initial one will be automatically calculated when slicing according to the slope of model surface"
+#~ msgstr "開啟這個選項，切片時將根據模型表面的斜率自動計算除首層外的其它層的層高"
+
+#~ msgid "Max print speed"
+#~ msgstr "最大列印速度"
+
+#~ msgid "Small walls"
+#~ msgstr "細小外牆"
+
+#~ msgid "Wall around the support"
+#~ msgstr "支撐外壁"
+
+#~ msgid "If enabled, bridges may look worse but can cover longer distance. If disabled, bridges look better but just for shorter distance."
+#~ msgstr "如果開啟，橋接表面質量會變差但是能跨越更長的距離。如果關閉，橋接表面質量看起來更好但是可跨越的距離會變短。"
+
+#~ msgid "Tool-MoveRotate"
+#~ msgstr "工具-移動和旋轉"
+
+#~ msgid "Move and Rotate"
+#~ msgstr "移動和旋轉"
+
+#~ msgid "Show Daily Tips"
+#~ msgstr "顯示每日小貼士"
+
+#~ msgid "New User Login"
+#~ msgstr "新使用者登入"
+
+#~ msgid "login"
+#~ msgstr "登陸"
+
+#~ msgid "Value is out of range, continue?"
+#~ msgstr "值越界，是否繼續？"
+
+#~ msgid "Open %s"
+#~ msgstr "開啟%s"
+
+#~ msgid "Check for Configuration Updates"
+#~ msgstr "檢查配置更新"
+
+#~ msgid "Check for configuration updates"
+#~ msgstr "檢查配置更新"
+
+#~ msgid "Application preferences"
+#~ msgstr "應用程式偏好選項"
+
+#~ msgid "Simple"
+#~ msgstr "簡單"
+
+#~ msgid "Simple Mode"
+#~ msgstr "簡單模式"
+
+#~ msgid "Advanced Mode"
+#~ msgstr "高階模式"
+
+#~ msgid "%s Mode"
+#~ msgstr "%s模式"
+
+#~ msgid "Restart application"
+#~ msgstr "重啟應用程式"
+
+#~ msgid "Choose language"
+#~ msgstr "選擇語言"
+
+#~ msgid "Configuration"
+#~ msgstr "配置"
+
+#~ msgid "Enter copies number:"
+#~ msgstr "輸入複製數量："
+
+#~ msgid "Enter copies Number"
+#~ msgstr "輸入複製數量"
+
+#~ msgid "Run %s"
+#~ msgstr "執行 %s"
+
+#~ msgid "Switch Language"
+#~ msgstr "切換語言"
+
+#~ msgid "Speed of outer wall which is outermost and visible. It's relative to inner wall speed if expressed as percentage"
+#~ msgstr "最外牆的速度。如果表示為百分數，則基數為內牆的速度"
+
+#~ msgid "Speed of internal solid infill, not the top and bottom surface. It's relative to sparse infill speed if it's percentage"
+#~ msgstr "內部實心填充的列印速度，不是頂面和底面填充。如果表示為百分數，則基數為稀疏填充的列印速度"
+
+#~ msgid "Speed of support interface. It's relative to support speed if expressed as percentage"
+#~ msgstr "支撐接觸面列印速度。如果表示為百分比，則基數為支撐速度"
+
+#~ msgid "Speed for printing support transition layers in which support infill direction is changed.If expressed as percentage (for example 50%) it will be calculated over support speed."
+#~ msgstr "支撐轉換層（填充方向變化時）的列印速度。如果表示為百分比，則基數為支撐列印速度。"
+
+#~ msgid "Speed of top surface infill which is solid. It's relative to internal solid infill speed if it's percentage"
+#~ msgstr "頂部表面實心填充的列印速度。如果表示為百分比，則基數為內部實心填充的速度"
+
+#~ msgid ""
+#~ "Switching the language will trigger the application restart.\n"
+#~ "Please confirm to switch?"
+#~ msgstr "切換語言需要重啟軟體，確認切換嗎？"
+
+#~ msgid "Currency"
+#~ msgstr "貨幣"
+
+#~ msgid "Software has new version."
+#~ msgstr "軟體有新版本。"
+
+#~ msgid ""
+#~ "The application requires OpenGL 2.0 capable graphics driver to run correctly, \n"
+#~ "current OpenGL version %s, render %s, vendor %s."
+#~ msgstr "應用程式需要OpenGL 2.0 圖形化驅動。當前OpenGL 版本 %s, render %s, vendor %s."
+
+#~ msgid "Repairing objects by the Netfabb service"
+#~ msgstr "透過Netfabb服務修復物件。"
+
+#~ msgid "Support will be generated for overhangs whose slope angle is below the threshold. Zero means automatic detection"
+#~ msgstr "將會為懸垂角度低於閾值的模型表面生成支撐。零值表示自動檢測。"
+
+#~ msgid "The number of solid layers of top shell, including top surface layer. When the thickness calculated by this value is thinner than top_shell_thickness, the top shell layers number will be increased when slicing"
+#~ msgstr "頂部殼體實心層層數，包括頂面。當由該層數計算的厚度小於頂部殼體厚度時，在切片時會增加頂部殼體層數"
+
+#~ msgid "Configuration update is available."
+#~ msgstr "檢測到可用的配置更新。"
+
+#~ msgid "See more."
+#~ msgstr "檢視詳情。"
+
+#~ msgid "Slicing finished."
+#~ msgstr "切片完成。"
+
+#~ msgid "Exporting finished."
+#~ msgstr "匯出完成。"
+
+#~ msgid "System Information"
+#~ msgstr "系統資訊"
+
+#~ msgid "Blacklisted libraries loaded into BambuStudio process:"
+#~ msgstr "已載入黑名單庫到BambuStudio程序中:"
+
+#~ msgid "Feature vectorization is supported:"
+#~ msgstr "支援特徵向量化:"
+
+#~ msgid "Copy to Clipboard"
+#~ msgstr "複製到剪下板"
+
+#~ msgid "This G-code is inserted between objects when print object by object"
+#~ msgstr "在逐件列印時模型之間切換時插入這段G-code"
+
+#~ msgid "This setting limits how much volume of filament can be milted and extruded per second. Printing speed is limited by max volumetric speed, in case of too high and unreasonable speed setting. Zero means no limit"
+#~ msgstr "這個設定限制了耗材絲在1秒內可以被融化和擠出的最大體積。列印速度"
+
+#~ msgid "Select a gcode file:"
+#~ msgstr "選擇GCode檔案："
+
+#~ msgid "Set as an individual objects"
+#~ msgstr "設定為獨立物件"
+
+#~ msgid "Arranging is done but there are unpacked items! Reduce spacing or bed_shrink and try again!"
+#~ msgstr "已完成自動擺放，但有一些無法擺放的元件！請減小間距或熱床收縮引數再嘗試！"
+
+#~ msgid "Show daily tips(TODO)"
+#~ msgstr "顯示每日小貼士"
+
+#~ msgid "%1$d Object has custom seam."
+#~ msgid_plural "%1$d Objects have custom seam."
+#~ msgstr[0] "%1$d 模型有自定义接缝。"
+
+#~ msgid "%1$d Object has multimaterial painting."
+#~ msgid_plural "%1$d Objects have multimaterial painting."
+#~ msgstr[0] "%1$d 模型有多材料绘制。"
+
+#~ msgid "%1$d Object has partial sinking."
+#~ msgid_plural "%1$d Objects have partial sinking."
+#~ msgstr[0] "%1$d 模型有局部下沉。"
+
+#~ msgid "It seems your model needs support to print! Please enable support material."
+#~ msgstr "可能需要為您的模型新增支撐以確保成功列印！"
+
+#~ msgid "Paint-on supports"
+#~ msgstr "繪製支撐"
+
+#~ msgid "Multimaterial painting"
+#~ msgstr "多材料塗色"
+
+#~ msgid "Project Downloaded %d%%"
+#~ msgstr "專案已下載 %d%%"
+
+#~ msgid "Error while loading G-code file"
+#~ msgstr "載入G-code檔案時發生錯誤"
+
+#~ msgid "Home page and Daily Tips"
+#~ msgstr "主頁和每日提示"
+
+#~ msgid "Stealth"
+#~ msgstr "隱身"
+
+#~ msgid "Material Settings"
+#~ msgstr "材料設定"
+
+#~ msgid "Preset \"%1%\" is not compatible with the new print profile and it contains the following unsaved changes:"
+#~ msgstr "預設 \"%1%\" 與新的工藝預設不相容，並且包含以下未儲存的修改:"
+
+#~ msgid ""
+#~ "The configuration package is incompatible with current APP.\n"
+#~ "%s will update the configuration package, Otherwise it won't be able to start"
+#~ msgstr ""
+#~ "該配置包與當前軟體不相容。\n"
+#~ "%s 將更新配置包，否則軟體無法執行"
+
+#~ msgid "Flushing volumes for fialment change"
+#~ msgstr "換料沖刷量"
+
+#~ msgid "Saving objects into the 3MF failed."
+#~ msgstr "儲存物件到3MF失敗。"
+
+#~ msgid "To manually specify the system certificate store, set the %1% environment variable to the correct CA and restart the application"
+#~ msgstr "設定%1%環境變數到正確的"
+
+#~ msgid "First layer bed temperature"
+#~ msgstr "首層床溫"
+
+#~ msgid "First layer density"
+#~ msgstr "首層密度"
+
+#~ msgid "First layer expansion"
+#~ msgstr "首層擴充套件"
+
+#~ msgid "Support layer uses layer height independent with object layer. This is to support custom support gap,but may cause extra extruder switches if support is specified as different extruder with object"
+#~ msgstr "支撐使用獨立於物件的層高。這樣就可以支援任意支撐間隙，但是可能會造成額外的材料"
+
+#~ msgid "Purging volumes - load/unload volumes"
+#~ msgstr "清理量 - 載入/解除安裝量"
+
+#~ msgid "Purging volumes - matrix"
+#~ msgstr "清理量 - 矩陣"
+
+#~ msgid "Visualize an already sliced and saved G-code"
+#~ msgstr "顯示已切片儲存的G-code檔案"
+
+#~ msgid "Support material Generated"
+#~ msgstr "已生成支撐"
+
+#~ msgid "Split triangles"
+#~ msgstr "分割三角形"
+
+#~ msgid "Remove all selection"
+#~ msgstr "移除所有繪製"
+
+#~ msgid "Paints all facets inside, regardless of their orientation."
+#~ msgstr "繪製所有處於球體內部的面片，無論它們的方向是怎樣的。"
+
+#~ msgid "Ignores facets facing away from the camera."
+#~ msgstr "忽略背對相機視角的面片。"
+
+#~ msgid "License agreements of all following programs (libraries) are part of application license agreement"
+#~ msgstr "所有以下程式(庫)的許可協議是應用程式許可協議的一部分"
+
+#~ msgid "is licensed under the"
+#~ msgstr "根據"
+
+#~ msgid "Contributions by Henrik Brix Andersen, Nicolas Dandrimont, Mark Hindess, Petr Ledvina, Joseph Lenox, Y. Sapir, Mike Sheldrake, Vojtech Bubnik and numerous others."
+#~ msgstr "Henrik Brix Andersen, Nicolas Dandrimont, Mark Hindess, Petr Ledvina, Joseph Lenox, Y. Sapir, Mike Sheldrake, Vojtech Bubnik 等人的貢獻。"
+
+#~ msgid ""
+#~ "Zero initial layer height is invalid.\n"
+#~ "\n"
+#~ "The first layer height will be reset to 0.01."
+#~ msgstr "首層層高不能為0。將重置為0.01。"
+
+#~ msgid "Alternate nozzles:"
+#~ msgstr "備用噴嘴："
+
+#~ msgid "All standard"
+#~ msgstr "所有標準"
+
+#~ msgid "Welcome to the %s Configuration Assistant"
+#~ msgstr "歡迎訪問 %s 配置助手"
+
+#~ msgid "Welcome to the %s Configuration Wizard"
+#~ msgstr "歡迎訪問 %s 配置嚮導"
+
+#~ msgid "Welcome"
+#~ msgstr "歡迎"
+
+#~ msgid "Hello, welcome to %s! This %s helps you with the initial configuration; just a few settings and you will be ready to print."
+#~ msgstr "您好，歡迎來到 %s！此 %s 可幫助您進行初始配置，只需進行幾項設定就可以列印了。"
+
+#~ msgid "%s Family"
+#~ msgstr "%s 系列"
+
+#~ msgid "filament"
+#~ msgstr "絲"
+
+#~ msgid "SLA material"
+#~ msgstr "SLA 材料"
+
+#~ msgid "Custom Printer Setup"
+#~ msgstr "自定義印表機設定"
+
+#~ msgid "Custom Printer"
+#~ msgstr "自定義印表機"
+
+#~ msgid "Define a custom printer profile"
+#~ msgstr "定義自定義印表機配置檔案"
+
+#~ msgid "Custom profile name:"
+#~ msgstr "自定義配置檔名稱："
+
+#~ msgid "Other Vendors"
+#~ msgstr "其他供應商"
+
+#~ msgid "Invalid numeric input."
+#~ msgstr "無效的數字輸入。"
+
+#~ msgid "Filament and Nozzle Diameters"
+#~ msgstr "耗材絲和噴嘴直徑"
+
+#~ msgid "Print Diameters"
+#~ msgstr "列印直徑"
+
+#~ msgid "Enter the diameter of your printer's hot end nozzle."
+#~ msgstr "輸入印表機熱端噴嘴的直徑。"
+
+#~ msgid "Nozzle Diameter:"
+#~ msgstr "噴嘴直徑："
+
+#~ msgid "Enter the diameter of your filament."
+#~ msgstr "輸入耗材絲的直徑。"
+
+#~ msgid "Good precision is required, so use a caliper and do multiple measurements along the filament, then compute the average."
+#~ msgstr "需要良好的精度, 因此請使用遊標卡尺, 沿耗材絲進行多次測量, 然後計算平均值。"
+
+#~ msgid "Filament Diameter:"
+#~ msgstr "耗材絲直徑:"
+
+#~ msgid "Temperatures"
+#~ msgstr "溫度"
+
+#~ msgid "A rule of thumb is 160 to 230 °C for PLA, and 215 to 250 °C for ABS."
+#~ msgstr "根據經驗, PLA 為160至 230°C, ABS 為215至250°C。"
+
+#~ msgid "Extrusion Temperature:"
+#~ msgstr "擠出溫度："
+
+#~ msgid "Enter the bed temperature needed for getting your filament to stick to your heated bed."
+#~ msgstr "輸入讓你的耗材粘在熱床上所需的床溫。"
+
+#~ msgid "A rule of thumb is 60 °C for PLA and 110 °C for ABS. Leave zero if you have no heated bed."
+#~ msgstr "根據經驗, PLA 為 60°C, ABS 為 110°C. 如果沒有加熱床, 請保留零。"
+
+#~ msgid "Bed Temperature:"
+#~ msgstr "熱床溫度:"
+
+#~ msgid "Select all standard printers"
+#~ msgstr "選擇所有標準印表機"
+
+#~ msgid "< &Back"
+#~ msgstr "< &返回"
+
+#~ msgid "&Next >"
+#~ msgstr "&繼續 >"
+
+#~ msgid "&Finish"
+#~ msgstr "&結束"
+
+#~ msgid "Configuration Assistant"
+#~ msgstr "配置助手"
+
+#~ msgid "Configuration &Assistant"
+#~ msgstr "配置 &助手"
+
+#~ msgid "Configuration Wizard"
+#~ msgstr "配置嚮導"
+
+#~ msgid "Configuration &Wizard"
+#~ msgstr "配置 &嚮導"
+
+#~ msgid "Upload and publish your design"
+#~ msgstr "上傳/釋出 作品"
+
+#~ msgid "preparing your designs"
+#~ msgstr "正在準備您的作品"
+
+#~ msgid "preparing your designs, reqeust project id..."
+#~ msgstr "正在準備您的作品，專案建立失敗！"
+
+#~ msgid "the Configuration package is imcompatible with current APP."
+#~ msgstr "該配置包與當前軟體不相容"
+
+#~ msgid "Experimental option for adding support material for sharp tails"
+#~ msgstr "實驗性選項，對尖尾加支撐"
+
+#~ msgid "Experimental option for removing support material for small overhangs"
+#~ msgstr "實驗性選項，不支援小懸空"
+
+#~ msgid "Use this setting to rotate the support material pattern on the horizontal plane."
+#~ msgstr "使用這個設定將支撐模式在水平面旋轉特定角度。"
+
+#~ msgid "Compare this preset with some another"
+#~ msgstr "配置集對比"
+
+#~ msgid "Wipe tower parameters"
+#~ msgstr "色塔引數"
+
+#~ msgid "New printer preset selected"
+#~ msgstr "選擇了新的配置集"
+
+#~ msgid "Bridges fan speed"
+#~ msgstr "橋接風扇速度"
+
+#~ msgid "Bed Shape and Size"
+#~ msgstr "熱床形狀和大小"
+
+#~ msgid "Set the shape of your printer's bed."
+#~ msgstr "設定印表機熱床的形狀。"
+
+#~ msgid "One layer mode"
+#~ msgstr "一層模式"
+
+#~ msgid "Extruder %d"
+#~ msgstr "擠出機 %d"
+
+#~ msgid "An object outside the print area was detected."
+#~ msgstr "檢測到有物件位於列印區域外。"
+
+#~ msgid "A toolpath outside the print area was detected."
+#~ msgstr "檢測到有零件位於列印區域外。"
+
+#~ msgid "SLA supports outside the print area were detected."
+#~ msgstr "檢測到SLA支撐位於列印區域外。"
+
+#~ msgid "Some objects are not visible during editing."
+#~ msgstr "一些物件在編輯過程不可見。"
+
+#~ msgid ""
+#~ "An object outside the print area was detected.\n"
+#~ "Resolve the current problem to continue slicing."
+#~ msgstr ""
+#~ "檢測到有物件位於列印區域外。\n"
+#~ "解決此問題以繼續切片。"
+
+#~ msgid "Rotate lower part upwards"
+#~ msgstr "旋轉下部向上"
+
+#~ msgid "Add supports"
+#~ msgstr "增加支撐"
+
+#~ msgid "Scale factors"
+#~ msgstr "縮放比例因子"
+
+#~ msgid "Could not arrange model objects! Some geometries may be invalid."
+#~ msgstr "無法排列模型物件！某些幾何圖形可能無效。"
+
+#~ msgid "(Re)slice"
+#~ msgstr "重新切片"
+
+#~ msgid "Select Plater Tab"
+#~ msgstr "選擇 列印板 選項卡"
+
+#~ msgid "Select Print Settings Tab"
+#~ msgstr "選擇 列印設定 選項卡"
+
+#~ msgid "Select Filament Settings Tab"
+#~ msgstr "選擇 耗材設定 選項卡"
+
+#~ msgid "Select Printer Settings Tab"
+#~ msgstr "選擇 印表機設定 選項卡"
+
+#~ msgid "Switch to 3D"
+#~ msgstr "切換到3D"
+
+#~ msgid "Switch to Preview"
+#~ msgstr "切換到預覽"
+
+#~ msgid "Camera view"
+#~ msgstr "攝像機檢視"
+
+#~ msgid "Arrange selection"
+#~ msgstr "整理選中的"
+
+#~ msgid "Add Instance of the selected object"
+#~ msgstr "新增所選物件的例項"
+
+#~ msgid "Remove Instance of the selected object"
+#~ msgstr "刪除所選物件的例項"
+
+#~ msgid "Show &Configuration Folder"
+#~ msgstr "開啟配置資料夾"
+
+#~ msgid "Report Bug(TODO)"
+#~ msgstr "Bug報告"
+
+#~ msgid "Report a bug of BambuStudio"
+#~ msgstr "報告BambuStudio的Bug"
+
+#~ msgid "Open BambuStudio"
+#~ msgstr "開啟BambuStudio"
+
+#~ msgid "Skirt Loops"
+#~ msgstr "Skirt圈數"
+
+#~ msgid "Number of bottom interface layers. -1 means same with use top interface layers"
+#~ msgstr "底部接觸面層數，-1代表和頂部相同"
+
+#~ msgid "Choose one file (3mf/amf):"
+#~ msgstr "選擇一個檔案（3mf/amf）"
+
+#~ msgid "G-code Viewer"
+#~ msgstr "G-code Viewer"
+
+#~ msgid "Open G-code Viewer"
+#~ msgstr "開啟G-code Viewer"
+
+#~ msgid "Open a new BambuStudio"
+#~ msgstr "開啟BambuStudio"
+
+#~ msgid "Open new G-code Viewer"
+#~ msgstr "開啟BambuStudio"
+
+#~ msgid "Goto Download page."
+#~ msgstr "前往下載頁面。"
+
+#~ msgid "WARN:"
+#~ msgstr "警告："
+
+#~ msgid "Your model needs support ! Please enable support material."
+#~ msgstr "此次模型需要開啟支撐！建議開啟材料支撐選項。"
+
+#~ msgid "Drag and drop G-code file"
+#~ msgstr "拖拽或丟棄G-code檔案"
+
+#~ msgid "Skirt/Brim"
+#~ msgstr "裙邊/側裙"
+
+#~ msgid "Mixed"
+#~ msgstr "混合"
+
+#~ msgid "Printer technology"
+#~ msgstr "印表機型別"
+
+#~ msgid "Between objects G-code"
+#~ msgstr "逐件列印G-code"
+
+#~ msgid "Bridges"
+#~ msgstr "橋接"
+
+#~ msgid "Label objects"
+#~ msgstr "標註模型"
+
+#~ msgid "Sparse infill anchor length"
+#~ msgstr "稀疏填充錨線長度"
+
+#~ msgid "5 mm"
+#~ msgstr "5 mm"
+
+#~ msgid "10 mm"
+#~ msgstr "10 mm"
+
+#~ msgid "Maximum length of the infill anchor"
+#~ msgstr "填充錨線的最大長度"
+
+#~ msgid "Name of parent profile"
+#~ msgstr "父配置名稱"
+
+#~ msgid "After layer change G-code"
+#~ msgstr "換層後G-code"
+
+#~ msgid "Perimeter"
+#~ msgstr "外牆"
+
+#~ msgid "Printer type"
+#~ msgstr "印表機型別"
+
+#~ msgid "Type of the printer"
+#~ msgstr "印表機型別"
+
+#~ msgid "Printer variant"
+#~ msgstr "印表機變種"
+
+#~ msgid "Retract on layer change"
+#~ msgstr "換層時回抽"
+
+#~ msgid "Retraction Length (Toolchange)"
+#~ msgstr "回抽長度(更換工具頭)"
+
+#~ msgid "Limited"
+#~ msgstr "限制"
+
+#~ msgid "Solid infill"
+#~ msgstr "實心填充"
+
+#~ msgid "Filament to print solid infill."
+#~ msgstr "列印實心填充的耗材絲"
+
+#~ msgid "Solid layers"
+#~ msgstr "實心層數"
+
+#~ msgid "Number of solid layers to generate on top and bottom surfaces."
+#~ msgstr "頂部和底部殼體的實心層數"
+
+#~ msgid "Minimum thickness of a top / bottom shell"
+#~ msgstr "頂部和底部殼體的最小厚度"
+
+#~ msgid "Single Extruder Multi Material"
+#~ msgstr "單擠出機多材料"
+
+#~ msgid "Use single nozzle to print multi filament"
+#~ msgstr "使用單噴嘴列印多耗材"
+
+#~ msgid "Bottom contact Z distance"
+#~ msgstr "底部Z距離"
+
+#~ msgid "Enforce support for the first"
+#~ msgstr "強制支撐前"
+
+#~ msgid "Enforce support for the first n layers"
+#~ msgstr "強制前若干層生成支撐"
+
+#~ msgid "Closing radius"
+#~ msgstr "閉合半徑"
+
+#~ msgid "Z travel"
+#~ msgstr "Z 旅行"
+
+#~ msgid "Speed of vertical travel along z axis. This is typically lower because build plate or gantry is hard to be moved. Zero means using travel speed directly in gcode, but will be limited by printer's ability when run gcode"
+#~ msgstr "Z方向垂直旅行的速度。一般這個數值更小一下，因為熱床或者機架更難移動。0代表直接使用旅行速度"
+
+#~ msgid "Changing of an application language"
+#~ msgstr "更改應用程式語言"
+
+#~ msgid "has zero size and can't be arranged!"
+#~ msgstr "大小為0因此無法擺放！"
+
+#~ msgid "Searching for optimal orientation..."
+#~ msgstr "搜尋最佳方向..."
+
+#~ msgid "Orientation search canceled."
+#~ msgstr "方向搜尋已取消。"
+
+#~ msgid "Orientation found."
+#~ msgstr "找到方向。"
+
+#~ msgid "Searching for optimal orientation"
+#~ msgstr "搜尋最佳方向"
+
+#~ msgid "Feature type"
+#~ msgstr "功能型別"
+
+#~ msgid "Height (mm)"
+#~ msgstr "高度（mm）"
+
+#~ msgid "Width (mm)"
+#~ msgstr "寬度 (mm)"
+
+#~ msgid ""
+#~ "Wipe tower does not work when Adaptive Layer Height or Independent Support Layer Height is on.\n"
+#~ "Which do you want to keep?\n"
+#~ "YES - Keep Wipe Tower\n"
+#~ "NO  - Keep Adaptive Layer Height and Independent Support Layer Height"
+#~ msgstr ""
+#~ "擦拭塔不支援和自適應層高或支撐獨立層高。同時開啟\n"
+#~ "如何選擇？\n"
+#~ "是 - 選擇開啟擦拭塔\n"
+#~ "否 - 選擇保留自適應層高或支撐獨立層高"
+
+#~ msgid ""
+#~ "Wipe tower does not work when Adaptive Layer Height is on.\n"
+#~ "Which do you want to keep?\n"
+#~ "YES - Keep Wipe Tower\n"
+#~ "NO  - Keep Adaptive Layer Height"
+#~ msgstr ""
+#~ "擦拭塔不支援和自適應層高同時開啟。\n"
+#~ "如何選擇？\n"
+#~ "是 - 選擇開啟擦拭塔\n"
+#~ "否 - 選擇保留自適應層高"
+
+#~ msgid ""
+#~ "Wipe tower does not work when Independent Support Layer Height is on.\n"
+#~ "Which do you want to keep?\n"
+#~ "YES - Keep Wipe Tower\n"
+#~ "NO  - Keep Independent Support Layer Height"
+#~ msgstr ""
+#~ "擦拭塔不支援和支撐獨立層高同時開啟。\n"
+#~ "如何選擇？\n"
+#~ "是 - 選擇開啟擦拭塔\n"
+#~ "否 - 選擇保留支撐獨立層高"
+
+#~ msgid "No object can be printed, maybe too small"
+#~ msgstr "沒有可列印的模型，可能尺寸過小。"
+
+#~ msgid "%s has encountered an error. It was likely caused by running out of memory. If you are sure you have enough RAM on your system, this may also be a bug and we would be glad if you reported it."
+#~ msgstr "%s 遇到錯誤。這可能是由於記憶體不足造成的。如果您確定您的系統上有足夠的記憶體，這可能也是一個軟體錯誤，歡迎你向我們提交問題報告。"
+
+#~ msgid "Masked SLA file exported to %1%"
+#~ msgstr "已將 貼面過 SLA 檔案匯出到 %1%"
+
+#~ msgid "G-code file exported to %1%"
+#~ msgstr "G 程式碼檔案匯出到 %1%"
+
+#~ msgid "Filament start gcode"
+#~ msgstr "材料相關的起始 G-code"
+
+#~ msgid "Filament end gcode"
+#~ msgstr "材料相關的結束 G-code"
+
+#~ msgid "Start gcode"
+#~ msgstr "起始  G-code"
+
+#~ msgid "End gcode"
+#~ msgstr "結束 G-code"
+
+#~ msgid "Layer change gcode"
+#~ msgstr "改變層 G-code"
+
+#~ msgid "Tool change gcode"
+#~ msgstr "切換工具 G-code"
+
+#~ msgid "Printing by object gcode"
+#~ msgstr "逐件列印 G-code"
+
+#~ msgid "Wipe tower"
+#~ msgstr "色塔"
+
+#~ msgid "First layer height"
+#~ msgstr "第一層高度"
+
+#~ msgid "choose a directory"
+#~ msgstr "選擇資料夾"
+
+#~ msgid "Print speed override"
+#~ msgstr "覆蓋列印速度"
+
+#~ msgid "Dependencies"
+#~ msgstr "依賴"
+
+#~ msgid "Profile dependencies"
+#~ msgstr "配置依賴"
+
+#~ msgid "full profile name"
+#~ msgstr "配置全稱"
+
+#~ msgid "symbolic profile name"
+#~ msgstr "配置名暱稱"
+
+#~ msgid "Firmware"
+#~ msgstr "韌體"
+
+#~ msgid "Supports"
+#~ msgstr "支撐"
+
+#~ msgid "Pad"
+#~ msgstr "墊"
+
+#~ msgid "Hollowing"
+#~ msgstr "掏空"
+
+#~ msgid ""
+#~ "The configuration is incompatible with current APP.\n"
+#~ "%s will update the configuration package, Otherwise it won't be able to start"
+#~ msgstr ""
+#~ "該配置與當前軟體不相容。\n"
+#~ "%s 將更新配置包"
+
+#~ msgid "reset##rotation"
+#~ msgstr "重置##旋轉"
+
+#~ msgid "Scale:"
+#~ msgstr "縮放："
+
+#~ msgid "reset##scale"
+#~ msgstr "重置##縮放"
+
+#~ msgid "reset##size"
+#~ msgstr "重置##尺寸"
+
+#~ msgid "request project id failed!"
+#~ msgstr "專案建立失敗"
+
+#~ msgid "Import Model"
+#~ msgstr "匯入專案"
+
+#~ msgid "Preselects faces by overhang angle. It is possible to restrict paintable facets to only preselected faces when the option \"%1%\" is enabled."
+#~ msgstr "根據懸空角度預選懸空面片。如果開啟了選項%1%，會限制畫刷的只能塗抹這些預選的懸空面片。"
+
+#~ msgid "Support threshold angle: "
+#~ msgstr "支撐角度閾值："
+
+#~ msgid "Highlight overhang by angle"
+#~ msgstr "高亮懸空區域"
+
+#~ msgid "Enforce"
+#~ msgstr "新增"
+
+#~ msgid "Overhang Threshold Angle"
+#~ msgstr "懸空角度閾值"
+
+#~ msgid "Paints facets according to the chosen painting brush."
+#~ msgstr "根據選擇的話刷在面片上繪製。"
+
+#~ msgid "Paints neighboring facets whose relative angle is less or equal to set angle."
+#~ msgstr "繪製一組連續面片，滿足相鄰面片之間的相對角度小於等於設定的閾值。"
+
+#~ msgid "Paints only one facet."
+#~ msgstr "僅繪製單個面片。"
+
+#~ msgid "Splits bigger facets into smaller ones while the object is painted."
+#~ msgstr "在繪製物件時，把大面片分裂成多個小面片。"
+
+#~ msgid "Support Preview"
+#~ msgstr "支撐預覽"
+
+#~ msgid " Generating ... "
+#~ msgstr "生成中 ..."
+
+#~ msgid " Close Preview  "
+#~ msgstr " 關閉預覽 "
+
+#~ msgid "Select what kind of support do you need"
+#~ msgstr "選擇支撐型別"
+
+#~ msgid "Support on build plate only"
+#~ msgstr "僅從熱床生成支撐"
+
+#~ msgid "For support enforcers only"
+#~ msgstr "僅從強制支撐生成"
+
+#~ msgid "Everywhere"
+#~ msgstr "任意"
+
+#~ msgid "This flag enables the brim that will be printed around each object on the first layer."
+#~ msgstr "啟用此設定會在在模型列印第一層時生成裙邊。"
+
+#~ msgid "Filament change flushing"
+#~ msgstr "換料沖刷量"
+
+#~ msgid "Below object"
+#~ msgstr "模型底部"
+
+#~ msgid "Around object"
+#~ msgstr "模型周圍"
+
+#~ msgid "Firmware Type"
+#~ msgstr "韌體型別"
+
+#~ msgid "Choose the type of firmware used by your printer."
+#~ msgstr "選擇印表機使用的韌體型別。"
+
+#~ msgid "Select by rectangle"
+#~ msgstr "框選"
+
+#~ msgid "Unselect by rectangle"
+#~ msgstr "框選取消"
+
+#~ msgid "Reset selection"
+#~ msgstr "重置選擇"
+
+#~ msgid "Simplify %1%"
+#~ msgstr "簡化 %1%"
+
+#~ msgid "Rename Object"
+#~ msgstr "重新命名物件"
+
+#~ msgid "Rename Part"
+#~ msgstr "重新命名零件"
+
+#~ msgid "Object parts order changed"
+#~ msgstr "物件中的零件順序已改變"
+
+#~ msgid "Object order changed"
+#~ msgstr "物件順序已改變"
+
+#~ msgid "Layer setting added"
+#~ msgstr "層設定已新增"
+
+#~ msgid "Part setting added"
+#~ msgstr "零件設定已新增"
+
+#~ msgid "Object setting added"
+#~ msgstr "物件設定已新增"
+
+#~ msgid "Height range settings added"
+#~ msgstr "高度範圍設定已填加"
+
+#~ msgid "Part settings added"
+#~ msgstr "零件設定已填加"
+
+#~ msgid "Object settings added"
+#~ msgstr "物件設定已填加"
+
+#~ msgid "Load Part"
+#~ msgstr "載入部件"
+
+#~ msgid "Load Modifier"
+#~ msgstr "載入修改器"
+
+#~ msgid "Add primitive"
+#~ msgstr "新增元件"
+
+#~ msgid "Remove support painting"
+#~ msgstr "移除支撐繪製"
+
+#~ msgid "Remove color painting"
+#~ msgstr "移除顏色繪製"
+
+#~ msgid "Delete Settings"
+#~ msgstr "刪除設定"
+
+#~ msgid "Delete part"
+#~ msgstr "刪除零件"
+
+#~ msgid "Merge parts to an object"
+#~ msgstr "合併零件為一個物件"
+
+#~ msgid "Add layers"
+#~ msgstr "新增層"
+
+#~ msgid "Remove selected from list"
+#~ msgstr "從列表中移除所選項"
+
+#~ msgid "Add selected to list"
+#~ msgstr "新增所選項到列表"
+
+#~ msgid "Change part type"
+#~ msgstr "更換零件型別"
+
+#~ msgid "Instances to Separated Objects"
+#~ msgstr "分隔物件的例項"
+
+#~ msgid "Change Filaments"
+#~ msgstr "更換耗材絲"
+
+#~ msgid "Additional Settings"
+#~ msgstr "其他設定"
+
+#~ msgid "Delete Option %s"
+#~ msgstr "刪除選項 %s"
+
+#~ msgid "Change Option %s"
+#~ msgstr "更改選項 %s"
+
+#~ msgid "NOTE:"
+#~ msgstr "注意："
+
+#~ msgid "Retractions"
+#~ msgstr "回抽"
+
+#~ msgid "Shells"
+#~ msgstr "殼"
+
+#~ msgid "ERROR: not enough resources to execute a new job."
+#~ msgstr "錯誤:沒有足夠的資源來執行新作業。"
+
+#~ msgid ""
+#~ "Switching the language will trigger application restart.\n"
+#~ "You will lose content of the plater."
+#~ msgstr ""
+#~ "切換語言將觸發應用程式重新啟動。\n"
+#~ "您將丟失未儲存的內容。"
+
+#~ msgid "Do you want to proceed?"
+#~ msgstr "是否繼續？"
+
+#~ msgid "Convert from imperial units"
+#~ msgstr "從英制轉換"
+
+#~ msgid "Revert conversion from imperial units"
+#~ msgstr "還原英制轉換"
+
+#~ msgid "Convert from meters"
+#~ msgstr "從單位米轉換"
+
+#~ msgid "Revert conversion from meters"
+#~ msgstr "還原單位米轉換"
+
+#~ msgid "Are you sure to delete \"%1%\" printer?"
+#~ msgstr "確定要刪除印表機“%1%”？"
+
+#~ msgid "Delete Physical Printer"
+#~ msgstr "刪除印表機"
+
+#~ msgid "Add physical printer"
+#~ msgstr "新增印表機"
+
+#~ msgid "Edit physical printer"
+#~ msgstr "編輯印表機"
+
+#~ msgid "Delete physical printer"
+#~ msgstr "刪除印表機"
+
+#~ msgid "Fialment Change - Purging volume adjustment"
+#~ msgstr "材料更換 - 沖刷體積調整"
+
+#~ msgid "Here you can adjust required purging volume (mm³) for any given pair of filaments."
+#~ msgstr "您可以在此為任意兩個耗材絲調整所需的沖刷體積（mm³）"
+
+#~ msgid "Fiament changed to"
+#~ msgstr "耗材絲切換到"
+
+#~ msgid "Total purging volume is calculated by summing two values below, depending on which filaments are loaded/unloaded."
+#~ msgstr "總沖刷量透過累加兩個數值得到，依賴於被載入/解除安裝的耗材絲。"
+
+#~ msgid "Volume to purge (mm³) when the filament is being"
+#~ msgstr "沖刷體積 (mm³) 當耗材絲被"
+
+#~ msgid ""
+#~ "Switching to simple settings will discard changes done in the advanced mode!\n"
+#~ "\n"
+#~ "Do you want to proceed?"
+#~ msgstr ""
+#~ "切換到簡單模式會丟棄在高階模式中進行的修改！\n"
+#~ "是否繼續？"
+
+#~ msgid "Please choose an action with \"%1%\" preset after saving?"
+#~ msgstr "請選擇儲存“%1%”後的操作"
+
+#~ msgid "The supplied name is not valid;"
+#~ msgstr "提供的名稱無效；"
+
+#~ msgid "the following suffix is not allowed:"
+#~ msgstr "不允許以下字尾："
+
+#~ msgid "The supplied name is not available."
+#~ msgstr "提供的名稱不可用。"
+
+#~ msgid "Cannot overwrite a system profile."
+#~ msgstr "無法覆蓋系統設定。"
+
+#~ msgid "Preset with name \"%1%\" already exists."
+#~ msgstr "名為 \"%1%\" 的預設已存在。"
+
+#~ msgid "Preset with name \"%1%\" already exists and is incompatible with selected printer."
+#~ msgstr "名為 \"%1%\" 的預設已存在。而且它和所選的印表機不相容。"
+
+#~ msgid "Note: This preset will be replaced after saving"
+#~ msgstr "注意：這個預設會在儲存後被替換"
+
+#~ msgid "The name cannot start with space character."
+#~ msgstr "名稱不能以空格開頭。"
+
+#~ msgid "The name cannot end with space character."
+#~ msgstr "名稱不能以空格結尾。"
+
+#~ msgid ""
+#~ "You have selected physical printer \"%1%\" \n"
+#~ "with related printer preset \"%2%\""
+#~ msgstr ""
+#~ "您已選擇物理印表機 “%1%”\n"
+#~ "以及相關的印表機預設“%2%”"
+
+#~ msgid "What would you like to do with \"%1%\" preset after saving?"
+#~ msgstr "在儲存預設%1%後，您希望對它做什麼操作？"
+
+#~ msgid "Change \"%1%\" to \"%2%\" for this physical printer \"%3%\""
+#~ msgstr "為這臺物理印表機%3%，從“%1%”改變到“%2%”"
+
+#~ msgid "Add \"%1%\" as a next preset for the the physical printer \"%2%\""
+#~ msgstr "為這臺物理列印%2%，把“%1%”增加為下一個預設"
+
+#~ msgid "Just switch to \"%1%\" preset"
+#~ msgstr "僅切換到預設“%1%”"
+
+#~ msgid "Choose one file (3MF/AMF):"
+#~ msgstr "選擇一個檔案 (3MF/AMF):"
+
+#~ msgid "Select coordinate space, in which the transformation will be performed."
+#~ msgstr "選擇座標空間，將在其中執行轉換。"
+
+#~ msgid "Toggle %c axis mirroring"
+#~ msgstr "切換 %c 軸映象"
+
+#~ msgid "You cannot use non-uniform scaling mode for multiple objects/parts selection"
+#~ msgstr "不能對多個物件/零件選擇使用非均勻縮放模式"
+
+#~ msgid ""
+#~ "The currently manipulated object is tilted (rotation angles are not multiples of 90°).\n"
+#~ "Non-uniform scaling of tilted objects is only possible in the World coordinate system,\n"
+#~ "once the rotation is embedded into the object coordinates."
+#~ msgstr ""
+#~ "當前操作的物件是傾斜的(旋轉角度不是 90° 的倍數)。\n"
+#~ "傾斜物件的非均勻縮放只能將旋轉嵌入到物件的座標中後,\n"
+#~ "在世界座標系中進行。"
+
+#~ msgid ""
+#~ "This operation is irreversible.\n"
+#~ "Do you want to proceed?"
+#~ msgstr ""
+#~ "此操作是不可逆的。\n"
+#~ "是否要繼續？"
+
+#~ msgid "Seq."
+#~ msgstr "順序"
+
+#~ msgid "Switch to Settings"
+#~ msgstr "切換頂部設定標籤"
+
+#~ msgid "Print Settings Tab"
+#~ msgstr "列印設定標籤"
+
+#~ msgid "Filament Settings Tab"
+#~ msgstr "耗材絲設定標籤"
+
+#~ msgid "Material Settings Tab"
+#~ msgstr "材料設定標籤"
+
+#~ msgid "Printer Settings Tab"
+#~ msgstr "印表機設定標籤"
+
+#~ msgid "Undo History"
+#~ msgstr "撤銷歷史操作"
+
+#~ msgid "Redo History"
+#~ msgstr "重做歷史操作"
+
+#~ msgid "Undo %1$d Action"
+#~ msgid_plural "Undo %1$d Actions"
+#~ msgstr[0] "撤消 %1$d 操作"
+
+#~ msgid "Redo %1$d Action"
+#~ msgid_plural "Redo %1$d Actions"
+#~ msgstr[0] "重做 %1$d 操作"
+
+#~ msgid "Press %1%left mouse button to enter the exact value"
+#~ msgstr "按%1%滑鼠左鍵輸入精確數值"
+
+#~ msgid "Enable rotations (slow)"
+#~ msgstr "開啟旋轉（慢）"
+
+#~ msgid "Click right mouse button to show auto-orientation options"
+#~ msgstr "點選滑鼠右鍵顯示自動朝向的選項"
+
+#~ msgid "Click right mouse button to show arrangement options"
+#~ msgstr "點選滑鼠右鍵顯示自動整理的選項"
+
+#~ msgid "Slice project"
+#~ msgstr "切片專案"
+
+#~ msgid "Slice Select"
+#~ msgstr "切片選項"
+
+#~ msgid "Print whole project"
+#~ msgstr "列印整個專案"
+
+#~ msgid "print one plate"
+#~ msgstr "列印單盤"
+
+#~ msgid "Print Select"
+#~ msgstr "列印選項"
+
+#~ msgid "Assemble View"
+#~ msgstr "拼裝檢視"
+
+#~ msgid "Click right mouse button to open/close History"
+#~ msgstr "點選滑鼠右鍵開啟/關閉歷史"
+
+#~ msgid "Next Undo action: %1%"
+#~ msgstr "下一個撤消操作： %1%"
+
+#~ msgid "Next Redo action: %1%"
+#~ msgstr "下一個重做操作： %1%"
+
+#~ msgid "Assemble Return"
+#~ msgstr "退出拼裝檢視"
+
+#~ msgid "total Volume:"
+#~ msgstr "總體積："
+
+#~ msgid "Assemble Info"
+#~ msgstr "拼裝體資訊"
+
+#~ msgid "total Size:"
+#~ msgstr "總尺寸："
+
+#~ msgid "Selection-Add from rectangle"
+#~ msgstr "從矩形選擇-新增"
+
+#~ msgid "Selection-Remove from rectangle"
+#~ msgstr "從矩形中選擇-刪除"
+
+#~ msgid "Place on face"
+#~ msgstr "放置在平面"
+
+#~ msgid "Your printer has more extruders than the multi-material painting gizmo supports. For this reason, only the first %1% extruders will be able to be used for painting."
+#~ msgstr "印表機上的材料個數超出了多材料塗色工具支援的上限。因此，僅前%1%個材料會被用作塗色。"
+
+#~ msgid "First color"
+#~ msgstr "第一個顏色"
+
+#~ msgid "Second color"
+#~ msgstr "第二個顏色"
+
+#~ msgid "Painted using: Extruder %1%"
+#~ msgstr "繪製使用：耗材絲 %1%"
+
+#~ msgid "ERROR: Please close all manipulators available from the left toolbar first"
+#~ msgstr "錯誤：請先關閉工具欄中所有的操作工具"
+
+#~ msgid "Gizmo-MoveRotate"
+#~ msgstr "移動旋轉工具"
+
+#~ msgid "Gizmo-Place on Face"
+#~ msgstr "選擇底面"
+
+#~ msgid "You are currently editing SLA support points. Please, apply or discard your changes first."
+#~ msgstr "您正在編輯SLA支撐點。請先應用或捨棄您的修改。"
+
+#~ msgid "Entering Paint-on supports!"
+#~ msgstr "開始支撐繪製！"
+
+#~ msgid "Entering Seam painting!"
+#~ msgstr "開始Z縫繪製！"
+
+#~ msgid "Leaving Paint-on supports"
+#~ msgstr "推出支撐繪製"
+
+#~ msgid "Instance Operations"
+#~ msgstr "例項操作"
+
+#~ msgid "%1% was substituted with %2%"
+#~ msgstr "%1% 被替換為了 %2%"
+
+#~ msgid "Most likely the configuration was produced by a newer version of BambuStudio or by some BambuStudio fork."
+#~ msgstr "這個配置很可能是從更新的BambuStudio版本生成的。"
+
+#~ msgid "The following values were substituted:"
+#~ msgstr "以下數值被替換了："
+
+#~ msgid "Review the substitutions and adjust them if needed."
+#~ msgstr "檢查這些替換，如果需要請修改它們。"
+
+#~ msgid "SLA print settings"
+#~ msgstr "SLA 列印設定"
+
+#~ msgid "Configuration bundle was loaded, however some configuration values were not recognized."
+#~ msgstr "已載入配置集，但部分設定值未被識別。"
+
+#~ msgid "Configuration file \"%1%\" was loaded, however some configuration values were not recognized."
+#~ msgstr "配置檔案 \"%1%\" 已被載入，但是存在一些未識別的配置項。"
+
+#~ msgid ""
+#~ "%s has encountered an error. It was likely caused by running out of memory. If you are sure you have enough RAM on your system, this may also be a bug and we would be glad if you reported it.\n"
+#~ "\n"
+#~ "The application will now terminate."
+#~ msgstr ""
+#~ "%s 遇到錯誤。這可能是由於記憶體不足造成的。如果您確定您的系統上有足夠的記憶體，這可能也是一個軟體錯誤，歡迎你向我們提交問題報告。\n"
+#~ "\n"
+#~ "應用程式現在將終止。"
+
+#~ msgid ""
+#~ "BambuStudio has encountered a localization error. Please report to BambuStudio team, what language was active and in which scenario this issue happened. Thank you.\n"
+#~ "\n"
+#~ "The application will now terminate."
+#~ msgstr ""
+#~ "BambuStudio遇到一個翻譯錯誤。請報告給BmbuStudio團隊，正在啟用的是什麼語言以及在什麼場景下發生的這個問題。謝謝。\n"
+#~ "\n"
+#~ "應用程式將會終止。"
+
+#~ msgid "Internal error: %1%"
+#~ msgstr "內部錯誤：%1%"
+
+#~ msgid "Error parsing BambuStudio config file, it is probably corrupted. Try to manually delete the file to recover from the error. Your user profiles will not be affected."
+#~ msgstr "解析BambStudio配置檔案時遇到錯誤，它可能已損壞。請嘗試手動刪除此檔案以便從錯誤中恢復。你的使用者配置不會收到影響。"
+
+#~ msgid "Error parsing BambuGCodeViewer config file, it is probably corrupted. Try to manually delete the file to recover from the error."
+#~ msgstr "解析BambStudio配置檔案時遇到錯誤，它可能已損壞。請嘗試手動刪除此檔案以便從錯誤中恢復。"
+
+#~ msgid "You are opening %1% version %2%."
+#~ msgstr "您正在開啟 %1% 版本 %2%。"
+
+#~ msgid ""
+#~ "The active configuration was created by <b>%1% %2%</b>,\n"
+#~ "while a newer configuration was found in <b>%3%</b>\n"
+#~ "created by <b>%1% %4%</b>.\n"
+#~ "\n"
+#~ "Shall the newer configuration be imported?\n"
+#~ "If so, your active configuration will be backed up before importing the new configuration."
+#~ msgstr ""
+#~ "當前使用的配置建立於 <b>%1% %2%</b>,\n"
+#~ "但在 <b>%3%</b> 中發現了更新的配置\n"
+#~ "建立於 <b>%1% %4%</b>.\n"
+#~ "\n"
+#~ "是否匯入更新的配置?\n"
+#~ "如果是，您的當前配置會在匯入新配置之前被備份。"
+
+#~ msgid ""
+#~ "An existing configuration was found in <b>%3%</b>\n"
+#~ "created by <b>%1% %2%</b>.\n"
+#~ "\n"
+#~ "Shall this configuration be imported?"
+#~ msgstr ""
+#~ "在 <b>%3%</b> 中找到一個現存的配置\n"
+#~ "建立於 <b>%1% %2%</b>.\n"
+#~ "\n"
+#~ "是否匯入這個配置?"
+
+#~ msgid "Don't import"
+#~ msgstr "不匯入"
+
+#~ msgid ""
+#~ "You are running a 32 bit build of BambuStudio on 64-bit Windows.\n"
+#~ "32 bit build of BambuStudio will likely not be able to utilize all the RAM available in the system.\n"
+#~ "Please download and install a 64 bit build of BambuStudio from https://www.Bambu3d.cz/Bambuslicer/.\n"
+#~ "Do you wish to continue?"
+#~ msgstr ""
+#~ "您正在64位Windows上執行32位版本的BambuStudio。\n"
+#~ "32位版本的BambuStudio可能無法使用系統中的全部記憶體。\n"
+#~ "請從https://www.Bambu3d.cz/Bambuslicer下載並安裝64位版本的BambuStudio。\n"
+#~ "是否繼續？"
+
+#~ msgid "Preparing settings tabs"
+#~ msgstr "正在準備設定頁"
+
+#~ msgid "You have the following presets with saved options for \"Print Host upload\""
+#~ msgstr "您的以下預設中包含未儲存的選項“列印主機上傳”"
+
+#~ msgid ""
+#~ "But since this version of BambuStudio we don't show this information in Printer Settings anymore.\n"
+#~ "Settings will be available in physical printers settings."
+#~ msgstr ""
+#~ "但是從這個BambuStudio版本開始，我們不再在印表機設定中顯示這個資訊了。\n"
+#~ "設定會被放置於物理印表機設定中。"
+
+#~ msgid ""
+#~ "By default new Printer devices will be named as \"Printer N\" during its creation.\n"
+#~ "Note: This name can be changed later from the physical printers settings"
+#~ msgstr ""
+#~ "新的印表機裝置會在建立時被預設命名為“印表機 N”。\n"
+#~ "注意：這個名稱可以後續在物理印表機設定中修改"
+
+#~ msgid "Recreating"
+#~ msgstr "重造"
+
+#~ msgid "Loading of current presets"
+#~ msgstr "載入當前預設"
+
+#~ msgid "Loading of a mode view"
+#~ msgstr "載入模式檢視"
+
+#~ msgid "Choose one or more files (STL/STEP/OBJ/AMF/3MF):"
+#~ msgstr "選擇一個或多個檔案（STL/STEP/OBJ/AMF/3MF）"
+
+#~ msgid "Choose one file (GCODE/.GCO/.G/.ngc/NGC):"
+#~ msgstr "選擇一個檔案（GCODE/.GCO）"
+
+#~ msgid "modified"
+#~ msgstr "修改"
+
+#~ msgid "&Configuration Snapshots"
+#~ msgstr "&配置快照"
+
+#~ msgid "Inspect / activate configuration snapshots"
+#~ msgstr "檢查/啟用配置快照"
+
+#~ msgid "Take Configuration &Snapshot"
+#~ msgstr "儲存配置 &快照"
+
+#~ msgid "Capture a configuration snapshot"
+#~ msgstr "捕獲配置快照"
+
+#~ msgid "Desktop Integration"
+#~ msgstr "桌面整合"
+
+#~ msgid "Simple View Mode"
+#~ msgstr "簡單介面模式"
+
+#~ msgid "Advanced View Mode"
+#~ msgstr "高階介面模式"
+
+#~ msgid "%s View Mode"
+#~ msgstr "%s 檢視模式"
+
+#~ msgid "Flash Printer &Firmware"
+#~ msgstr "燒錄印表機韌體"
+
+#~ msgid "Upload a firmware image into an Arduino based printer"
+#~ msgstr "將韌體映象上傳到基於 arduino 的印表機"
+
+#~ msgid "Taking a configuration snapshot"
+#~ msgstr "進行配置快照"
+
+#~ msgid "Some presets are modified and the unsaved changes will not be captured by the configuration snapshot."
+#~ msgstr "一些預設已被修改，未儲存的修改將不會被配置快照捕捉。"
+
+#~ msgid "Snapshot name"
+#~ msgstr "快照名稱"
+
+#~ msgid "The preset modifications are successfully saved"
+#~ msgid_plural "The presets modifications are successfully saved"
+#~ msgstr[0] "预设的修改已被保存"
+
+#~ msgid "For new project all modifications will be reseted"
+#~ msgstr "對新專案，所有修改都被重置"
+
+#~ msgid "It's impossible to print multi-part object(s) with SLA technology."
+#~ msgstr "無法使用 SLA 技術列印多部分物件。"
+
+#~ msgid "Configuration is editing from ConfigWizard"
+#~ msgstr "正在從配置嚮導裡編輯配置"
+
+#~ msgid "Pad and Support"
+#~ msgstr "墊和支撐"
+
+#~ msgid "Add negative volume"
+#~ msgstr "增加負零件"
+
+#~ msgid "Select showing settings"
+#~ msgstr "選擇顯示設定"
+
+#~ msgid "Remove the selected object"
+#~ msgstr "刪除所選物件"
+
+#~ msgid "Slab"
+#~ msgstr "板坯"
+
+#~ msgid "Set as a Separated Object"
+#~ msgstr "設定為獨立的物件"
+
+#~ msgid "Set as a Separated Objects"
+#~ msgstr "設定為獨立的物件"
+
+#~ msgid "Fix through the Netfabb"
+#~ msgstr "透過Netfabb修復"
+
+#~ msgid "Change extruder"
+#~ msgstr "更換擠出機"
+
+#~ msgid "Set extruder for selected items"
+#~ msgstr "為選定的項設定擠出機"
+
+#~ msgid "Merge objects to the one multipart object"
+#~ msgstr "合併多個物件為一個多零件物件"
+
+#~ msgid "Merge objects to the one single object"
+#~ msgstr "合併多個物件為一個單零件物件"
+
+#~ msgid "Merge parts to the one single part"
+#~ msgstr "合併多個零件為單個零件"
+
+#~ msgid "Mirror the selected object along the X axis"
+#~ msgstr "沿 X 軸映象所選物件"
+
+#~ msgid "Mirror the selected object along the Y axis"
+#~ msgstr "沿 Y 軸映象所選物件"
+
+#~ msgid "Mirror the selected object along the Z axis"
+#~ msgstr "沿 Z 軸映象所選物件"
+
+#~ msgid "Mirror the selected object"
+#~ msgstr "映象所選物件"
+
+#~ msgid "Add Shape"
+#~ msgstr "新增形狀"
+
+#~ msgid "Split the selected object into individual objects"
+#~ msgstr "拆分所選物件位多個獨立物件"
+
+#~ msgid "Split the selected object into individual parts"
+#~ msgstr "拆分所選物件為多個獨立零件"
+
+#~ msgid "Optimize the rotation of the object for better print results."
+#~ msgstr "最佳化物件的旋轉，以取得更好的列印效果。"
+
+#~ msgid "Input Clone Number"
+#~ msgstr "輸入克隆數量"
+
+#~ msgid "Edit each object print parameters"
+#~ msgstr "編輯每個物件的工藝引數"
+
+#~ msgid "Start at height"
+#~ msgstr "開始高度"
+
+#~ msgid "Stop at height"
+#~ msgstr "停止高度"
+
+#~ msgid "Remove layer range"
+#~ msgstr "移除圖層範圍"
+
+#~ msgid "Add layer range"
+#~ msgstr "新增圖層範圍"
+
+#~ msgid "No errors detected"
+#~ msgstr "未檢測到錯誤"
+
+#~ msgid "Auto-repaired %1$d error"
+#~ msgid_plural "Auto-repaired %1$d errors"
+#~ msgstr[0] "已自动修复 %1$d 个错误"
+
+#~ msgid "%1$d degenerate facet"
+#~ msgid_plural "%1$d degenerate facets"
+#~ msgstr[0] "%1$d 个退化面片"
+
+#~ msgid "%1$d edge fixed"
+#~ msgid_plural "%1$d edges fixed"
+#~ msgstr[0] "%1$d 条边已修复"
+
+#~ msgid "%1$d facet removed"
+#~ msgid_plural "%1$d facets removed"
+#~ msgstr[0] "%1$d 个面已移除"
+
+#~ msgid "%1$d facet reversed"
+#~ msgid_plural "%1$d facets reversed"
+#~ msgstr[0] "%1$d 个面已反向"
+
+#~ msgid "%1$d backward edge"
+#~ msgid_plural "%1$d backward edges"
+#~ msgstr[0] "%1$d 条朝后的边"
+
+#~ msgid "Right button click the icon to fix STL through Netfabb"
+#~ msgstr "右按鈕單擊圖示, 透過 Netfabb 修復 STL"
+
+#~ msgid "Click the icon to drop the object settings"
+#~ msgstr "點選此圖示以捨棄物件的設定"
+
+#~ msgid "Click the icon to drop the object printable property"
+#~ msgstr "點選此圖示以捨棄物件的可列印屬性"
+
+#~ msgid "Rename Sub-object"
+#~ msgstr "重新命名子物件"
+
+#~ msgid "Volumes in Object reordered"
+#~ msgstr "重新排序的物件中的空間"
+
+#~ msgid "Object reordered"
+#~ msgstr "物件重新排序"
+
+#~ msgid "Add Settings for Layers"
+#~ msgstr "新增圖層設定"
+
+#~ msgid "Add Settings for Sub-object"
+#~ msgstr "新增子物件的設定"
+
+#~ msgid "Add Settings for Object"
+#~ msgstr "新增物件的設定"
+
+#~ msgid "Add Settings Bundle for Height range"
+#~ msgstr "為高度範圍新增配置組"
+
+#~ msgid "Add Settings Bundle for Sub-object"
+#~ msgstr "為子物件新增配置組"
+
+#~ msgid "Add Settings Bundle for Object"
+#~ msgstr "為物件新增配置組"
+
+#~ msgid "Add Generic Subobject"
+#~ msgstr "新增通用子物件"
+
+#~ msgid "Add Shape from Gallery"
+#~ msgstr "從倉庫新增形狀"
+
+#~ msgid "Add Shapes from Gallery"
+#~ msgstr "從倉庫新增形狀"
+
+#~ msgid "Remove paint-on supports"
+#~ msgstr "移除支撐繪製"
+
+#~ msgid "Remove paint-on seam"
+#~ msgstr "移除Z縫繪製"
+
+#~ msgid "Remove Multi Material painting"
+#~ msgstr "移除多材料繪製"
+
+#~ msgid "Shift objects to bed"
+#~ msgstr "移動物件到熱床"
+
+#~ msgid "Delete All Instances from Object"
+#~ msgstr "從物件中刪除所有例項"
+
+#~ msgid "Delete Height Range"
+#~ msgstr "刪除高度範圍"
+
+#~ msgid "From Object List You can't delete the last solid part from object."
+#~ msgstr "從物件列表中無法從物件中刪除最後一個實體零件。"
+
+#~ msgid "Delete Subobject"
+#~ msgstr "刪除子物件"
+
+#~ msgid "Last instance of an object cannot be deleted."
+#~ msgstr "無法刪除物件的最後一個例項。"
+
+#~ msgid "Delete Instance"
+#~ msgstr "刪除例項"
+
+#~ msgid "The selected object couldn't be split because it contains only one part."
+#~ msgstr "無法拆分所選物件，因為它僅包含一個部件。"
+
+#~ msgid "Split to Parts"
+#~ msgstr "拆分為零件"
+
+#~ msgid "Merge all parts to the one single object"
+#~ msgstr "合併所有零件為一個物件"
+
+#~ msgid "Add Layers"
+#~ msgstr "新增圖層"
+
+#~ msgid "Delete Selected Item"
+#~ msgstr "刪除所選專案"
+
+#~ msgid "Delete Selected"
+#~ msgstr "刪除所選"
+
+#~ msgid "Add Height Range"
+#~ msgstr "新增高度範圍"
+
+#~ msgid ""
+#~ "Cannot insert a new layer range after the current layer range.\n"
+#~ "The next layer range is too thin to be split to two\n"
+#~ "without violating the minimum layer height."
+#~ msgstr ""
+#~ "無法在當前圖層範圍之後插入新的圖層範圍。\n"
+#~ "下一個圖層範圍太小，以至於受到最小層高的限制而無法分裂成兩個。"
+
+#~ msgid ""
+#~ "Cannot insert a new layer range between the current and the next layer range.\n"
+#~ "The gap between the current layer range and the next layer range\n"
+#~ "is thinner than the minimum layer height allowed."
+#~ msgstr ""
+#~ "無法在當前圖層範圍和下一個圖層範圍的中間插入新的圖層範圍。\n"
+#~ "當前圖層範圍和下一個圖層範圍之間的間隙小於允許的最小層高。"
+
+#~ msgid ""
+#~ "Cannot insert a new layer range after the current layer range.\n"
+#~ "Current layer range overlaps with the next layer range."
+#~ msgstr ""
+#~ "無法在當前圖層範圍之後插入新的圖層範圍。\n"
+#~ "當前圖層範圍和下一個圖層範圍有重疊。"
+
+#~ msgid "Edit Height Range"
+#~ msgstr "編輯高度範圍"
+
+#~ msgid "Selection-Remove from list!"
+#~ msgstr "選擇-從列表中去除！"
+
+#~ msgid "Selection-Add from list!"
+#~ msgstr "選擇-新增到列表！"
+
+#~ msgid "Object or Instance"
+#~ msgstr "物件或例項"
+
+#~ msgid "Unsupported selection"
+#~ msgstr "不支援的選擇"
+
+#~ msgid "You started your selection with %s Item."
+#~ msgstr "你從 %s 項開始選擇。"
+
+#~ msgid "In this mode you can select only other %s Items%s"
+#~ msgstr "在此模式下，您只能選擇其他 %s 項%s"
+
+#~ msgid "of a current Object"
+#~ msgstr "當前物件的"
+
+#~ msgid "Negative Volume"
+#~ msgstr "負零件"
+
+#~ msgid "Select type of part"
+#~ msgstr "選擇零件型別"
+
+#~ msgid "Change Part Type"
+#~ msgstr "更改零件型別"
+
+#~ msgid "Repairing model"
+#~ msgstr "修復模型"
+
+#~ msgid "Fix through NetFabb"
+#~ msgstr "透過NetFabb修復"
+
+#~ msgid "Fixing through NetFabb"
+#~ msgstr "正在使用NetFabb修復"
+
+#~ msgid "The following model was repaired successfully"
+#~ msgid_plural "The following models were repaired successfully"
+#~ msgstr[0] "以下模型已被成功修复"
+
+#~ msgid "Folowing model repair failed"
+#~ msgid_plural "Folowing models repair failed"
+#~ msgstr[0] "以下模型修复失败"
+
+#~ msgid "Set Printable group"
+#~ msgstr "設定可列印組"
+
+#~ msgid "Set Unprintable group"
+#~ msgstr "設定不可列印組"
+
+#~ msgid "Set Printable Instance"
+#~ msgstr "設定可列印例項"
+
+#~ msgid "Set Unprintable Instance"
+#~ msgstr "設定不可列印的例項"
+
+#~ msgid "Higher print quality versus higher print speed."
+#~ msgstr "高精度 vs 高速度。"
+
+#~ msgid "Variable layer height - Manual edit"
+#~ msgstr "可變層高 - 手動編輯"
+
+#~ msgid "Variable layer height - Reset"
+#~ msgstr "可變層高 - 重置"
+
+#~ msgid "Variable layer height - Adaptive"
+#~ msgstr "可變層高 - 自適應"
+
+#~ msgid "Variable layer height - Smooth all"
+#~ msgstr "可變層高 - 平滑"
+
+#~ msgid "Remove variable layer height"
+#~ msgstr "移除可變層高"
+
+#~ msgid "%s doesn't support percentage"
+#~ msgstr "%s 不支援百分比"
+
+#~ msgid "Input value is out of range"
+#~ msgstr "輸入值超出範圍外"
+
+#~ msgid ""
+#~ "Do you mean %s%% instead of %s %s?\n"
+#~ "Select YES if you want to change this value to %s%%, \n"
+#~ "or NO if you are sure that %s %s is a correct value."
+#~ msgstr ""
+#~ "您指的是 %s%% 而不是 %s %s？\n"
+#~ "如果要將此值更改為 %s%%,請選擇\"是\",\n"
+#~ "或 否,如果您確定 %s %s 是一個正確的值。"
+
+#~ msgid "Switch to the %s mode"
+#~ msgstr "切換到%s模式"
+
+#~ msgid "Current mode is %s"
+#~ msgstr "當前模式是%s"
+
+#~ msgctxt "Mode"
+#~ msgid "Advanced"
+#~ msgstr "高階"
+
+#~ msgid "Quick Add Settings (%s)"
+#~ msgstr "快速新增設定 （%s）"
+
+#~ msgid "Add instance"
+#~ msgstr "新增例項"
+
+#~ msgid "Add one more instance of the selected object"
+#~ msgstr "再新增一個選定物件的例項"
+
+#~ msgid "Remove instance"
+#~ msgstr "刪除例項"
+
+#~ msgid "Remove one instance of the selected object"
+#~ msgstr "刪除所選物件的一個例項"
+
+#~ msgid "Set number of instances"
+#~ msgstr "設定例項數"
+
+#~ msgid "Change the number of instances of the selected object"
+#~ msgstr "更改所選物件的例項數"
+
+#~ msgid "Start the application"
+#~ msgstr "啟動應用程式"


### PR DESCRIPTION
Hello, thank you for the great work on BambuStudio!

I noticed that there is currently no Traditional Chinese (zh_TW) translation available. As a user from Taiwan, I would love to contribute a zh_TW translation to help more Traditional Chinese users.

- Converted from `zh_CN` using OpenCC `s2twp` (Simplified to Traditional with Taiwan standard phrases)
- Contains 4,997 translated entries covering the full UI
- Taiwan-specific phrasing is used (e.g. 列印 instead of 打印, 支援 instead of 支持, 噴嘴 instead of 喷嘴)

I hope this translation can be helpful to the community. Please let me know if any changes are needed. Thank you!