### PR TITLE
FIX issue #8196: AMS slots show "Default" k-profile until Calibration tab is visited

### DIFF
--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -1172,6 +1172,19 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
     // Set the flag whether to open the filament setting dialog from the device page
     m_comboBox_filament->SetClientData(new int(1));
 
+    // Request PA calibration history if not loaded yet — needed for k-profile dropdown
+    if (obj->GetCalib()->IsVersionInited() && !obj->GetCalib()->IsPAHistoryReady()) {
+        PACalibExtruderInfo cali_info;
+        int ext_id = obj->get_extruder_id_by_ams_id(std::to_string(ams_id));
+        cali_info.nozzle_diameter        = obj->GetExtderSystem()->GetNozzleDiameter(ext_id);
+        cali_info.use_extruder_id        = false;
+        cali_info.use_nozzle_volume_type = false;
+        CalibUtils::emit_get_PA_calib_infos(cali_info);
+        m_pa_data_pending = true;
+    } else {
+        m_pa_data_pending = false;
+    }
+
     update();
     Layout();
     Fit();
@@ -1183,6 +1196,21 @@ void AMSMaterialsSetting::post_select_event(int index) {
     event.SetInt(index);
     event.SetEventObject(m_comboBox_filament);
     wxPostEvent(m_comboBox_filament, event);
+}
+
+void AMSMaterialsSetting::TryRefreshPAProfiles()
+{
+    if (!m_pa_data_pending || !obj) return;
+    if (!obj->GetCalib()->IsPAHistoryReady()) return;
+
+    m_pa_data_pending = false;
+
+    // Re-trigger filament selection to repopulate PA profile dropdown with real data
+    int sel = m_comboBox_filament->GetSelection();
+    if (sel >= 0) {
+        m_comboBox_filament->SetClientData(new int(1));
+        post_select_event(sel);
+    }
 }
 
 void AMSMaterialsSetting::on_select_cali_result(wxCommandEvent &evt)

--- a/src/slic3r/GUI/AMSMaterialsSetting.hpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.hpp
@@ -110,6 +110,7 @@ public:
                wxString k = wxEmptyString, wxString n = wxEmptyString);
 
     void post_select_event(int index);
+    void TryRefreshPAProfiles();
     void set_color(wxColour color);
     void set_empty_color(wxColour color);
     void set_colors(std::vector<wxColour> colors);
@@ -190,6 +191,7 @@ protected:
     int                 m_filament_selection;
 
     int m_pa_cali_select_id = 0;
+    bool m_pa_data_pending{false};
 
 #ifdef __APPLE__
     wxComboBox *m_comboBox_filament;

--- a/src/slic3r/GUI/StatusPanel.cpp
+++ b/src/slic3r/GUI/StatusPanel.cpp
@@ -3270,7 +3270,12 @@ void StatusPanel::update_ams(MachineObject *obj)
 {
     // update obj in sub dlg
     if (m_ams_setting_dlg && m_ams_setting_dlg->IsShown()) { m_ams_setting_dlg->UpdateByObj(obj); }
-    if (m_filament_setting_dlg) { m_filament_setting_dlg->obj = obj; }
+    if (m_filament_setting_dlg) {
+        m_filament_setting_dlg->obj = obj;
+        if (m_filament_setting_dlg->IsShown()) {
+            m_filament_setting_dlg->TryRefreshPAProfiles();
+        }
+    }
 
     if (obj && obj->GetCalib()->IsVersionExpired() && obj->is_security_control_ready()) {
         obj->GetCalib()->SyncCalibVersion();


### PR DESCRIPTION
Issue #8196 

PA calibration history is loaded asynchronously via MQTT, but nothing refreshed the AMS material settings dialog when the data arrived. Now the dialog requests PA history on open if not yet loaded, and auto-refreshes the k-profile dropdown once the response arrives.