### PR TITLE
Use filament profile default colour on selection

### DIFF
--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -2,6 +2,7 @@
 #include "ExtrusionCalibration.hpp"
 #include "MsgDialog.hpp"
 #include "GUI_App.hpp"
+#include "FilamentPresetUtils.hpp"
 #include "libslic3r/Preset.hpp"
 #include "I18N.hpp"
 #include <boost/log/trivial.hpp>
@@ -1418,6 +1419,7 @@ void AMSMaterialsSetting::on_select_filament(wxCommandEvent &evt)
 
     m_filament_type = "";
     PresetBundle* preset_bundle = wxGetApp().preset_bundle;
+    const Preset* selected_filament_preset = nullptr;
     if (preset_bundle) {
         std::ostringstream stream;
         if (obj)
@@ -1439,6 +1441,7 @@ void AMSMaterialsSetting::on_select_filament(wxCommandEvent &evt)
                         }
                     }
                     if (!it->is_system && !has_compatible_printer) continue;
+                    selected_filament_preset = &(*it);
                     // ) if nozzle_temperature_range is found
                     ConfigOption* opt_min = it->config.option("nozzle_temperature_range_low");
                     if (opt_min) {
@@ -1527,9 +1530,23 @@ void AMSMaterialsSetting::on_select_filament(wxCommandEvent &evt)
             if (it->alias.compare(into_u8(m_comboBox_filament->GetValue())) == 0) {
                 ams_filament_id = it->filament_id;
                 ams_setting_id = it->setting_id;
+                if (!selected_filament_preset) {
+                    selected_filament_preset = &(*it);
+                }
                 break;
             }
         }
+    }
+
+    if (!selected_filament_preset && preset_bundle && !ams_filament_id.empty()) {
+        selected_filament_preset = find_filament_preset_by_id(preset_bundle, ams_filament_id);
+    }
+
+    std::string default_color = filament_default_colour(selected_filament_preset);
+    if (!default_color.empty()) {
+        wxColour color = DevAmsTray::decode_color(default_color);
+        set_color(color);
+        set_colors({ color });
     }
 
     auto get_cali_index = [this](const std::string& str) -> int{

--- a/src/slic3r/GUI/FilamentPresetUtils.hpp
+++ b/src/slic3r/GUI/FilamentPresetUtils.hpp
@@ -1,0 +1,46 @@
+#ifndef slic3r_GUI_FilamentPresetUtils_hpp_
+#define slic3r_GUI_FilamentPresetUtils_hpp_
+
+#include <string>
+
+#include "libslic3r/Preset.hpp"
+#include "libslic3r/PresetBundle.hpp"
+
+namespace Slic3r { namespace GUI {
+
+inline std::string filament_default_colour(const Preset* preset)
+{
+    return preset ? preset->config.opt_string("default_filament_colour", 0u) : std::string();
+}
+
+inline const Preset* find_preset_by_name_or_alias(
+    const PresetBundle* preset_bundle,
+    Preset::Type preset_type,
+    const PresetCollection* collection,
+    const std::string& name_or_alias)
+{
+    if (!collection || name_or_alias.empty())
+        return nullptr;
+
+    std::string preset_name = Preset::remove_suffix_modified(name_or_alias);
+    if (preset_bundle)
+        preset_name = preset_bundle->get_preset_name_by_alias(preset_type, preset_name);
+
+    return collection->find_preset(preset_name);
+}
+
+inline const Preset* find_filament_preset_by_id(const PresetBundle* preset_bundle, const std::string& filament_id)
+{
+    if (!preset_bundle || filament_id.empty())
+        return nullptr;
+
+    for (auto it = preset_bundle->filaments.begin(); it != preset_bundle->filaments.end(); ++it)
+        if (it->filament_id == filament_id)
+            return &(*it);
+
+    return nullptr;
+}
+
+}} // namespace Slic3r::GUI
+
+#endif // slic3r_GUI_FilamentPresetUtils_hpp_

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -78,6 +78,7 @@
 
 #include "GUI.hpp"
 #include "GUI_App.hpp"
+#include "FilamentPresetUtils.hpp"
 #include "GuiColor.hpp"
 #include "GUI_ObjectList.hpp"
 #include "GUI_Utils.hpp"
@@ -11211,6 +11212,19 @@ void Plater::priv::on_select_preset(wxCommandEvent &evt)
         wxGetApp().preset_bundle->set_filament_preset(idx, preset_name);
         if (!q->on_filament_change(idx))
             wxGetApp().preset_bundle->set_filament_preset(idx, old_name);
+        else if (idx >= 0) {
+            auto* preset = find_preset_by_name_or_alias(wxGetApp().preset_bundle, Preset::TYPE_FILAMENT, &wxGetApp().preset_bundle->filaments, preset_name);
+            std::string color = filament_default_colour(preset);
+            if (!color.empty()) {
+                auto& project_config = wxGetApp().preset_bundle->project_config;
+                if (auto* color_opt = project_config.option<ConfigOptionStrings>("filament_colour");
+                    color_opt && static_cast<size_t>(idx) < color_opt->values.size())
+                    color_opt->values[idx] = color;
+                if (auto* multi_color_opt = project_config.option<ConfigOptionStrings>("filament_multi_colour");
+                    multi_color_opt && static_cast<size_t>(idx) < multi_color_opt->values.size())
+                    multi_color_opt->values[idx] = color;
+            }
+        }
         wxGetApp().plater()->update_project_dirty_from_presets();
         wxGetApp().preset_bundle->export_selections(*wxGetApp().app_config);
         dynamic_filament_list.update();

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -42,6 +42,7 @@
 #include "MsgDialog.hpp"
 #include "ParamsDialog.hpp"
 #include "FilamentPickerDialog.hpp"
+#include "FilamentPresetUtils.hpp"
 #include "wxExtensions.hpp"
 
 #include "DeviceCore/DevManager.h"
@@ -233,11 +234,10 @@ int PresetComboBox::update_ams_color()
     std::string color;
     std::string ctype;
     std::vector<std::string> colors;
+    auto* preset = find_preset_by_name_or_alias(wxGetApp().preset_bundle, m_type, m_collection, GetValue().ToUTF8().data());
+    color = filament_default_colour(preset);
+    bool use_preset_default_color = !color.empty();
     if (idx < 0) {
-        auto  name   = Preset::remove_suffix_modified(GetValue().ToUTF8().data());
-        auto *preset = m_collection->find_preset(name);
-        if (preset)
-            color = preset->config.opt_string("default_filament_colour", 0u);
         if (color.empty()) return -1;
     } else {
         auto &ams_list = wxGetApp().preset_bundle->filament_ams_list;
@@ -246,9 +246,11 @@ int PresetComboBox::update_ams_color()
             BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(": ams %1% out of range %2%") % idx % ams_list.size();
             return -1;
         }
-        color = iter->second.opt_string("filament_colour", 0u);
+        if (color.empty())
+            color = iter->second.opt_string("filament_colour", 0u);
         ctype = iter->second.opt_string("filament_colour_type", 0u);
-        colors = iter->second.opt<ConfigOptionStrings>("filament_multi_colour")->values;
+        if (!use_preset_default_color)
+            colors = iter->second.opt<ConfigOptionStrings>("filament_multi_colour")->values;
     }
     DynamicPrintConfig *cfg        = &wxGetApp().preset_bundle->project_config;
     auto color_head = static_cast<ConfigOptionStrings*>(cfg->option("filament_colour")->clone()); // single color (the first color if multi-color filament)


