### PR TITLE
Restore `--datadir` CLI arg. functionality & add local configuration folder search for easily portable Studio instances.

### DIFF
--- a/src/BambuStudio.cpp
+++ b/src/BambuStudio.cpp
@@ -104,6 +104,15 @@ using namespace Slic3r;
 
 #define MAX_CLONEABLE_SIZE 512
 
+// Folder name for portable version configuration storage location.
+// If a directory with this name is found at startup next to the program's executable,
+// it will be used for all settings/profiles storage instead of the usual OS-dependent location.
+// This check can also be overridden using the --datadir CLI argument.
+// The folder check can be disabled entirely at build time by setting this macro to an empty _string_ value ("").
+#ifndef PORTABLE_DATA_DIR_NAME
+    #define PORTABLE_DATA_DIR_NAME  "configuration"
+#endif
+
 std::map<int, std::string> cli_errors = {
     {CLI_SUCCESS, "Success."},
     {CLI_ENVIRONMENT_ERROR, "Failed setting up server environment."},
@@ -8184,29 +8193,37 @@ bool CLI::setup(int argc, char **argv)
     }
 #endif
 
-    // See Invoking prusa-slicer from $PATH environment variable crashes #5542
-    // boost::filesystem::path path_to_binary = boost::filesystem::system_complete(argv[0]);
-    boost::filesystem::path path_to_binary = boost::dll::program_location();
+    // Fully resolved directory path of program's runtime base "installation" folder, which may be "portable" version run from any arbitrary location.
+    boost::filesystem::path install_path;
+    // Starting with the current location of the binary being executed.
+    try {
+        install_path = boost::filesystem::canonical(boost::dll::program_location()).parent_path();
+    } catch (std::exception &e) {
+        // boost log not initialized yet
+        boost::nowide::cerr << "Could not determine canonical path to application directory!" << std::endl << e.what() << std::endl << std::endl;
+        return false;
+    }
 
-    // Path from the Slic3r binary to its resources.
+    // Path from the program binary to its resources.
 #ifdef __APPLE__
-    // The application is packed in the .dmg archive as 'Slic3r.app/Contents/MacOS/Slic3r'
-    // The resources are packed to 'Slic3r.app/Contents/Resources'
-    boost::filesystem::path path_resources = boost::filesystem::canonical(path_to_binary).parent_path().parent_path() / "Resources";
-#elif defined _WIN32
+    // The application is packed in the .dmg archive as 'BambuStudio.app/Contents/MacOS/BambuStudio'
+    // The resources are packed to 'BambuStudio.app/Contents/Resources'
+    const boost::filesystem::path path_resources = install_path.parent_path() / "Resources";
+    // For file system access outside the bundle, to check for datadir folder at that level.
+    install_path = install_path.parent_path().parent_path().parent_path();
+#elif defined(_WIN32)
     // The application is packed in the .zip archive in the root,
-    // The resources are packed to 'resources'
-    // Path from Slic3r binary to resources:
-    boost::filesystem::path path_resources = path_to_binary.parent_path() / "resources";
-#elif defined SLIC3R_FHS
+    // The resources are packed to 'resources' in the root.
+    const boost::filesystem::path path_resources = install_path / "resources";
+#elif defined(SLIC3R_FHS)
     // The application is packaged according to the Linux Filesystem Hierarchy Standard
     // Resources are set to the 'Architecture-independent (shared) data', typically /usr/share or /usr/local/share
-    boost::filesystem::path path_resources = SLIC3R_FHS_RESOURCES;
+    const boost::filesystem::path path_resources = SLIC3R_FHS_RESOURCES;
 #else
-    // The application is packed in the .tar.bz archive (or in AppImage) as 'bin/slic3r',
-    // The resources are packed to 'resources'
-    // Path from Slic3r binary to resources:
-    boost::filesystem::path path_resources = boost::filesystem::canonical(path_to_binary).parent_path().parent_path() / "resources";
+    // The application is packed in the .tar.bz archive (or in AppImage) as 'bin/bambu-studio',
+    // The resources are packed to 'resources' in the root.
+    install_path = install_path.parent_path();
+    const boost::filesystem::path path_resources = install_path / "resources";
 #endif
 
     set_resources_dir(path_resources.string());
