### PR TITLE
Fix CLI Preview Generation/Add EGL headless rendering support for CLI mode

### DIFF
--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -171,10 +171,13 @@ then
     then
         rm -fr build
     fi
-    BUILD_ARGS=""
+    # Preserve BUILD_ARGS from environment if set
+    if [[ -z "${BUILD_ARGS}" ]]; then
+        BUILD_ARGS=""
+    fi
     if [[ -n "${FOUND_GTK3_DEV}" ]]
     then
-        BUILD_ARGS="-DSLIC3R_GTK=3"
+        BUILD_ARGS="${BUILD_ARGS} -DSLIC3R_GTK=3"
     fi
     if [[ -n "${BUILD_DEBUG}" ]]
     then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,8 +520,8 @@ find_package(PNG REQUIRED)
 set(OpenGL_GL_PREFERENCE "LEGACY")
 find_package(OpenGL REQUIRED)
 
-# On Linux, also link OSMesa for headless rendering
-if(UNIX AND NOT APPLE)
+# On Linux, link OSMesa for headless rendering if enabled
+if(SLIC3R_HEADLESS AND UNIX AND NOT APPLE)
     find_library(OSMESA_LIBRARY OSMesa)
     if(OSMESA_LIBRARY)
         message(STATUS "Found OSMesa: ${OSMESA_LIBRARY}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,13 @@ option(SLIC3R_MSVC_COMPILE_PARALLEL "Compile on Visual Studio in parallel" 1)
 option(SLIC3R_MSVC_PDB          "Generate PDB files on MSVC in Release mode" 1)
 option(SLIC3R_PERL_XS           "Compile XS Perl module and enable Perl unit and integration tests" 0)
 option(SLIC3R_ASAN              "Enable ASan on Clang and GCC" 0)
+option(SLIC3R_HEADLESS          "Enable EGL headless rendering support for CLI mode (Linux only)" OFF)
 # If SLIC3R_FHS is 1 -> SLIC3R_DESKTOP_INTEGRATION is always 0, othrewise variable.
 CMAKE_DEPENDENT_OPTION(SLIC3R_DESKTOP_INTEGRATION "Allow performing desktop integration during runtime" 1 "NOT SLIC3R_FHS" 0)
+
+if(SLIC3R_HEADLESS)
+    add_definitions(-DENABLE_HEADLESS_RENDERING_MODE)
+endif()
 
 set(OPENVDB_FIND_MODULE_PATH "" CACHE PATH "Path to OpenVDB installation's find modules.")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,6 +515,17 @@ find_package(PNG REQUIRED)
 set(OpenGL_GL_PREFERENCE "LEGACY")
 find_package(OpenGL REQUIRED)
 
+# On Linux, also link OSMesa for headless rendering
+if(UNIX AND NOT APPLE)
+    find_library(OSMESA_LIBRARY OSMesa)
+    if(OSMESA_LIBRARY)
+        message(STATUS "Found OSMesa: ${OSMESA_LIBRARY}")
+        list(APPEND OpenGL_LIBRARIES ${OSMESA_LIBRARY})
+    else()
+        message(WARNING "OSMesa library not found - headless rendering may not work")
+    endif()
+endif()
+
 # Find glew or use bundled version
 if (SLIC3R_STATIC AND NOT SLIC3R_STATIC_EXCLUDE_GLEW)
     set(GLEW_USE_STATIC_LIBS ON)

--- a/DockerEntrypoint.sh
+++ b/DockerEntrypoint.sh
@@ -76,7 +76,16 @@ if [ ! -d "$HOME/.config" ]; then
     mkdir -p "$HOME/.config"
 fi
 
+# Start Xvfb for EGL to use as display backend
+Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+sleep 1
+
+# Set XDG_RUNTIME_DIR
+export XDG_RUNTIME_DIR=/tmp/runtime-$EXEC_USER
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+
 # Using su $USER -c will pass all the important ENV args when Bamboo Studio starts in a different shell
 # Continue with Bambu Studio using correct user, passing all arguments
-exec su "$EXEC_USER" -s /bin/bash -c 'export LD_LIBRARY_PATH=/BambuStudio/build/package/bin:$LD_LIBRARY_PATH; export LIBGL_ALWAYS_SOFTWARE=1; export GALLIUM_DRIVER=llvmpipe; export __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json; exec /BambuStudio/build/package/bin/bambu-studio "$@"' -- bash "$@"
+exec su "$EXEC_USER" -s /bin/bash -c 'export DISPLAY=:99; export XDG_RUNTIME_DIR=/tmp/runtime-'"$EXEC_USER"'; export LD_LIBRARY_PATH=/BambuStudio/build/package/bin:$LD_LIBRARY_PATH; export LIBGL_ALWAYS_SOFTWARE=1; export GALLIUM_DRIVER=llvmpipe; export MESA_LOADER_DRIVER_OVERRIDE=swrast; export __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json; exec /BambuStudio/build/package/bin/bambu-studio "$@"' -- bash "$@"
 

--- a/DockerEntrypoint.sh
+++ b/DockerEntrypoint.sh
@@ -76,6 +76,7 @@ if [ ! -d "$HOME/.config" ]; then
     mkdir -p "$HOME/.config"
 fi
 
-# Using su $USER -c will retain all the important ENV args when Bamboo Studio starts in a different shell
+# Using su $USER -c will pass all the important ENV args when Bamboo Studio starts in a different shell
 # Continue with Bambu Studio using correct user, passing all arguments
-exec su "$EXEC_USER" -c "/BambuStudio/build/package/bin/bambu-studio $*"
+exec su "$EXEC_USER" -s /bin/bash -c 'export LD_LIBRARY_PATH=/BambuStudio/build/package/bin:$LD_LIBRARY_PATH; export LIBGL_ALWAYS_SOFTWARE=1; export GALLIUM_DRIVER=llvmpipe; export __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json; exec /BambuStudio/build/package/bin/bambu-studio "$@"' -- bash "$@"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install  -y \
     extra-cmake-modules \
     file \
     git \
+    ffmpeg \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-libav \
     libcairo2-dev \
@@ -48,6 +49,11 @@ RUN apt-get update && apt-get install  -y \
     wayland-protocols \
     libwebkit2gtk-4.1-dev \
     wget 
+
+#temp fix for 24.10 dependency
+RUN echo 'deb http://gb.archive.ubuntu.com/ubuntu jammy main' >> /etc/apt/sources.list
+
+RUN apt-get update && apt-get install -y libwebkit2gtk-4.0-dev
 
 # Change your locale here if you want.  See the output
 # of `locale -a` to pick the correct string formatting.
@@ -123,6 +129,11 @@ SHELL ["/bin/bash", "-l", "-c"]
 
 # Point FFMPEG Library search to the binary built upon BambuStudio build time
 ENV LD_LIBRARY_PATH=/BambuStudio/build/package/bin
+
+# Force software rendering in the container to avoid GPU driver issues.  This is needed for the preview to work in CLI mode, and also prevents potential GPU driver issues when running the GUI version in a container.
+ENV LIBGL_ALWAYS_SOFTWARE=1
+ENV GALLIUM_DRIVER=llvmpipe
+ENV __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json
 
 # Using an entrypoint instead of CMD because the binary
 # accepts several command line arguments.

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,11 +50,6 @@ RUN apt-get update && apt-get install  -y \
     libwebkit2gtk-4.1-dev \
     wget 
 
-#temp fix for 24.10 dependency
-RUN echo 'deb http://gb.archive.ubuntu.com/ubuntu jammy main' >> /etc/apt/sources.list
-
-RUN apt-get update && apt-get install -y libwebkit2gtk-4.0-dev
-
 # Change your locale here if you want.  See the output
 # of `locale -a` to pick the correct string formatting.
 ENV LC_ALL=en_US.utf8
@@ -116,7 +111,8 @@ USER $USER
 # Build dependencies in ./deps
 RUN ./BuildLinux.sh -d
 
-# Build slic3r
+# Build slic3r with headless rendering enabled
+ENV BUILD_ARGS="-DSLIC3R_HEADLESS=ON"
 RUN ./BuildLinux.sh -s
 
 # Build AppImage

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,7 @@ ENV LD_LIBRARY_PATH=/BambuStudio/build/package/bin
 # Force software rendering in the container to avoid GPU driver issues.  This is needed for the preview to work in CLI mode, and also prevents potential GPU driver issues when running the GUI version in a container.
 ENV LIBGL_ALWAYS_SOFTWARE=1
 ENV GALLIUM_DRIVER=llvmpipe
+ENV MESA_LOADER_DRIVER_OVERRIDE=swrast
 ENV __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json
 
 # Using an entrypoint instead of CMD because the binary

--- a/src/BambuStudio.cpp
+++ b/src/BambuStudio.cpp
@@ -85,6 +85,11 @@ using namespace nlohmann;
 #include "slic3r/GUI/GuiColor.hpp"
 #include <GLFW/glfw3.h>
 
+#ifdef __linux__
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#endif
+
 #ifdef __WXGTK__
 #include <X11/Xlib.h>
 #endif
@@ -5885,6 +5890,81 @@ int CLI::run(int argc, char **argv)
         glfwGetVersion(&gl_major, &gl_minor, &gl_verbos);
         BOOST_LOG_TRIVIAL(info) << boost::format("opengl version %1%.%2%.%3%")%gl_major %gl_minor %gl_verbos;
 
+#ifdef __linux__
+        // Use EGL for headless rendering in CLI mode (Docker/server environments)
+        EGLDisplay egl_display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+        if (egl_display == EGL_NO_DISPLAY) {
+            BOOST_LOG_TRIVIAL(error) << "Failed to get EGL display";
+            return false;
+        }
+        
+        EGLint major, minor;
+        if (!eglInitialize(egl_display, &major, &minor)) {
+            BOOST_LOG_TRIVIAL(error) << "Failed to initialize EGL";
+            return false;
+        }
+        
+        EGLint config_attribs[] = {
+            EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+            EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+            EGL_RED_SIZE, 8,
+            EGL_GREEN_SIZE, 8,
+            EGL_BLUE_SIZE, 8,
+            EGL_ALPHA_SIZE, 8,
+            EGL_DEPTH_SIZE, 24,
+            EGL_NONE
+        };
+        
+        EGLConfig egl_config;
+        EGLint num_configs;
+        if (!eglChooseConfig(egl_display, config_attribs, &egl_config, 1, &num_configs) || num_configs == 0) {
+            BOOST_LOG_TRIVIAL(error) << "Failed to choose EGL config";
+            eglTerminate(egl_display);
+            return false;
+        }
+        
+        if (!eglBindAPI(EGL_OPENGL_API)) {
+            BOOST_LOG_TRIVIAL(error) << "Failed to bind OpenGL API";
+            eglTerminate(egl_display);
+            return false;
+        }
+        
+        EGLint context_attribs[] = {
+            EGL_CONTEXT_MAJOR_VERSION, 3,
+            EGL_CONTEXT_MINOR_VERSION, 3,
+            EGL_NONE
+        };
+        
+        EGLContext egl_context = eglCreateContext(egl_display, egl_config, EGL_NO_CONTEXT, context_attribs);
+        if (egl_context == EGL_NO_CONTEXT) {
+            BOOST_LOG_TRIVIAL(error) << "Failed to create EGL context";
+            eglTerminate(egl_display);
+            return false;
+        }
+        
+        EGLint pbuffer_attribs[] = {
+            EGL_WIDTH, 512,
+            EGL_HEIGHT, 512,
+            EGL_NONE
+        };
+        
+        EGLSurface egl_surface = eglCreatePbufferSurface(egl_display, egl_config, pbuffer_attribs);
+        if (egl_surface == EGL_NO_SURFACE) {
+            BOOST_LOG_TRIVIAL(error) << "Failed to create EGL pbuffer surface";
+            eglDestroyContext(egl_display, egl_context);
+            eglTerminate(egl_display);
+            return false;
+        }
+        
+        if (!eglMakeCurrent(egl_display, egl_surface, egl_surface, egl_context)) {
+            BOOST_LOG_TRIVIAL(error) << "Failed to make EGL context current";
+            eglDestroySurface(egl_display, egl_surface);
+            eglDestroyContext(egl_display, egl_context);
+            eglTerminate(egl_display);
+            return false;
+        }
+#else
+        // Use GLFW for Windows/Mac CLI mode
         glfwSetErrorCallback(glfw_callback);
         int ret = glfwInit();
         if (ret == GLFW_FALSE) {
@@ -5893,7 +5973,6 @@ int CLI::run(int argc, char **argv)
             return false;
         }
         else {
-            BOOST_LOG_TRIVIAL(info) << "glfwInit Success."<< std::endl;
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, gl_major);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, gl_minor);
             glfwWindowHint(GLFW_RED_BITS, 8);
