### PR TITLE
Fix multicolor top-surface artifacts when interface shells and one-wall top surfaces are enabled

### DIFF
--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -166,6 +166,10 @@ void LayerRegion::make_perimeters(const SurfaceCollection &slices, const Perimet
     if (this->layer()->upper_layer != NULL)
         g.upper_slices = &this->layer()->upper_layer->lslices;
 
+    int region_id = this->region().print_object_region_id();
+    if (this->layer()->upper_layer != NULL)
+        g.upper_slices_same_region = &this->layer()->upper_layer->get_region(region_id)->slices;
+
     g.layer_id              = (int)this->layer()->id();
     g.ext_perimeter_flow    = this->flow(frExternalPerimeter);
     g.overhang_flow         = this->bridging_flow(frPerimeter, object_config.thick_bridges);

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1127,7 +1127,11 @@ void PerimeterGenerator::process_classic()
                     last_box.offset(SCALED_EPSILON);
 
                     // BBS: get the Polygons upper the polygon this layer
-                    Polygons upper_polygons_series_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(*this->upper_slices, last_box);
+                    Polygons upper_polygons_series_clipped;
+                    if (this->object_config->interface_shells && this->upper_slices_same_region != nullptr)
+                        upper_polygons_series_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(to_expolygons(this->upper_slices_same_region->surfaces), last_box);
+                    else
+                        upper_polygons_series_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(*this->upper_slices, last_box);
                     upper_polygons_series_clipped = offset(upper_polygons_series_clipped, min_width_top_surface);
 
                     //set the clip to a virtual "second perimeter"
@@ -1569,8 +1573,12 @@ void PerimeterGenerator::process_arachne()
                 infill_bbox.offset(EPSILON);
 
                 Polygons upper_polygons_clipped;
-                if (this->upper_slices)
-                    upper_polygons_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(*this->upper_slices, infill_bbox);
+                if (this->upper_slices) {
+                    if (this->object_config->interface_shells && this->upper_slices_same_region != nullptr)
+                        upper_polygons_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(to_expolygons(this->upper_slices_same_region->surfaces), infill_bbox);
+                    else
+                        upper_polygons_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(*this->upper_slices, infill_bbox);
+                }
                 top_expolys_by_one_wall = diff_ex(infill_contour_by_one_wall, upper_polygons_clipped);
 
                 Polygons lower_polygons_clipped;

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -34,6 +34,7 @@ public:
     // Inputs:
     const SurfaceCollection     *slices;
     const ExPolygons            *upper_slices;
+    const SurfaceCollection     *upper_slices_same_region;
     const ExPolygons            *lower_slices;
     double                       layer_height;
     int                          layer_id;
@@ -81,7 +82,7 @@ public:
         //BBS
         ExPolygons*                 fill_no_overlap,
         std::vector<LoopNode>       *loop_nodes)
