### PR TITLE
ENH: Add advanced mode option to skip nozzle/AMS sync warning dialog before slicing.

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -513,6 +513,9 @@ void AppConfig::set_defaults()
     if (get("show_support_recommend_dialog").empty()) {
         set_bool("show_support_recommend_dialog", true);
     }
+    if (get("show_sync_before_slice_warning").empty()) {
+        set_bool("show_sync_before_slice_warning", true);
+    }
     if (get("ignore_module_cert").empty()) {
         set_bool("ignore_module_cert", false);
     }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -15958,44 +15958,41 @@ bool Plater::priv::check_ams_status_impl(bool is_slice_all)
             is_same_as_printer = is_extruder_stat_synced();
         }
 
-        std::vector<std::map<int, int>> ams_count_info;
-        ams_count_info.resize(2);
-
-        std::map<std::pair<int, int>, int> ams_cnt_map{
-            {{MAIN_EXTRUDER_ID, 1}, 0},
-            {{DEPUTY_EXTRUDER_ID, 1}, 0},
-            {{MAIN_EXTRUDER_ID, 4}, 0},
-            {{DEPUTY_EXTRUDER_ID, 4}, 0},
-        };
-        for (const auto &ams : obj->GetFilaSystem()->GetAmsList()) {
-            for (auto extruder_id : ams.second->GetBindedExtruderSet()) {
-                if (sidebar->is_fila_switch_ready()) {
-                    auto switcher_pos = ams.second->GetSwitcherPos();
-                    if (!switcher_pos) { continue; }
-                    auto switcher_id = obj->is_main_extruder_on_left() ? (1 - static_cast<int>(switcher_pos.value())) : static_cast<int>(switcher_pos.value());
-                    if (extruder_id != switcher_id) { continue; }
+        if (is_same_as_printer && !preset_bundle->extruder_ams_counts.empty() && !preset_bundle->extruder_ams_counts.front().empty()) {
+            std::map<std::pair<int, int>, int> ams_cnt_map{
+                {{MAIN_EXTRUDER_ID, 1}, 0},
+                {{DEPUTY_EXTRUDER_ID, 1}, 0},
+                {{MAIN_EXTRUDER_ID, 4}, 0},
+                {{DEPUTY_EXTRUDER_ID, 4}, 0},
+            };
+            for (const auto &ams : obj->GetFilaSystem()->GetAmsList()) {
+                for (auto extruder_id : ams.second->GetBindedExtruderSet()) {
+                    if (sidebar->is_fila_switch_ready()) {
+                        auto switcher_pos = ams.second->GetSwitcherPos();
+                        if (!switcher_pos) { continue; }
+                        auto switcher_id = obj->is_main_extruder_on_left() ? (1 - static_cast<int>(switcher_pos.value())) : static_cast<int>(switcher_pos.value());
+                        if (extruder_id != switcher_id) { continue; }
+                    }
+                    std::pair<int, int> key = {extruder_id, ams.second->GetAmsType() == DevAmsType::N3S ? 1 : 4};
+                    ams_cnt_map[key]++;
                 }
-                std::pair<int, int> key = {extruder_id, ams.second->GetAmsType() == DevAmsType::N3S ? 1 : 4};
-                ams_cnt_map[key]++;
             }
-        }
 
-        int left_4  = ams_cnt_map[{MAIN_EXTRUDER_ID, 4}];
-        int left_1  = ams_cnt_map[{MAIN_EXTRUDER_ID, 1}];
-        int right_4 = ams_cnt_map[{DEPUTY_EXTRUDER_ID, 4}];
-        int right_1 = ams_cnt_map[{DEPUTY_EXTRUDER_ID, 1}];
-        if (!obj->is_main_extruder_on_left()) {
-            left_4  = ams_cnt_map[{DEPUTY_EXTRUDER_ID, 4}];
-            left_1  = ams_cnt_map[{DEPUTY_EXTRUDER_ID, 1}];
-            right_4 = ams_cnt_map[{MAIN_EXTRUDER_ID, 4}];
-            right_1 = ams_cnt_map[{MAIN_EXTRUDER_ID, 1}];
-        }
+            int left_4  = ams_cnt_map[{MAIN_EXTRUDER_ID, 4}];
+            int left_1  = ams_cnt_map[{MAIN_EXTRUDER_ID, 1}];
+            int right_4 = ams_cnt_map[{DEPUTY_EXTRUDER_ID, 4}];
+            int right_1 = ams_cnt_map[{DEPUTY_EXTRUDER_ID, 1}];
+            if (!obj->is_main_extruder_on_left()) {
+                left_4  = ams_cnt_map[{DEPUTY_EXTRUDER_ID, 4}];
+                left_1  = ams_cnt_map[{DEPUTY_EXTRUDER_ID, 1}];
+                right_4 = ams_cnt_map[{MAIN_EXTRUDER_ID, 4}];
+                right_1 = ams_cnt_map[{MAIN_EXTRUDER_ID, 1}];
+            }
 
-        if (!preset_bundle->extruder_ams_counts.empty() && !preset_bundle->extruder_ams_counts.front().empty()) {
-            is_same_as_printer &= preset_bundle->extruder_ams_counts[0][4] == left_4
-            && preset_bundle->extruder_ams_counts[0][1] == left_1
-            && preset_bundle->extruder_ams_counts[1][4] == right_4
-            && preset_bundle->extruder_ams_counts[1][1] == right_1;
+            is_same_as_printer = preset_bundle->extruder_ams_counts[0][4] == left_4
+                && preset_bundle->extruder_ams_counts[0][1] == left_1
+                && preset_bundle->extruder_ams_counts[1][4] == right_4
+                && preset_bundle->extruder_ams_counts[1][1] == right_1;
         }
 
         if (!is_same_as_printer) {
@@ -16010,10 +16007,15 @@ bool Plater::priv::check_ams_status_impl(bool is_slice_all)
                 {
                     add_button(wxID_YES, true, _L("Sync now"));
                     add_button(wxID_NO, true, _L("Later"));
+                    if (wxGetApp().get_mode() >= ConfigOptionMode::comAdvanced)
+                        show_dsa_button(_L("Don't warn me again (may cause unsynced settings; can be reset in Preferences).") + "  ");
                 }
             } dlg(q);
             dlg.Fit();
-            if (dlg.ShowModal() == wxID_YES) {
+            const auto result = dlg.ShowModal();
+            if (wxGetApp().get_mode() >= ConfigOptionMode::comAdvanced && dlg.get_checkbox_state())
+                wxGetApp().app_config->set_bool("show_sync_before_slice_warning", false);
+            if (result == wxID_YES) {
                 if (GUI::wxGetApp().sidebar().sync_extruder_list()) {
                     if (is_slice_all)
                         wxPostEvent(q, SimpleEvent(EVT_GLTOOLBAR_SLICE_ALL));
@@ -24368,16 +24370,13 @@ void Plater::update_objects_position_when_select_preset(const std::function<void
 
 bool Plater::check_ams_status(bool is_slice_all)
 {
-    if (m_check_status == 0) {
-        if (!p->check_ams_status_impl(is_slice_all)) {
-            m_check_status = 0;
-            return false;
-        }
-        else {
-            m_check_status = 1;
-        }
-    }
+    if (m_check_status != 0 || (wxGetApp().get_mode() >= ConfigOptionMode::comAdvanced && !wxGetApp().app_config->get_bool("show_sync_before_slice_warning")))
+        return true;
 
+    if (!p->check_ams_status_impl(is_slice_all))
+        return false;
+
+    m_check_status = 1;
     return true;
 }
 

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1339,6 +1339,15 @@ wxWindow* PreferencesDialog::create_general_page()
     auto item_beta_version_update = create_item_checkbox(_L("Support beta version update."), page, _L("With this option enabled, you can receive beta version updates."), 50, "enable_beta_version_update");
     auto item_mix_print_high_low_temperature = create_item_checkbox(_L("Remove the restriction on mixed printing of high and low temperature filaments."), page, _L("With this option enabled, you can print materials with a large temperature difference together."), 50, "enable_high_low_temp_mixed_printing");
     auto item_camera_fullscreen_active_monitor_only = create_item_checkbox(_L("Open full screen camera view on active monitor only."), page, _L("When enabled, the camera full screen view opens only on the monitor that contains Bambu Studio."), 50, "camera_fullscreen_active_monitor_only");
+
+    wxBoxSizer * item_show_sync_b4_slice_dlg = nullptr;
+    if (wxGetApp().get_mode() >= ConfigOptionMode::comAdvanced) {
+        item_show_sync_b4_slice_dlg = create_item_checkbox(
+            _L("Prompt to synchronize nozzle and AMS data with connected printer before slicing."), page, 
+            _L("Shows a dialog before any slicing operation when a printer is connected and the current synchronization is outdated or the status is unknown."), 50, "show_sync_before_slice_warning"
+        );
+    }
+
     auto item_restore_hide_pop_ups = create_item_button(_L("Clear my choice for synchronizing printer preset after loading the file."), _L("Clear"), page, {}, []() {
         wxGetApp().app_config->erase("app", "sync_after_load_file_show_flag");
     });
@@ -1516,6 +1525,8 @@ wxWindow* PreferencesDialog::create_general_page()
     sizer_page->Add(item_auto_transfer_when_switch_preset, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_mix_print_high_low_temperature, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_camera_fullscreen_active_monitor_only, 0, wxTOP, FromDIP(3));
+    if (item_show_sync_b4_slice_dlg)
+        sizer_page->Add(item_show_sync_b4_slice_dlg, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_restore_hide_pop_ups, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_restore_hide_3mf_info, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_restore_support_recommend_dlg, 0, wxTOP, FromDIP(3));


### PR DESCRIPTION
The warning dialog that pops up before slicing about syncing nozzle & AMS info with connected printer can be disruptive, sometimes counter-productive, and in some cases shown multiple times.

This PR adds an option to disable that dialog. Both from program Preferences dialog and also as a "don't show again" option on the warning dialog itself.

To make this more palatable (less error-prone for basic users), I made this an "advanced mode" option.  Doesn't have to be, of course.

<img width="804" height="160" alt="image" src="https://github.com/user-attachments/assets/62d9895f-bad7-403c-800a-52c14c202952" />
<img width="643" height="496" alt="image" src="https://github.com/user-attachments/assets/a4005a5a-7585-4603-b60e-27f66a65baae" />

Since I was in `check_ams_status_impl()` already, I got rid of a boolean bitwise operation warning and had it skip some checks if they're not needed in the first place (printer already doesn't match, etc).  Most of that change is just indentation.

Thank you for your consideration,
-Max

--

Related:
#8941
#9235
https://forum.bambulab.com/t/warning-pop-up-for-sync-how-do-i-disable-this-feature/218235
