### PR TITLE
Remove closure on click of adaptive layer height editor

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -5042,7 +5042,7 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
     else if (evt.LeftDown() || evt.RightDown() || evt.MiddleDown()) {
         //BBS: add orient deactivate logic
         if (!m_gizmos.on_mouse(evt)) {
-            if (_deactivate_arrange_menu() || _deactivate_orient_menu() || _deactivate_layersediting_menu())
+            if (_deactivate_arrange_menu() || _deactivate_orient_menu())
                 return;
         }
 


### PR DESCRIPTION
Fix erroneous closure of the adaptive layer height edit strip when clicking - which made the adaptive layer editor strip unusable.  This should have been caught when testing the change.
Fixes #9767