### PR TITLE
Fix and reject some warning-classes when building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,15 @@ if (NOT MSVC AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMP
     # On GCC and Clang, no return from a non-void function is a warning only. Here, we make it an error.
     add_compile_options(-Werror=return-type)
 
+    # Prevent common bugs that can be caught at compile time:
+    # - misleading-indentation: code that looks like it's in a block but isn't
+    add_compile_options(-Werror=misleading-indentation)
+
+    # C++-only warnings (these flags are not valid for C):
+    # - pessimizing-move: std::move() preventing copy elision (RVO/NRVO)
+    # - catch-value: catching exceptions by value instead of reference (slicing)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror=pessimizing-move> $<$<COMPILE_LANGUAGE:CXX>:-Werror=catch-value>)
+
     add_compile_options(-Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-label -Wno-unused-local-typedefs)
 
     # removes LOTS of extraneous Eigen warnings (GCC only supports it since 6.1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,12 +262,16 @@ if (NOT MSVC AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMP
 
     # Prevent common bugs that can be caught at compile time:
     # - misleading-indentation: code that looks like it's in a block but isn't
-    add_compile_options(-Werror=misleading-indentation)
+    # - return-local-addr: returning reference/pointer to local variable
+    # - dangling-else: ambiguous else clause
+    add_compile_options(-Werror=misleading-indentation -Werror=return-local-addr -Werror=dangling-else)
 
     # C++-only warnings (these flags are not valid for C):
     # - pessimizing-move: std::move() preventing copy elision (RVO/NRVO)
     # - catch-value: catching exceptions by value instead of reference (slicing)
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror=pessimizing-move> $<$<COMPILE_LANGUAGE:CXX>:-Werror=catch-value>)
+    # - self-move: moving object to itself
+    # - mismatched-new-delete: new[]/delete or new/delete[] mismatch
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror=pessimizing-move> $<$<COMPILE_LANGUAGE:CXX>:-Werror=catch-value> $<$<COMPILE_LANGUAGE:CXX>:-Werror=self-move> $<$<COMPILE_LANGUAGE:CXX>:-Werror=mismatched-new-delete>)
 
     add_compile_options(-Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-label -Wno-unused-local-typedefs)
 

--- a/src/BambuStudio.cpp
+++ b/src/BambuStudio.cpp
@@ -2029,7 +2029,7 @@ int CLI::run(int argc, char **argv)
             }
         }
         catch (std::exception& e) {
-            boost::nowide::cerr << construct_assemble_list << ": " << e.what() << std::endl;
+            boost::nowide::cerr << "construct_assemble_list: " << e.what() << std::endl;
             record_exit_reson(outfile_dir, CLI_DATA_FILE_ERROR, 0, cli_errors[CLI_DATA_FILE_ERROR], sliced_info);
             flush_and_exit(CLI_DATA_FILE_ERROR);
         }
@@ -5026,7 +5026,7 @@ int CLI::run(int argc, char **argv)
                     }
                 }
 
-                if (!arrange_cfg.is_seq_print && (assemble_plate.filaments_count > 1)||(enable_wrapping_detect && !current_wrapping_exclude_area.empty()))
+                if ((!arrange_cfg.is_seq_print && (assemble_plate.filaments_count > 1)) || (enable_wrapping_detect && !current_wrapping_exclude_area.empty()))
                 {
                     //prepare the wipe tower
                     int plate_count = partplate_list.get_plate_count();

--- a/src/admesh/util.cpp
+++ b/src/admesh/util.cpp
@@ -326,7 +326,7 @@ void stl_repair(
   	if (nearby_flag || fixall_flag) {
     	if (! tolerance_flag)
       		tolerance = stl->stats.shortest_edge;
- 	   	if (! increment_flag)
+    	if (! increment_flag)
       		increment = stl->stats.bounding_diameter / 10000.0;
     }
 

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -734,7 +734,7 @@ std::string AppConfig::load()
                 }
             }
         }
-    } catch(std::exception err) {
+    } catch(const std::exception& err) {
         BOOST_LOG_TRIVIAL(info) << format("parse app config \"%1%\", error: %2%", PathSanitizer::sanitize(AppConfig::loading_path()), err.what());
 
         return err.what();

--- a/src/libslic3r/Brim.cpp
+++ b/src/libslic3r/Brim.cpp
@@ -588,9 +588,9 @@ double getadhesionCoeff(const PrintObject* printObject)
     }
     double adhesionCoeff = 1;
     for (const ModelVolume* modelVolume : objectVolumes) {
-        for (auto iter = extrudersFirstLayer.begin(); iter != extrudersFirstLayer.end(); iter++)
+        for (auto iter = extrudersFirstLayer.begin(); iter != extrudersFirstLayer.end(); iter++) {
             if (modelVolume->extruder_id() == *iter) {
-                if (Model::extruderParamsMap.find(modelVolume->extruder_id()) != Model::extruderParamsMap.end())
+                if (Model::extruderParamsMap.find(modelVolume->extruder_id()) != Model::extruderParamsMap.end()) {
                     if (Model::extruderParamsMap.at(modelVolume->extruder_id()).materialName == "PETG" ||
                         Model::extruderParamsMap.at(modelVolume->extruder_id()).materialName == "PCTG") {
                         adhesionCoeff = 2;
@@ -598,7 +598,9 @@ double getadhesionCoeff(const PrintObject* printObject)
                                Model::extruderParamsMap.at(modelVolume->extruder_id()).materialName == "TPU-AMS") {
                         adhesionCoeff = 0.5;
                     }
+                }
             }
+        }
     }
 
     return adhesionCoeff;

