### PR TITLE
ENH: Add "Fit camera to scene or selection" function from 3D navigator as a global shortcut.

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -2254,6 +2254,23 @@ void GLCanvas3D::zoom_to_plate(int plate_idx)
     }
 }
 
+void GLCanvas3D::zoom_to_fit()
+{
+    if (!can_show_3d_navigator())
+        return;
+
+    select_view("plate");
+    if (m_selection.is_empty()) {
+        if (m_canvas_type == ECanvasType::CanvasAssembleView)
+            zoom_to_volumes();
+        else
+            zoom_to_bed();
+    }
+    else {
+        zoom_to_selection();
+    }
+}
+
 void GLCanvas3D::select_view(const std::string& direction)
 {
     get_active_camera().select_view(direction);
@@ -4183,18 +4200,6 @@ void GLCanvas3D::on_char(wxKeyEvent& evt)
             break;
         }
 #endif // ENABLE_RENDER_PICKING_PASS
-        //case 'Z':
-        //case 'z': {
-        //    if (!m_selection.is_empty())
-        //        zoom_to_selection();
-        //    else {
-        //        if (!m_volumes.empty())
-        //            zoom_to_volumes();
-        //        else
-        //            _zoom_to_box(m_gcode_viewer.get_paths_bounding_box());
-        //    }
-        //    break;
-        //}
         default:  { evt.Skip(); break; }
         }
     }
@@ -8883,18 +8888,7 @@ void GLCanvas3D::_render_fit_camera_toolbar()
 
     if (ImGui::ImageButton3(normal_id, hover_id, button_icon_size, ImVec2(0, 0), ImVec2(1, 1),  -1,
                            ImVec4(0, 0, 0, 0), ImVec4(1, 1, 1, 1), ImVec2(10, 0))) {
-        select_view("plate");
-        if (m_selection.is_empty()) {
-            if (m_canvas_type == ECanvasType::CanvasAssembleView) {
-                zoom_to_volumes();
-            }
-            else {
-                zoom_to_bed();
-            }
-        }
-        else {
-            zoom_to_selection();
-        }
+        zoom_to_fit();
     }
     if (ImGui::IsItemHovered()) {
         auto temp_tooltip = _L("Fit camera to scene or selected object.");

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -922,6 +922,7 @@ public:
     void zoom_to_gcode();
     //BBS -1 for current plate
     void zoom_to_plate(int plate_idx = -1);
+    void zoom_to_fit();
     void select_view(const std::string& direction);
     //BBS: add part plate related logic
     void select_plate();

--- a/src/slic3r/GUI/KBShortcutsDialog.cpp
+++ b/src/slic3r/GUI/KBShortcutsDialog.cpp
@@ -250,6 +250,7 @@ void KBShortcutsDialog::fill_shortcuts()
             {ctrl + "5", L("Camera view - Left")},
             {ctrl + "6", L("Camera view - Right")},
             {ctrl + "7", L("Camera view - Isometric")},
+            {       "Z", L("Camera view - Fit to scene or selection")},
             {ctrl + "W", L("Reset Window Layout")},
             {ctrl + "E", L("Show Labels")},
             {ctrl + "L", L("Show &Overhang")},

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -707,6 +707,12 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
             if (m_plater) { m_plater->add_file(); }
             return;
         }
+
+        if (!evt.HasAnyModifiers() && evt.GetKeyCode() == 'Z') {
+            view_zoom_to_fit();
+            return;
+        }
+
         evt.Skip();
     });
 
@@ -2623,6 +2629,8 @@ static void add_common_view_menu_items(wxMenu* view_menu, MainFrame* mainFrame, 
     append_menu_item(view_menu, wxID_ANY, _CTX(L_CONTEXT("Isometric", "Camera"), "Camera") + " 3", _L("Isometric View") + " 3",
         [mainFrame](wxCommandEvent &) { mainFrame->select_view("iso_3"); }, "", nullptr, [can_change_view]() { return can_change_view(); }, mainFrame);
 #endif
+    append_menu_item(view_menu, wxID_ANY, _L("Fit Camera") + "\t" "Z", _L("Fit camera to scene or selected object."), 
+        [mainFrame](wxCommandEvent &) { mainFrame->view_zoom_to_fit(); }, "", nullptr, [can_change_view]() { return can_change_view(); }, mainFrame);
 }
 
 void MainFrame::init_menubar_as_editor()
@@ -3920,6 +3928,12 @@ void MainFrame::select_view(const std::string& direction)
 {
      if (m_plater)
          m_plater->select_view(direction);
+}
+
+void MainFrame::view_zoom_to_fit() const
+{
+    if (GLCanvas3D *canvas = m_plater ? m_plater->canvas3D() : nullptr)
+        canvas->zoom_to_fit();
 }
 
 // #ys_FIXME_to_delete

--- a/src/slic3r/GUI/MainFrame.hpp
+++ b/src/slic3r/GUI/MainFrame.hpp
@@ -329,6 +329,7 @@ public:
     void        request_select_tab(TabPosition pos);
     int         get_calibration_curr_tab();
     void        select_view(const std::string& direction);
+    void        view_zoom_to_fit() const;
     // Propagate changed configuration from the Tab to the Plater and save changes to the AppConfig
     void        on_config_changed(DynamicPrintConfig* cfg) const ;
     void        set_print_button_to_default(PrintSelectType select_type);


### PR DESCRIPTION
As requested in #10017 , and by myself.  :)

This adds the shortcut event handler directly to `MainFrame` so it can be triggered even if focus is in the sidebar/object tree (unlike the other view shortcuts).  This is handy because it may be the most convenient, or only, way to select a part of an object to focus on. For example if a part/modifier is completely inside another object.

<strike>I chose <kbd>CTRL + HOME</kbd> as the shortcut, as suggested in the issue. Seemed logical...  Just <kbd>HOME</kbd> could also be used, as it doesn't really interfere with anything else right now (in the object tree it will jump to the top of the list, but so will <kbd>PAGE UP</kbd>).</strike>  
Now using `Z` as the shortcut, which matches the other Slic3r forks.  
Sill open to other suggestions/preferences of course.

Thanks,
-Max

--
Closes #10017 
Closes #7337
Related: 
#1416