@@ -8252,6 +8269,24 @@ bool CLI::setup(int argc, char **argv)
         // Don't validate existence or create it right now, should be done in GUI_App::init_app_config(), same as for default data dir.
         // We do want to store the full path in native format because that's how all other sources of the global data_dir are stored.
         set_data_dir(boost::filesystem::absolute(m_config.opt_string("datadir")).make_preferred().string());
+    }
+    // Check for special configuration folder at the same level as the installation path.
+    else if (std::strlen(PORTABLE_DATA_DIR_NAME) > 0) {
+        boost::filesystem::path local_data_dir_path = install_path / PORTABLE_DATA_DIR_NAME;
+        if (boost::filesystem::exists(local_data_dir_path)) {
+            set_data_dir(local_data_dir_path.make_preferred().string());
+        }
+#if defined(__linux__) || defined(__LINUX__)
+        // If running from an AppImage, the original package location is stored in APPIMAGE env. var.
+        // The user may have a loclal config folder at the same level as the image file, not inside the image itself.
+        else if (const char *appimage_env = std::getenv("APPIMAGE")) {
+            boost::system::error_code ec;
+            local_data_dir_path = boost::filesystem::canonical(boost::filesystem::path(appimage_env).parent_path() / PORTABLE_DATA_DIR_NAME, ec);
+            // Ignore errors, no local config folder or couldn't resolve APPIMAGE at all for some reason.
+            if (!ec)
+                set_data_dir(local_data_dir_path.string());
+        }
+#endif  // __linux__
     }
 
     return true;

--- a/src/BambuStudio.cpp
+++ b/src/BambuStudio.cpp
@@ -8239,14 +8239,19 @@ bool CLI::setup(int argc, char **argv)
         for (const t_optiondef_map::value_type &optdef : *options)
             m_config.option(optdef.first, true);
 
-    //set_data_dir(m_config.opt_string("datadir"));
-
     //FIXME Validating at this stage most likely does not make sense, as the config is not fully initialized yet.
     if (!validity.empty()) {
         boost::nowide::cerr << "Params in command line error: "<< std::endl;
         for (std::map<std::string, std::string>::iterator it=validity.begin(); it!=validity.end(); ++it)
             boost::nowide::cerr << it->first <<": "<< it->second << std::endl;
         return false;
+    }
+
+    // Set custom configuration storage location if invoked with --datadir argument.
+    if (m_config.has("datadir") && !m_config.opt_string("datadir").empty()) {
+        // Don't validate existence or create it right now, should be done in GUI_App::init_app_config(), same as for default data dir.
+        // We do want to store the full path in native format because that's how all other sources of the global data_dir are stored.
+        set_data_dir(boost::filesystem::absolute(m_config.opt_string("datadir")).make_preferred().string());
     }
 
     return true;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -9764,6 +9764,11 @@ CLIMiscConfigDef::CLIMiscConfigDef()
     def->tooltip = L("Automatically export current configuration to the specified file.");
 */
 
+    def = this->add("datadir", coString);
+    def->label = "Configuration data directory";
+    def->tooltip = "Use and store all program settings at the given directory instead of the default location.";
+    def->cli_params = "dir";
+
     def = this->add("outputdir", coString);
     def->label = "Output directory";
     def->tooltip = "Output directory for the exported files.";


### PR DESCRIPTION
Hello,

**Issue**

Studio can't be easily run as a truly portable application (w/out creating some kind of virtual environment). Nor is there any way to easily test a different version than currently installed, w/out overwriting all the presets, possibly changing the app config, etc.

Furthermore, there is a popular misconception that the `.zip` distribution provided in GH releases is "portable" and that it's "safe to try it out" alongside another installed version.  This is incorrect, or at least misleading, at best.

**Proposed Solution(s)**

1) Restore the `--datadir` CLI argument (and related functionality).
   * `+` Allows greater flexibility as to where all the configuration data is stored, including network shares, etc.
   * `+` Brings Studio (back) inline with _Slic3r_ and derivatives (_Prusa_, _Orca_, _Super_), all of which support `--datadir` (added back after forking, in the case of the latter two).
   * `-` Requires user action to ensure the desired folder is used (invoking from CLI, using a specific shortcut, etc).
