### PR TITLE
Add 12-hour time format (AM/PM) setting

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -151,6 +151,9 @@ void AppConfig::set_defaults()
 
         if (get("use_inches").empty())
             set("use_inches", "0");
+
+        if (get("use_12hour_time").empty())
+            set_bool("use_12hour_time", false);
     }
     else {
 #ifdef _WIN32

--- a/src/libslic3r/Utils.hpp
+++ b/src/libslic3r/Utils.hpp
@@ -801,7 +801,7 @@ inline std::string get_bbl_monitor_time_dhm(float time_in_secs)
     return buffer;
 }
 
-inline std::string get_bbl_finish_time_dhm(float time_in_secs)
+inline std::string get_bbl_finish_time_dhm(float time_in_secs, bool use_12hour = false)
 {
     if (time_in_secs < 1) return "Finished";
     time_t   finish_time    = std::time(nullptr) + static_cast<time_t>(time_in_secs);
@@ -833,7 +833,14 @@ inline std::string get_bbl_finish_time_dhm(float time_in_secs)
     }
 
     std::ostringstream formattedTime;
-    formattedTime << std::setw(2) << std::setfill('0') << finish_hour << ":" << std::setw(2) << std::setfill('0') << finish_minute;
+    if (use_12hour) {
+        std::string period = (finish_hour >= 12) ? " PM" : " AM";
+        int display_hour = finish_hour % 12;
+        if (display_hour == 0) display_hour = 12;
+        formattedTime << display_hour << ":" << std::setw(2) << std::setfill('0') << finish_minute << period;
+    } else {
+        formattedTime << std::setw(2) << std::setfill('0') << finish_hour << ":" << std::setw(2) << std::setfill('0') << finish_minute;
+    }
     std::string finish_time_str = formattedTime.str();
     if (diff_day != 0) finish_time_str += "+" + std::to_string(diff_day);
 

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1319,6 +1319,7 @@ wxWindow* PreferencesDialog::create_general_page()
     auto item_step_mesh_setting = create_item_checkbox(_L("Show the step mesh parameter setting dialog."), page, _L("If enabled,a parameter settings dialog will appear during STEP file import."), 50, "enable_step_mesh_setting");
     auto item_beta_version_update = create_item_checkbox(_L("Support beta version update."), page, _L("With this option enabled, you can receive beta version updates."), 50, "enable_beta_version_update");
     auto item_mix_print_high_low_temperature = create_item_checkbox(_L("Remove the restriction on mixed printing of high and low temperature filaments."), page, _L("With this option enabled, you can print materials with a large temperature difference together."), 50, "enable_high_low_temp_mixed_printing");
+    auto item_12hour_time = create_item_checkbox(_L("Use 12-hour time format (AM/PM)"), page, _L("Display estimated finish time in 12-hour format with AM/PM instead of 24-hour format"), 50, "use_12hour_time");
     auto item_restore_hide_pop_ups = create_item_button(_L("Clear my choice for synchronizing printer preset after loading the file."), _L("Clear"), page, _L("Clear my choice for synchronizing printer preset after loading the file."), []() {
         wxGetApp().app_config->erase("app", "sync_after_load_file_show_flag");
     });
@@ -1467,6 +1468,7 @@ wxWindow* PreferencesDialog::create_general_page()
     sizer_page->Add(item_beta_version_update, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_auto_transfer_when_switch_preset, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_mix_print_high_low_temperature, 0, wxTOP, FromDIP(3));
+    sizer_page->Add(item_12hour_time, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_restore_hide_pop_ups, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_restore_hide_3mf_info, 0, wxTOP, FromDIP(3));
     sizer_page->Add(_3d_settings, 0, wxTOP | wxEXPAND, FromDIP(20));

--- a/src/slic3r/GUI/StatusPanel.cpp
+++ b/src/slic3r/GUI/StatusPanel.cpp
@@ -1261,7 +1261,8 @@ void PrintingTaskPanel::update_left_time(int mc_left_time)
 
     try {
         left_time  = get_bbl_time_dhms(mc_left_time);
-        right_time = get_bbl_finish_time_dhm(mc_left_time);
+        bool use_12hour = wxGetApp().app_config->get_bool("use_12hour_time");
+        right_time = get_bbl_finish_time_dhm(mc_left_time, use_12hour);
     } catch (...) {
         ;
     }


### PR DESCRIPTION
Implement user preference for 12-hour time format with AM/PM indicator:
- Add use_12hour_time config setting (default: false for 24-hour format)
- Update get_bbl_finish_time_dhm() to support 12-hour formatting
- Add checkbox in Preferences > General Settings
- Read setting and pass to formatter in StatusPanel

When enabled, finish time displays as "2:30 PM" instead of "14:30".

With setting enabled:
<img width="462" height="180" alt="Screenshot 2026-02-19 at 9 32 41 AM" src="https://github.com/user-attachments/assets/39c76451-857b-4cd0-ba04-c58624108679" />

Added setting:
<img width="462" height="180" alt="Screenshot 2026-02-19 at 9 33 28 AM" src="https://github.com/user-attachments/assets/0f0d95e6-5b16-464c-b822-ce2d80d8bc6e" />
