### PR TITLE
Prevent access violation due to out of bounds index when trying to map to non-existing filament

### DIFF
--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -1778,8 +1778,8 @@ bool PartPlate::check_tpu_nozzle_has_multiple_filaments(const DynamicPrintConfig
     std::unordered_map<NozzleVolumeType, int> nozzle_fils;
     if (!used_filaments.empty()) {
         for (auto filament_idx : used_filaments) {
-            int              filament_id  = filament_idx - 1;
             std::vector<int> filament_map = get_real_filament_maps(config);
+            int              filament_id  = std::clamp(filament_idx, 1, (int)filament_map.size()) - 1;
             int              extruder_idx = filament_map[filament_id] - 1;
 
             NozzleVolumeType volume_type = (NozzleVolumeType) config.option<ConfigOptionEnumsGeneric>("nozzle_volume_type")->values.at(extruder_idx);


### PR DESCRIPTION
Fixes https://github.com/bambulab/BambuStudio/issues/9965 

This prevents a crash, and it is always good to check for index bounds. (hint hint)

However I'm not sure if the filament index from the pasted object was supposed to be validated earlier in the paste object sequence somewhere.... not that I saw, but perhaps there's a separate issue in there somewhere.

Simple fix, if you choose to implement it in your internal version directly, just let me know and go ahead and close this.

Thanks,
-Max