--- a/src/libslic3r/ClipperUtils.cpp
+++ b/src/libslic3r/ClipperUtils.cpp
@@ -102,7 +102,7 @@ template<typename PointType> inline void clip_clipper_polygon_with_subject_bbox_
     }
 
     // Never produce just a single point output polygon.
-    if (!out.empty())
+    if (!out.empty()) {
         if(get_entire_polygons){
             out=src;
         }else{
@@ -114,7 +114,7 @@ template<typename PointType> inline void clip_clipper_polygon_with_subject_bbox_
             (sides_prev & sides_this & sides_next) == 0)
             out.emplace_back(src.back());
         }
-
+    }
 }
 
 void clip_clipper_polygon_with_subject_bbox(const Points &src, const BoundingBox &bbox, Points &out, const bool get_entire_polygons) { clip_clipper_polygon_with_subject_bbox_templ(src, bbox, out, get_entire_polygons); }

--- a/src/libslic3r/Config.cpp
+++ b/src/libslic3r/Config.cpp
@@ -1810,7 +1810,8 @@ const double& DynamicConfig::opt_float(const t_config_option_key &opt_key, unsig
         return opt_floats_nullable->get_at(idx);
     } else {
         assert(false);
-        return 0;
+        static const double s_zero = 0.0;
+        return s_zero;
     }
 }
 

--- a/src/libslic3r/Format/STEP.cpp
+++ b/src/libslic3r/Format/STEP.cpp
@@ -709,7 +709,7 @@ unsigned int Step::get_triangle_num(double linear_defletion, double angle_deflet
                 return 0;
             }
         }
