### PR TITLE
ENH: Add 3Dconnexion "SpaceMouse Pro Wireless Bluetooth Edition" product code to properly save settings.

### DIFF
--- a/src/slic3r/GUI/Mouse3DController.cpp
+++ b/src/slic3r/GUI/Mouse3DController.cpp
@@ -49,6 +49,7 @@ static const std::vector<int> _3DCONNEXION_DEVICES =
     0xc633,	/* 50739 spacemouse enterprise */
     0xc635,	/* 50741 spacemouse compact *TESTED* */
     0xc636,	/* 50742 spacemouse module */
+    0xc638,	/* 50737 spacemouse pro wireless BT edition (via USB & BT) *TESTED* */
     0xc63a,	/* 60060 spacemouse wireless (Bluetooth) */
     0xc652, /* 50770 3Dconnexion universal receiver *TESTED* */
 };
@@ -134,6 +135,7 @@ static std::string format_device_string(int vid, int pid)
     case 0xc633: { ret += "spacemouse enterprise"; break; }
     case 0xc635: { ret += "spacemouse compact"; break; }
     case 0xc636: { ret += "spacemouse module"; break; }
+    case 0xc638: { ret += "spacemouse pro wireless BT edition"; break; }
     case 0xc640: { ret += "nulooq"; break; }
     case 0xc652: { ret += "3Dconnexion universal receiver"; break; }
     default:     { ret += "UNKNOWN"; break; }


### PR DESCRIPTION
This "Bluetooth edition" is a relatively new device, adding BT support in addition their existing wireless protocol (and no more sticky rubber coating, yay).  

When connected directly via USB or via BT, it has a unique product code (otherwise it uses the "Universal Receiver" which is already supported).  The mouse worked fine, but customized Studio settings were not being properly loaded/associated for the device when Studio restarted.

Tested on Windows 10 & 11.

Thanks,
-Max