@@ -5901,17 +5980,11 @@ int CLI::run(int argc, char **argv)
             glfwWindowHint(GLFW_BLUE_BITS, 8);
             glfwWindowHint(GLFW_ALPHA_BITS, 8);
             glfwWindowHint(GLFW_VISIBLE, false);
-            //glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-            //glfwDisable(GLFW_AUTO_POLL_EVENTS);
 #ifdef __WXMAC__
             glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
             glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 #else
             glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_COMPAT_PROFILE);
-#endif
-
-#ifdef __linux__
-            glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_OSMESA_CONTEXT_API);
 #endif
 
             GLFWwindow* window = glfwCreateWindow(640, 480, "base_window", NULL, NULL);
@@ -5923,6 +5996,7 @@ int CLI::run(int argc, char **argv)
             else
                 glfwMakeContextCurrent(window);
         }
+#endif
 
         bool gl_valid = p_opengl_mgr->init_gl(false);
         if (!gl_valid) {

--- a/src/BambuStudio.cpp
+++ b/src/BambuStudio.cpp
@@ -85,7 +85,7 @@ using namespace nlohmann;
 #include "slic3r/GUI/GuiColor.hpp"
 #include <GLFW/glfw3.h>
 
-#ifdef __linux__
+#ifdef ENABLE_HEADLESS_RENDERING_MODE
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #endif

--- a/src/BambuStudio.cpp
+++ b/src/BambuStudio.cpp
@@ -5890,7 +5890,7 @@ int CLI::run(int argc, char **argv)
         glfwGetVersion(&gl_major, &gl_minor, &gl_verbos);
         BOOST_LOG_TRIVIAL(info) << boost::format("opengl version %1%.%2%.%3%")%gl_major %gl_minor %gl_verbos;
 
-#ifdef __linux__
+#ifdef ENABLE_HEADLESS_RENDERING_MODE
         // Use EGL for headless rendering in CLI mode (Docker/server environments)
         EGLDisplay egl_display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
         if (egl_display == EGL_NO_DISPLAY) {

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -712,12 +712,16 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     find_package(CURL REQUIRED)
     target_link_libraries(libslic3r_gui ${DBUS_LIBRARIES})
     target_link_libraries(libslic3r_gui
-        OpenGL::EGL
         ${WAYLAND_SERVER_LIBRARIES}
         ${WAYLAND_EGL_LIBRARIES}
         ${WAYLAND_CLIENT_LIBRARIES}
         ${CURL_LIBRARIES}
     )
+    
+    # Link EGL for headless rendering if enabled
+    if(SLIC3R_HEADLESS)
+        target_link_libraries(libslic3r_gui OpenGL::EGL)
+    endif()
 elseif (APPLE)
     target_link_libraries(libslic3r_gui ${DISKARBITRATION_LIBRARY})
 endif()

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -687,17 +687,30 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SLIC3R_GUI_SOURCES})
 
 encoding_check(libslic3r_gui)
 
