### PR TITLE
FIX: Properly initialize `BaseRenderer::m_config` with `nullptr`.

### DIFF
--- a/src/slic3r/GUI/GCodeRenderer/BaseRenderer.cpp
+++ b/src/slic3r/GUI/GCodeRenderer/BaseRenderer.cpp
@@ -597,9 +597,10 @@ namespace Slic3r
                             { min.x(), max.y() } };
                     }*/
                 }
-                else if (&wxGetApp() && wxGetApp().app_config->get_bool("show_shells_in_preview")) { // BBS: load shell at helio_gcode
+                else if (m_config && &wxGetApp() && wxGetApp().app_config->get_bool("show_shells_in_preview")) { // BBS: load shell at helio_gcode
                     load_shells(print, initialized,true);
-                    update_shells_color_by_extruder(m_config);
+                    if (!m_shells.volumes.empty())
+                        update_shells_color_by_extruder(m_config);
                 }
                 m_print_statistics = gcode_result.print_statistics;
                 if (m_time_estimate_mode != PrintEstimatedStatistics::ETimeMode::Normal) {

--- a/src/slic3r/GUI/GCodeRenderer/BaseRenderer.hpp
+++ b/src/slic3r/GUI/GCodeRenderer/BaseRenderer.hpp
@@ -251,7 +251,7 @@ namespace Slic3r {
                 bool m_only_gcode_in_preview{ false };
                 //BBS
                 Shells            m_shells;
-                const DynamicPrintConfig *m_config;//equal glcanvas3d m_config
+                const DynamicPrintConfig *m_config{ nullptr };  //equal glcanvas3d m_config
                 GCodeCheckResult  m_gcode_check_result;
                 FilamentPrintableResult filament_printable_reuslt;
                 ConflictResultOpt m_conflict_result;


### PR DESCRIPTION
Fixes https://github.com/bambulab/BambuStudio/issues/9991

Since: https://github.com/bambulab/BambuStudio/commit/9705d20636718bf47257c184c824251fa56880d6

Since the pointer wasn't initialized, whether the crash happened or not was inconsistent. Required "always show shells" option to be enabled.

The 2nd commit here skips some unnecessary processing if there is no config or no shells.  Seems to be that most gcode-only previews wouldn't have shells, so I assume from the comment this has something to do with Helio.

In case it means anything, I noticed that when loading a gcode file (as in the linked Issue), the code path in the 2nd commit gets hit twice, once without a print config, and then the 2nd time with one.

Cheers,
-Max