### PR DESCRIPTION
# PR Draft: Use Filament Profile Default Colour When Selecting Filament Presets

## Proposed Title

Use filament profile default colour when selecting filament presets

## Summary

This change updates Bambu Studio so filament selections use the selected filament preset's `default_filament_colour` instead of keeping the previous project or AMS slot colour.

The affected flows are:

- Prepare tab filament preset selection
- Project config update after changing a filament preset
- AMS Materials Setting dialog colour preview

This makes the displayed project filament colour follow the selected filament profile, which is useful when filament profiles are used as the source of truth for material colour.

## Problem

When a user selects a different filament profile, Bambu Studio can keep using the existing `filament_colour` value from the project or AMS slot instead of the selected profile's `default_filament_colour`.

That means the filament type/name can change while the visible colour remains stale.

Example:

- AMS slot or project filament is currently magenta.
- User selects a Beige PLA profile whose `default_filament_colour` is beige.
- The selected profile changes, but the UI may continue showing the old magenta colour.

## Implementation

Added a small GUI helper:

`src/slic3r/GUI/FilamentPresetUtils.hpp`

The helper centralises:

- Resolving selected preset names and aliases
- Finding filament presets by filament id
- Reading `default_filament_colour`

Updated:

- `src/slic3r/GUI/PresetComboBoxes.cpp`
  - `PresetComboBox::update_ams_color()` now prefers the selected preset's `default_filament_colour`.
  - Falls back to AMS slot `filament_colour` when the preset has no default colour.

- `src/slic3r/GUI/Plater.cpp`
  - After a successful filament preset change, project `filament_colour` and `filament_multi_colour` are updated from the selected preset's default colour.

- `src/slic3r/GUI/AMSMaterialsSetting.cpp`
  - The AMS Materials Setting dialog colour chip updates when a filament preset is selected.
  - The value used on Confirm comes from the selected profile colour.

## Behaviour

If the selected filament preset has a non-empty `default_filament_colour`, that colour is used.

If the selected preset does not define a default colour, existing fallback behaviour is preserved.

## Validation

Built locally on Windows with Visual Studio 2022, Release configuration.

Tested with local filament profiles and `.3mf` projects:

- Prepare tab updates to the selected profile colour.
- Saved `.3mf` files retain the corrected project colours.
- Reopening the saved file in official Bambu Studio shows the corrected visual colours.
- AMS Materials Setting dialog colour chip updates when changing the filament profile.

## Known Limitation

Hardware AMS slot updates cannot be fully validated from a locally compiled unsigned Bambu Studio build.

The network/printer layer reports:

`Your software is not signed, and some printing functions have been restricted. Please use the officially signed software version.`

Because of that, local testing can validate the UI and project config behaviour, but actual printer/AMS hardware persistence requires an officially signed build.

## Suggested Reviewer Notes

The change intentionally affects only the selected preset colour resolution and keeps existing fallback behaviour when no default colour is defined.

The AMS hardware command path is not changed directly; the dialog simply uses the selected profile colour before the existing Confirm flow sends the current dialog colour.