-        : slices(slices), upper_slices(nullptr), lower_slices(nullptr), layer_height(layer_height),
+        : slices(slices), upper_slices(nullptr), upper_slices_same_region(nullptr), lower_slices(nullptr), layer_height(layer_height),
             layer_id(-1), perimeter_flow(flow), ext_perimeter_flow(flow),
             overhang_flow(flow), solid_infill_flow(flow),
             config(config), object_config(object_config), print_config(print_config),

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1233,8 +1233,13 @@ bool PrintObject::invalidate_state_by_config_options(
             }
 #endif
         } else if (
-               opt_key == "interface_shells"
-            || opt_key == "fill_multiline"
+               opt_key == "interface_shells") {
+            // interface_shells affects both perimeter generation (one-wall-top uses same-region
+            // upper slices) and infill preparation (surface type detection at material boundaries).
+            steps.emplace_back(posPerimeters);
+            steps.emplace_back(posPrepareInfill);
+        } else if (
+               opt_key == "fill_multiline"
             || opt_key == "infill_combination"
             || opt_key == "bottom_shell_thickness"
             || opt_key == "top_shell_thickness"
@@ -1577,7 +1582,7 @@ void PrintObject::detect_surfaces_type(std::vector<std::vector<SurfaceCollection
                         surfaces_append(top, diff_ex(top_polygons, bottom), stTop);
                     }
 
-                    if (detect_top && upper_layer && ! top.empty()) {
+                    if (interface_shells && detect_top && upper_layer && ! top.empty()) {
                         ExPolygons covered_by_upper = interface_shells ?
                             intersection_ex(layerm->slices.surfaces, upper_layer->m_regions[region_id]->slices.surfaces, ApplySafetyOffset::Yes) :
                             intersection_ex(layerm->slices.surfaces, upper_layer->lslices, ApplySafetyOffset::Yes);

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1577,6 +1577,27 @@ void PrintObject::detect_surfaces_type(std::vector<std::vector<SurfaceCollection
                         surfaces_append(top, diff_ex(top_polygons, bottom), stTop);
                     }
 
+                    if (detect_top && upper_layer && ! top.empty()) {
+                        ExPolygons covered_by_upper = interface_shells ?
+                            intersection_ex(layerm->slices.surfaces, upper_layer->m_regions[region_id]->slices.surfaces, ApplySafetyOffset::Yes) :
+                            intersection_ex(layerm->slices.surfaces, upper_layer->lslices, ApplySafetyOffset::Yes);
+                        ExPolygons top_expolygons = union_ex(top);
+                        Polygons   filled_top_holes;
+                        for (const ExPolygon &expolygon : top_expolygons) {
+                            for (const Polygon &hole : expolygon.holes) {
+                                Polygons   hole_polygon{ hole };
+                                ExPolygons hole_expolygons = to_expolygons(hole_polygon);
+                                if (! intersection_ex(hole_expolygons, covered_by_upper, ApplySafetyOffset::Yes).empty())
+                                    filled_top_holes.push_back(hole);
+                            }
+                        }
+                        if (! filled_top_holes.empty()) {
+                            top_expolygons = union_ex(top_expolygons, to_expolygons(filled_top_holes));
+                            top.clear();
+                            surfaces_append(top, std::move(top_expolygons), stTop);
+                        }
+                    }
+
         #ifdef SLIC3R_DEBUG_SLICE_PROCESSING
                     {
                         static int iRun = 0;


### PR DESCRIPTION
Fixes #7279.

Problem
When Interface shells and Only one wall on top surfaces = Top surfaces are enabled together, Bambu Studio can leave artifacts on the layer below upper different-color/material geometry.

This happened in two related cases:
1. Multipart multicolor models
2. Single-part multicolor models

Root cause

Multipart multicolor case
Top-surface single-wall detection was checking against full upper-layer slices instead of same-region upper slices when interface_shells is enabled.
As a result, geometry from other color/material regions on the upper layer affected top-surface classification for the current region and produced artifacts.

Single-part multicolor case
In detect_surfaces_type(), the top surface on the layer below the colored text/shape could be created with enclosed holes matching the upper colored geometry.
Those holes later became internal regions and preserved the upper footprint on the visible surface below.
The fix fills only the enclosed top-surface holes that are actually covered by upper geometry.

## Validation

### Repro from #7279 (multi-part object)
This screenshot uses 2 walls because increasing wall count partially hides the artifact, but does not resolve the underlying bug.

Without the fix:
<img width="1572" height="877" alt="image" src="https://github.com/user-attachments/assets/055d1635-1c52-4525-bffb-411365ec6776" />

With the fix:
<img width="1585" height="879" alt="image" src="https://github.com/user-attachments/assets/d8bda8d1-69f4-4c5e-bf1b-9a142dbc0773" />

### Additional repro (single-part object)
Without the fix:
<img width="1285" height="451" alt="image" src="https://github.com/user-attachments/assets/680ad54a-1da1-4e16-baab-91ce6b28638c" />

With the fix:
<img width="1269" height="441" alt="image" src="https://github.com/user-attachments/assets/0362bddf-5ea6-47f1-b720-1b239afad2fd" />