### PR TITLE
ENH: Re-add 12-hour time format support with thread-safety fix

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -487,6 +487,10 @@ void AppConfig::set_defaults()
         set_bool("prompt_for_brittle_filaments", true);
     }
 
+    if (get("use_12h_time_format").empty()) {
+        set_bool("use_12h_time_format", false);
+    }
+
     // Remove legacy window positions/sizes
     erase("app", "main_frame_maximized");
     erase("app", "main_frame_pos");

--- a/src/libslic3r/Utils.hpp
+++ b/src/libslic3r/Utils.hpp
@@ -801,19 +801,55 @@ inline std::string get_bbl_monitor_time_dhm(float time_in_secs)
     return buffer;
 }
 
-inline std::string get_bbl_finish_time_dhm(float time_in_secs)
+// Thread-safe wrapper around localtime. Returns a std::tm by value.
+inline std::tm safe_localtime(const time_t* timep)
+{
+    std::tm result{};
+#ifdef _WIN32
+    localtime_s(&result, timep);
+#else
+    localtime_r(timep, &result);
+#endif
+    return result;
+}
+
+// Centralized function to format time from a std::tm structure
+// This is the single source of truth for time formatting throughout the application
+inline std::string format_time_hm(const std::tm* tm, bool use_12h_format = false)
+{
+    std::ostringstream formattedTime;
+
+    if (use_12h_format) {
+        int hour = tm->tm_hour;
+        std::string suffix = (hour >= 12) ? "PM" : "AM";
+        int display_hour = hour % 12;
+        if (display_hour == 0) display_hour = 12; // Midnight = 12AM, Noon = 12PM
+        formattedTime << std::setw(2) << std::setfill('0') << display_hour << ":"
+                      << std::setw(2) << std::setfill('0') << tm->tm_min << suffix;
+    } else {
+        // 24-hour format
+        formattedTime << std::setw(2) << std::setfill('0') << tm->tm_hour << ":"
+                      << std::setw(2) << std::setfill('0') << tm->tm_min;
+    }
+
+    return formattedTime.str();
+}
+
+inline std::string get_bbl_finish_time_dhm(float time_in_secs, bool use_12h_format = false)
 {
     if (time_in_secs < 1) return "Finished";
-    time_t   finish_time    = std::time(nullptr) + static_cast<time_t>(time_in_secs);
-    std::tm *finish_tm      = std::localtime(&finish_time);
-    int      finish_hour    = finish_tm->tm_hour;
-    int      finish_minute  = finish_tm->tm_min;
-    int      finish_day     = finish_tm->tm_yday;
-    int      finish_year    = finish_tm->tm_year + 1900;
+
+    // Get current time first (thread-safe)
     time_t   current_time   = std::time(nullptr);
-    std::tm *current_tm     = std::localtime(&current_time);
-    int      current_day    = current_tm->tm_yday;
-    int      current_year   = current_tm->tm_year + 1900;
+    std::tm  current_tm     = safe_localtime(&current_time);
+    int      current_day    = current_tm.tm_yday;
+    int      current_year   = current_tm.tm_year + 1900;
+
+    // Calculate finish time and get its local time (thread-safe)
+    time_t   finish_time    = current_time + static_cast<time_t>(time_in_secs);
+    std::tm  finish_tm      = safe_localtime(&finish_time);
+    int      finish_day     = finish_tm.tm_yday;
+    int      finish_year    = finish_tm.tm_year + 1900;
 
     int diff_day = 0;
     if (current_year != finish_year) {
@@ -832,9 +868,7 @@ inline std::string get_bbl_finish_time_dhm(float time_in_secs)
         diff_day = finish_day - current_day;
     }
 
-    std::ostringstream formattedTime;
-    formattedTime << std::setw(2) << std::setfill('0') << finish_hour << ":" << std::setw(2) << std::setfill('0') << finish_minute;
-    std::string finish_time_str = formattedTime.str();
+    std::string finish_time_str = format_time_hm(&finish_tm, use_12h_format);
     if (diff_day != 0) finish_time_str += "+" + std::to_string(diff_day);
 
     return finish_time_str;

--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -194,9 +194,17 @@ static std::string get_curr_time()
 
     std::time_t time = std::chrono::system_clock::to_time_t(now);
 
-    std::tm            local_time = *std::localtime(&time);
+    std::tm local_time = Slic3r::safe_localtime(&time);
     std::ostringstream time_stream;
-    time_stream << std::put_time(&local_time, "%Y_%m_%d_%H_%M_%S");
+
+    bool use_12h_format = wxGetApp().app_config->get("use_12h_time_format") == "true";
+
+    std::string hm_formatted = Slic3r::format_time_hm(&local_time, use_12h_format);
+    // Replace colons with underscores for filename compatibility
+    std::replace(hm_formatted.begin(), hm_formatted.end(), ':', '_');
+
+    time_stream << std::put_time(&local_time, "%Y_%m_%d_") << hm_formatted << "_"
+                << std::put_time(&local_time, "%S");
 
     std::string current_time = time_stream.str();
     return current_time;

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -6697,6 +6697,7 @@ void GUI_App::open_preferences(size_t open_on_tab, const std::string& highlight_
         // so we put it into an inner scope
         PreferencesDialog dlg(mainframe, open_on_tab, highlight_option);
         dlg.ShowModal();
+
         // BBS
         //app_layout_changed = dlg.settings_layout_changed();
 #if ENABLE_GCODE_LINES_ID_IN_H_SLIDER
@@ -6721,6 +6722,15 @@ void GUI_App::open_preferences(size_t open_on_tab, const std::string& highlight_
                 associate_files(L"gcode");
         }
 #endif // _WIN32
+
+        // Refresh the recent projects list if time format changed
+        if (dlg.use_12h_time_format_changed() && mainframe && mainframe->m_webview) {
+            CallAfter([mainframe = this->mainframe]() {
+                if (mainframe && mainframe->m_webview) {
+                    mainframe->m_webview->SendRecentList(-1);
+                }
+            });
+        }
     }
 
     // BBS

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -699,6 +699,15 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
             if (dlg.seq_top_layer_only_changed())
 #endif // ENABLE_GCODE_LINES_ID_IN_H_SLIDER
                 plater()->refresh_print();
+
+            // Refresh recent list if time format changed
+            if (dlg.use_12h_time_format_changed() && m_webview) {
+                wxGetApp().CallAfter([this]() {
+                    if (m_webview) {
+                        m_webview->SendRecentList(-1);
+                    }
+                });
+            }
             return;
         }
 