-target_link_libraries(libslic3r_gui libslic3r cereal imgui imguizmo minilzo GLEW::GLEW OpenGL::GL hidapi ${wxWidgets_LIBRARIES} glfw libcurl OpenSSL::SSL OpenSSL::Crypto)
-#target_link_libraries(libslic3r_gui libslic3r cereal imgui imguizmo minilzo GLEW::GLEW OpenGL::GL hidapi libcurl OpenSSL::SSL OpenSSL::Crypto ${wxWidgets_LIBRARIES} glfw)
+# On Linux, use OSMesa instead of OpenGL::GL for headless rendering
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    # Link OSMesa FIRST before GLEW to ensure OSMesa symbols are used
+    find_library(OSMESA_LIB OSMesa REQUIRED)
+    target_link_libraries(libslic3r_gui libslic3r cereal imgui imguizmo minilzo ${OSMESA_LIB} GLEW::GLEW hidapi ${wxWidgets_LIBRARIES} glfw libcurl OpenSSL::SSL OpenSSL::Crypto)
+else()
+    target_link_libraries(libslic3r_gui libslic3r cereal imgui imguizmo minilzo GLEW::GLEW OpenGL::GL hidapi ${wxWidgets_LIBRARIES} glfw libcurl OpenSSL::SSL OpenSSL::Crypto)
+endif()
 
 if (MSVC)
     target_link_libraries(libslic3r_gui Setupapi.lib)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    # Add OSMesa for headless rendering support - force link with --no-as-needed
