### PR TITLE
Refactor GUI parameter entry validation to allow floating point minimum/maximum values instead of just integers.

### DIFF
--- a/src/libslic3r/Config.hpp
+++ b/src/libslic3r/Config.hpp
@@ -3,6 +3,7 @@
 
 #include <assert.h>
 #include <map>
+#include <cfloat>
 #include <climits>
 #include <cstdio>
 #include <cstdlib>
@@ -2384,10 +2385,13 @@ public:
     // Optional width of an input field.
     int                                 width           = -1;
     // <min, max> limit of a numeric input.
-    // If not set, the <min, max> is set to <INT_MIN, INT_MAX>
+    // If not set explicitly, the <min, max> default to <-DBL_MAX, DBL_MAX>, which can be refenced externally
+    // using the static `min_default`/`max_default` members to check if a value was set.
     // By setting min=0, only nonnegative input is allowed.
-    int                                 min = INT_MIN;
-    int                                 max = INT_MAX;
+    static constexpr double             min_default = -DBL_MAX;
+    static constexpr double             max_default = DBL_MAX;
+    double                              min = min_default;
+    double                              max = max_default;
     // To check if it's not a typo and a % is missing
     double                              max_literal = 1;
     ConfigOptionMode                    mode = comSimple;

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -259,7 +259,7 @@ void Field::get_value_by_opt_type(wxString& str, const bool check_value/* = true
 			wxString label = m_opt.full_label.empty() ? _(m_opt.label) : _(m_opt.full_label);
             show_error(m_parent, from_u8((boost::format(_utf8(L("%s can't be percentage"))) % into_u8(label)).str()));
 			set_value(double_to_string(m_opt.min), true);
-			m_value = double(m_opt.min);
+			m_value = m_opt.min;
 			break;
 		}
         double val;
@@ -1002,17 +1002,17 @@ void SpinCtrl::BUILD() {
 		break;
 	}
 
-    const int min_val = m_opt.min == INT_MIN
+    const int min_val = m_opt.min == ConfigOptionDef::min_default
 #ifdef __WXOSX__
     // We will forcibly set the input value for SpinControl, since the value
     // inserted from the keyboard is not updated under OSX.
     // So, we can't set min control value bigger then 0.
     // Otherwise, it couldn't be possible to input from keyboard value
     // less then min_val.
-    || m_opt.min > 0
+    || m_opt.min > 0.0
 #endif
-    ? 0 : m_opt.min;
-	const int max_val = m_opt.max < 2147483647 ? m_opt.max : 2147483647;
+    ? 0 : (int)std::clamp<double>(m_opt.min, INT_MIN, INT_MAX);
+    const int max_val = (int)std::clamp<double>(m_opt.max, INT_MIN, INT_MAX);
 
     static Builder<SpinInput> builder;
 	auto temp = builder.build(m_parent, "", "", wxDefaultPosition, size,
@@ -1068,7 +1068,7 @@ void SpinCtrl::BUILD() {
         if (!parsed || value < INT_MIN || value > INT_MAX)
             tmp_value = UNDEF_VALUE;
         else {
-            tmp_value = std::min(std::max((int)value, m_opt.min), m_opt.max);
+            tmp_value = (int)std::clamp<double>(std::clamp<double>(value, m_opt.min, m_opt.max), INT_MIN, INT_MAX);
 #ifdef __WXOSX__
 #ifdef UNDEFINED__WXOSX__ // BBS
             // Forcibly set the input value for SpinControl, since the value
@@ -1110,9 +1110,9 @@ void SpinCtrl::propagate_value()
 	} else {
 #ifdef __WXOSX__
         // check input value for minimum
-        if (m_opt.min > 0 && tmp_value < m_opt.min) {
+        if (m_opt.min > 0.0 && tmp_value < m_opt.min) {
             SpinInput* spin = static_cast<SpinInput*>(window);
-            spin->SetValue(m_opt.min);
+            spin->SetValue((int)std::clamp<double>(m_opt.min, INT_MIN, INT_MAX));
             // spin->GetText()->SetInsertionPointEnd(); // BBS
         }
 #endif
@@ -1129,7 +1129,7 @@ void SpinCtrl::set_value(const boost::any& value, bool change_event) {
     m_disable_change_event = !change_event;
     m_value = value;
     if (value.empty()) { // BBS: null value
-        dynamic_cast<SpinInput*>(window)->SetValue(m_opt.min);
+        dynamic_cast<SpinInput*>(window)->SetValue((int)std::clamp<double>(m_opt.min, INT_MIN, INT_MAX));
         dynamic_cast<SpinInput*>(window)->GetTextCtrl()->SetValue("");
     }
     else {
@@ -2135,9 +2135,9 @@ void SliderCtrl::BUILD()
 
 	auto temp = new wxBoxSizer(wxHORIZONTAL);
 
-	auto def_val = m_opt.get_default_value<ConfigOptionInt>()->value;
-	auto min = m_opt.min == INT_MIN ? 0 : m_opt.min;
-	auto max = m_opt.max == INT_MAX ? 100 : m_opt.max;
+	const int def_val = m_opt.get_default_value<ConfigOptionInt>()->value;
+	const int min = m_opt.min == ConfigOptionDef::min_default ? 0 : (int)std::clamp<double>(m_opt.min, INT_MIN, INT_MAX);
+	const int max = m_opt.max == ConfigOptionDef::max_default ? 100 : (int)std::clamp<double>(m_opt.max, INT_MIN, INT_MAX);
 
 	m_slider = new wxSlider(m_parent, wxID_ANY, def_val * m_scale,
 							min * m_scale, max * m_scale,


### PR DESCRIPTION
Hello,

As I mentioned in #9925, there is an issue/limitation with UI parameter entry validation for floating point types. The current min/max for a `ConfigOptionDef` are integer types, which of course can't represent something like `0.1`.  There are several places in the current code that actually try to set a default like that, but it doesn't work. For example:
https://github.com/bambulab/BambuStudio/blob/6a3e8bb3888b549df716a56266c1f6f3d0259012/src/libslic3r/PrintConfig.cpp#L1911

https://github.com/bambulab/BambuStudio/blob/6a3e8bb3888b549df716a56266c1f6f3d0259012/src/libslic3r/PrintConfig.cpp#L4442

The minimum ends up being zero. And if a user does enter an invalid value (eg. negative or too large), it will auto-correct to zero.

Thee are some other parameters which could benefit from having a non-zero but < 1 minimum, I think, like some of the other flow rates for example.

This turned out to be even simpler than I thought because most of the `Field` derivatives already treated the min/max as `double` types anyway, relying on implicit conversion from int.  For example:

https://github.com/bambulab/BambuStudio/blob/6a3e8bb3888b549df716a56266c1f6f3d0259012/src/slic3r/GUI/Field.cpp#L291  (and the whole block below that; `val` is a `double` here)

https://github.com/bambulab/BambuStudio/blob/6a3e8bb3888b549df716a56266c1f6f3d0259012/src/slic3r/GUI/Field.cpp#L2069

I did search extensively and it seems that `ConfigOptionDef::min` and `max` are _only_ used with UI fields and not any other internal validation.
EDIT: also used to validate the config outside of GUI, eg. from CLI, here: https://github.com/bambulab/BambuStudio/blob/6a3e8bb3888b549df716a56266c1f6f3d0259012/src/libslic3r/PrintConfig.cpp#L8671

Thanks for your consideration,
-Max

---

Related:
#9716
#9976
