### PR TITLE
Fix `SwitchBoard` control not registering left side mouse clicks when shown on secondary left side monitors.

### DIFF
--- a/src/slic3r/GUI/Widgets/SwitchButton.cpp
+++ b/src/slic3r/GUI/Widgets/SwitchButton.cpp
@@ -306,19 +306,9 @@ void SwitchBoard::on_left_down(wxMouseEvent &evt)
     if (!is_enable) {
         return;
     }
-    int index = -1;
-    auto pos = ClientToScreen(evt.GetPosition());
-    auto rect = ClientToScreen(wxPoint(0, 0));
 
-    if (pos.x > 0 && pos.x < rect.x + GetSize().x / 2) {
-        switch_left = true;
-        switch_right = false;
-        index = 1;
-    } else {
-        switch_left  = false;
-        switch_right = true;
-        index = 0;
-    }
+    switch_left = evt.GetPosition().x < GetSize().GetWidth() / 2;
+    switch_right = !switch_left;
 
     if (auto_disable_when_switch)
     {
@@ -327,7 +317,7 @@ void SwitchBoard::on_left_down(wxMouseEvent &evt)
     Refresh();
 
     wxCommandEvent event(wxCUSTOMEVT_SWITCH_POS);
-    event.SetInt(index);
+    event.SetInt((int)switch_left);
     wxPostEvent(this, event);
 }
 


### PR DESCRIPTION
**Issue**:
When a `SwitchBoard` control was shown on a secondary monitor, to the left of the primary, the control would never register a click on the left half. Therefore it was not possible to select the left option/toggle in several places, for example to switch back from "Hotends" view to "Filaments" in the device status panel. 

**Cause**:
This was due to `ClientToScreen(wxMouseEvent::GetPosition())` returning negative X values on screens arranged to the left of primary, which is how screen coordinates are typically reported.

**Fix**:
It is not necessary to do any coordinate mapping at all in this case because the mouse click's `wxMouseEvent.GetPosition()` is already in local widget coordinates (0,0 is always widget top left). So it is enough to simply check where the click X was in relation to half the control's current width.

**UI Elements Affected** (indirectly):
* "Left/Right" Extruder switch in `StatusPanel`
* "Filament/Hotends" switch in `StatusPanel`
* "Open Door Detection" options in `PrintOptionsDialog` and `SafetyOptionsDialog`
* "Purify Air at Print End" toggle option in `PrintOptionsDialog`
* "Left/Right" selector in `AmsReplaceMaterialDialog` ("Auto Refill")


Thanks for your consideration,
-Max