+    find_library(OSMESA_LIBRARY OSMesa)
+    if(OSMESA_LIBRARY)
+        message(STATUS "Linking OSMesa for headless rendering: ${OSMESA_LIBRARY}")
+        target_link_libraries(libslic3r_gui "-Wl,--no-as-needed" ${OSMESA_LIBRARY} "-Wl,--as-needed")
+    endif()
+    
     FIND_LIBRARY(WAYLAND_SERVER_LIBRARIES NAMES wayland-server)
     FIND_LIBRARY(WAYLAND_EGL_LIBRARIES    NAMES wayland-egl)
     FIND_LIBRARY(WAYLAND_CLIENT_LIBRARIES NAMES wayland-client)
     find_package(CURL REQUIRED)
-    target_link_libraries(libslic3r_gui ${DBUS_LIBRARIES} OSMesa)
+    target_link_libraries(libslic3r_gui ${DBUS_LIBRARIES})
     target_link_libraries(libslic3r_gui
         OpenGL::EGL
         ${WAYLAND_SERVER_LIBRARIES}

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -699,13 +699,6 @@ endif()
 if (MSVC)
     target_link_libraries(libslic3r_gui Setupapi.lib)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    # Add OSMesa for headless rendering support - force link with --no-as-needed
-    find_library(OSMESA_LIBRARY OSMesa)
-    if(OSMESA_LIBRARY)
-        message(STATUS "Linking OSMesa for headless rendering: ${OSMESA_LIBRARY}")
-        target_link_libraries(libslic3r_gui "-Wl,--no-as-needed" ${OSMESA_LIBRARY} "-Wl,--as-needed")
-    endif()
-    
     FIND_LIBRARY(WAYLAND_SERVER_LIBRARIES NAMES wayland-server)
     FIND_LIBRARY(WAYLAND_EGL_LIBRARIES    NAMES wayland-egl)
     FIND_LIBRARY(WAYLAND_CLIENT_LIBRARIES NAMES wayland-client)

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -687,14 +687,7 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SLIC3R_GUI_SOURCES})
 
 encoding_check(libslic3r_gui)
 
