### PR TITLE
Fix memory leak from allocated but uncleared object instance in `ConfigOptionDef::create_default_option()`

### DIFF
--- a/src/libslic3r/Config.cpp
+++ b/src/libslic3r/Config.cpp
@@ -300,17 +300,14 @@ ConfigOption* ConfigOptionDef::create_default_option() const
             return new ConfigOptionEnumGeneric(this->enum_keys_map, this->default_value->getInt());
 
         if (type == coEnums) {
-            auto dft = this->default_value->clone();
-            if (dft->nullable()) {
+            if (this->default_value->nullable()) {
                 ConfigOptionEnumsGenericNullable *opt = dynamic_cast<ConfigOptionEnumsGenericNullable *>(this->default_value->clone());
                 opt->keys_map = this->enum_keys_map;
                 return opt;
-            } else {
-                ConfigOptionEnumsGeneric *opt = dynamic_cast<ConfigOptionEnumsGeneric *>(this->default_value->clone());
-                opt->keys_map = this->enum_keys_map;
-                return opt;
             }
-            delete dft;
+            ConfigOptionEnumsGeneric *opt = dynamic_cast<ConfigOptionEnumsGeneric *>(this->default_value->clone());
+            opt->keys_map = this->enum_keys_map;
+            return opt;
         }
 
         return this->default_value->clone();


### PR DESCRIPTION
The cloned instance wasn't deleted before the method returned, and not really needed in the first place.

Thanks,
-Max