### PR TITLE
FIX: Preserve nozzle grouping metadata through Helio Enhance for H2C printers (#53)

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -2396,6 +2396,9 @@ void GCodeProcessor::reset()
     m_detect_layer_based_on_tag = false;
 
     m_seams_count = 0;
+
+    m_nozzle_group_result.reset();
+
 #if ENABLE_GCODE_VIEWER_DATA_CHECKING
     m_mm3_per_mm_compare.reset();
     m_height_compare.reset();

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -2081,7 +2081,19 @@ void HelioBackgroundProcess::load_helio_file_to_viwer(std::string file_path, std
 {
     const Vec3d origin = GUI::wxGetApp().plater()->get_partplate_list().get_current_plate_origin();
     m_gcode_processor.set_xy_offset(origin(0), origin(1));
+
+    // Preserve nozzle grouping context from original slicing for multi-nozzle printers (H2C)
+    if (m_gcode_result && m_gcode_result->nozzle_group_result.has_value())
+        m_gcode_processor.initialize_from_context(m_gcode_result->nozzle_group_result.value());
+
     m_gcode_processor.process_file(file_path);
+
+    // Carry over fields that GCodeProcessor cannot reconstruct from gcode parsing
+    if (m_gcode_result) {
+        m_gcode_processor.result().nozzle_group_result = m_gcode_result->nozzle_group_result;
+        m_gcode_processor.result().used_filaments = m_gcode_result->used_filaments;
+    }
+
     auto res       = &m_gcode_processor.result();
     m_gcode_result = res;
 


### PR DESCRIPTION


After Helio Enhance, the GCodeProcessor result was missing nozzle_group_result and used_filaments, causing H2C firmware to fail with "failed to build nozzle auto-mapping table". Preserve these fields from the original slicing result through the Helio processing path, and clear stale nozzle data on processor reset.