### PR TITLE
Fix multi-material top-surface artifacts (#2906)

### DIFF
--- a/src/libslic3r/Layer.cpp
+++ b/src/libslic3r/Layer.cpp
@@ -13,6 +13,26 @@ static const int dist_scale_threshold = 1.2;
 
 namespace Slic3r {
 
+ExPolygons interface_shell_upper_slices_for_top_holes(const Layer &upper_layer, size_t region_id)
+{
+    const bool single_region_interface_shells = upper_layer.object()->num_printing_regions() == 1;
+
+    ExPolygons upper_interface_slices;
+    const LayerRegionPtrs &upper_regions = upper_layer.regions();
+    if (upper_regions.size() > 1) {
+        for (size_t upper_region_id = 0; upper_region_id < upper_regions.size(); ++upper_region_id) {
+            if (upper_region_id == region_id)
+                continue;
+            expolygons_append(upper_interface_slices, to_expolygons(upper_regions[upper_region_id]->slices.surfaces));
+        }
+    } else if (single_region_interface_shells)
+        upper_interface_slices = upper_layer.lslices;
+
+    if (! upper_interface_slices.empty())
+        upper_interface_slices = union_ex(upper_interface_slices);
+    return upper_interface_slices;
+}
+
 Layer::~Layer()
 {
     this->lower_layer = this->upper_layer = nullptr;

--- a/src/libslic3r/Layer.hpp
+++ b/src/libslic3r/Layer.hpp
@@ -285,6 +285,9 @@ private:
     LayerRegionPtrs     m_regions;
 };
 
+// Upper-layer footprint allowed to act as top surface at interface-shell transitions.
+ExPolygons interface_shell_upper_slices_for_top_holes(const Layer &upper_layer, size_t region_id);
+
 class SupportLayer : public Layer
 {
 public:

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -163,17 +163,18 @@ void LayerRegion::make_perimeters(const SurfaceCollection &slices, const Perimet
     if (this->layer()->lower_layer != nullptr)
         // Cummulative sum of polygons over all the regions.
         g.lower_slices = &this->layer()->lower_layer->lslices;
-    if (this->layer()->upper_layer != NULL)
-        g.upper_slices = &this->layer()->upper_layer->lslices;
-
-    // Interface shells need top-surface holes filled at material transitions to
-    // prevent different wall counts (e.g., text on keytags). Painted (mm)
-    // objects already have correct top surface detection.
-    g.fill_top_surface_holes = object_config.interface_shells && ! this->layer()->object()->model_object()->is_mm_painted();
-
     int region_id = this->region().print_object_region_id();
-    if (this->layer()->upper_layer != NULL)
+    ExPolygons upper_slices_for_top_holes;
+    if (this->layer()->upper_layer != NULL) {
+        g.upper_slices = &this->layer()->upper_layer->lslices;
         g.upper_slices_same_region = &this->layer()->upper_layer->get_region(region_id)->slices;
+        upper_slices_for_top_holes = interface_shell_upper_slices_for_top_holes(*this->layer()->upper_layer, size_t(region_id));
+        g.upper_slices_for_top_holes = &upper_slices_for_top_holes;
+    }
+
+    // Interface-shell transitions need to participate in one-wall top detection,
+    // but only over the selected upper-layer footprint.
+    g.fill_top_surface_holes = object_config.interface_shells && ! this->layer()->object()->model_object()->is_mm_painted();
 
     g.layer_id              = (int)this->layer()->id();
     g.ext_perimeter_flow    = this->flow(frExternalPerimeter);

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -166,10 +166,10 @@ void LayerRegion::make_perimeters(const SurfaceCollection &slices, const Perimet
     if (this->layer()->upper_layer != NULL)
         g.upper_slices = &this->layer()->upper_layer->lslices;
 
-    // For non-painted multi-material objects, fill holes in top surfaces at material
-    // transitions to prevent different wall counts (e.g., text on keytags).
-    // Painted (mm) objects already have correct top surface detection.
-    g.fill_top_surface_holes = ! this->layer()->object()->model_object()->is_mm_painted();
+    // Interface shells need top-surface holes filled at material transitions to
+    // prevent different wall counts (e.g., text on keytags). Painted (mm)
+    // objects already have correct top surface detection.
+    g.fill_top_surface_holes = object_config.interface_shells && ! this->layer()->object()->model_object()->is_mm_painted();
 
     int region_id = this->region().print_object_region_id();
     if (this->layer()->upper_layer != NULL)

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -166,6 +166,10 @@ void LayerRegion::make_perimeters(const SurfaceCollection &slices, const Perimet
     if (this->layer()->upper_layer != NULL)
         g.upper_slices = &this->layer()->upper_layer->lslices;
 
+    int region_id = this->region().print_object_region_id();
+    if (this->layer()->upper_layer != NULL)
+        g.upper_slices_same_region = &this->layer()->upper_layer->get_region(region_id)->slices;
+
     g.layer_id              = (int)this->layer()->id();
     g.ext_perimeter_flow    = this->flow(frExternalPerimeter);
     g.overhang_flow         = this->bridging_flow(frPerimeter, object_config.thick_bridges);

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -166,6 +166,11 @@ void LayerRegion::make_perimeters(const SurfaceCollection &slices, const Perimet
     if (this->layer()->upper_layer != NULL)
         g.upper_slices = &this->layer()->upper_layer->lslices;
 
+    // For non-painted multi-material objects, fill holes in top surfaces at material
+    // transitions to prevent different wall counts (e.g., text on keytags).
+    // Painted (mm) objects already have correct top surface detection.
+    g.fill_top_surface_holes = ! this->layer()->object()->model_object()->is_mm_painted();
+
     int region_id = this->region().print_object_region_id();
     if (this->layer()->upper_layer != NULL)
         g.upper_slices_same_region = &this->layer()->upper_layer->get_region(region_id)->slices;

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1141,19 +1141,15 @@ void PerimeterGenerator::process_classic()
                     ExPolygons bridge_checker;
 
                     ExPolygons top_polygons = diff_ex(last, upper_polygons_series_clipped, ApplySafetyOffset::Yes);
-                    // Fill holes in top areas that are covered by the upper layer to prevent
-                    // different wall counts at material transitions (e.g., text on keytags).
-                    if (this->fill_top_surface_holes && ! top_polygons.empty() && this->upper_slices) {
+                    // Treat only the selected interface footprint as top for one-wall
+                    // detection; using all upper coverage changes normal wall counts.
+                    if (this->fill_top_surface_holes && ! top_polygons.empty() &&
+                        this->upper_slices_for_top_holes != nullptr && ! this->upper_slices_for_top_holes->empty()) {
                         ExPolygons top_union = union_ex(top_polygons);
-                        Polygons   filled_holes;
-                        for (const ExPolygon &ep : top_union)
-                            for (const Polygon &hole : ep.holes) {
-                                ExPolygons hole_ex = to_expolygons(Polygons{hole});
-                                if (! intersection_ex(hole_ex, *this->upper_slices, ApplySafetyOffset::Yes).empty())
-                                    filled_holes.push_back(hole);
-                            }
-                        if (! filled_holes.empty())
-                            top_polygons = union_ex(top_union, to_expolygons(filled_holes));
+                        ExPolygons upper_overlap = intersection_ex(last, *this->upper_slices_for_top_holes, ApplySafetyOffset::Yes);
+                        ExPolygons interface_top = diff_ex(upper_overlap, top_union, ApplySafetyOffset::Yes);
+                        if (! interface_top.empty())
+                            top_polygons = union_ex(top_union, interface_top);
                     }
                     //get the not-top surface, from the "real top" but enlarged by external_infill_margin (and the min_width_top_surface we removed a bit before)
                     ExPolygons temp_gap        = diff_ex(top_polygons, fill_clip);
@@ -1594,19 +1590,15 @@ void PerimeterGenerator::process_arachne()
                         upper_polygons_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(*this->upper_slices, infill_bbox);
                 }
                 top_expolys_by_one_wall = diff_ex(infill_contour_by_one_wall, upper_polygons_clipped);
-                // Fill holes in top areas that are covered by the upper layer to prevent
-                // different wall counts at material transitions (e.g., text on keytags).
-                if (this->fill_top_surface_holes && ! top_expolys_by_one_wall.empty() && this->upper_slices) {
+                // Treat only the selected interface footprint as top for one-wall
+                // detection; using all upper coverage changes normal wall counts.
+                if (this->fill_top_surface_holes && ! top_expolys_by_one_wall.empty() &&
+                    this->upper_slices_for_top_holes != nullptr && ! this->upper_slices_for_top_holes->empty()) {
                     ExPolygons top_union = union_ex(top_expolys_by_one_wall);
-                    Polygons   filled_holes;
-                    for (const ExPolygon &ep : top_union)
-                        for (const Polygon &hole : ep.holes) {
-                            ExPolygons hole_ex = to_expolygons(Polygons{hole});
-                            if (! intersection_ex(hole_ex, *this->upper_slices, ApplySafetyOffset::Yes).empty())
-                                filled_holes.push_back(hole);
-                        }
-                    if (! filled_holes.empty())
-                        top_expolys_by_one_wall = union_ex(top_union, to_expolygons(filled_holes));
+                    ExPolygons upper_overlap = intersection_ex(infill_contour_by_one_wall, *this->upper_slices_for_top_holes, ApplySafetyOffset::Yes);
+                    ExPolygons interface_top = diff_ex(upper_overlap, top_union, ApplySafetyOffset::Yes);
+                    if (! interface_top.empty())
+                        top_expolys_by_one_wall = union_ex(top_union, interface_top);
                 }
 
                 Polygons lower_polygons_clipped;

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1127,7 +1127,11 @@ void PerimeterGenerator::process_classic()
                     last_box.offset(SCALED_EPSILON);
 
                     // BBS: get the Polygons upper the polygon this layer
-                    Polygons upper_polygons_series_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(*this->upper_slices, last_box);
+                    Polygons upper_polygons_series_clipped;
+                    if (this->object_config->interface_shells && this->upper_slices_same_region != nullptr)
+                        upper_polygons_series_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(to_expolygons(this->upper_slices_same_region->surfaces), last_box);
+                    else
+                        upper_polygons_series_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(*this->upper_slices, last_box);
                     upper_polygons_series_clipped = offset(upper_polygons_series_clipped, min_width_top_surface);
 
                     //set the clip to a virtual "second perimeter"
@@ -1569,8 +1573,12 @@ void PerimeterGenerator::process_arachne()
                 infill_bbox.offset(EPSILON);
 
                 Polygons upper_polygons_clipped;
-                if (this->upper_slices)
-                    upper_polygons_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(*this->upper_slices, infill_bbox);
+                if (this->upper_slices) {
+                    if (this->object_config->interface_shells && this->upper_slices_same_region != nullptr)
+                        upper_polygons_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(to_expolygons(this->upper_slices_same_region->surfaces), infill_bbox);
+                    else
+                        upper_polygons_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(*this->upper_slices, infill_bbox);
+                }
                 top_expolys_by_one_wall = diff_ex(infill_contour_by_one_wall, upper_polygons_clipped);
 
                 Polygons lower_polygons_clipped;

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1141,6 +1141,20 @@ void PerimeterGenerator::process_classic()
                     ExPolygons bridge_checker;
 
                     ExPolygons top_polygons = diff_ex(last, upper_polygons_series_clipped, ApplySafetyOffset::Yes);
+                    // Fill holes in top areas that are covered by the upper layer to prevent
+                    // different wall counts at material transitions (e.g., text on keytags).
+                    if (this->fill_top_surface_holes && ! top_polygons.empty() && this->upper_slices) {
+                        ExPolygons top_union = union_ex(top_polygons);
+                        Polygons   filled_holes;
+                        for (const ExPolygon &ep : top_union)
+                            for (const Polygon &hole : ep.holes) {
+                                ExPolygons hole_ex = to_expolygons(Polygons{hole});
+                                if (! intersection_ex(hole_ex, *this->upper_slices, ApplySafetyOffset::Yes).empty())
+                                    filled_holes.push_back(hole);
+                            }
+                        if (! filled_holes.empty())
+                            top_polygons = union_ex(top_union, to_expolygons(filled_holes));
+                    }
                     //get the not-top surface, from the "real top" but enlarged by external_infill_margin (and the min_width_top_surface we removed a bit before)
                     ExPolygons temp_gap        = diff_ex(top_polygons, fill_clip);
                     ExPolygons inner_polygons = diff_ex(last,
@@ -1580,6 +1594,20 @@ void PerimeterGenerator::process_arachne()
                         upper_polygons_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(*this->upper_slices, infill_bbox);
                 }
                 top_expolys_by_one_wall = diff_ex(infill_contour_by_one_wall, upper_polygons_clipped);
+                // Fill holes in top areas that are covered by the upper layer to prevent
+                // different wall counts at material transitions (e.g., text on keytags).
+                if (this->fill_top_surface_holes && ! top_expolys_by_one_wall.empty() && this->upper_slices) {
+                    ExPolygons top_union = union_ex(top_expolys_by_one_wall);
+                    Polygons   filled_holes;
+                    for (const ExPolygon &ep : top_union)
+                        for (const Polygon &hole : ep.holes) {
+                            ExPolygons hole_ex = to_expolygons(Polygons{hole});
+                            if (! intersection_ex(hole_ex, *this->upper_slices, ApplySafetyOffset::Yes).empty())
+                                filled_holes.push_back(hole);
+                        }
+                    if (! filled_holes.empty())
+                        top_expolys_by_one_wall = union_ex(top_union, to_expolygons(filled_holes));
+                }
 
                 Polygons lower_polygons_clipped;
                 if (this->lower_slices)

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -35,6 +35,7 @@ public:
     const SurfaceCollection     *slices;
     const ExPolygons            *upper_slices;
     const SurfaceCollection     *upper_slices_same_region;
+    const ExPolygons            *upper_slices_for_top_holes;
     const ExPolygons            *lower_slices;
     bool                         fill_top_surface_holes = false;
     double                       layer_height;
@@ -83,7 +84,7 @@ public:
         //BBS
         ExPolygons*                 fill_no_overlap,
         std::vector<LoopNode>       *loop_nodes)
-        : slices(slices), upper_slices(nullptr), upper_slices_same_region(nullptr), lower_slices(nullptr), layer_height(layer_height),
+        : slices(slices), upper_slices(nullptr), upper_slices_same_region(nullptr), upper_slices_for_top_holes(nullptr), lower_slices(nullptr), layer_height(layer_height),
             layer_id(-1), perimeter_flow(flow), ext_perimeter_flow(flow),
             overhang_flow(flow), solid_infill_flow(flow),
             config(config), object_config(object_config), print_config(print_config),

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -36,6 +36,7 @@ public:
     const ExPolygons            *upper_slices;
     const SurfaceCollection     *upper_slices_same_region;
     const ExPolygons            *lower_slices;
+    bool                         fill_top_surface_holes = false;
     double                       layer_height;
     int                          layer_id;
     Flow                         perimeter_flow;

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -34,6 +34,7 @@ public:
     // Inputs:
     const SurfaceCollection     *slices;
     const ExPolygons            *upper_slices;
+    const SurfaceCollection     *upper_slices_same_region;
     const ExPolygons            *lower_slices;
     double                       layer_height;
     int                          layer_id;
@@ -81,7 +82,7 @@ public:
         //BBS
         ExPolygons*                 fill_no_overlap,
         std::vector<LoopNode>       *loop_nodes)
-        : slices(slices), upper_slices(nullptr), lower_slices(nullptr), layer_height(layer_height),
+        : slices(slices), upper_slices(nullptr), upper_slices_same_region(nullptr), lower_slices(nullptr), layer_height(layer_height),
             layer_id(-1), perimeter_flow(flow), ext_perimeter_flow(flow),
             overhang_flow(flow), solid_infill_flow(flow),
             config(config), object_config(object_config), print_config(print_config),

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -579,6 +579,7 @@ private:
     void bridge_over_infill();
     void clip_fill_surfaces();
     void discover_horizontal_shells();
+    void apply_interface_shell_top_surface_hole_fill();
     void merge_infill_types();
     void combine_infill();
     void _generate_support_material();

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1673,36 +1673,38 @@ void PrintObject::detect_surfaces_type(std::vector<std::vector<SurfaceCollection
         BOOST_LOG_TRIVIAL(debug) << "Detecting solid surfaces for region " << region_id << " - clipping in parallel - end";
     } // for each this->print->region_count
 
-    // Reclassify stInternal surfaces as stTop when they are covered by the upper layer
-    // on layers that also have stTop. This prevents visible fill-pattern boundaries
-    // (monotonic vs rectilinear) at material transitions (e.g., text footprint on keytag base).
-    // Skip mm-painted objects which already have correct surface classification.
-    if (! this->model_object()->is_mm_painted())
-    for (size_t idx_layer = 0; idx_layer + 1 < m_layers.size(); ++idx_layer) {
-        Layer *layer       = m_layers[idx_layer];
-        Layer *upper_layer = m_layers[idx_layer + 1];
-        for (size_t region_id = 0; region_id < layer->m_regions.size(); ++region_id) {
-            LayerRegion *layerm = layer->m_regions[region_id];
-            bool has_top = false;
-            bool has_internal = false;
-            for (const Surface &s : layerm->slices.surfaces) {
-                if (s.surface_type == stTop) has_top = true;
-                else if (s.surface_type == stInternal) has_internal = true;
-                if (has_top && has_internal) break;
-            }
-            if (! has_top || ! has_internal)
-                continue;
-            bool reclassified = false;
-            for (Surface &surface : layerm->slices.surfaces) {
-                if (surface.surface_type != stInternal)
-                    continue;
-                if (! intersection_ex(ExPolygons{surface.expolygon}, upper_layer->lslices, ApplySafetyOffset::Yes).empty()) {
-                    surface.surface_type = stTop;
-                    reclassified = true;
+    // Interface shells reclassify stInternal surfaces as stTop when they are
+    // covered by the upper layer on layers that also have stTop. This prevents
+    // visible fill-pattern boundaries (monotonic vs rectilinear) at material
+    // transitions (e.g., text footprint on keytag base). Skip mm-painted
+    // objects which already have correct surface classification.
+    if (interface_shells && ! this->model_object()->is_mm_painted()) {
+        for (size_t idx_layer = 0; idx_layer + 1 < m_layers.size(); ++idx_layer) {
+            Layer *layer       = m_layers[idx_layer];
+            Layer *upper_layer = m_layers[idx_layer + 1];
+            for (size_t region_id = 0; region_id < layer->m_regions.size(); ++region_id) {
+                LayerRegion *layerm = layer->m_regions[region_id];
+                bool has_top = false;
+                bool has_internal = false;
+                for (const Surface &s : layerm->slices.surfaces) {
+                    if (s.surface_type == stTop) has_top = true;
+                    else if (s.surface_type == stInternal) has_internal = true;
+                    if (has_top && has_internal) break;
                 }
+                if (! has_top || ! has_internal)
+                    continue;
+                bool reclassified = false;
+                for (Surface &surface : layerm->slices.surfaces) {
+                    if (surface.surface_type != stInternal)
+                        continue;
+                    if (! intersection_ex(ExPolygons{surface.expolygon}, upper_layer->lslices, ApplySafetyOffset::Yes).empty()) {
+                        surface.surface_type = stTop;
+                        reclassified = true;
+                    }
+                }
+                if (reclassified)
+                    layerm->slices_to_fill_surfaces_clipped();
             }
-            if (reclassified)
-                layerm->slices_to_fill_surfaces_clipped();
         }
     }
 

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -652,10 +652,12 @@ void PrintObject::prepare_infill()
             m_print->throw_if_canceled();
         }
 
+    this->apply_interface_shell_top_surface_hole_fill();
+    m_print->throw_if_canceled();
+
     // Add solid fills to ensure the shell vertical thickness.
     this->discover_vertical_shells();
     m_print->throw_if_canceled();
-
 
     // this will detect bridges and reverse bridges
     // and rearrange top/bottom/internal surfaces
@@ -1582,27 +1584,6 @@ void PrintObject::detect_surfaces_type(std::vector<std::vector<SurfaceCollection
                         surfaces_append(top, diff_ex(top_polygons, bottom), stTop);
                     }
 
-                    if (interface_shells && detect_top && upper_layer && ! top.empty()) {
-                        ExPolygons covered_by_upper = interface_shells ?
-                            intersection_ex(layerm->slices.surfaces, upper_layer->m_regions[region_id]->slices.surfaces, ApplySafetyOffset::Yes) :
-                            intersection_ex(layerm->slices.surfaces, upper_layer->lslices, ApplySafetyOffset::Yes);
-                        ExPolygons top_expolygons = union_ex(top);
-                        Polygons   filled_top_holes;
-                        for (const ExPolygon &expolygon : top_expolygons) {
-                            for (const Polygon &hole : expolygon.holes) {
-                                Polygons   hole_polygon{ hole };
-                                ExPolygons hole_expolygons = to_expolygons(hole_polygon);
-                                if (! intersection_ex(hole_expolygons, covered_by_upper, ApplySafetyOffset::Yes).empty())
-                                    filled_top_holes.push_back(hole);
-                            }
-                        }
-                        if (! filled_top_holes.empty()) {
-                            top_expolygons = union_ex(top_expolygons, to_expolygons(filled_top_holes));
-                            top.clear();
-                            surfaces_append(top, std::move(top_expolygons), stTop);
-                        }
-                    }
-
         #ifdef SLIC3R_DEBUG_SLICE_PROCESSING
                     {
                         static int iRun = 0;
@@ -1673,43 +1654,68 @@ void PrintObject::detect_surfaces_type(std::vector<std::vector<SurfaceCollection
         BOOST_LOG_TRIVIAL(debug) << "Detecting solid surfaces for region " << region_id << " - clipping in parallel - end";
     } // for each this->print->region_count
 
-    // Interface shells reclassify stInternal surfaces as stTop when they are
-    // covered by the upper layer on layers that also have stTop. This prevents
-    // visible fill-pattern boundaries (monotonic vs rectilinear) at material
-    // transitions (e.g., text footprint on keytag base). Skip mm-painted
-    // objects which already have correct surface classification.
-    if (interface_shells && ! this->model_object()->is_mm_painted()) {
-        for (size_t idx_layer = 0; idx_layer + 1 < m_layers.size(); ++idx_layer) {
-            Layer *layer       = m_layers[idx_layer];
-            Layer *upper_layer = m_layers[idx_layer + 1];
-            for (size_t region_id = 0; region_id < layer->m_regions.size(); ++region_id) {
-                LayerRegion *layerm = layer->m_regions[region_id];
-                bool has_top = false;
-                bool has_internal = false;
-                for (const Surface &s : layerm->slices.surfaces) {
-                    if (s.surface_type == stTop) has_top = true;
-                    else if (s.surface_type == stInternal) has_internal = true;
-                    if (has_top && has_internal) break;
-                }
-                if (! has_top || ! has_internal)
-                    continue;
-                bool reclassified = false;
-                for (Surface &surface : layerm->slices.surfaces) {
-                    if (surface.surface_type != stInternal)
-                        continue;
-                    if (! intersection_ex(ExPolygons{surface.expolygon}, upper_layer->lslices, ApplySafetyOffset::Yes).empty()) {
-                        surface.surface_type = stTop;
-                        reclassified = true;
-                    }
-                }
-                if (reclassified)
-                    layerm->slices_to_fill_surfaces_clipped();
-            }
-        }
-    }
-
     // Mark the object to have the region slices classified (typed, which also means they are split based on whether they are supported, bridging, top layers etc.)
     m_typed_slices = true;
+}
+
+void PrintObject::apply_interface_shell_top_surface_hole_fill()
+{
+    const bool spiral_mode      = this->print()->config().spiral_mode.value;
+    const bool interface_shells = ! spiral_mode && m_config.interface_shells.value;
+    if (! interface_shells || this->model_object()->is_mm_painted())
+        return;
+
+    // Patch fill surfaces without changing slice classification. Vertical shell
+    // discovery can then honor top-shell depth without making lower layers top.
+    for (size_t idx_layer = 0; idx_layer + 1 < m_layers.size(); ++idx_layer) {
+        m_print->throw_if_canceled();
+        Layer *layer       = m_layers[idx_layer];
+        Layer *upper_layer = m_layers[idx_layer + 1];
+        for (size_t region_id = 0; region_id < layer->m_regions.size(); ++region_id) {
+            LayerRegion *layerm = layer->m_regions[region_id];
+            if (! layerm->slices.has(stTop))
+                continue;
+
+            ExPolygons upper_interface_slices = interface_shell_upper_slices_for_top_holes(*upper_layer, region_id);
+            if (upper_interface_slices.empty())
+                continue;
+
+            ExPolygons top_expolygons = union_ex(to_expolygons(layerm->slices.filter_by_type(stTop)));
+            if (top_expolygons.empty())
+                continue;
+
+            ExPolygons internal_slices = to_expolygons(layerm->slices.filter_by_type(stInternal));
+            ExPolygons reclassify_area = intersection_ex(internal_slices, upper_interface_slices, ApplySafetyOffset::Yes);
+            if (reclassify_area.empty())
+                continue;
+
+            bool reclassified = false;
+            Surfaces surfaces_new;
+            surfaces_new.reserve(layerm->fill_surfaces.surfaces.size() + reclassify_area.size());
+            for (Surface &surface : layerm->fill_surfaces.surfaces) {
+                if (surface.surface_type != stInternal && surface.surface_type != stInternalSolid) {
+                    surfaces_new.emplace_back(std::move(surface));
+                    continue;
+                }
+
+                ExPolygons surface_expolygons{ surface.expolygon };
+                ExPolygons surface_top = intersection_ex(surface_expolygons, reclassify_area, ApplySafetyOffset::Yes);
+                if (surface_top.empty()) {
+                    surfaces_new.emplace_back(std::move(surface));
+                    continue;
+                }
+
+                Surface top_templ = surface;
+                top_templ.surface_type = stTop;
+                ExPolygons surface_internal = diff_ex(surface_expolygons, surface_top, ApplySafetyOffset::Yes);
+                surfaces_append(surfaces_new, std::move(surface_internal), surface);
+                surfaces_append(surfaces_new, std::move(surface_top), top_templ);
+                reclassified = true;
+            }
+            if (reclassified)
+                layerm->fill_surfaces.surfaces = std::move(surfaces_new);
+        }
+    }
 }
 
 void PrintObject::process_external_surfaces()
@@ -1904,8 +1910,11 @@ void PrintObject::discover_vertical_shells()
                         float        top_bottom_expansion = float(layerm.flow(frSolidInfill).scaled_spacing()) * top_bottom_expansion_coeff;
                         // Top surfaces.
                         auto &cache = cache_top_botom_regions[idx_layer];
-                        cache.top_surfaces = offset(layerm.slices.filter_by_type(stTop), top_bottom_expansion);
-//                        append(cache.top_surfaces, offset(layerm.fill_surfaces().filter_by_type(stTop), top_bottom_expansion));
+                        Polygons slice_top = offset(layerm.slices.filter_by_type(stTop), top_bottom_expansion);
+                        // Include synthetic interface-shell top patches kept out of slices.
+                        Polygons fill_top  = offset(layerm.fill_surfaces.filter_by_type(stTop), top_bottom_expansion);
+                        cache.top_surfaces = std::move(slice_top);
+                        append(cache.top_surfaces, std::move(fill_top));
                         // Bottom surfaces.
                         cache.bottom_surfaces = offset(layerm.slices.filter_by_types(surfaces_bottom), top_bottom_expansion);
 //                        append(cache.bottom_surfaces, offset(layerm.fill_surfaces().filter_by_types(surfaces_bottom), top_bottom_expansion));

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1233,8 +1233,13 @@ bool PrintObject::invalidate_state_by_config_options(
             }
 #endif
         } else if (
-               opt_key == "interface_shells"
-            || opt_key == "fill_multiline"
+               opt_key == "interface_shells") {
+            // interface_shells affects both perimeter generation (one-wall-top uses same-region
+            // upper slices) and infill preparation (surface type detection at material boundaries).
+            steps.emplace_back(posPerimeters);
+            steps.emplace_back(posPrepareInfill);
+        } else if (
+               opt_key == "fill_multiline"
             || opt_key == "infill_combination"
             || opt_key == "bottom_shell_thickness"
             || opt_key == "top_shell_thickness"
@@ -1577,7 +1582,7 @@ void PrintObject::detect_surfaces_type(std::vector<std::vector<SurfaceCollection
                         surfaces_append(top, diff_ex(top_polygons, bottom), stTop);
                     }
 
-                    if (detect_top && upper_layer && ! top.empty()) {
+                    if (interface_shells && detect_top && upper_layer && ! top.empty()) {
                         ExPolygons covered_by_upper = interface_shells ?
                             intersection_ex(layerm->slices.surfaces, upper_layer->m_regions[region_id]->slices.surfaces, ApplySafetyOffset::Yes) :
                             intersection_ex(layerm->slices.surfaces, upper_layer->lslices, ApplySafetyOffset::Yes);

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1577,6 +1577,27 @@ void PrintObject::detect_surfaces_type(std::vector<std::vector<SurfaceCollection
                         surfaces_append(top, diff_ex(top_polygons, bottom), stTop);
                     }
 
+                    if (detect_top && upper_layer && ! top.empty()) {
+                        ExPolygons covered_by_upper = interface_shells ?
+                            intersection_ex(layerm->slices.surfaces, upper_layer->m_regions[region_id]->slices.surfaces, ApplySafetyOffset::Yes) :
+                            intersection_ex(layerm->slices.surfaces, upper_layer->lslices, ApplySafetyOffset::Yes);
+                        ExPolygons top_expolygons = union_ex(top);
+                        Polygons   filled_top_holes;
+                        for (const ExPolygon &expolygon : top_expolygons) {
+                            for (const Polygon &hole : expolygon.holes) {
+                                Polygons   hole_polygon{ hole };
+                                ExPolygons hole_expolygons = to_expolygons(hole_polygon);
+                                if (! intersection_ex(hole_expolygons, covered_by_upper, ApplySafetyOffset::Yes).empty())
+                                    filled_top_holes.push_back(hole);
+                            }
+                        }
+                        if (! filled_top_holes.empty()) {
+                            top_expolygons = union_ex(top_expolygons, to_expolygons(filled_top_holes));
+                            top.clear();
+                            surfaces_append(top, std::move(top_expolygons), stTop);
+                        }
+                    }
+
         #ifdef SLIC3R_DEBUG_SLICE_PROCESSING
                     {
                         static int iRun = 0;

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1673,6 +1673,39 @@ void PrintObject::detect_surfaces_type(std::vector<std::vector<SurfaceCollection
         BOOST_LOG_TRIVIAL(debug) << "Detecting solid surfaces for region " << region_id << " - clipping in parallel - end";
     } // for each this->print->region_count
 
+    // Reclassify stInternal surfaces as stTop when they are covered by the upper layer
+    // on layers that also have stTop. This prevents visible fill-pattern boundaries
+    // (monotonic vs rectilinear) at material transitions (e.g., text footprint on keytag base).
+    // Skip mm-painted objects which already have correct surface classification.
+    if (! this->model_object()->is_mm_painted())
+    for (size_t idx_layer = 0; idx_layer + 1 < m_layers.size(); ++idx_layer) {
+        Layer *layer       = m_layers[idx_layer];
+        Layer *upper_layer = m_layers[idx_layer + 1];
+        for (size_t region_id = 0; region_id < layer->m_regions.size(); ++region_id) {
+            LayerRegion *layerm = layer->m_regions[region_id];
+            bool has_top = false;
+            bool has_internal = false;
+            for (const Surface &s : layerm->slices.surfaces) {
+                if (s.surface_type == stTop) has_top = true;
+                else if (s.surface_type == stInternal) has_internal = true;
+                if (has_top && has_internal) break;
+            }
+            if (! has_top || ! has_internal)
+                continue;
+            bool reclassified = false;
+            for (Surface &surface : layerm->slices.surfaces) {
+                if (surface.surface_type != stInternal)
+                    continue;
+                if (! intersection_ex(ExPolygons{surface.expolygon}, upper_layer->lslices, ApplySafetyOffset::Yes).empty()) {
+                    surface.surface_type = stTop;
+                    reclassified = true;
+                }
+            }
+            if (reclassified)
+                layerm->slices_to_fill_surfaces_clipped();
+        }
+    }
+
     // Mark the object to have the region slices classified (typed, which also means they are split based on whether they are supported, bridging, top layers etc.)
     m_typed_slices = true;
 }


### PR DESCRIPTION
Fixes #2906.

This PR is stacked on top of #10069.
Please review on top of that PR. After #10069 merges, this branch can be rebased onto `master`.

## Problem
Multi-material objects (e.g., keytag with raised text as a separate part in a different material) show the text outline as visible artifacts on the base layer below the text. Two separate issues contribute:

1. **Fill pattern boundary**: The text footprint area is classified as `stInternal` (rectilinear fill) while the surrounding exposed base is `stTop` (monotonic fill), creating a visible outline.
2. **Wall count difference**: `PerimeterGenerator` computes one-wall-top areas independently of surface classification. The text footprint creates holes in the top area, causing different wall counts at the text boundary.

## Fix

**PrintObject.cpp** — After `detect_surfaces_type`, reclassify `stInternal` surfaces as `stTop` on layers that have both types, when the internal surface is covered by the upper layer. This unifies the fill pattern across the entire visible top surface.

**PerimeterGenerator.cpp** — Fill holes in the one-wall-top area that are covered by the upper layer, for both classic and arachne paths. This unifies the wall count across the entire visible top surface.

**PerimeterGenerator.hpp / LayerRegion.cpp** — Pass a `fill_top_surface_holes` flag set to `!is_mm_painted()`. Both fixes are skipped for mm-painted (single-part multicolor) objects which already have correct surface classification and would otherwise regress.

## Validation
### Repro from #2906 — multi-material keytag (text as separate part, different material)

Without the fix:
<img width="717" height="315" alt="image" src="https://github.com/user-attachments/assets/78d0fa24-8819-4620-bff4-58a6cde6ef6f" />

With the fix:
<img width="713" height="293" alt="image" src="https://github.com/user-attachments/assets/a3abb3e4-df16-4eb1-9ad6-ad8bb47d6326" />
