### PR TITLE
CI build: replace macos-13 with macos-15-intel

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -46,7 +46,7 @@ jobs:
           - os: ubuntu-22.04
           - os: ubuntu-24.04
           - os: windows-latest
-          - os: macos-13
+          - os: macos-15-intel
             arch: x86_64
           - os: macos-15
             arch: arm64

--- a/.github/workflows/build_bambu.yml
+++ b/.github/workflows/build_bambu.yml
@@ -75,7 +75,7 @@ jobs:
 
   #   Mac
       - name: Build slicer mac
-        if: inputs.os == 'macos-13'
+        if: inputs.os == 'macos-15-intel'
         working-directory: ${{ github.workspace }}
         run: |
           brew install automake texinfo
@@ -101,12 +101,12 @@ jobs:
           ./BuildMac.sh -s -x -a universal -t 10.15 -1
 
       - name: pack mac app
-        if: github.ref != 'refs/heads/main' && (inputs.os == 'macos-13' || inputs.os == 'macos-15')
+        if: github.ref != 'refs/heads/main' && (inputs.os == 'macos-15-intel' || inputs.os == 'macos-15')
         working-directory: ${{ github.workspace }}
         run: zip -r BambuStudio_Mac_${{inputs.arch}}_${{ env.ver }}.zip ${{ github.workspace }}/build
 
       - name: Upload artifacts mac
-        if: inputs.os == 'macos-13' || inputs.os == 'macos-15'
+        if: inputs.os == 'macos-15-intel' || inputs.os == 'macos-15'
         uses: actions/upload-artifact@v6
         with:
           name: BambuStudio_Mac_${{inputs.arch}}_${{ env.ver }}

--- a/.github/workflows/build_check_cache.yml
+++ b/.github/workflows/build_check_cache.yml
@@ -30,7 +30,7 @@ jobs:
       - name: set outputs
         id: set_outputs
         env:
-          dep-folder-name: ${{ inputs.os == 'windows-latest' && '/BambuStudio_dep' || ((inputs.os == 'macos-13' || inputs.os == 'macos-15') && '') || (inputs.os != 'macos-13' && inputs.os != 'macos-15') && '/destdir' || '' }}
+          dep-folder-name: ${{ inputs.os == 'windows-latest' && '/BambuStudio_dep' || ((inputs.os == 'macos-15-intel' || inputs.os == 'macos-15') && '') || (inputs.os != 'macos-15-intel' && inputs.os != 'macos-15') && '/destdir' || '' }}
           output-cmd: ${{ inputs.os == 'windows-latest' && '$env:GITHUB_OUTPUT' || '"$GITHUB_OUTPUT"'}}
         run: |
           echo cache-key=${{ inputs.os }}-cache-bambustudio_deps-build-${{ hashFiles('deps/**') }} >> ${{ env.output-cmd }}

--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -76,7 +76,7 @@ jobs:
         shell: pwsh
           
       - name: Fix python install error on mac
-        if: inputs.os == 'macos-13'
+        if: inputs.os == 'macos-15-intel'
         working-directory: ${{ github.workspace }}
         run: |
           find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
@@ -92,7 +92,7 @@ jobs:
           df -h
 
       - name: Build on Mac ${{ inputs.arch }}
-        if: inputs.os == 'macos-13'
+        if: inputs.os == 'macos-15-intel'
         working-directory: ${{ github.workspace }}
         run: |
             brew install automake texinfo nasm yasm x264
@@ -130,7 +130,7 @@ jobs:
             brew install zstd
 
       - name: pack deps on Macos
-        if: inputs.os == 'macos-13' || inputs.os == 'macos-15'
+        if: inputs.os == 'macos-15-intel' || inputs.os == 'macos-15'
         working-directory: ${{ github.workspace }}
         run: |
           cd ${{ github.workspace }}/deps
@@ -149,14 +149,14 @@ jobs:
 
       # Upload Artifacts
       - name: Upload Mac ${{ inputs.arch }} artifacts
-        if: inputs.os == 'macos-13' || inputs.os == 'macos-15'
+        if: inputs.os == 'macos-15-intel' || inputs.os == 'macos-15'
         uses: actions/upload-artifact@v6
         with:
           name: BambuStudio_dep_mac_${{ inputs.arch }}_${{ env.date }}
           path: ${{ github.workspace }}/deps/BambuStudio_dep_mac_${{ inputs.arch }}*.tar.gz
 
       - name: clean artifacts
-        if: inputs.os == 'macos-13' || inputs.os == 'macos-15'
+        if: inputs.os == 'macos-15-intel' || inputs.os == 'macos-15'
         working-directory: ${{ github.workspace }}
         run: rm -rf ${{ github.workspace }}/deps/build/BambuStudio_dep_mac_${{ inputs.arch }}*.tar.gz
 


### PR DESCRIPTION
According the the latest build messages, macos-13 x86_64 were deprecated and removed: https://github.com/actions/runner-images/issues/13046
<img width="2033" height="90" alt="image" src="https://github.com/user-attachments/assets/b7dfd03e-c8a8-4601-9eaf-f273132c1a88" />
<img width="597" height="80" alt="image" src="https://github.com/user-attachments/assets/cb9a8a7c-57b0-4252-856d-ed4398509199" />

This PR brings back the x86_64 builds via macos-15-intel images. Built and ran ok with the new image: https://github.com/raulp/BambuStudio/actions/runs/21788141244


