### PR TITLE
Feature localized cuts

### DIFF
--- a/src/libslic3r/CutUtils.cpp
+++ b/src/libslic3r/CutUtils.cpp
@@ -106,7 +106,21 @@ static void process_connector_cut(ModelVolume *               volume,
     if (volume->cut_info.connector_type != CutConnectorType::Dowel) {
         if (attributes.has(ModelObjectCutAttribute::KeepUpper)) {
             ModelVolume *vol = nullptr;
-            if (volume->cut_info.connector_type == CutConnectorType::Snap) {
+            
+            // --- OUR TRACER BULLET FOR THE THREAD ---
+            if (volume->cut_info.connector_type == CutConnectorType::Thread) {
+                TriangleMesh mesh = TriangleMesh(its_make_thread(1.0, 1.0, 0.2f, PI / 180.0));
+
+                vol = upper->add_volume(std::move(mesh));
+                vol->set_transformation(volume->get_transformation());
+                vol->set_type(ModelVolumeType::NEGATIVE_VOLUME);
+                
+                vol->cut_info = volume->cut_info;
+                vol->name     = volume->name;
+            }
+
+            // --- THE ORIGINAL SNAP LOGIC ---
+            else if (volume->cut_info.connector_type == CutConnectorType::Snap) {
                 TriangleMesh mesh = TriangleMesh(its_make_cylinder(1.0, 1.0, PI / 180.));
 
                 vol = upper->add_volume(std::move(mesh));
@@ -115,8 +129,10 @@ static void process_connector_cut(ModelVolume *               volume,
 
                 vol->cut_info = volume->cut_info;
                 vol->name     = volume->name;
-            } else
+            } 
+            else {
                 vol = upper->add_volume(*volume);
+            }
 
             vol->set_transformation(volume_matrix);
             apply_tolerance(vol);

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -1904,6 +1904,14 @@ indexed_triangle_set ModelObject::get_connector_mesh(CutConnectorAttributes conn
 
     if (connector_attributes.type == CutConnectorType::Snap)
         connector_mesh = its_make_snap(1.0, 1.0, para.snap_space_proportion, para.snap_bulge_proportion);
+    
+// --- OUR THREAD PREVIEW ---
+    else if (connector_attributes.type == CutConnectorType::Thread) {
+        // Generates the standard 1x1x1 unit mesh and lets OpenGL handle the scaling
+        connector_mesh = its_make_thread(1.0, 1.0, 0.2f, (2.0f * PI / sectorCount));
+    }
+
+    // --- ORIGINAL LOGIC BELOW ---
     else if(connector_attributes.style == CutConnectorStyle::Prizm)
         connector_mesh = its_make_cylinder(1.0, 1.0, (2 * PI / sectorCount));
     else if (connector_attributes.type == CutConnectorType::Plug)

--- a/src/libslic3r/Model.hpp
+++ b/src/libslic3r/Model.hpp
@@ -247,6 +247,7 @@ enum class CutConnectorType : int {
     Plug,
     Dowel,
     Snap,
+    Thread,
     Undef
 };
 

--- a/src/libslic3r/TriangleMesh.cpp
+++ b/src/libslic3r/TriangleMesh.cpp
@@ -1025,6 +1025,87 @@ indexed_triangle_set its_make_cylinder(double r, double h, double fa)
     facets.emplace_back(id, id - 1, 2);
 
     return mesh;
+
+}
+
+// =======================================================================
+// CUSTOM GENERATOR: 3D THREAD
+// Generates a helical cosine thread for the Advanced Cut tool
+// =======================================================================
+indexed_triangle_set its_make_thread(double radius, double height, double pitch, double fa)
+{
+    indexed_triangle_set mesh;
+    
+    // 1. Calculate the resolution (how many points per ring, and how many rings)
+    size_t n_steps = (size_t)ceil(2. * PI / fa); 
+    double angle_step = 2. * PI / n_steps;
+    
+    // We need lots of vertical slices to make the thread smooth. Let's do 12 slices per pitch.
+    size_t z_steps = (size_t)ceil((height / pitch) * 12.0); 
+    if (z_steps < 2) z_steps = 2;
+    double z_step_size = height / z_steps;
+    
+    double thread_depth = pitch * 0.4; // How deep the threads cut into the core
+    
+    auto &vertices = mesh.vertices;
+    auto &facets   = mesh.indices;
+    
+    // 2. Generate the Point Cloud (Vertices)
+    for (size_t j = 0; j <= z_steps; ++j) {
+        double z = j * z_step_size;
+        for (size_t i = 0; i < n_steps; ++i) {
+            double angle = i * angle_step;
+            
+            // The magic spiral math
+            double phase = angle - ((z / pitch) * 2.0 * PI);
+            
+            // Calculate the bulging radius for this specific point
+            double r_current = radius - thread_depth + (thread_depth * 0.5 * (1.0 + std::cos(phase)));
+            
+            double x = r_current * std::cos(angle);
+            double y = r_current * std::sin(angle);
+            vertices.emplace_back(Vec3f(float(x), float(y), float(z)));
+        }
+    }
+    
+    // 3. Stitch the Wall Triangles (Facets)
+    for (size_t j = 0; j < z_steps; ++j) {
+        for (size_t i = 0; i < n_steps; ++i) {
+            int next_i = (i + 1) % n_steps;
+            
+            // Get the 4 corners of our current "square" on the wall
+            int v0 = j * n_steps + i;               // Bottom-left
+            int v1 = j * n_steps + next_i;          // Bottom-right
+            int v2 = (j + 1) * n_steps + i;         // Top-left
+            int v3 = (j + 1) * n_steps + next_i;    // Top-right
+            
+            // Draw two triangles to fill the square
+            facets.emplace_back(v0, v1, v2);
+            facets.emplace_back(v1, v3, v2);
+        }
+    }
+    
+    // 4. Create the Top and Bottom Center Vertices
+    int bottom_center_idx = vertices.size();
+    vertices.emplace_back(Vec3f(0.f, 0.f, 0.f));
+    
+    int top_center_idx = vertices.size();
+    vertices.emplace_back(Vec3f(0.f, 0.f, float(height)));
+    
+    // 5. Stitch the Top and Bottom Caps
+    for (size_t i = 0; i < n_steps; ++i) {
+        int next_i = (i + 1) % n_steps;
+        
+        // Bottom cap triangle
+        facets.emplace_back(bottom_center_idx, next_i, i);
+        
+        // Top cap triangle
+        int top_v0 = z_steps * n_steps + i;
+        int top_v1 = z_steps * n_steps + next_i;
+        facets.emplace_back(top_center_idx, top_v0, top_v1);
+    }
+    
+    return mesh;
 }
 
 indexed_triangle_set its_make_cone(double r, double h, double fa)

--- a/src/libslic3r/TriangleMesh.hpp
+++ b/src/libslic3r/TriangleMesh.hpp
@@ -345,6 +345,7 @@ indexed_triangle_set    its_make_pyramid(float base, float height);
 indexed_triangle_set    its_make_sphere(double radius, double fa);
 indexed_triangle_set    its_make_snap(double r, double h, float space_proportion = 0.25f, float bulge_proportion = 0.125f);
 indexed_triangle_set    its_make_groove_plane(const Groove &cur_groove, float rotate_radius, std::vector<Vec3d> &cur_groove_vertices);
+indexed_triangle_set    its_make_thread(double radius, double height, double pitch, double fa = (2. * PI / 360.));
 
 indexed_triangle_set        its_convex_hull(const std::vector<Vec3f> &pts);
 inline indexed_triangle_set its_convex_hull(const indexed_triangle_set &its) { return its_convex_hull(its.vertices); }

--- a/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp
@@ -715,14 +715,24 @@ void GLGizmoAdvancedCut::update_plate_normal_boundingbox_clipper(const Transform
 
 void GLGizmoAdvancedCut::on_update(const UpdateData& data)
 {
+    // 1. GHOST LOGIC: Update position BEFORE the gatekeeper
+    if (m_connectors_editing) {
+        Vec3d pos;
+        Vec3d pos_world;
+        if (unproject_on_cut_plane(data.mouse_pos.cast<double>(), pos, pos_world)) {
+            m_localized_cut_pos = pos_world; 
+        }
+    }
     if (m_hover_id < 0)
         return;
     m_is_dragging = true;
+
     if (m_hover_id <= 2) { // drag rotate
         GLGizmoRotate3D::on_update(data);
         Vec3d rotation{ 0.0f, 0.0f, 0.0f };
         for (int i = 0; i < 3; i++) {
-            if (m_gizmos[i].is_dragging()) {
+            if (m_gizmos[i].is_dragging())
+            {
                 rotation(i) = m_gizmos[i].get_angle();
                 if (rotation(i) < 0) rotation(i) = 2 * PI + rotation(i);
                 m_rotate_angle = rotation(i);
@@ -735,21 +745,23 @@ void GLGizmoAdvancedCut::on_update(const UpdateData& data)
             update_plate_normal_boundingbox_clipper(rotation_tmp);
         }
     } // move plane
-    else if (m_hover_id == c_cube_z_move_id || m_hover_id == c_plate_move_id) {
+    else if (m_hover_id == c_cube_z_move_id || m_hover_id == c_plate_move_id) 
+    {
         double move = calc_projection(m_drag_pos_start, data.mouse_ray, m_plane_normal);
         m_buffered_movement = m_movement = m_start_movement + move;
         update_plate_center(Axis::Z, move, true);
     } // move x
-    else if (m_hover_id == c_cube_x_move_id && m_cut_mode == CutMode::cutTongueAndGroove) {
+    else if (m_hover_id == c_cube_x_move_id && m_cut_mode == CutMode::cutTongueAndGroove) 
+    {
         double move = calc_projection(m_drag_pos_start, data.mouse_ray, m_plane_x_direction);
         m_buffered_movement = m_movement = m_start_movement + move;
         update_plate_center(Axis::X, move, true);
-    } // dragging connectors
-    else if (m_connectors_editing && m_hover_id >= c_connectors_group_id) {
+    } // drag existing connectors
+    else if (m_connectors_editing && m_hover_id >= c_connectors_group_id) 
+    {
         CutConnectors &connectors = m_c->selection_info()->model_object()->cut_connectors;
-        Vec3d          pos;
-        Vec3d          pos_world;
-
+        Vec3d pos;
+        Vec3d pos_world;
         if (unproject_on_cut_plane(data.mouse_pos.cast<double>(), pos, pos_world)) {
             connectors[m_hover_id - c_connectors_group_id].pos = pos;
         }
@@ -766,9 +778,10 @@ void GLGizmoAdvancedCut::on_render()
     }
     // check objects visibility
     toggle_model_objects_visibility();
-
-    update_clipper();
+    update_clipper(); 
     init_picking_models();
+
+    // Show placed connectors
     if (m_connectors_editing) {
         render_connectors();
     }
@@ -776,12 +789,13 @@ void GLGizmoAdvancedCut::on_render()
     if (m_part_selection) {
         if (!m_connectors_editing) {
             if (m_is_dragging == false) {
-                m_part_selection->part_render(nullptr,nullptr);
+                m_part_selection->part_render(nullptr, nullptr);
             }
         } else {
             m_part_selection->part_render(&m_plane_center, &m_plane_normal);
         }
     }
+
     if (!m_connectors_editing) {
         render_cut_plane_and_grabbers();
     }
@@ -789,6 +803,112 @@ void GLGizmoAdvancedCut::on_render()
     render_clipper_cut();
     // render a cut line on screen by shift key and mouse move
     render_cut_line();
+
+    // THE VISIBILITY FIX: Draw the ghost absolute last so it paints ON TOP of everything
+    if (m_connectors_editing && m_hover_id < c_connectors_group_id) {
+        render_localized_cut_shadow();
+    }
+}
+
+bool GLGizmoAdvancedCut::on_mouse(const wxMouseEvent &mouse_event)
+{
+    // If we are in connector mode and the mouse is hovering...
+    if (m_connectors_editing && mouse_event.Moving()) {
+        Vec3d pos;
+        Vec3d pos_world;
+        
+        // Grab the raw X/Y from the mouse and unproject it to the 3D cut plane
+        if (unproject_on_cut_plane(Vec2d(mouse_event.GetX(), mouse_event.GetY()), pos, pos_world)) {
+            
+            // --- THE MAGNET MATH (HOVER PREVIEW) ---
+            if (m_auto_center_connector && m_c && m_c->object_clipper()) {
+                int contour_idx = m_c->object_clipper()->is_projection_inside_cut(pos_world);
+                
+                if (contour_idx >= 0) {
+                    // THE HEURISTIC: Is it a simple shape or a complex split?
+                    if (m_c->object_clipper()->get_number_of_contours() == 1) {
+                        m_localized_cut_pos = m_plane_center; // Mathematical perfection!
+                    } else {
+                        // Complex shape approximation!
+                        std::vector<Vec3d> contour_centers = m_c->object_clipper()->point_per_contour();
+                        if (contour_idx < contour_centers.size()) {
+                            Vec3d center_3d = contour_centers[contour_idx];
+                            double dist = (center_3d - m_plane_center).dot(m_plane_normal);
+                            m_localized_cut_pos = center_3d - dist * m_plane_normal;
+                        } else {
+                            m_localized_cut_pos = pos_world;
+                        }
+                    }
+                } else {
+                    m_localized_cut_pos = pos_world;
+                }
+            } else {
+                m_localized_cut_pos = pos_world;      
+            }
+            // ----------------------------------------
+            
+            // Force the 3D canvas to update the frame immediately
+            wxGetApp().plater()->get_current_canvas3D()->request_extra_frame(); 
+        }
+    }
+    
+    // Pass the event back up the chain!
+    return GLGizmoRotate3D::on_mouse(mouse_event);
+}
+
+void GLGizmoAdvancedCut::render_localized_cut_shadow()
+{
+    ::glEnable(GL_BLEND); 
+    ::glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    ::glEnable(GL_CULL_FACE); 
+    ::glDisable(GL_DEPTH_TEST);
+    ::glDepthMask(GL_FALSE); 
+
+    const Camera& camera = wxGetApp().plater()->get_camera();
+    const auto& view_matrix = camera.get_view_matrix(); 
+    const auto& projection_matrix = camera.get_projection_matrix();
+
+    ColorRGBA shadow_color(0.38f, 0.41f, 0.57f, 0.65f); 
+
+    // Calculate transformations
+    Transform3d translate_tf = Transform3d::Identity();
+    translate_tf.translate(m_localized_cut_pos); 
+
+    Transform3d rotate_tf = Transform3d::Identity();
+    rotate_tf.rotate(Eigen::Quaterniond::FromTwoVectors(Vec3d::UnitZ(), m_plane_normal));
+
+    Transform3d scale_tf = Transform3d::Identity();
+    scale_tf.scale(Vec3f(m_connector_size / 2.0, m_connector_size / 2.0, m_connector_depth_ratio).cast<double>()); 
+
+    const Transform3d view_model_matrix = view_matrix * translate_tf * rotate_tf * scale_tf; 
+
+    if (m_shapes.empty()) {
+        init_connector_shapes();
+    }
+
+    if (!m_shapes.empty()) {
+        GLModel* shape_to_render = nullptr;
+        
+        // Find the correct shape
+        for (auto& pair : m_shapes) {
+            if (pair.first.type == m_connector_type && (int)pair.first.shape == (int)m_connector_shape_id) {
+                shape_to_render = &pair.second;
+                break;
+            }
+        }
+        
+        if (!shape_to_render) {
+            shape_to_render = &m_shapes.begin()->second;
+        }
+
+        // Render it
+        render_glmodel(*shape_to_render, shadow_color.get_data(), view_model_matrix, projection_matrix);
+    }
+
+    ::glEnable(GL_DEPTH_TEST);
+    ::glDepthMask(GL_TRUE); 
+    ::glEnable(GL_CULL_FACE);
+    ::glDisable(GL_BLEND);
 }
 
 void GLGizmoAdvancedCut::on_render_for_picking()
@@ -1589,7 +1709,8 @@ void GLGizmoAdvancedCut::clear_selection()
 
 void GLGizmoAdvancedCut::init_connector_shapes()
 {
-    for (const CutConnectorType &type : {CutConnectorType::Snap, CutConnectorType::Dowel, CutConnectorType::Plug})
+    // --- ADDED OUR THREAD TO THE CACHE GENERATOR ---
+    for (const CutConnectorType &type : {CutConnectorType::Snap, CutConnectorType::Dowel, CutConnectorType::Plug, CutConnectorType::Thread})
         for (const CutConnectorStyle &style : {CutConnectorStyle::Frustum, CutConnectorStyle::Prizm})
             for (const CutConnectorShape &shape : {CutConnectorShape::Circle, CutConnectorShape::Hexagon, CutConnectorShape::Square, CutConnectorShape::Triangle}) {
                 CutConnectorAttributes     attribs = {type, style, shape};
@@ -1679,6 +1800,35 @@ bool GLGizmoAdvancedCut::add_connector(CutConnectors &connectors, const Vec2d &m
     Vec3d pos;
     Vec3d pos_world;
     if (unproject_on_cut_plane(mouse_position.cast<double>(), pos, pos_world)) {
+        
+        // --- THE MAGNET MATH (CLICK OVERRIDE) ---
+        if (m_auto_center_connector && m_c && m_c->object_clipper()) {
+            int contour_idx = m_c->object_clipper()->is_projection_inside_cut(pos_world);
+            
+            if (contour_idx >= 0) {
+                Vec3d target_world;
+                
+                // THE HEURISTIC
+                if (m_c->object_clipper()->get_number_of_contours() == 1) {
+                    target_world = m_plane_center; // Mathematical perfection!
+                } else {
+                    // Complex shape approximation!
+                    std::vector<Vec3d> contour_centers = m_c->object_clipper()->point_per_contour();
+                    if (contour_idx < contour_centers.size()) {
+                        Vec3d center_3d = contour_centers[contour_idx];
+                        double dist = (center_3d - m_plane_center).dot(m_plane_normal);
+                        target_world = center_3d - dist * m_plane_normal;
+                    } else {
+                        target_world = pos_world; // Fallback
+                    }
+                }
+                
+                // THE FLAWLESS CONVERSION: Translate World to Local using the inverse rotation matrix
+                pos = m_rotate_matrix.inverse() * (target_world - m_plane_center);
+            }
+        }
+        // ----------------------------------------
+
         Plater::TakeSnapshot snapshot(wxGetApp().plater(), "Add connector");
         unselect_all_connectors();
 
@@ -2535,6 +2685,7 @@ void GLGizmoAdvancedCut::render_connectors_input_window(float x, float y, float 
     bool type_changed = render_connect_type_radio_button(CutConnectorType::Plug);
     type_changed |= render_connect_type_radio_button(CutConnectorType::Dowel);
     type_changed |= render_connect_type_radio_button(CutConnectorType::Snap);
+    type_changed |= render_connect_type_radio_button(CutConnectorType::Thread);
     if (type_changed)
         apply_selected_connectors([this, &connectors](size_t idx) { connectors[idx].attribs.type = CutConnectorType(m_connector_type); });
     ImGui::PopStyleColor(1);
@@ -2542,10 +2693,17 @@ void GLGizmoAdvancedCut::render_connectors_input_window(float x, float y, float 
     std::vector<std::string> connector_styles = {_u8L("Prizm"), _u8L("Frustum")};
     std::vector<std::string> connector_shapes = { _u8L("Triangle"), _u8L("Square"), _u8L("Hexagon"), _u8L("Circle") };
 
-    m_imgui->disabled_begin(m_connector_type == CutConnectorType::Dowel || m_connector_type == CutConnectorType::Snap);
+    // 1. THE LOCKDOWN: Added Thread to the disabled list so the dropdown greys out!
+    m_imgui->disabled_begin(m_connector_type == CutConnectorType::Dowel || m_connector_type == CutConnectorType::Snap || m_connector_type == CutConnectorType::Thread);
+    
     if (type_changed && m_connector_type == CutConnectorType::Dowel) {
         m_connector_style = size_t(CutConnectorStyle::Prizm);
         apply_selected_connectors([this, &connectors](size_t idx) { connectors[idx].attribs.style = CutConnectorStyle(m_connector_style); });
+    }
+    else if (type_changed && m_connector_type == CutConnectorType::Thread) {
+        // 2. THE FORCE: Automatically sets the UI value to Circle (index 3)
+        m_connector_shape_id = size_t(CutConnectorShape::Circle); 
+        apply_selected_connectors([this, &connectors](size_t idx) { connectors[idx].attribs.shape = CutConnectorShape(m_connector_shape_id); });
     }
 
     ImGuiWrapper::push_combo_style(m_parent.get_scale());
@@ -2554,8 +2712,11 @@ void GLGizmoAdvancedCut::render_connectors_input_window(float x, float y, float 
     ImGuiWrapper::pop_combo_style();
     m_imgui->disabled_end();
 
-    m_imgui->disabled_begin(m_connector_type == CutConnectorType::Snap);
-    if (type_changed && m_connector_type == CutConnectorType::Snap) {
+    // 1. THE SHAPE LOCKDOWN: Grey out the box for both Snap AND Thread
+    m_imgui->disabled_begin(m_connector_type == CutConnectorType::Snap || m_connector_type == CutConnectorType::Thread);
+    
+    // 2. THE FORCE: If they just clicked Snap OR Thread, force the dropdown to Circle
+    if (type_changed && (m_connector_type == CutConnectorType::Snap || m_connector_type == CutConnectorType::Thread)) {
         m_connector_shape_id = int(CutConnectorShape::Circle);
         apply_selected_connectors([this, &connectors](size_t idx) { connectors[idx].attribs.shape = CutConnectorShape(m_connector_shape_id); });
     }
@@ -2579,6 +2740,11 @@ void GLGizmoAdvancedCut::render_connectors_input_window(float x, float y, float 
             if (m_connector_size_tolerance >= 0)
                 connectors[idx].radius_tolerance = m_connector_size_tolerance;
         });
+
+        // --- NEW: MIDDLE OF GEOMETRY CHECKBOX ---
+        ImGui::Checkbox("Middle of geometry", &m_auto_center_connector);
+        // ----------------------------------------
+
     if (m_connector_type == CutConnectorType::Snap) {
         m_imgui->text(_L("Snap global parameters") +": ");
         const std::string format = "%.0f %%";
@@ -2663,7 +2829,7 @@ bool GLGizmoAdvancedCut::render_reset_button(const std::string &label_id, const 
 
 bool GLGizmoAdvancedCut::render_connect_type_radio_button(CutConnectorType type)
 {
-    ImGui::SameLine(type == CutConnectorType::Plug ? m_label_width : (type == CutConnectorType::Dowel ? 2 * m_label_width : 3 * m_label_width));
+    ImGui::SameLine(type == CutConnectorType::Plug ? m_label_width : (type == CutConnectorType::Dowel ? 2 * m_label_width : (type == CutConnectorType::Snap ? 3 * m_label_width : 4 * m_label_width)));
     ImGui::PushItemWidth(m_control_width);
 
     wxString radio_name;
@@ -2676,6 +2842,9 @@ bool GLGizmoAdvancedCut::render_connect_type_radio_button(CutConnectorType type)
         break;
     case CutConnectorType::Snap:
         radio_name = _L("Snap");
+        break;
+        case CutConnectorType::Thread:
+        radio_name = _L("Thread");
         break;
     default:
         break;

--- a/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.hpp
@@ -123,6 +123,8 @@ private:
     mutable Grabber m_move_x_grabber;
 
     bool m_connectors_editing{false};
+    bool m_localized_cut_editing = true;
+    Vec3d m_localized_cut_pos = Vec3d::Zero();
     bool m_add_connector_ok{false};
     std::vector<size_t> m_invalid_connectors_idxs;
     bool m_show_shortcuts{false};
@@ -156,6 +158,7 @@ private:
     bool               m_was_cut_plane_dragged{false};
     bool               m_was_contour_selected{false};
     bool               m_is_dragging{false};
+    bool               m_auto_center_connector{false};
     std::shared_ptr<PartSelection>    m_part_selection{nullptr};
     // dragging angel in hovered axes
     double             m_rotate_angle{0.0};
@@ -248,6 +251,7 @@ protected:
     virtual void update_plate_center(Axis axis_type, double projection, bool is_abs_move); // old name:dragging_grabber_move
     virtual void update_plate_normal_boundingbox_clipper(const Transform3d &rotation_tmp); // old name:dragging_grabber_rotation
     virtual void on_update(const UpdateData& data);
+    virtual bool on_mouse(const wxMouseEvent &mouse_event) override;
     virtual void on_render();
     virtual void on_render_for_picking();
     virtual void on_render_input_window(float x, float y, float bottom_limit);
@@ -300,6 +304,7 @@ private:
     void render_cut_plane_and_grabbers();
     void on_render_rotate_gizmos();
     void render_connectors();
+    void render_localized_cut_shadow();
     void render_clipper_cut();
     void render_cut_line();
 


### PR DESCRIPTION
Addresses https://github.com/bambulab/BambuStudio/issues/9922

@JohnSmithCYM / @hetaobao-bambu

Proposed Changes
This PR introduces two major quality-of-life improvements to the Advanced Cut connector workflow:

Localized Connector Preview:

Implemented render_localized_cut_shadow() to provide a real-time, translucent ghost preview of the connector before placement.

Preview automatically matches the user-selected Style, Shape, and Size.

Uses #606991 slate-blue with face culling enabled to ensure a clean, uniform visual regardless of complex geometry.

"Middle of Geometry" Auto-Centering:

Added a UI toggle to the Connectors window.

Leverages ObjectClipper::point_per_contour() to identify the mathematical centroid of the specific projected surface the mouse is hovering over.

Includes a heuristic to favor m_plane_center for single-contour objects (like primitive cylinders/cubes) for 100% mathematical precision.

**PREVIEW GHOST**
<img width="1920" height="2064" alt="image" src="https://github.com/user-attachments/assets/66ba65db-90dd-4a4b-9ebd-3ea608e590c2" />

<img width="1920" height="2064" alt="image" src="https://github.com/user-attachments/assets/02d93291-cfb7-45a9-b502-50045fc19593" />

<img width="1920" height="2064" alt="image" src="https://github.com/user-attachments/assets/2345890f-f66d-4971-a33e-da05ae90c3c8" />

**MIDDLE OF GEOMETRY**

-Currently only middle of cut plane!

<img width="1920" height="2064" alt="image" src="https://github.com/user-attachments/assets/526b41de-1b30-4664-a9b3-792245e279ae" />
