### PR TITLE
Fix auto-arrangement boundary for skirt loops

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -9346,7 +9346,30 @@ bool has_skirt(const DynamicPrintConfig& cfg)
         || (opt_draft_shield && opt_draft_shield->getInt() != dsDisabled);
 }
 float get_real_skirt_dist(const DynamicPrintConfig& cfg) {
-    return has_skirt(cfg) ? cfg.opt_float("skirt_distance") : 0;
+    if (!has_skirt(cfg)) return 0.f;
+
+    float dist = cfg.opt_float("skirt_distance");
+
+    int loops = cfg.opt_int("skirt_loops");
+    auto opt_draft_shield = cfg.option("draft_shield");
+    if (opt_draft_shield && opt_draft_shield->getInt() != dsDisabled && loops == 0) {
+        loops = 1;
+    }
+
+    float width = cfg.opt_float("initial_layer_line_width");
+    if (width <= 0.f) {
+        width = cfg.opt_float("line_width");
+    }
+    if (width <= 0.f) {
+        auto* nd = cfg.opt<ConfigOptionFloats>("nozzle_diameter");
+        if (nd && !nd->values.empty()) {
+            width = *std::max_element(nd->values.begin(), nd->values.end());
+        } else {
+            width = 0.4f;
+        }
+    }
+
+    return dist + loops * width;
 }
 } // namespace Slic3r
 

--- a/tests/libslic3r/test_config.cpp
+++ b/tests/libslic3r/test_config.cpp
@@ -237,3 +237,31 @@ SCENARIO("DynamicPrintConfig serialization", "[Config]") {
         }
     }
 }
+
+SCENARIO("get_real_skirt_dist calculates the correct boundary including loop width", "[Config]") {
+    GIVEN("A DynamicPrintConfig with skirt loops and spacing") {
+        Slic3r::DynamicPrintConfig config = Slic3r::DynamicPrintConfig::full_print_config();
+
+        config.set("skirt_distance", 2.0);
+        config.set("skirt_loops", 3);
+        config.set("initial_layer_line_width", 0.4);
+        config.set("draft_shield", "disabled"); // Just to be safe, dsDisabled is 0 usually
+
+        WHEN("get_real_skirt_dist is called") {
+            float dist = Slic3r::get_real_skirt_dist(config);
+
+            THEN("The distance includes the width of the skirt loops") {
+                // 2.0 + 3 * 0.4 = 3.2
+                REQUIRE(dist == Approx(3.2));
+            }
+        }
+
+        WHEN("skirt_loops is 0") {
+            config.set("skirt_loops", 0);
+            float dist = Slic3r::get_real_skirt_dist(config);
+            THEN("The distance is exactly 0 because has_skirt() should return false") {
+                REQUIRE(dist == 0.0f);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The `get_real_skirt_dist` function previously only returned the configured `skirt_distance`, ignoring the actual physical width of the skirt loops themselves. This caused the auto-arrangement algorithm to not allocate sufficient space, potentially placing skirt loops outside the buildable area.

This commit updates `get_real_skirt_dist` to calculate and include the total width of the skirt loops in its returned distance. The width is derived from `initial_layer_line_width`, falling back to `line_width`, `nozzle_diameter`, or a safe default of 0.4mm. It also ensures proper loop handling when a draft shield is enabled.

Additionally, unit tests have been added to verify this correct boundary calculation logic.