2) Add an automatic search at program start for the presence of a directory, with a specific "magic" name, at the same folder level as the program is being run from.
   * `+` Addresses the last point above, making possible a fully portable "installation" just by adding a folder to store the configs (which could also be a symlink). It would be easier and less error-prone to start, eg. just by executing via file browser from an external disk/network share/etc, or even from a file type association.
   * `-` Adds a small delay/overhead to program startup due to check for directory (potentially twice in the case of an AppImage being used).
   * `-` By itself (w/out `1` above) this would still provide some flexibility with using different versions in parallel, for example, but not as much, possibly _requiring_ symlinks in order to use shared or remote storage locations.
   * `+` This feature parallels the one available now in _SuperSlicer_ and _OrcaSlicer_ (_Prusa_ and _Slic3r_ don't implement this).

So the two features combined provide the most flexibility, though either could stand alone as well.

**Proposed Implementation**

I split these commits on purpose since they have separate functionalities (either could be implemented on their own). OTOH to implement both makes sense to build the 2nd on top of the first, and the functionality is related, so I think it makes sense to present/discuss together.

I can squash, split to different PRs, edit... whatever is preferred.

1. Adding `--datadir` back, essentially, is very straight-forward and doesn't affect any existing functionality. From my tests, when started with `--datadir`, it never tries to write or read config data from anywhere else.  There's a minor issue with where the logs are written (see below) but otherwise this seems like a simple solution.
2. For the local config folder feature:
   * I chose "configuration" for the magic folder name. This matches _SuperSlicer_, but not _OrcaSlicer_, which uses "data_dir".
   * This name could be configured with a macro at build time.
   * The whole search for a local configuration folder step can be disabled at build time by defining the macro as an empty string.
      * I'm not sure the last two are entirely necessary, but mostly I dislike having "magic strings" hidden deep in code.
      * I'm also not sure if that's the "best" place to check for/define the macro, but nothing else jumped out, and that was the closest place to where it needs to be used.
   * On Mac the config folder is expected to be at the same folder level as the .app bundle.
   * On Linux it is expected to be at the same level as the "resources" folder (above "bin"), _or_ at the same folder level as the AppImage, if one is being used (it can also be stored _inside_ the AppImage archive, alongside resources, which is checked first).
   * On Windows it is expected to be in the rood folder where the binary and "resources", etc, are located.

**Issues & Related**

1) When used with a custom configuration folder, right now the main log file ends up in the current working directory.  This is because the act of switching CWD to the log folder is done in [GUI_App::init_app_config()](https://github.com/bambulab/BambuStudio/blob/c7bdea548a0519715d26c2a6c2a4dfc8365ea7ad/src/slic3r/GUI/GUI_App.cpp#L2505) _only_ if the current `data_dir().empty()` and it uses the default storage location.  (The networking log ends up correctly in `log` subfolder of config directory.)
   * The relevant block of code in `GUI_App::init_app_config()` is directly related to issue and code in PR #9477.  @wtji-bbl mentioned in the comments that a fix was already implemented.  I haven't seen that commit (sorry if I missed it), but I didn't want to touch any of that if you've already made changes. It's a relatively minor issue, and I'm happy to work on it if it still exists after whatever change is pending for it now. (Shouldn't the log path be absolute anyway, not related to CWD?)
2) When using either custom config location option, there's no validation being done that the destination is readable or writable (at least at startup).  This may result in crash or other UB.  _However_ I think this check should be done in `init_app_config()`, for whatever `data_dir()` currently is, _after_ it may have created the default storage location. Because really a folder could become un-read/writable at any time (for example app is running with different permissions).
   * Again I didn't want to step on whatever changes are being done in relation to the setting not getting saved, so I didn't implement it here, but happy to add later if needed.

**"Prior art"**
https://github.com/OrcaSlicer/OrcaSlicer/commit/771ef9fd80de4fe2f43e2e1ba2ff5268a84d0e41
https://github.com/OrcaSlicer/OrcaSlicer/commit/6ca1741e83ce8ea7e9338fa1f7a401acd07c2b8d & https://github.com/OrcaSlicer/OrcaSlicer/commit/fb032cd85f2dc7ffb1b32d478192a63ef53688cf
https://github.com/supermerill/SuperSlicer/commit/e4233d4e7dc075919323c72fd8b284ac3ac0ea57 & https://github.com/supermerill/SuperSlicer/pull/2160

---

Please let me know if any question, concerns, issues, etc.  And thank you for your time!
-Max

---
Closes https://github.com/bambulab/BambuStudio/issues/1651

---
Related: #9858  so Windows users can interact with the CLI better.