### PR TITLE
batch pressure advance calibration

### DIFF
--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -980,6 +980,7 @@ private:
     int start_next_slice();
 
     void _calib_pa_pattern(const Calib_Params &params);
+    void _calib_pa_pattern_gen_gcode();
     void _calib_pa_tower(const Calib_Params &params);
     void _calib_pa_select_added_objects();
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -6078,12 +6078,10 @@ bool Tab::may_discard_current_dirty_preset(PresetCollection* presets /*= nullptr
     if (dlg.ShowModal() == wxID_CANCEL)
         return false;
 
-    if (dlg.save_preset()) {
+    if (dlg.save_preset())
         handle_save_action();
-    }
-    else if (dlg.transfer_changes()) {
+    else if (dlg.transfer_changes())
         handle_transfer_action();
-    }
 
     return true;
 }

--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -1284,6 +1284,9 @@ static wxString get_string_value(std::string opt_key, const DynamicPrintConfig& 
     wxString out;
 
     const ConfigOptionDef* opt = config.def()->get(opt_key);
+    if (!opt) {
+        return _L("N/A");
+    }
     bool is_nullable = opt->nullable;
 
     switch (opt->type) {
@@ -1318,12 +1321,12 @@ static wxString get_string_value(std::string opt_key, const DynamicPrintConfig& 
     case coBools: {
         if (is_nullable) {
             auto values = config.opt<ConfigOptionBoolsNullable>(opt_key);
-            if (opt_idx < values->size())
+            if (values && opt_idx < values->size())
                 return values->get_at(opt_idx) ? "true" : "false";
         }
         else {
             auto values = config.opt<ConfigOptionBools>(opt_key);
-            if (opt_idx < values->size())
+            if (values && opt_idx < values->size())
                 return values->get_at(opt_idx) ? "true" : "false";
         }
         return _L("Undef");

--- a/src/slic3r/GUI/calib_dlg.hpp
+++ b/src/slic3r/GUI/calib_dlg.hpp
@@ -40,6 +40,8 @@ protected:
 	TextInput* m_tiStartPA;
 	TextInput* m_tiEndPA;
 	TextInput* m_tiPAStep;
+	TextInput* m_tiBMAccels;
+	TextInput* m_tiBMSpeeds;
 	CheckBox* m_cbPrintNum;
 	Button* m_btnStart;
 


### PR DESCRIPTION
This PR adds the ability to test multiple speed/acceleration combinations in a single PA Pattern calibration print, like OrcaSlicer. Original work here: https://github.com/OrcaSlicer/OrcaSlicer/pull/7199/changes#diff-eca08a5705cbb985a1c40eec4d872104395681026980e05ce808dbd5445c4691

Instead of running one calibration at a time, you can enter comma-separated speeds (e.g. 60,200) and accelerations (e.g. 2000,5000) in the calibration dialog. Each combination gets its own labeled pattern, automatically arranged across plates when they don't all fit on one.

Added validation for min and max speed and accelerations.
Right side prints the speed/acceleration as well, to easily distinguish between tests.

Tested on my H2C.

![image](https://github.com/user-attachments/assets/9e6d25a4-544f-475b-8988-35dda0d800fc)
![image](https://github.com/user-attachments/assets/f7af6da5-17db-4bab-9221-b98aa5c27c0d)
![image](https://github.com/user-attachments/assets/19293b16-cf16-4323-a83f-d70473eb950b)
