### PR TITLE
ENH: Add alternate extra wall option

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -916,6 +916,9 @@ void PerimeterGenerator::process_classic()
         const Surface &surface = this->slices->surfaces[surface_order[order_idx]];
         // detect how many perimeters must be generated for this island
         int        loop_number = this->config->wall_loops + surface.extra_perimeters - 1;  // 0-indexed loops
+        int sparse_infill_density = this->config->sparse_infill_density.value;
+        if (this->config->alternate_extra_wall && this->layer_id % 2 == 1 && !m_spiral_vase && sparse_infill_density > 0)
+            loop_number++;
         //BBS: set the topmost and bottom most layer to be one wall
         if (loop_number > 0 && ((this->object_config->top_one_wall_type != TopOneWallType::None && this->upper_slices == nullptr) || (this->object_config->only_one_wall_first_layer && layer_id == 0)))
             loop_number = 0;
@@ -1500,6 +1503,9 @@ void PerimeterGenerator::process_arachne()
     for (const Surface& surface : this->slices->surfaces) {
         // detect how many perimeters must be generated for this island
         int loop_number = this->config->wall_loops + surface.extra_perimeters - 1; // 0-indexed loops
+        int sparse_infill_density = this->config->sparse_infill_density.value;
+        if (this->config->alternate_extra_wall && this->layer_id % 2 == 1 && !m_spiral_vase && sparse_infill_density > 0)
+            loop_number++;
 
         bool apply_circle_compensation = true;
         // Orca: properly adjust offset for the outer wall if precise_outer_wall is enabled.

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1000,7 +1000,8 @@ static std::vector<std::string> s_Preset_print_options {
     "exclude_object", "override_filament_scarf_seam_setting", "seam_slope_type", "seam_slope_conditional", "scarf_angle_threshold",
     "seam_slope_start_height", "seam_slope_entire_loop", "seam_slope_min_length",
     "seam_slope_steps", "seam_slope_inner_walls", "role_base_wipe_speed", "seam_slope_gap", "precise_outer_wall",
-    "interlocking_beam", "interlocking_orientation", "interlocking_beam_layer_count", "interlocking_depth", "interlocking_boundary_avoidance", "interlocking_beam_width", "embedding_wall_into_infill" };
+    "interlocking_beam", "interlocking_orientation", "interlocking_beam_layer_count", "interlocking_depth", "interlocking_boundary_avoidance", "interlocking_beam_width", "embedding_wall_into_infill",
+    "alternate_extra_wall" };
 
 static std::vector<std::string> s_Preset_filament_options{/*"filament_colour", */ "default_filament_colour", "required_nozzle_HRC", "filament_diameter", "volumetric_speed_coefficients", "filament_type",
                                                           "filament_soluble", "filament_is_support", "filament_printable", "filament_scarf_seam_type", "filament_scarf_height",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -366,7 +366,8 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
             || opt_key == "seam_slope_start_height"
             || opt_key == "seam_slope_gap"
             || opt_key == "seam_slope_min_length"
-            || opt_key == "embedding_wall_into_infill") {
+            || opt_key == "embedding_wall_into_infill"
+            || opt_key == "alternate_extra_wall") {
             osteps.emplace_back(posPerimeters);
             osteps.emplace_back(posInfill);
             osteps.emplace_back(posSupportMaterial);

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3909,6 +3909,12 @@ void PrintConfigDef::init_fff_params()
     def->tooltip  = L("Embedding the wall into parts where the wall loops are absent ensures that the wall connects seamlessly to the infill.");
     def->set_default_value(new ConfigOptionBool(false));
 
+    def = this->add("alternate_extra_wall", coBool);
+    def->label = L("Alternate extra wall");
+    def->category = L("Strength");
+    def->tooltip  = L("Add an extra wall on alternating layers to improve layer bonding and part strength without the full cost of a permanent extra wall.");
+    def->set_default_value(new ConfigOptionBool(false));
+
     def = this->add("post_process", coStrings);
     def->label = L("Post-processing Scripts");
     def->tooltip = L("If you want to process the output G-code through custom scripts, "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1048,6 +1048,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionInt,                  seam_slope_steps))
     ((ConfigOptionBool,                 seam_slope_inner_walls))
     ((ConfigOptionBool,                 embedding_wall_into_infill))
