### PR TITLE
Implement per-object top,bottom,initial flow ratios

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6073,7 +6073,10 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
     auto _mm3_per_mm = path.mm3_per_mm * double(this->config().print_flow_ratio.value);
     if( path.role() == erTopSolidInfill )
         _mm3_per_mm *= NOZZLE_CONFIG(top_solid_infill_flow_ratio);
-    else if (this->on_first_layer())
+    else if (path.role() == erBottomSurface)
+        _mm3_per_mm *= NOZZLE_CONFIG(bottom_solid_infill_flow_ratio);
+
+    if (this->on_first_layer() && path.role() != erTopSolidInfill)
         _mm3_per_mm *= m_config.initial_layer_flow_ratio.value;
 
     double e_per_mm = m_writer.filament()->e_per_mm3() * _mm3_per_mm;

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -989,7 +989,7 @@ static std::vector<std::string> s_Preset_print_options {
      "timelapse_type", "internal_bridge_support_thickness",
      "wall_generator", "wall_transition_length", "wall_transition_filter_deviation", "wall_transition_angle",
      "wall_distribution_count", "min_feature_size", "min_bead_width", "post_process",
-    "seam_gap", "wipe_speed", "top_solid_infill_flow_ratio", "initial_layer_flow_ratio",
+    "seam_gap", "wipe_speed", "top_solid_infill_flow_ratio", "bottom_solid_infill_flow_ratio", "initial_layer_flow_ratio",
     "default_jerk", "outer_wall_jerk", "inner_wall_jerk", "infill_jerk", "top_surface_jerk", "initial_layer_jerk", "travel_jerk",
     "filter_out_gap_fill", "mmu_segmented_region_max_width", "mmu_segmented_region_interlocking_depth",
     "small_perimeter_speed", "small_perimeter_threshold", "z_direction_outwall_speed_continuous",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1145,6 +1145,15 @@ void PrintConfigDef::init_fff_params()
     def->mode = comDevelop;
     def->set_default_value(new ConfigOptionFloatsNullable{1});
 
+    def = this->add("bottom_solid_infill_flow_ratio", coFloats);
+    def->label = L("Bottom surface flow ratio");
+    def->gui_type = ConfigOptionDef::GUIType::multi_variant;
+    def->tooltip = L("This factor affects the amount of material for bottom solid infill.");
+    def->min = 0;
+    def->max = 2;
+    def->mode = comDevelop;
+    def->set_default_value(new ConfigOptionFloatsNullable{1});
+
     def = this->add("initial_layer_flow_ratio", coFloat);
     def->label = L("Initial layer flow ratio");
     def->tooltip = L("This factor affects the amount of material for the initial layer");
@@ -6483,8 +6492,6 @@ void PrintConfigDef::handle_legacy(t_config_option_key &opt_key, std::string &va
         opt_key = "enable_prime_tower";
     } else if (opt_key == "wipe_tower_width") {
         opt_key = "prime_tower_width";
-    } else if (opt_key == "bottom_solid_infill_flow_ratio") {
-        opt_key = "initial_layer_flow_ratio";
     } else if (opt_key == "wiping_volume") {
         opt_key = "filament_prime_volume";
     }
@@ -6697,7 +6704,8 @@ std::set<std::string> print_options_with_variant = {
     "top_surface_acceleration",
     "print_extruder_id", //coInts
     "print_extruder_variant", //coStrings
-    "top_solid_infill_flow_ratio"
+    "top_solid_infill_flow_ratio",
+    "bottom_solid_infill_flow_ratio"
 };
 
 std::set<std::string> filament_options_with_variant = {
@@ -6805,7 +6813,8 @@ std::set<std::string> printer_options_with_variant_2 = {
 };
 
 std::set<std::string> multi_variant_text_ctrl_options = {
-    "top_solid_infill_flow_ratio"
+    "top_solid_infill_flow_ratio",
+    "bottom_solid_infill_flow_ratio"
 };
 
 std::set<std::string> empty_options;

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1032,6 +1032,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloatOrPercent, sparse_infill_anchor_max))
     //OrcaSlicer
     ((ConfigOptionFloatsNullable, top_solid_infill_flow_ratio))
+    ((ConfigOptionFloatsNullable, bottom_solid_infill_flow_ratio))
     ((ConfigOptionFloat, initial_layer_flow_ratio))
     ((ConfigOptionFloat, filter_out_gap_fill))
     ((ConfigOptionBool, precise_outer_wall))

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -15173,6 +15173,9 @@ void Plater::calib_flowrate(int pass)
         auto config_opt = dynamic_cast<const ConfigOptionFloatsNullable *>(_obj->config.option("top_solid_infill_flow_ratio"));
         if (config_opt)
             _obj->config.set_key_value("top_solid_infill_flow_ratio", new ConfigOptionFloatsNullable(config_opt->size(), 1.0f));
+        config_opt = dynamic_cast<const ConfigOptionFloatsNullable *>(_obj->config.option("bottom_solid_infill_flow_ratio"));
+        if (config_opt)
+            _obj->config.set_key_value("bottom_solid_infill_flow_ratio", new ConfigOptionFloatsNullable(config_opt->size(), 1.0f));
 
         // extract flowrate from name, filename format: flowrate_xxx
         std::string obj_name = _obj->name;

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2692,6 +2692,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("thick_bridges","parameter/bridge");
         optgroup->append_single_option_line("print_flow_ratio");
         optgroup->append_single_option_line("top_solid_infill_flow_ratio","parameter/quality-advance-settings");
+        optgroup->append_single_option_line("bottom_solid_infill_flow_ratio","parameter/quality-advance-settings");
         optgroup->append_single_option_line("initial_layer_flow_ratio","parameter/quality-advance-settings");
         optgroup->append_single_option_line("top_one_wall_type","parameter/quality-advance-settings");
         optgroup->append_single_option_line("top_area_threshold","parameter/quality-advance-settings");


### PR DESCRIPTION
Building locally on osx breaks with every release, it feels like, so pushing to GH just to get the action to build for me. 