### PR TITLE
Fix CLI segfault (SIGSEGV) when using --info, --slice, or --export-3mf

### DIFF
--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -2885,24 +2885,26 @@ bool PartPlate::set_shape(const Pointfs& shape, const Pointfs& exclude_areas, co
 
 		calc_bounding_boxes();
 
-		ExPolygon logo_poly;
-		generate_logo_polygon(logo_poly);
-        auto triangles = triangulate_expolygon_2f(logo_poly, NORMALS_UP);
-        m_logo_triangles.reset();
-		if (!m_logo_triangles.init_model_from_poly(triangles, GROUND_Z + 0.01f))
-			BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ":Unable to create logo triangles\n";
-		else {
-			;
-		}
-        BoundingBoxf3 box_in_plate_origin;
-        if (calc_bed_3d_boundingbox(box_in_plate_origin)) {
-            if ((m_cur_bed_boundingbox.center() - box_in_plate_origin.center()).norm() > 1.0f) {
-				set_logo_box_by_bed(box_in_plate_origin);
+		if (m_plater != nullptr) { // render data, skip in CLI mode where m_plater is null
+			ExPolygon logo_poly;
+			generate_logo_polygon(logo_poly);
+			auto triangles = triangulate_expolygon_2f(logo_poly, NORMALS_UP);
+			m_logo_triangles.reset();
+			if (!m_logo_triangles.init_model_from_poly(triangles, GROUND_Z + 0.01f))
+				BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ":Unable to create logo triangles\n";
+			else {
+				;
 			}
-        }
+			BoundingBoxf3 box_in_plate_origin;
+			if (calc_bed_3d_boundingbox(box_in_plate_origin)) {
+				if ((m_cur_bed_boundingbox.center() - box_in_plate_origin.center()).norm() > 1.0f) {
+					set_logo_box_by_bed(box_in_plate_origin);
+				}
+			}
 
-	    calc_vertex_for_plate_name(m_name_texture, m_plate_name_icon);//if (generate_plate_name_texture())
-		calc_vertex_for_plate_name_edit_icon(&m_name_texture, 0, m_plate_name_edit_icon);
+			calc_vertex_for_plate_name(m_name_texture, m_plate_name_icon);//if (generate_plate_name_texture())
+			calc_vertex_for_plate_name_edit_icon(&m_name_texture, 0, m_plate_name_edit_icon);
+		}
 	}
 	calc_height_limit();
 
@@ -6083,7 +6085,7 @@ bool PartPlateList::set_shapes(const Pointfs              &shape,
 	update_logo_texture_filename(texture_filename);
     update_plate_trans(get_plate_count());
 
-    { // prepare render data
+    if (m_plater != nullptr) { // prepare render data, skip in CLI mode where m_plater is null
         ExPolygon poly;
         generate_print_polygon(poly);
         calc_triangles(poly);


### PR DESCRIPTION
## Summary

The BambuStudio CLI crashes with a segmentation fault (exit code 139) on **every** command that loads a model (`--info`, `--slice`, `--export-3mf`). This makes the CLI completely unusable.

**Root cause:** In CLI mode, `PartPlateList` is constructed with a `NULL` plater pointer (`BambuStudio.cpp:3917`). When `set_shapes()` is subsequently called, it unconditionally executes render data preparation code that dereferences the null plater through calls like `generate_print_polygon()` → `wxGetApp().plater()`.

**Fix:** Add `if (m_plater != nullptr)` guards around two render-only code blocks that are not needed in CLI mode:

- **`PartPlateList::set_shapes()`** — skip polygon generation, triangle calculation, gridlines, and icon vertex computation
- **`PartPlate::set_shape()`** — skip logo triangles, bed bounding box, and plate name texture computation

This has **zero impact on GUI mode** where `m_plater` is always a valid pointer. Only CLI mode (where `m_plater` is `NULL`) is affected.

## Steps to reproduce

```bash
# Any of these crash with exit code 139 (SIGSEGV):
BambuStudio --info model.stl
BambuStudio --slice 0 model.stl
BambuStudio --export-3mf output.3mf model.stl
```

## After fix

```
$ BambuStudio --info 3DBenchy.stl
[3DBenchy.stl]
size_x = 60.000999
size_y = 31.004000
size_z = 48.000000
...
number_of_facets = 225154
manifold = yes
volume = 15550.382812
```