### PR TITLE
FIX: StatusPanel, show current-print thumbnail on wxGTK

### DIFF
--- a/src/slic3r/GUI/StatusPanel.cpp
+++ b/src/slic3r/GUI/StatusPanel.cpp
@@ -1345,6 +1345,9 @@ void PrintingTaskPanel::set_thumbnail_img(const wxBitmap &bmp, const std::string
 
     m_thumbnail_bmp_display_name = bmp_name;
     m_thumbnail_bmp_display      = bmp;
+    if (m_bitmap_thumbnail && bmp.IsOk()) {
+        m_bitmap_thumbnail->SetBitmap(bmp);
+    }
     Refresh();
 }
 


### PR DESCRIPTION
On Linux (wxGTK) wxStaticBitmap is a native GtkImage wrapper and does
not dispatch wxEVT_PAINT to Bind()'d handlers. As a result, the
PrintingTaskPanel::paint() override that wxMSW/wxOSX rely on to
composite m_thumbnail_bmp_display over the panel is never invoked, and
set_thumbnail_img() has no visible effect - the placeholder sent to
the widget at construction time stays on screen for the whole session.

Push the bitmap through the widget's native SetBitmap() path in
addition to the existing Refresh() so the new image shows up on all
platforms regardless of whether wxEVT_PAINT fires.