### PR TITLE
Fix possible infinite loop in painted fuzzy skin generation with invalid parameters.

### DIFF
--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -3141,8 +3141,10 @@ PrintRegionConfig region_config_from_model_volume(const PrintRegionConfig &defau
         config.sparse_infill_density.value = 0;
     else
         config.sparse_infill_density.value = std::min(config.sparse_infill_density.value, 100.);
-    if (config.fuzzy_skin.value != FuzzySkinType::None && (config.fuzzy_skin_point_distance.value < 0.01 || config.fuzzy_skin_thickness.value < 0.001))
-        config.fuzzy_skin.value = FuzzySkinType::None;
+    // Very small fuzzy_skin_point_distance value may cause infinite recursion, and a near-zero thickness doesn't generate anything anyway.
+    // Check here even if `fuzzy_skin == None` because that setting allows painting and the type may get reset later (but `Disabled_fuzzy` will not).
+    if (config.fuzzy_skin.value != FuzzySkinType::Disabled_fuzzy && (config.fuzzy_skin_point_distance.value < 0.01 || config.fuzzy_skin_thickness.value < 0.001))
+        config.fuzzy_skin.value = FuzzySkinType::Disabled_fuzzy;
     return config;
 }
 


### PR DESCRIPTION
**Issue**:

Fuzzy skin distance value can be set to zero (in the UI or manually edited config).  Doing this when the fuzzy skin is painted, and skin type is set to "None (allow paint)", will cause an infinite loop during fuzz generation, resulting in an out-of-memory crash.

I was first alerted to this when I came across the bug report at Orca repo: https://github.com/OrcaSlicer/OrcaSlicer/issues/11069  (Thanks @Thynix !)

**Repro**

Example project attached. It is a cube painted with fuzzy skin on 3 sides. Global fuzzy skin setting is "None (allow paint)" and the distance is set to zero.  (FWIW I wasn't able to recreate the issue when the cube was painted on all 4 sides.)

(No need to unpack, just rename to remove the .zip file extension.)
[fuzzy-painting-oom-test.bs25.3mf.zip](https://github.com/user-attachments/files/26001765/fuzzy-painting-oom-test.bs25.3mf.zip)

**Cause**

There was already a sanity check for minimum fuzzy skin config values, but it was being skipped for painted surfaces (at least in some cases like the repro). As mentioned in the added comments, checking for `FuzzySkinType::None` wasn't catching those cases since "None" still allows painted fuzzies.

For example the `fuzzy_skin` value could get reset later [here](https://github.com/bambulab/BambuStudio/blob/c7bdea548a0519715d26c2a6c2a4dfc8365ea7ad/src/libslic3r/PrintApply.cpp#L844) or [here](https://github.com/bambulab/BambuStudio/blob/c7bdea548a0519715d26c2a6c2a4dfc8365ea7ad/src/libslic3r/PrintApply.cpp#L1087).

**Alternative/parallel fix**

There is another enabled/sanity check being performed in https://github.com/bambulab/BambuStudio/blob/c7bdea548a0519715d26c2a6c2a4dfc8365ea7ad/src/libslic3r/FuzzySkin.cpp#L125 .  It could make sense to add another check there, closer to the source in case of any other such oversights in the future.  The current validation could be removed, but from my tests, with the current validation in place, the slicer doesn't even enter the fuzzy skin routines, which is of course more efficient.

**UI Fix**

If my #9956 is merged (or something similar), proper parameter validation can be done in the UI in the first place.  I'm happy to submit a PR if that happens (already tested in my code).


Thank you,
-Max