-# On Linux, use OSMesa instead of OpenGL::GL for headless rendering
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    # Link OSMesa FIRST before GLEW to ensure OSMesa symbols are used
-    find_library(OSMESA_LIB OSMesa REQUIRED)
-    target_link_libraries(libslic3r_gui libslic3r cereal imgui imguizmo minilzo ${OSMESA_LIB} GLEW::GLEW hidapi ${wxWidgets_LIBRARIES} glfw libcurl OpenSSL::SSL OpenSSL::Crypto)
-else()
-    target_link_libraries(libslic3r_gui libslic3r cereal imgui imguizmo minilzo GLEW::GLEW OpenGL::GL hidapi ${wxWidgets_LIBRARIES} glfw libcurl OpenSSL::SSL OpenSSL::Crypto)
-endif()
+target_link_libraries(libslic3r_gui libslic3r cereal imgui imguizmo minilzo GLEW::GLEW OpenGL::GL hidapi ${wxWidgets_LIBRARIES} glfw libcurl OpenSSL::SSL OpenSSL::Crypto)
 
 if (MSVC)
     target_link_libraries(libslic3r_gui Setupapi.lib)

--- a/src/slic3r/GUI/OpenGLManager.cpp
+++ b/src/slic3r/GUI/OpenGLManager.cpp
@@ -11,7 +11,7 @@
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
 
-#ifdef __linux__
+#ifdef ENABLE_HEADLESS_RENDERING_MODE
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #endif


### PR DESCRIPTION
A proposed fix for issue #7918 

Use EGL headless rendering to generate 3mf (or CLI requested export) preview image. This change should only effect CLI mode. Its especially useful for when running Bambu Studio CLI purely headlessly, like in a Docker Container as a service.
@lanewei120 mentioned OSMESA was tested in headless mode, but i could not replicate even if i build GLFW&GLEW with Wayland disabled and OSMESA enabled. Attmpted to do code change to allow OMESA to run with GL, but it generate pure/solid white image as preview output, some rendering isn't working right. This fix uses EGL, which is likely a better idea for headless setup anyways.

Tested in baremetal CLI and DockerCLI(in Docker, forcing llvmpipe is required)


Also in this PR:
1. Upstream reverted docker base image to 24.04 from 24.10, which resulted in DockerEntrypoint.sh to be out-of-date as `su` behaves differently in these two base imaged and does not pass ENV var correctly in 24.04, change to passing manually.
2. Update DockerFile and Entrypoint.sh so it included ENV vars needed to force EGL into headless/CPU render mode.