@@ -3210,6 +3219,15 @@ void MainFrame::init_menubar_as_editor()
             if (dlg.seq_top_layer_only_changed())
 #endif
                 plater()->refresh_print();
+
+            // Refresh recent list if time format changed
+            if (dlg.use_12h_time_format_changed() && m_webview) {
+                wxGetApp().CallAfter([this]() {
+                    if (m_webview) {
+                        m_webview->SendRecentList(-1);
+                    }
+                });
+            }
         },
         "", nullptr, []() { return true; }, this, 1);
     //parent_menu->Insert(1, preference_item);
@@ -3236,6 +3254,15 @@ void MainFrame::init_menubar_as_editor()
             if (dlg.seq_top_layer_only_changed())
 #endif
                 plater()->refresh_print();
+
+            // Refresh recent list if time format changed
+            if (dlg.use_12h_time_format_changed() && m_webview) {
+                wxGetApp().CallAfter([this]() {
+                    if (m_webview) {
+                        m_webview->SendRecentList(-1);
+                    }
+                });
+            }
         },
         "", nullptr, []() { return true; }, this);
     //m_topbar->AddDropDownMenuItem(preference_item);
@@ -4075,8 +4102,17 @@ void MainFrame::get_recent_projects(boost::property_tree::wptree &tree, int imag
         boost::system::error_code ec;
         std::time_t t = boost::filesystem::last_write_time(proj, ec);
         if (!ec) {
-            std::wstring time = wxDateTime(t).FormatISOCombined(' ').ToStdWstring();
-            item.put(L"time", time);
+            std::tm local_tm = Slic3r::safe_localtime(&t);
+            bool use_12h_format = wxGetApp().app_config->get("use_12h_time_format") == "true";
+
+            // Format date and time: YYYY-MM-DD HH:MM[:SS][AM/PM]
+            std::wstringstream time_stream;
+            time_stream << std::setw(4) << std::setfill(L'0') << (local_tm.tm_year + 1900) << L"-"
+                       << std::setw(2) << std::setfill(L'0') << (local_tm.tm_mon + 1) << L"-"
+                       << std::setw(2) << std::setfill(L'0') << local_tm.tm_mday << L" "
+                       << from_u8(Slic3r::format_time_hm(&local_tm, use_12h_format));
+
+            item.put(L"time", time_stream.str());
             if (i <= images) {
                 auto thumbnail = m_recent_projects.GetThumbnailUrl(i);
                 if (!thumbnail.empty()) item.put(L"image", thumbnail);

--- a/src/slic3r/GUI/MediaPlayCtrl.cpp
+++ b/src/slic3r/GUI/MediaPlayCtrl.cpp
@@ -758,7 +758,16 @@ void MediaPlayCtrl::SetStatus(wxString const &msg2, bool hyperlink)
         int state2 = m_last_state >= MEDIASTATE_IDLE ? m_last_state - MEDIASTATE_IDLE :
                                                        m_last_state + MEDIASTATE_BUFFERING - MEDIASTATE_IDLE;
         msg += wxString::Format(" [%d:%d]", state2, m_failed_code);
-        msg += wxDateTime::Now().Format(_T(" <%m-%d %H:%M>"));
+
+        time_t now = time(nullptr);
+        std::tm local_tm = Slic3r::safe_localtime(&now);
+        bool use_12h_format = wxGetApp().app_config->get("use_12h_time_format") == "true";
+        std::string time_str = Slic3r::format_time_hm(&local_tm, use_12h_format);
+
+        msg += wxString::Format(_T(" <%02d-%02d %s>"),
+                               local_tm.tm_mon + 1,
+                               local_tm.tm_mday,
+                               time_str);
     }
     BOOST_LOG_TRIVIAL(info) << "MediaPlayCtrl::SetStatus: " << msg.ToUTF8().data() << " tutk_state: " << m_tutk_state;
 #ifdef __WXMSW__

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1131,6 +1131,7 @@ PreferencesDialog::PreferencesDialog(wxWindow *parent, wxWindowID id, const wxSt
     : DPIDialog(parent, id, _L("Preferences"), pos, size, style)
 {
     SetBackgroundColour(*wxWHITE);
+    m_original_use_12h_time_format = wxGetApp().app_config->get("use_12h_time_format");
     create();
     wxGetApp().UpdateDlgDarkUI(this);
     Bind(wxEVT_CLOSE_WINDOW, [this](wxCloseEvent& event) {
@@ -1144,6 +1145,11 @@ PreferencesDialog::PreferencesDialog(wxWindow *parent, wxWindowID id, const wxSt
                 agent->track_event("preferences_changed", j.dump());
             }
         } catch(...) {}
+
+        // Check if time format changed
+        std::string current_use_12h_time_format = wxGetApp().app_config->get("use_12h_time_format");
+        m_use_12h_time_format_changed = (m_original_use_12h_time_format != current_use_12h_time_format);
+
         event.Skip();
         });
 }
@@ -1298,6 +1304,7 @@ wxWindow* PreferencesDialog::create_general_page()
 
     std::vector<wxString> Units         = {_L("Metric") + " (mm, g)", _L("Imperial") + " (in, oz)"};
     auto item_currency = create_item_combobox(_L("Units"), page, _L("Units"), "use_inches", Units,{"0","1"});
+    auto item_12h_time_format = create_item_checkbox(_L("Use 12-hour time format"), page, _L("Display time in 12-hour format with AM/PM instead of 24-hour format"), 50, "use_12h_time_format");
     auto item_single_instance = create_item_checkbox(_L("Keep only one Bambu Studio instance"), page,
 #if __APPLE__
         _L("On OSX there is always only one instance of app running by default. However it is allowed to run multiple instances "

--- a/src/slic3r/GUI/Preferences.hpp
+++ b/src/slic3r/GUI/Preferences.hpp
@@ -69,10 +69,13 @@ protected:
     // bool								m_settings_layout_changed {false};
     bool m_seq_top_layer_only_changed{false};
     bool m_recreate_GUI{false};
+    bool m_use_12h_time_format_changed{false};
+    std::string m_original_use_12h_time_format;
 
 public:
     bool seq_top_layer_only_changed() const { return m_seq_top_layer_only_changed; }
     bool recreate_GUI() const { return m_recreate_GUI; }
+    bool use_12h_time_format_changed() const { return m_use_12h_time_format_changed; }
     void on_dpi_changed(const wxRect &suggested_rect) override;
 
 public:

--- a/src/slic3r/GUI/StatusPanel.cpp
+++ b/src/slic3r/GUI/StatusPanel.cpp
@@ -1260,8 +1260,9 @@ void PrintingTaskPanel::update_left_time(int mc_left_time)
     wxString    left_time_text = NA_STR;
 
     try {
+        bool use_12h_format = wxGetApp().app_config->get("use_12h_time_format") == "true";
         left_time  = get_bbl_time_dhms(mc_left_time);
-        right_time = get_bbl_finish_time_dhm(mc_left_time);
+        right_time = get_bbl_finish_time_dhm(mc_left_time, use_12h_format);
     } catch (...) {
         ;
     }

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -2047,7 +2047,7 @@ void WebViewPanel::SwitchWebContent(std::string modelname, int refresh)
                 std::regex pattern("&keyword=[^&]*");
                 TmpNowUrl = std::regex_replace(TmpNowUrl, pattern, "");
                 if(TmpNowUrl != m_browserMW->GetCurrentURL().ToStdString()) {
-                    m_browserMW->LoadURL(TmpNowUrl); 
+                    m_browserMW->LoadURL(TmpNowUrl);
                 }
             }
         }

--- a/tests/libslic3r/test_timeutils.cpp
+++ b/tests/libslic3r/test_timeutils.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch.hpp>
 
 #include "libslic3r/Time.hpp"
+#include "libslic3r/Utils.hpp"
 
 #include <sstream>
 #include <iomanip>
@@ -11,39 +12,94 @@ using namespace Slic3r;
 static void test_time_fmt(Slic3r::Utils::TimeFormat fmt) {
     using namespace Slic3r::Utils;
     time_t t = get_current_time_utc();
-    
+
     std::string tstr = time2str(t, TimeZone::local, fmt);
     time_t parsedtime = str2time(tstr, TimeZone::local, fmt);
     REQUIRE(t == parsedtime);
-    
+
     tstr = time2str(t, TimeZone::utc, fmt);
     parsedtime = str2time(tstr, TimeZone::utc, fmt);
     REQUIRE(t == parsedtime);
-    
+
     parsedtime = str2time("not valid string", TimeZone::local, fmt);
     REQUIRE(parsedtime == time_t(-1));
-    
+
     parsedtime = str2time("not valid string", TimeZone::utc, fmt);
     REQUIRE(parsedtime == time_t(-1));
 }
 
 TEST_CASE("ISO8601Z", "[Timeutils]") {
     test_time_fmt(Slic3r::Utils::TimeFormat::iso8601Z);
-    
+
     std::string mydate = "20190710T085000Z";
     time_t t = Slic3r::Utils::parse_iso_utc_timestamp(mydate);
     std::string date = Slic3r::Utils::iso_utc_timestamp(t);
-    
+
     REQUIRE(date == mydate);
 }
 
 TEST_CASE("Slic3r_UTC_Time_Format", "[Timeutils]") {
     using namespace Slic3r::Utils;
     test_time_fmt(TimeFormat::gcode);
-    
+
     std::string mydate = "2019-07-10 at 08:50:00 UTC";
     time_t t = Slic3r::Utils::str2time(mydate, TimeZone::utc, TimeFormat::gcode);
     std::string date = Slic3r::Utils::utc_timestamp(t);
-    
+
     REQUIRE(date == mydate);
+}
+
+TEST_CASE("12_Hour_Time_Format", "[Timeutils]") {
+    // Test format_time_hm centralized function with std::tm
+
+    std::tm tm = {};
+
+    // Test midnight (0:00) -> 12:00AM
+    tm.tm_hour = 0;
+    tm.tm_min = 0;
+    auto result = format_time_hm(&tm, true);
+    REQUIRE(result == "12:00AM");
+
+    // Test noon (12:00) -> 12:00PM
+    tm.tm_hour = 12;
+    tm.tm_min = 0;
+    result = format_time_hm(&tm, true);
+    REQUIRE(result == "12:00PM");
+
+    // Test morning (9:30) -> 09:30AM
+    tm.tm_hour = 9;
+    tm.tm_min = 30;
+    result = format_time_hm(&tm, true);
+    REQUIRE(result == "09:30AM");
+
+    // Test afternoon (15:45) -> 03:45PM
+    tm.tm_hour = 15;
+    tm.tm_min = 45;
+    result = format_time_hm(&tm, true);
+    REQUIRE(result == "03:45PM");
+
+    // Test evening (23:59) -> 11:59PM
+    tm.tm_hour = 23;
+    tm.tm_min = 59;
+    result = format_time_hm(&tm, true);
+    REQUIRE(result == "11:59PM");
+
+    // Test 24-hour format (should not add AM/PM)
+    tm.tm_hour = 15;
+    tm.tm_min = 45;
+    result = format_time_hm(&tm, false);
+    REQUIRE(result == "15:45");
+
+    // Test get_bbl_finish_time_dhm with 12-hour format
+    // Test with 1 hour remaining (3600 seconds)
+    std::string finish_time_24h = get_bbl_finish_time_dhm(3600.0f, false);
+    std::string finish_time_12h = get_bbl_finish_time_dhm(3600.0f, true);
+
+    // 24-hour format should have HH:MM format
+    REQUIRE(finish_time_24h.find(":") != std::string::npos);
+    REQUIRE(finish_time_24h.find("AM") == std::string::npos);
+    REQUIRE(finish_time_24h.find("PM") == std::string::npos);
+
+    // 12-hour format should have either AM or PM
+    REQUIRE((finish_time_12h.find("AM") != std::string::npos || finish_time_12h.find("PM") != std::string::npos));
 }


### PR DESCRIPTION
#5597 and #9187 again.
Re-applies the 12-hour time format feature from commit 0a89a33b which was reverted in 331496e4 due to crashes (likely) caused by thread-unsafe std::localtime() calls.

Fix: Added safe_localtime() wrapper in Utils.hpp that uses localtime_s (Win) or localtime_r (POSIX) to return std::tm by value, eliminating the shared static buffer race condition that caused crashes on multi-threaded access.

All call sites now use safe_localtime() instead of std::localtime():
- get_bbl_finish_time_dhm() in Utils.hpp
- MediaPlayCtrl::SetStatus()
- MainFrame::get_recent_projects()
- CreatePresetsDialog::get_curr_time()

I'm sort of guessing a bit on the crashes, though if we have more logs or info i may be able to confirm/check.