-    } catch(Exception e) {
+    } catch(const Exception& e) {
         return 0;
     }
     

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3198,7 +3198,7 @@ void GCode::process_layers(
                 print.throw_if_canceled();
                 GCode::LayerResult res = this->process_layer(print, layer.second, layer_tools, &layer == &layers_to_print.back(), &print_object_instances_ordering, tool_ordering.get_most_used_extruder(), size_t(-1));
                 res.gcode_store_pos = layer_to_print_idx - 1;
-                return std::move(res);
+                return res;
             }
         });
     if (m_spiral_vase) {
@@ -3219,7 +3219,7 @@ void GCode::process_layers(
     [&gcode_editer = *this->m_gcode_editer.get(), &layers_extruder_adjustments, object_label](GCode::LayerResult in) -> GCode::LayerResult{
         //record gcode
         in.gcode = gcode_editer.process_layer(std::move(in.gcode), in.not_set_additional_fan, in.layer_id, layers_extruder_adjustments[in.gcode_store_pos], object_label, in.cooling_buffer_flush, false);
-         return std::move(in);
+         return in;
     });
 
     //step2: cooling
@@ -3230,7 +3230,7 @@ void GCode::process_layers(
     const auto cooling = tbb::make_filter<GCode::LayerResult, GCode::LayerResult>(slic3r_tbb_filtermode::serial_in_order,
     [&cooling_processor, &layers_extruder_adjustments](GCode::LayerResult in) -> GCode::LayerResult {
         in.layer_time = cooling_processor.calculate_layer_slowdown(layers_extruder_adjustments[in.gcode_store_pos]);
-         return std::move(in);
+         return in;
     });
 
     // step 4.1: record node date
@@ -3337,7 +3337,7 @@ void GCode::process_layers(
                 print.throw_if_canceled();
                 GCode::LayerResult res = this->process_layer(print, {std::move(layer)}, tool_ordering.tools_for_layer(layer.print_z()), &layer == &layers_to_print.back(), nullptr, tool_ordering.get_most_used_extruder(), single_object_idx, prime_extruder);
                 res.gcode_store_pos = layer_to_print_idx - 1;
-                return std::move(res);
+                return res;
             }
         });
     if (m_spiral_vase) {
@@ -3362,7 +3362,7 @@ void GCode::process_layers(
     [&gcode_editer = *this->m_gcode_editer.get(), &layers_extruder_adjustments, object_label](GCode::LayerResult in) -> GCode::LayerResult{
         //record gcode
         in.gcode = gcode_editer.process_layer(std::move(in.gcode), in.not_set_additional_fan, in.layer_id, layers_extruder_adjustments[in.gcode_store_pos], object_label, in.cooling_buffer_flush, false);
-         return std::move(in);
+         return in;
     });
 
     // step 3: cooling
@@ -3372,7 +3372,7 @@ void GCode::process_layers(
     const auto cooling = tbb::make_filter<GCode::LayerResult, GCode::LayerResult>(slic3r_tbb_filtermode::serial_in_order,
     [&cooling_processor, &layers_extruder_adjustments](GCode::LayerResult in) -> GCode::LayerResult {
         in.layer_time = cooling_processor.calculate_layer_slowdown(layers_extruder_adjustments[in.gcode_store_pos]);
-         return std::move(in);
+         return in;
     });
 
     // step 4.1: record node date

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -958,8 +958,8 @@ void GCodeProcessor::TimeProcessor::post_process(const std::string& filename, st
 
     auto handle_filament_change = [&filament_blocks,&machine_start_gcode_end_line_id,&machine_end_gcode_start_line_id](int filament_id,int line_id){
         // skip the filaments change in machine start/end gcode
-        if (machine_start_gcode_end_line_id == (unsigned int)(-1) && (unsigned int)(line_id)<machine_start_gcode_end_line_id ||
-            machine_end_gcode_start_line_id != (unsigned int)(-1) && (unsigned int)(line_id)>machine_end_gcode_start_line_id)
+        if ((machine_start_gcode_end_line_id != (unsigned int)(-1) && (unsigned int)(line_id) < machine_start_gcode_end_line_id) ||
+            (machine_end_gcode_start_line_id != (unsigned int)(-1) && (unsigned int)(line_id) > machine_end_gcode_start_line_id))
             return;
 
         if (!filament_blocks.empty())
@@ -1700,7 +1700,7 @@ bool GCodeProcessor::check_multi_extruder_gcode_valid(const int                 
     std::map<int, std::map<int, GCodePosInfo>> gcode_path_pos; // object_id, filament_id, pos
     for (const GCodeProcessorResult::MoveVertex &move : m_result.moves) {
         // sometimes, the start line extrude was outside the edge of plate a little, this is allowed, so do not include into the gcode_path_pos
-        if (move.type == EMoveType::Extrude && move.extrusion_role != ExtrusionRole::erFlush /* || move.type == EMoveType::Travel*/)
+        if (move.type == EMoveType::Extrude && move.extrusion_role != ExtrusionRole::erFlush /* || move.type == EMoveType::Travel*/) {
             if (move.extrusion_role == ExtrusionRole::erCustom) {
                 if (move.is_arc_move_with_interpolation_points()) {
                     for (int i = 0; i < move.interpolation_points.size(); i++) {
@@ -1722,6 +1722,7 @@ bool GCodeProcessor::check_multi_extruder_gcode_valid(const int                 
                 gcode_path_pos[move.object_label_id][int(move.extruder_id)].max_print_z = std::max(gcode_path_pos[move.object_label_id][int(move.extruder_id)].max_print_z,
                                                                                                    move.print_z);
             }
+        }
     }
 
     bool valid = true;

--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -164,11 +164,13 @@ unsigned int LayerTools::extruder(const ExtrusionEntityCollection &extrusions, c
                 }
             if (curr_priority == 0) // default
                 extruder = region.config().wall_filament.value;
-        }else
+        } else {
             extruder = region.config().wall_filament.value;
-    }else
+        }
+    } else {
         extruder = this->extruder_override;
-	return (extruder == 0) ? 0 : extruder - 1;
+    }
+    return (extruder == 0) ? 0 : extruder - 1;
 }
 
 static double calc_max_layer_height(const PrintConfig &config, double max_object_layer_height)

--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -3854,9 +3854,10 @@ WipeTower::ToolChangeResult WipeTower::finish_block_solid(const WipeTowerBlock &
             if (stop_pos.x() < printer_bbx.min[0]) stop_pos.x() = printer_bbx.min[0];
             if (stop_pos.x() > printer_bbx.max[0]) stop_pos.x() = printer_bbx.max[0];
             initial_pos = stop_pos;
-            if (m_filpar[m_current_tool].filament_tower_interface_print_temp != m_filpar[m_current_tool].nozzle_temperature)
+            if (m_filpar[m_current_tool].filament_tower_interface_print_temp != m_filpar[m_current_tool].nozzle_temperature) {
                 writer.append(format_line_M109(m_filpar[m_current_tool].filament_tower_interface_print_temp, m_filament_map[this->m_current_tool] - 1));
-                writer.retract(-m_filpar[m_current_tool].filament_tower_interface_pre_extrusion_length - 2.f, 100.f);
+            }
+            writer.retract(-m_filpar[m_current_tool].filament_tower_interface_pre_extrusion_length - 2.f, 100.f);
         }
         writer.set_initial_position(initial_pos, m_wipe_tower_width, m_wipe_tower_depth, m_internal_rotation);
 

--- a/src/libslic3r/MeshBoolean.cpp
+++ b/src/libslic3r/MeshBoolean.cpp
@@ -589,6 +589,8 @@ MCAPI_ATTR void MCAPI_CALL mcDebugOutput(McDebugSource source,
         case MC_DEBUG_SOURCE_KERNEL:
             BOOST_LOG_TRIVIAL(debug)<<("Source: Kernel");
             break;
+        default:
+            break;
         }
 
     switch (type) {
@@ -600,6 +602,8 @@ MCAPI_ATTR void MCAPI_CALL mcDebugOutput(McDebugSource source,
             break;
         case MC_DEBUG_TYPE_OTHER:
             BOOST_LOG_TRIVIAL(debug)<<("Type: Other");
+            break;
+        default:
             break;
         }
 
@@ -615,6 +619,8 @@ MCAPI_ATTR void MCAPI_CALL mcDebugOutput(McDebugSource source,
             break;
         case MC_DEBUG_SEVERITY_NOTIFICATION:
             BOOST_LOG_TRIVIAL(debug)<<("Severity: notification");
+            break;
+        default:
             break;
         }
 }

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -1189,7 +1189,7 @@ ModelObject& ModelObject::assign_copy(ModelObject &&rhs)
     this->sla_support_points          = std::move(rhs.sla_support_points);
     this->sla_points_status           = std::move(rhs.sla_points_status);
     this->sla_drain_holes             = std::move(rhs.sla_drain_holes);
-    this->brim_points                 = std::move(brim_points);
+    this->brim_points                 = std::move(rhs.brim_points);
     this->layer_config_ranges         = std::move(rhs.layer_config_ranges);
     this->layer_height_profile        = std::move(rhs.layer_height_profile);
     this->printable                   = std::move(rhs.printable);
@@ -2839,7 +2839,7 @@ unsigned int ModelObject::update_instances_print_volume_state(const BuildVolume 
 
     //BBS: add logs for build_volume
     //const BoundingBoxf3& print_volume = build_volume.bounding_volume();
-    //BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(", print_volume {%1%, %2%, %3%} to {%4%, %5%, %6%}")\
+    //BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(", print_volume {%1%, %2%, %3%} to {%4%, %5%, %6%}")
     //    %print_volume.min.x() %print_volume.min.y() %print_volume.min.z()%print_volume.max.x() %print_volume.max.y() %print_volume.max.z();
     for (ModelInstance* model_instance : this->instances) {
         unsigned int inside_outside = 0;
@@ -4061,7 +4061,7 @@ double getadhesionCoeff(const ModelVolumePtrs objectVolumes)
 {
     double adhesionCoeff = 1;
     for (const ModelVolume* modelVolume : objectVolumes) {
-        if (Model::extruderParamsMap.find(modelVolume->extruder_id()) != Model::extruderParamsMap.end())
+        if (Model::extruderParamsMap.find(modelVolume->extruder_id()) != Model::extruderParamsMap.end()) {
             if (Model::extruderParamsMap.at(modelVolume->extruder_id()).materialName == "PETG" ||
                 Model::extruderParamsMap.at(modelVolume->extruder_id()).materialName == "PCTG") {
                 adhesionCoeff = 2;
@@ -4069,6 +4069,7 @@ double getadhesionCoeff(const ModelVolumePtrs objectVolumes)
             else if (Model::extruderParamsMap.at(modelVolume->extruder_id()).materialName == "TPU" || Model::extruderParamsMap.at(modelVolume->extruder_id()).materialName == "TPU-AMS") {
                 adhesionCoeff = 0.5;
             }
+        }
     }
     return adhesionCoeff;
 }

--- a/src/libslic3r/Point.cpp
+++ b/src/libslic3r/Point.cpp
@@ -191,8 +191,8 @@ bool Point::is_in_lines(const Points &pts) const
         if ((check_point.x() == pt.x() && check_point.y() == pt.y()) || (check_point.x() == prev_pt.x() && check_point.y() == prev_pt.y()))
             return true;
 
-        bool in_x_range = !(check_point.x() > pt.x() == check_point.x() > prev_pt.x());
-        bool in_y_range = !(check_point.y() > pt.y() == check_point.y() > prev_pt.y());
+        bool in_x_range = !((check_point.x() > pt.x()) == (check_point.x() > prev_pt.x()));
+        bool in_y_range = !((check_point.y() > pt.y()) == (check_point.y() > prev_pt.y()));
 
         //on vert line
         if (pt.x() == prev_pt.x()) {

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -2895,8 +2895,8 @@ size_t PresetCollection::update_compatible_internal(const PresetWithVendorProfil
         preset_edited.is_compatible = is_compatible_with_printer(this_preset_with_vendor_profile, active_printer, &config);
         if (preset_edited.is_compatible)
             some_compatible++;
-	    if (active_print != nullptr)
-	        preset_edited.is_compatible &= is_compatible_with_print(this_preset_with_vendor_profile, *active_print, active_printer);
+        if (active_print != nullptr)
+            preset_edited.is_compatible &= is_compatible_with_print(this_preset_with_vendor_profile, *active_print, active_printer);
         if (! preset_edited.is_compatible && selected &&
             (unselect_if_incompatible == PresetSelectCompatibleType::Always || (unselect_if_incompatible == PresetSelectCompatibleType::OnlyIfWasCompatible && was_compatible)))
         {

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -2861,7 +2861,7 @@ std::vector<Polygons> Print::get_extruder_printable_polygons() const
         Polygons ploys = {Polygon::new_scale(e_printable_area)};
         extruder_printable_polys.emplace_back(ploys);
     }
-    return std::move(extruder_printable_polys);
+    return extruder_printable_polys;
 }
 
 std::vector<Polygons> Print::get_extruder_unprintable_polygons() const
@@ -2874,7 +2874,7 @@ std::vector<Polygons> Print::get_extruder_unprintable_polygons() const
         Polygons ploys = diff(printable_poly, Polygon::new_scale(e_printable_area));
         extruder_unprintable_polys.emplace_back(ploys);
     }
-    return std::move(extruder_unprintable_polys);
+    return extruder_unprintable_polys;
 }
 
 Polygons Print::get_extruder_shared_printable_polygon() const

--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -1314,8 +1314,8 @@ void PrintObject::slice_volumes()
                         }
 	                }
 	                // Merge all regions' slices to get islands, chain them by a shortest path.
-                    if (this->config().enable_circle_compensation)
-                        layer->apply_auto_circle_compensation();
+	                if (this->config().enable_circle_compensation)
+	                    layer->apply_auto_circle_compensation();
 	                layer->make_slices();
 	            }
 	        });

