### PR TITLE
feat: Re-parse G-code after post-processing scripts for live preview

### DIFF
--- a/src/slic3r/GUI/BackgroundSlicingProcess.cpp
+++ b/src/slic3r/GUI/BackgroundSlicingProcess.cpp
@@ -776,6 +776,16 @@ void BackgroundSlicingProcess::finalize_gcode()
 
     run_post_process_scripts(m_temp_output_path, false, "File", m_temp_output_path, m_fff_print->full_print_config());
 
+    // Re-parse the G-code if post-processing scripts modified it,
+    // so the preview reflects the post-processed toolpath
+    const auto *post_process = m_fff_print->full_print_config().opt<ConfigOptionStrings>("post_process");
+    if (post_process && !post_process->values.empty() && m_gcode_result) {
+        m_print->set_status(97, _utf8(L("Updating preview with post-processed G-code")));
+        GCodeProcessor processor;
+        processor.process_file(m_temp_output_path);
+        *m_gcode_result = std::move(processor.extract_result());
+    }
+
     m_print->set_status(100, _utf8(L("Successfully executed post-processing script")));
 }
 


### PR DESCRIPTION
## Post-Processing Script Preview

After slicing with post-processing scripts configured, the G-code is automatically re-parsed so the preview shows the post-processed toolpath. No need to export and drag the file back in.

### Problem

Currently, when post-processing scripts (configured in Process Settings → Post-processing Scripts) modify the G-code after slicing, the slicer preview still shows the original unmodified toolpath. Users have to manually export the G-code and drag it back into the slicer to see the actual post-processed result.

This is especially painful for scripts like [BrickLayers](https://github.com/GeekDetour/BrickLayers) that modify layer Z-heights for interlocking — the whole point is to visually verify the interlocking pattern before printing.

### Solution

In `BackgroundSlicingProcess::finalize_gcode()`, after `run_post_process_scripts()` completes, re-run `GCodeProcessor::process_file()` on the modified G-code and replace `m_gcode_result` with the new result. The existing `on_process_completed` → `update_fff_scene()` → `reload_print()` path then picks up the post-processed data and renders it in the preview.

The re-parsing only runs when post-processing scripts are configured and non-empty, so there is zero impact on normal slicing without scripts.

### Implementation

```cpp
// In BackgroundSlicingProcess::finalize_gcode()
const auto *post_process = m_fff_print->full_print_config().opt<ConfigOptionStrings>("post_process");
if (post_process && !post_process->values.empty() && m_gcode_result) {
    GCodeProcessor processor;
    processor.process_file(m_temp_output_path);
    *m_gcode_result = std::move(processor.extract_result());
}
```

10 lines added to one file.