### PR TITLE
Allow 3D view preset shortcuts (CTRL + [0-7]) to still work when canvas doesn't have focus

### DIFF
--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -123,43 +123,10 @@ void Field::PostInitialize()
 
 	BUILD();
 
-	// For the mode, when settings are in non-modal dialog, neither dialog nor tabpanel doesn't receive wxEVT_KEY_UP event, when some field is selected.
-	// So, like a workaround check wxEVT_KEY_UP event for the Filed and switch between tabs if Ctrl+(1-4) was pressed
-    if (getWindow()) {
-        if (m_opt.readonly) {
-            this->disable();
-        } else {
-            this->enable();
-        }
-		getWindow()->Bind(wxEVT_KEY_UP, [](wxKeyEvent& evt) {
-		    if ((evt.GetModifiers() & wxMOD_CONTROL) != 0) {
-			    int tab_id = -1;
-			    switch (evt.GetKeyCode()) {
-			    case '1': { tab_id = 0; break; }
-			    case '2': { tab_id = 1; break; }
-				case '3': { tab_id = 2; break; }
-				case '4': { tab_id = 3; break; }
-#ifdef __APPLE__
-				case 'f':
-#else /* __APPLE__ */
-				case WXK_CONTROL_F:
-#endif /* __APPLE__ */
-                case 'F': {
-                    //wxGetApp().plater()->search(false, Preset::TYPE_MODEL, nullptr, nullptr);
-                    break;
-                }
-			    default: break;
-			    }
-			    if (tab_id >= 0)
-					wxGetApp().mainframe->select_tab(tab_id);
-				if (tab_id > 0)
-					// tab panel should be focused for correct navigation between tabs
-				    wxGetApp().tab_panel()->SetFocus();
-		    }
-
-		    evt.Skip();
-	    }, getWindow()->GetId());
-    }
+    if (m_opt.readonly)
+        this->disable();
+    else
+        this->enable();
 }
 
 // Values of width to alignments of fields

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -646,6 +646,7 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
             });
 ;    }
     this->Bind(wxEVT_CHAR_HOOK, [this](wxKeyEvent &evt) {
+        const int key_code = evt.GetKeyCode();
 #ifdef __APPLE__
         if (evt.CmdDown() && (evt.GetKeyCode() == 'H')) {
             //call parent_menu hide behavior
@@ -720,6 +721,19 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
 
         if (!evt.HasAnyModifiers() && evt.GetKeyCode() == 'Z') {
             view_zoom_to_fit();
+            return;
+        }
+
+        // Pass 3D view preset shortcuts directly to the current canvas. (Only 0-7 currently used but reserve 8 & 9 anyway.)
+        if (evt.CmdDown() && ((key_code >= '0' && key_code <= '9') || (key_code >= WXK_NUMPAD0 && key_code <= WXK_NUMPAD9)) && m_plater) {
+            if (auto *canvas = m_plater->canvas3D()) {
+                if (auto *target = (wxWindow*)canvas->get_wxglcanvas()) {
+                    wxKeyEvent e(evt);
+                    e.SetEventType(wxEVT_KEY_UP);
+                    e.SetEventObject(target);
+                    wxPostEvent(target, e);
+                }
+            }
             return;
         }
 


### PR DESCRIPTION
Currently the 3D view shortcuts only work when the 3D canvas has focus. If the last focus was on the sidebar, for example, the shortcuts are ineffective.  The current focus area usually isn't obvious, and switching focus to the canvas typically requires a mouse click.

There was also an odd situation when a combo box type `Field` had focus in the sidebar -- pressing `CTRL+[1-3]` keys would actually switch the active main tab (between Home/Prepare/Preview, depending on the digit).  Looks like some very legacy code there, since those shortcuts don't switch tabs in any other case.

Suggested solution is to simply pass the view shortcut key events from `MainFrame` through to the current canvas view.  And removing the legacy code in `Field`.

Thanks for your consideration,
-Max