--- a/src/libslic3r/ShortestPath.cpp
+++ b/src/libslic3r/ShortestPath.cpp
@@ -826,9 +826,9 @@ std::vector<std::pair<size_t, bool>> chain_segments_greedy_constrained_reversals
 				assert(chain1 == nullptr || (chain1_flip ? (chain1->begin == end_point1_other || chain1->end == end_point1_other) : (chain1->begin == end_point1 || chain1->end == end_point1)));
 				assert(chain2 == nullptr || (chain2_flip ? (chain2->begin == end_point2_other || chain2->end == end_point2_other) : (chain2->begin == end_point2 || chain2->end == end_point2)));
 				if (chain1_flip)
-		    		chain1->flip(end_points);
-		    	if (chain2_flip)
-		    		chain2->flip(end_points);
+					chain1->flip(end_points);
+				if (chain2_flip)
+					chain2->flip(end_points);
 				assert(chain1 == nullptr || chain1->begin == end_point1 || chain1->end == end_point1);
 				assert(chain2 == nullptr || chain2->begin == end_point2 || chain2->end == end_point2);
 		    	size_t chain_id = chains.merge(end_point1_chain_id, end_point2_chain_id);

--- a/src/libslic3r/Slicing.cpp
+++ b/src/libslic3r/Slicing.cpp
@@ -454,7 +454,7 @@ void adjust_layer_height_profile(
     if (z < z_span_variable.first || z > z_span_variable.second)
         return;
 
-	assert(layer_height_profile.size() >= 2);
+    assert(layer_height_profile.size() >= 2);
     assert(std::abs(layer_height_profile[layer_height_profile.size() - 2] - slicing_params.object_print_z_height()) < EPSILON);
 
     // 1) Get the current layer thickness at z.

--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -2528,7 +2528,7 @@ void TreeSupport::draw_circles()
                         for (size_t i = 0; i <= bottom_gap_layers && i <= obj_layer_nr_next; i++)
                         {
                             const Layer *below_layer      = m_object->get_layer(obj_layer_nr_next - i);
-                            ExPolygons bottom_interface = std::move(intersection_ex(base_areas, below_layer->lslices));
+                            ExPolygons bottom_interface = intersection_ex(base_areas, below_layer->lslices);
                             floor_areas.insert(floor_areas.end(), bottom_interface.begin(), bottom_interface.end());
                         }
                     }
