### PR TITLE
Fix divide by zero exception in `InterlockingGenerator`.

### DIFF
--- a/src/libslic3r/Interlocking/InterlockingGenerator.cpp
+++ b/src/libslic3r/Interlocking/InterlockingGenerator.cpp
@@ -70,7 +70,8 @@ void InterlockingGenerator::generate_embedding_wall(PrintObject* print_object){
 void InterlockingGenerator::generate_interlocking_structure(PrintObject* print_object)
 {
     const auto& config = print_object->config();
-    if (!config.interlocking_beam) {
+    // Check if interlocking is enabled, and avoid errors like division by zero due to invalid configuration.
+    if (!config.interlocking_beam || config.interlocking_beam_layer_count < 1 || config.interlocking_depth < 1 || config.interlocking_beam_width < EPSILON ) {
         return;
     }
 


### PR DESCRIPTION
Fixes https://github.com/bambulab/BambuStudio/issues/9910

There's a more fundamental issue in that the current config option minimum/maximum [value types are `int`](https://github.com/bambulab/BambuStudio/blob/6a3e8bb3888b549df716a56266c1f6f3d0259012/src/libslic3r/Config.hpp#L2386), so setting a minimum of something like `0.1` doesn't work (minimum becomes zero). The GUI validation then doesn't work as expected.  Some of the code seems to completely ignore that fact, like for this interlocking beam width option: https://github.com/bambulab/BambuStudio/blob/6a3e8bb3888b549df716a56266c1f6f3d0259012/src/libslic3r/PrintConfig.cpp#L3379

I'll likely submit a PR for that fix next, unless it turns into a bigger deal than it appears so far.

Thanks,
-Max