+    ((ConfigOptionBool,                 alternate_extra_wall))
 )
 
 PRINT_CONFIG_CLASS_DEFINE(

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -691,6 +691,24 @@ void ConfigManipulation::update_print_fff_config(DynamicPrintConfig* config, con
         apply(config, &new_conf);
         is_msg_dlg_already_exist = false;
     }
+
+    if (config->opt_bool("alternate_extra_wall") &&
+        config->opt_enum<EnsureVerticalThicknessLevel>("ensure_vertical_shell_thickness") == EnsureVerticalThicknessLevel::evtEnabled) {
+        const wxString msg_text = _L("Alternate extra wall doesn't work well when ensure vertical shell thickness is set to Enable.\n"
+                                     "Change these settings automatically?\n"
+                                     "Yes - Change ensure vertical shell thickness to Partial and enable alternate extra wall\n"
+                                     "No  - Don't use alternate extra wall");
+        MessageDialog dialog(m_msg_dlg_parent, msg_text, "", wxICON_WARNING | wxYES | wxNO);
+        DynamicPrintConfig new_conf = *config;
+        is_msg_dlg_already_exist = true;
+        auto answer = dialog.ShowModal();
+        if (answer == wxID_YES)
+            new_conf.set_key_value("ensure_vertical_shell_thickness", new ConfigOptionEnum<EnsureVerticalThicknessLevel>(EnsureVerticalThicknessLevel::evtPartial));
+        else
+            new_conf.set_key_value("alternate_extra_wall", new ConfigOptionBool(false));
+        apply(config, &new_conf);
+        is_msg_dlg_already_exist = false;
+    }
 }
 
 void ConfigManipulation::apply_null_fff_config(DynamicPrintConfig *config, std::vector<std::string> const &keys, std::map<ObjectBase *, ModelConfig *> const &configs)

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2707,6 +2707,7 @@ void TabPrint::build()
     page = add_options_page(L("Strength"), "empty");
         optgroup = page->new_optgroup(L("Walls"), L"param_wall");
         optgroup->append_single_option_line("wall_loops","wall-generator");
+        optgroup->append_single_option_line("alternate_extra_wall");
         optgroup->append_single_option_line("embedding_wall_into_infill");
 
         optgroup->append_single_option_line("detect_thin_wall","wall-generator");


### PR DESCRIPTION
## Summary

This PR ports the **Alternate Extra Wall** feature from OrcaSlicer (which itself ported it from Ultimaker Cura). A big thank you to the OrcaSlicer and Cura teams for the original work.

The feature adds an extra perimeter on alternating layers, improving layer bonding and part strength without the full material and time cost of a permanent extra wall on every layer.

## How it works

- When enabled, odd-numbered layers receive one additional wall beyond the configured wall count
- Even-numbered layers use the normal wall count
- The alternating pattern creates a staggered wall structure that mechanically interlocks adjacent layers

**ON**
<img width="1368" height="1158" alt="SCR-20260424-rlu-2" src="https://github.com/user-attachments/assets/af8744bb-c7ba-4eba-a2d9-51efb4ff5216" />

**OFF**
<img width="529" height="426" alt="image" src="https://github.com/user-attachments/assets/7584de97-eabf-4d0b-bee0-554fdb9d9ff4" />

Thanks to Angus Deveson from Maker's Muse for his video on the subject links here --> [https://www.youtube.com/watch?v=c7CI6yBTKMc](url)

## Behavior

- **Spiral vase mode**: automatically skipped (spiral vase forces a single wall anyway)
- **0% infill density**: automatically skipped (no structural benefit without infill)
- **Ensure vertical shell thickness set to Enable**: a warning dialog is shown, offering to automatically switch it to Partial for best results — matching OrcaSlicer's behavior
- 
<img width="1434" height="312" alt="SCR-20260424-rm8" src="https://github.com/user-attachments/assets/90ba623a-db9f-4467-b64c-0494cc88f3a4" />

## Location

Process settings → **Strength** → **Walls** → *Alternate extra wall* checkbox

## Files Changed

| File | Change |
|------|--------|
| `src/libslic3r/PrintConfig.hpp` / `.cpp` | New `alternate_extra_wall` bool config option |
| `src/libslic3r/PerimeterGenerator.cpp` | Apply extra wall on odd layers, both classic and Arachne paths |
| `src/libslic3r/Preset.cpp` | Register option in `s_Preset_print_options` |
| `src/libslic3r/Print.cpp` | Invalidate perimeters step on option change |
| `src/slic3r/GUI/Tab.cpp` | Add checkbox to Strength > Walls UI |
| `src/slic3r/GUI/ConfigManipulation.cpp` | Conflict warning dialog with ensure vertical shell thickness |

## Credits

- Original implementation: [Ultimaker Cura](https://github.com/Ultimaker/Cura)
- Ported to OrcaSlicer by the [OrcaSlicer](https://github.com/SoftFever/OrcaSlicer) team