@@ -2540,7 +2540,7 @@ void TreeSupport::draw_circles()
                 }
                 if (bottom_gap_layers > 0 && m_ts_data->layer_heights[layer_nr].obj_layer_nr > bottom_gap_layers) {
                     const Layer* below_layer = m_object->get_layer(m_ts_data->layer_heights[layer_nr].obj_layer_nr - bottom_gap_layers);
-                    ExPolygons bottom_gap_area = std::move(intersection_ex(floor_areas, below_layer->lslices));
+                    ExPolygons bottom_gap_area = intersection_ex(floor_areas, below_layer->lslices);
                     if (!bottom_gap_area.empty()) {
                         floor_areas = std::move(diff_ex(floor_areas, bottom_gap_area));
                     }
@@ -2931,7 +2931,7 @@ void TreeSupport::drop_nodes()
 
         m_object->print()->set_status(60 + int(10 * (1 - float(layer_nr) / contact_nodes.size())), _u8L("Generating support"));// (boost::format(_u8L("Support: propagate branches at layer %d")) % layer_nr).str());
 
-        Polygons layer_contours = std::move(m_ts_data->get_contours_with_holes(obj_layer_nr));
+        Polygons layer_contours = m_ts_data->get_contours_with_holes(obj_layer_nr);
         //std::unordered_map<Line, bool, LineHash>& mst_line_x_layer_contour_cache = m_mst_line_x_layer_contour_caches[layer_nr];
         tbb::concurrent_unordered_map<Line, bool, LineHash> mst_line_x_layer_contour_cache;
         auto is_line_cut_by_contour = [&mst_line_x_layer_contour_cache,&layer_contours](Point a, Point b)
@@ -4228,7 +4228,7 @@ const ExPolygons& TreeSupportData::calculate_collision(const RadiusLayerPair& ke
 {
     assert(key.layer_nr < m_layer_outlines.size());
 
-    ExPolygons collision_areas = std::move(offset_ex(m_layer_outlines[key.layer_nr], scale_(key.radius+m_xy_distance)));
+    ExPolygons collision_areas = offset_ex(m_layer_outlines[key.layer_nr], scale_(key.radius+m_xy_distance));
     collision_areas = expolygons_simplify(collision_areas, scale_(m_radius_sample_resolution));
     // collision_areas.emplace_back(m_machine_border);
     const auto ret = m_collision_cache.insert({ key, std::move(collision_areas) });

--- a/src/libslic3r/Utils.hpp
+++ b/src/libslic3r/Utils.hpp
@@ -257,15 +257,15 @@ private:
         }
 
         if (raw.length() < full.length() || raw.empty()) {
-            return std::move(file_name(raw));
+            return file_name(raw);
         }
 
         if (raw[0] != full[0] || raw[full.length() - 1] != full[full.length() - 1]) {
             if (std::isupper(raw[start_pos]) && std::tolower(raw[start_pos]) == full[start_pos]) {
                 raw.replace(start_pos, 12, std::string(12, '*'));
-                return std::move(file_name(raw));
+                return file_name(raw);
             }
-            return std::move(file_name(raw));
+            return file_name(raw);
         }
 
         if (raw[start_pos + name_size] == '\\' || raw[start_pos + name_size] == '/') {
@@ -273,7 +273,7 @@ private:
         } else if (std::isupper(raw[start_pos]) && std::tolower(raw[start_pos]) == full[start_pos]) {
             raw.replace(start_pos, 12, std::string(12, '*'));
         } else {
-            return std::move(file_name(raw));
+            return file_name(raw);
         }
 
         if (id_start_pos != std::string::npos && id_start_pos < raw.length() && (raw[id_start_pos - 1] == '\\' || raw[id_start_pos - 1] == '/') &&
@@ -286,7 +286,7 @@ private:
             raw.replace(id_start_pos, id_end_pos - id_start_pos, std::string(id_end_pos - id_start_pos, '*'));
         }
 
-        return std::move(file_name(raw));
+        return file_name(raw);
     }
 };
 

