### PR TITLE
feat: add winget_updater github action

### DIFF
--- a/.github/workflows/winget_updater.yml
+++ b/.github/workflows/winget_updater.yml
@@ -1,0 +1,14 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [ released ]
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: Bambulab.BambuStudio
+          version: ${{ github.event.release.tag_name }}
+          token: ${{ secrets.WINGET_TOKEN }}
+          installers-regex: '\.exe$'


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate publishing releases to WinGet when a new release is created.

Continuous deployment automation:

* Added a `.github/workflows/winget_updater.yml` workflow that triggers on release events and uses the `winget-releaser` action to automatically publish new versions of `Bambulab.BambuStudio` to WinGet, using the release tag as the version and filtering `.exe` installers.

Bambu Studio is already published on [Winget ](https://github.com/microsoft/winget-pkgs/tree/master/manifests/b/Bambulab/Bambustudio) but it is currently community maintained.  

To make this PR work please [add a repository secret called WINGET_TOKEN with the proper permissions](https://github.com/russellbanks/komac#github-token-setup): it requires just the `public_repo`, nothing more.