### PR TITLE
fix: migrate to WebKitGTK 4.1 for modern Linux distributions (#9450)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install  -y \
     libgtk-3-dev \
     libdbus-1-dev \
     libcairo2-dev \
-    libgtk-3-dev libwebkit2gtk-4.0-dev \
+    libgtk-3-dev libwebkit2gtk-4.1-dev \
     libsoup2.4-dev \
     libgstreamer1.0-dev libgstreamer-plugins-good1.0-dev libgstreamer-plugins-base1.0-dev libgstreamerd-3-dev \
     libosmesa6-dev \

--- a/Containerfile
+++ b/Containerfile
@@ -42,7 +42,7 @@ RUN apt-get update && apt-get install  -y \
     libdbus-1-dev \
     libcairo2-dev \
     libgtk-3-dev libwebkit2gtk-4.1-dev \
-    libsoup2.4-dev \
+    libsoup-3.0-dev \
     libgstreamer1.0-dev libgstreamer-plugins-good1.0-dev libgstreamer-plugins-base1.0-dev libgstreamerd-3-dev \
     libosmesa6-dev \
     libssl3 libssl-dev libcurl4-openssl-dev libsecret-1-dev \

--- a/linux.d/debian
+++ b/linux.d/debian
@@ -35,17 +35,7 @@ REQUIRED_DEV_PACKAGES=(
 
 if [[ -n "$UPDATE_LIB" ]]
 then
-    # for ubuntu 22+ and 23+:
-    ubu_major_version="$(grep VERSION_ID /etc/os-release | cut -d "=" -f 2 | cut -d "." -f 1 | tr -d /\"/)"
-    if [ $ubu_major_version = "22" ] || [ $ubu_major_version = "23" ]
-    then
-        REQUIRED_DEV_PACKAGES+=(libwebkit2gtk-4.0-dev curl libfuse-dev libssl-dev libcurl4-openssl-dev m4)
-    elif [ $ubu_major_version = "24" ]
-    then
-        REQUIRED_DEV_PACKAGES+=(libwebkit2gtk-4.1-dev)
-    else
-        REQUIRED_DEV_PACKAGES+=(libwebkit2gtk-4.0-dev)
-    fi
+    REQUIRED_DEV_PACKAGES+=(libwebkit2gtk-4.1-dev)
     if [[ -n "$BUILD_DEBUG" ]]
     then
         REQUIRED_DEV_PACKAGES+=(libssl-dev libcurl4-openssl-dev)

--- a/linux.d/fedora
+++ b/linux.d/fedora
@@ -44,13 +44,7 @@ REQUIRED_DEV_PACKAGES=(
 if [[ -n "$UPDATE_LIB" ]]
 then
     NEEDED_PKGS=""
-    fedora_version=$(awk -F= '/^VERSION_ID=/ {print $2}' /etc/os-release)
-    if [ $fedora_version == "40" ]
-    then
-        REQUIRED_DEV_PACKAGES+=(webkit2gtk4.1-devel)
-    else
-        REQUIRED_DEV_PACKAGES+=(webkit2gtk4.0-devel)
-    fi
+    REQUIRED_DEV_PACKAGES+=(webkit2gtk4.1-devel)
     for PKG in ${REQUIRED_DEV_PACKAGES[@]}; do
         rpm -q ${PKG} > /dev/null || NEEDED_PKGS+=" ${PKG}"
     done

--- a/src/slic3r/GUI/Widgets/WebView.cpp
+++ b/src/slic3r/GUI/Widgets/WebView.cpp
@@ -23,20 +23,22 @@
 #include <gtk/gtk.h>
 #define WEBKIT_API
 struct WebKitWebView;
-struct WebKitJavascriptResult;
+struct _JSCValue;
+typedef struct _JSCValue JSCValue;
 extern "C" {
 WEBKIT_API void
-webkit_web_view_run_javascript                       (WebKitWebView             *web_view,
+webkit_web_view_evaluate_javascript                  (WebKitWebView             *web_view,
                                                       const gchar               *script,
+                                                      gssize                     length,
+                                                      const gchar               *world_name,
+                                                      const gchar               *source_uri,
                                                       GCancellable              *cancellable,
                                                       GAsyncReadyCallback       callback,
                                                       gpointer                  user_data);
-WEBKIT_API WebKitJavascriptResult *
-webkit_web_view_run_javascript_finish                (WebKitWebView             *web_view,
+WEBKIT_API JSCValue *
+webkit_web_view_evaluate_javascript_finish           (WebKitWebView             *web_view,
                                                       GAsyncResult              *result,
-						      GError                    **error);
-WEBKIT_API void
-webkit_javascript_result_unref              (WebKitJavascriptResult *js_result);
+                                                      GError                    **error);
 }
 
 static GOnce register_handler_once = G_ONCE_INIT;
@@ -357,15 +359,16 @@ bool WebView::RunScript(wxWebView *webView, wxString const &javascript)
         return true;
 #else
         WebKitWebView *wkWebView = (WebKitWebView *) webView->GetNativeBackend();
-        webkit_web_view_run_javascript(
-            wkWebView, javascript.utf8_str(), NULL,
+        webkit_web_view_evaluate_javascript(
+            wkWebView, javascript.utf8_str(), -1, NULL, NULL, NULL,
             [](GObject *wkWebView, GAsyncResult *res, void *) {
-                GError * error = NULL;
-                auto result = webkit_web_view_run_javascript_finish((WebKitWebView*)wkWebView, res, &error);
-                if (!result)
-                    g_error_free (error);
-                else
-                    webkit_javascript_result_unref (result);
+                GError *error = NULL;
+                JSCValue *result = webkit_web_view_evaluate_javascript_finish((WebKitWebView*)wkWebView, res, &error);
+                if (!result) {
+                    if (error) g_error_free(error);
+                } else {
+                    g_object_unref(result);
+                }
         }, NULL);
         return true;
 #endif


### PR DESCRIPTION
## Summary
Fixes #9450. Migrates Linux build from WebKitGTK 4.0 (libsoup2, EOL) to 4.1 (libsoup3), and replaces the removed `webkit_web_view_run_javascript` API with `webkit_web_view_evaluate_javascript` (WebKit 2.40+).

## Changes
- `linux.d/debian`, `linux.d/fedora` — require `libwebkit2gtk-4.1-dev` / `webkit2gtk4.1-devel` unconditionally (drop the old version branches).
- `Containerfile` — `libwebkit2gtk-4.0-dev` → `4.1-dev`, `libsoup2.4-dev` → `libsoup-3.0-dev`. Base `ubuntu:22.04` unchanged (jammy-updates provides 4.1).
- `src/slic3r/GUI/Widgets/WebView.cpp` — `extern` decl + `RunScript()` migrated to `evaluate_javascript` / `evaluate_javascript_finish` (returns `JSCValue*`, freed via `g_object_unref`).

## Compatibility
Drops Ubuntu 20.04 / Debian 11 (EOL, WebKitGTK 4.0 only). Ubuntu 22.04+ (via jammy-updates), 24.04+, Fedora 40+, and Flatpak `org.gnome.Platform//48` all supported.

## Testing

### Runtime — AppImage launched on

Ubuntu 25.10 is the bare-metal host that originally reproduced #9450. The other three are GNOME Boxes VM desktops.

| Host | Type | Environment |
| --- | --- | --- |
| Ubuntu 25.10 | bare-metal | GNOME 49 / WebKitGTK 2.50 (#9450 reproducer — crash gone) |
| Ubuntu 24.04 LTS | VM (Boxes) | GNOME 46 / WebKitGTK 2.44 |
| Ubuntu 22.04 LTS | VM (Boxes) | GNOME 42 / WebKitGTK 2.50 (jammy-updates) |
| Fedora 42 | VM (Boxes) | GNOME 48 / WebKitGTK 2.48 (matches Flatpak Platform 48) |

<img width="1854" height="1015" alt="Ubuntu25" src="https://github.com/user-attachments/assets/1f63cc6f-97f9-441a-ab72-634a8c547135" />

<img width="1854" height="1047" alt="Ubuntu22" src="https://github.com/user-attachments/assets/d1b149d5-8c61-4288-bc51-e1e1187055ab" />

<img width="1853" height="1048" alt="Fedora42" src="https://github.com/user-attachments/assets/a99939b8-7883-48c5-bd8b-4f251017584a" />

### CI / compile
Fork's `build_all` green on `ubuntu-22.04`, `ubuntu-24.04`, `windows-latest`, `macos-15-intel`, `macos-15` (arm64). Fedora 40 compile via `podman` also succeeds with correct 4.1 / libsoup-3.0 linkage.

## Follow-up: Flatpak manifest

[flathub/com.bambulab.BambuStudio](https://github.com/flathub/com.bambulab.BambuStudio) is managed separately. To fully close #9450 for Flathub users, could a maintainer please update the manifest so the packaged runtime matches this PR (`runtime-version: '48'`, any `libsoup2.4` / `webkit2gtk-4.0` module references switched to the 3.0 / 4.1 variants) and republish?