--- a/src/slic3r/GUI/ConfigWizard.cpp
+++ b/src/slic3r/GUI/ConfigWizard.cpp
@@ -2707,7 +2707,7 @@ ConfigWizard::ConfigWizard(wxWindow *parent)
     if (p->only_sla_mode)
         p->any_fff_selected = p->check_fff_selected();
 
-	p->add_page(p->page_custom = new PageCustom(this));
+    p->add_page(p->page_custom = new PageCustom(this));
     p->custom_printer_selected = p->page_custom->custom_wanted();
 
     p->add_page(p->page_firmware = new PageFirmware(this));

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -1937,10 +1937,10 @@ void PointCtrl::BUILD()
     const wxSize field_size(4 * m_em_unit, -1);
     Slic3r::Vec2d default_pt;
     if(m_opt.type == coPoints)
-	    default_pt = m_opt.get_default_value<ConfigOptionPoints>()->values.at(0);
+        default_pt = m_opt.get_default_value<ConfigOptionPoints>()->values.at(0);
     else
         default_pt = m_opt.get_default_value<ConfigOptionPoint>()->value;
-	double val = default_pt(0);
+    double val = default_pt(0);
 	wxString X = val - int(val) == 0 ? wxString::Format(_T("%i"), int(val)) : wxNumberFormatter::ToString(val, 2, wxNumberFormatter::Style_None);
 	val = default_pt(1);
 	wxString Y = val - int(val) == 0 ? wxString::Format(_T("%i"), int(val)) : wxNumberFormatter::ToString(val, 2, wxNumberFormatter::Style_None);
@@ -2060,10 +2060,10 @@ void PointCtrl::set_value(const boost::any& value, bool change_event)
             ConfigOptionPoints* pts = boost::any_cast<ConfigOptionPoints*>(value);
             pt = pts->values.at(0);
         }
-    }
-    else
+    } else {
         pt = *ptf;
-	set_value(pt, change_event);
+    }
+    set_value(pt, change_event);
 }
 
 boost::any& PointCtrl::get_value()

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -1956,11 +1956,12 @@ void GLCanvas3D::update_instance_printable_state_for_object(const size_t obj_idx
         ModelInstance* instance = model_object->instances[inst_idx];
 
         for (GLVolume* volume : m_volumes.volumes) {
-            if ((volume->object_idx() == (int)obj_idx) && (volume->instance_idx() == inst_idx))
+            if ((volume->object_idx() == (int)obj_idx) && (volume->instance_idx() == inst_idx)) {
                 volume->printable = instance->printable;
                 if (!volume->printable) {
                     volume->render_color = GLVolume::UNPRINTABLE_COLOR;
                 }
+            }
         }
     }
 }
@@ -2650,8 +2651,8 @@ void GLCanvas3D::render(bool only_init)
         if (tooltip.empty())
             tooltip = m_layers_editing.get_tooltip(*this);
 
-	    if (tooltip.empty())
-	        tooltip = m_gizmos.get_tooltip();
+        if (tooltip.empty())
+            tooltip = m_gizmos.get_tooltip();
 
         if (tooltip.empty()) {
             const auto& p_main_toolbar = get_main_toolbar();
@@ -8185,7 +8186,7 @@ void GLCanvas3D::_render_overlays()
     if (m_layers_editing.last_object_id >= 0 && m_layers_editing.object_max_z() > 0.0f)
         m_layers_editing.render_overlay(*this);
 
-	auto curr_plate = wxGetApp().plater()->get_partplate_list().get_curr_plate();
+    auto curr_plate = wxGetApp().plater()->get_partplate_list().get_curr_plate();
     auto curr_print_seq = curr_plate->get_real_print_seq();
     bool sequential_print = (curr_print_seq == PrintSequence::ByObject);
     std::vector<const ModelInstance*> sorted_instances;

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -7642,7 +7642,8 @@ const std::shared_ptr<GLShaderProgram>& GUI_App::get_shader(const std::string &s
         return p_ogl_manager->get_shader(shader_name);
     }
 
-    return nullptr;
+    static const std::shared_ptr<GLShaderProgram> s_null_shader;
+    return s_null_shader;
 }
 
 const std::shared_ptr<GLShaderProgram> GUI_App::get_current_shader() const

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2341,9 +2341,10 @@ void MainFrame::update_slice_print_status(SlicePrintEventType event, bool can_sl
     }
 
 
-    if (!old_slice_status && enable_slice)
+    if (!old_slice_status && enable_slice) {
         m_plater->stop_helio_process();
         m_plater->reset_check_status();
+    }
 }
 
 

--- a/src/slic3r/GUI/NotificationManager.cpp
+++ b/src/slic3r/GUI/NotificationManager.cpp
@@ -789,13 +789,13 @@ void NotificationManager::PopNotification::render_close_button(ImGuiWrapper& img
 	}
 	ImVec2 button_pic_size = ImGui::CalcTextSize(into_u8(button_text).c_str());
 	ImVec2 button_size(button_pic_size.x * 1.25f, button_pic_size.y * 1.25f);
