### PR TITLE
[Windows] Attach GUI to current console when started from a command line

### DIFF
--- a/src/BambuStudio_app_msvc.cpp
+++ b/src/BambuStudio_app_msvc.cpp
@@ -190,7 +190,15 @@ extern "C" {
 }
 extern "C" {
 #ifdef SLIC3R_WRAPPER_NOCONSOLE
-    int APIENTRY wWinMain(HINSTANCE /* hInstance */, HINSTANCE /* hPrevInstance */, PWSTR /* lpCmdLine */, int /* nCmdShow */)    {
+    int APIENTRY wWinMain(HINSTANCE /* hInstance */, HINSTANCE /* hPrevInstance */, PWSTR /* lpCmdLine */, int /* nCmdShow */)
+    {
+        // if started from console/CLI then reopen stdout/stderr pipes to it for printf/cout output,
+        // which includes --help content and any option parsing errors.
+        if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+          freopen("CONOUT$", "w", stdout);
+          freopen("CONOUT$", "w", stderr);
+        }
+
         int 	  argc;
         wchar_t** argv = ::CommandLineToArgvW(::GetCommandLineW(), &argc);
 #else


### PR DESCRIPTION
Currently there is no output to the console when running Studio from a command line on Windows. For example `--help` output or CLI parameter parsing errors.  The program just appears to not do anything at all in these cases.  This is typical for Windows GUI programs since they don't usually need console interaction.

This fix will attach to the current console, _if there is one_, meaning only if it was started from a console in the first place.  It will **not** open a new console window or start a new process.  
[I use this technique on "all" my Win GUI programs for a couple decades now.]

Of course `--help` is the only way to get a real listing of currently supported switches, since the Wiki article is rather dated/missing a lot of them.

Thanks,
-Max