-	ImGui::SetCursorPosX(win_size.x - m_line_height * 2.75f);
-	//ImGui::SetCursorPosY(win_size.y / 2 - button_size.y);
+    ImGui::SetCursorPosX(win_size.x - m_line_height * 2.75f);
+    //ImGui::SetCursorPosY(win_size.y / 2 - button_size.y);
     if (m_minimize_b_visible)
-		ImGui::SetCursorPosY(0);
+        ImGui::SetCursorPosY(0);
     else
         ImGui::SetCursorPosY(win_size.y / 2 - button_size.y);
-	if (imgui.button(button_text.c_str(), button_size.x, button_size.y))
+    if (imgui.button(button_text.c_str(), button_size.x, button_size.y))
 	{
 		close();
 	}

--- a/src/slic3r/GUI/OptionsGroup.cpp
+++ b/src/slic3r/GUI/OptionsGroup.cpp
@@ -992,8 +992,8 @@ void ConfigOptionsGroup::refresh()
 
 boost::any ConfigOptionsGroup::config_value(const std::string& opt_key, int opt_index, bool deserialize) {
 
-    if (opt_key == "bed_type")
-        return boost::any((int)BedType::btPC);
+	if (opt_key == "bed_type")
+		return boost::any((int)BedType::btPC);
 
 	if (deserialize) {
 		// Want to edit a vector value(currently only multi - strings) in a single edit box.

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -2051,8 +2051,8 @@ void PartPlate::set_pos_and_size(Vec3d& origin, int width, int depth, int height
 		clear();
 	}
 
-    if (m_print)
-        m_print->set_plate_origin(origin);
+	if (m_print)
+		m_print->set_plate_origin(origin);
 
 	m_origin = origin;
 	m_width = width;

--- a/src/slic3r/GUI/SendToPrinter.cpp
+++ b/src/slic3r/GUI/SendToPrinter.cpp
@@ -1382,11 +1382,12 @@ void SendToPrinterDialog::Enable_Refresh_Button(bool en)
 
 void SendToPrinterDialog::show_status(PrintDialogStatus status, std::vector<wxString> params)
 {
-    if (m_print_status != status)
+    if (m_print_status != status) {
         BOOST_LOG_TRIVIAL(info) << "select_machine_dialog: show_status = " << status;
-    else
+    } else {
         return;
-	m_print_status = status;
+    }
+    m_print_status = status;
 
 	// m_comboBox_printer
 	if (status == PrintDialogStatus::PrintStatusRefreshingMachineList)

--- a/src/slic3r/GUI/WebGuideDialog.cpp
+++ b/src/slic3r/GUI/WebGuideDialog.cpp
@@ -1095,9 +1095,10 @@ int GuideFrame::GetFilamentInfo( std::string VendorDirectory, json & pFilaList, 
                     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << "sType is Empty";
                     return -1;
                 }
-                else
+                else {
                     sVendor = "Generic";
                     return 0;
+                }
             }
         }
         else

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -1094,18 +1094,18 @@ bool WebViewPanel::SaveBase64ToLocal(std::string Base64Buf, std::string FileName
 
     std::ofstream outFile(download_file.ToStdString(), std::ios::binary);
     if (!outFile) {
-        delete DstBuf;
+        delete[] DstBuf;
         std::cerr << "Error opening file for writing." << std::endl;
         return false;
     }
     outFile.write(DstBuf, nWrite);
     if (!outFile) {
-        delete DstBuf;
+        delete[] DstBuf;
         std::cerr << "Error writing to file." << std::endl;
         return false;
     }
 
-    delete DstBuf;
+    delete[] DstBuf;
     outFile.close();
     std::cout << "Data written to file successfully." << std::endl;
     wxLogMessage("Makerlab Binary Write to %s", download_file.ToStdString());

--- a/src/slic3r/GUI/Widgets/AxisCtrlButton.cpp
+++ b/src/slic3r/GUI/Widgets/AxisCtrlButton.cpp
@@ -307,60 +307,60 @@ void AxisCtrlButton::mouseMoving(wxMouseEvent& event)
 {
     if (pressedDown)
         return;
-	wxPoint mouse_pos(event.GetX(), event.GetY());
-	wxPoint transformed_mouse_pos = mouse_pos - center;
-	double r_temp = transformed_mouse_pos.x * transformed_mouse_pos.x + transformed_mouse_pos.y * transformed_mouse_pos.y;
-	if (r_temp > r_outer * r_outer) {
-		current_pos = CurrentPos::UNDEFINED;
-	}
-	else if (r_temp > r_inner * r_inner) {
-		if (transformed_mouse_pos.y < transformed_mouse_pos.x - gap && transformed_mouse_pos.y < -transformed_mouse_pos.x - gap)
-		{
-			current_pos = CurrentPos::OUTER_UP;
-		}
-		else if (transformed_mouse_pos.y > transformed_mouse_pos.x + gap && transformed_mouse_pos.y < -transformed_mouse_pos.x - gap)
-		{
-			current_pos = CurrentPos::OUTER_LEFT;
-		}
-		else if (transformed_mouse_pos.y > transformed_mouse_pos.x + gap && transformed_mouse_pos.y > -transformed_mouse_pos.x + gap)
-		{
-			current_pos = CurrentPos::OUTER_DOWN;
-		}
-		else if (transformed_mouse_pos.y < transformed_mouse_pos.x - gap && transformed_mouse_pos.y > -transformed_mouse_pos.x + gap)
-		{
-			current_pos = CurrentPos::OUTER_RIGHT;
-		}
+    wxPoint mouse_pos(event.GetX(), event.GetY());
+    wxPoint transformed_mouse_pos = mouse_pos - center;
+    double r_temp = transformed_mouse_pos.x * transformed_mouse_pos.x + transformed_mouse_pos.y * transformed_mouse_pos.y;
+    if (r_temp > r_outer * r_outer) {
+        current_pos = CurrentPos::UNDEFINED;
+    }
+    else if (r_temp > r_inner * r_inner) {
+        if (transformed_mouse_pos.y < transformed_mouse_pos.x - gap && transformed_mouse_pos.y < -transformed_mouse_pos.x - gap)
+        {
+            current_pos = CurrentPos::OUTER_UP;
+        }
+        else if (transformed_mouse_pos.y > transformed_mouse_pos.x + gap && transformed_mouse_pos.y < -transformed_mouse_pos.x - gap)
+        {
+            current_pos = CurrentPos::OUTER_LEFT;
+        }
+        else if (transformed_mouse_pos.y > transformed_mouse_pos.x + gap && transformed_mouse_pos.y > -transformed_mouse_pos.x + gap)
+        {
+            current_pos = CurrentPos::OUTER_DOWN;
+        }
+        else if (transformed_mouse_pos.y < transformed_mouse_pos.x - gap && transformed_mouse_pos.y > -transformed_mouse_pos.x + gap)
+        {
+            current_pos = CurrentPos::OUTER_RIGHT;
+        }
         else {
             current_pos = CurrentPos::UNDEFINED;
         }
-	}
-	else if (r_temp > r_blank * r_blank) {
-		if (transformed_mouse_pos.y < transformed_mouse_pos.x - gap && transformed_mouse_pos.y < -transformed_mouse_pos.x - gap)
-		{
-			current_pos = CurrentPos::INNER_UP;
-		}
-		else if (transformed_mouse_pos.y > transformed_mouse_pos.x + gap && transformed_mouse_pos.y < -transformed_mouse_pos.x - gap)
-		{
-			current_pos = CurrentPos::INNER_LEFT;
-		}
-		else if (transformed_mouse_pos.y > transformed_mouse_pos.x + gap && transformed_mouse_pos.y > -transformed_mouse_pos.x + gap)
-		{
-			current_pos = CurrentPos::INNER_DOWN;
-		}
-		else if (transformed_mouse_pos.y < transformed_mouse_pos.x - gap && transformed_mouse_pos.y > -transformed_mouse_pos.x + gap)
-		{
-			current_pos = CurrentPos::INNER_RIGHT;
-		}
+    }
+    else if (r_temp > r_blank * r_blank) {
+        if (transformed_mouse_pos.y < transformed_mouse_pos.x - gap && transformed_mouse_pos.y < -transformed_mouse_pos.x - gap)
+        {
+            current_pos = CurrentPos::INNER_UP;
+        }
+        else if (transformed_mouse_pos.y > transformed_mouse_pos.x + gap && transformed_mouse_pos.y < -transformed_mouse_pos.x - gap)
+        {
+            current_pos = CurrentPos::INNER_LEFT;
+        }
+        else if (transformed_mouse_pos.y > transformed_mouse_pos.x + gap && transformed_mouse_pos.y > -transformed_mouse_pos.x + gap)
+        {
+            current_pos = CurrentPos::INNER_DOWN;
+        }
+        else if (transformed_mouse_pos.y < transformed_mouse_pos.x - gap && transformed_mouse_pos.y > -transformed_mouse_pos.x + gap)
+        {
+            current_pos = CurrentPos::INNER_RIGHT;
+        }
         else {
             current_pos = CurrentPos::UNDEFINED;
         }
     } else if (r_temp <= r_home * r_home) {
         current_pos = INNER_HOME;
     }
-	if (last_pos != current_pos) {
-		last_pos = current_pos;
-		Refresh();
-	}
+    if (last_pos != current_pos) {
+        last_pos = current_pos;
+        Refresh();
+    }
 }
 
 void AxisCtrlButton::sendButtonEvent()

--- a/src/slic3r/GUI/Widgets/AxisCtrlButton.cpp
+++ b/src/slic3r/GUI/Widgets/AxisCtrlButton.cpp
@@ -124,7 +124,7 @@ void AxisCtrlButton::SetInnerBackgroundColor(StateColor const& color)
 
 void AxisCtrlButton::SetBitmap(ScalableBitmap &bmp)
 {
-    if (&bmp  && (& bmp.bmp()) && (bmp.bmp().IsOk())) {
+    if (bmp.bmp().IsOk()) {
         m_icon = bmp;
     }
 }


### PR DESCRIPTION
Building Bambu Studio generates _thousands_ of warnings. A few of these represents real bugs, I.E. using "null" for a reference is illegal C++, and causes undefined behavior. Others are just noise, and contributing to a bad state of [broken windows](https://blog.codinghorror.com/the-broken-window-theory/).

Trying to improve the situation in this codebase, the first two commits of this PR fixes a few of the "simple & safe" classes of warnings, such as `pessimizing-move`, `misleading-indentation` and `catch-value`, and turns these warnings into errors - to avoid future reappearance.

The second two commits continues with warnings that require _slightly_ more complex analysis, but should still be fairly safe to fix without introducing new problems. Here are a few cases where the warnings represent _actual_ bugs (illegal C++), such as returning a reference to a stack-local null.