### PR TITLE
Fix STEP import: MANIFOLD_SOLID_BREP body names lost for bodies inside root components

### DIFF
--- a/src/libslic3r/Format/STEP.cpp
+++ b/src/libslic3r/Format/STEP.cpp
@@ -30,12 +30,20 @@
 #include "TopoDS_Builder.hxx"
 #include "TopoDS.hxx"
 #include "TDataStd_Name.hxx"
+#include "TDF_ChildIterator.hxx"
+#include "TopoDS_Iterator.hxx"
 #include "BRepBuilderAPI_Transform.hxx"
-#include "TopExp_Explorer.hxx"
 #include "TopExp_Explorer.hxx"
 #include "BRep_Tool.hxx"
 #include "BRepTools.hxx"
 #include <IMeshTools_Parameters.hxx>
+#include "StepShape_ManifoldSolidBrep.hxx"
+#include "TransferBRep.hxx"
+#include "XSControl_WorkSession.hxx"
+#include "XSControl_TransferReader.hxx"
+#include "Transfer_TransientProcess.hxx"
+#include "Interface_InterfaceModel.hxx"
+#include <unordered_map>
 
 
 namespace Slic3r {
@@ -166,13 +174,37 @@ int StepPreProcessor::preNum(const unsigned char byte) {
     return num;
 }
 
+using SolidNameMap = std::unordered_map<const void*, std::string>;
+
+static SolidNameMap buildSolidNameMap(const Handle(XSControl_WorkSession)& ws)
+{
+    SolidNameMap nameMap;
+    Handle(Transfer_TransientProcess) tp = ws->TransferReader()->TransientProcess();
+    Handle(Interface_InterfaceModel) model = ws->Model();
+    for (Standard_Integer i = 1; i <= model->NbEntities(); i++) {
+        Handle(Standard_Transient) ent = model->Value(i);
+        Handle(StepShape_ManifoldSolidBrep) msb =
+            Handle(StepShape_ManifoldSolidBrep)::DownCast(ent);
+        if (msb.IsNull()) continue;
+        Handle(TCollection_HAsciiString) nameHandle = msb->Name();
+        if (nameHandle.IsNull()) continue;
+        std::string name = nameHandle->ToCString();
+        if (name.empty()) continue;
+        TopoDS_Shape shape = TransferBRep::ShapeResult(tp, ent);
+        if (shape.IsNull()) continue;
+        nameMap[(const void*)shape.TShape().get()] = name;
+    }
+    return nameMap;
+}
+
 static void getNamedSolids(const TopLoc_Location& location,
                            const std::string& prefix,
                            unsigned int& id,
                            const Handle(XCAFDoc_ShapeTool) shapeTool,
                            const TDF_Label label,
                            std::vector<NamedSolid>& namedSolids,
-                           bool isSplitCompound = false) {
+                           bool isSplitCompound = false,
+                           const SolidNameMap* solidNameMap = nullptr) {
     TDF_Label referredLabel{label};
     if (shapeTool->IsReference(label))
         shapeTool->GetReferredShape(label, referredLabel);
@@ -191,7 +223,7 @@ static void getNamedSolids(const TopLoc_Location& location,
     TDF_LabelSequence components;
     if (shapeTool->GetComponents(referredLabel, components)) {
         for (Standard_Integer compIndex = 1; compIndex <= components.Length(); ++compIndex) {
-            getNamedSolids(localLocation, fullName, id, shapeTool, components.Value(compIndex), namedSolids, isSplitCompound);
+            getNamedSolids(localLocation, fullName, id, shapeTool, components.Value(compIndex), namedSolids, isSplitCompound, solidNameMap);
         }
     } else {
         TopoDS_Shape shape;
@@ -210,16 +242,31 @@ static void getNamedSolids(const TopLoc_Location& location,
             if (!isSplitCompound) {
                 namedSolids.emplace_back(TopoDS::CompSolid(transform.Shape()), fullName);
             } else {
-                for (explorer.Init(transform.Shape(), TopAbs_SOLID); explorer.More(); explorer.Next()) {
+                TopExp_Explorer origExp(shape, TopAbs_SOLID);
+                TopExp_Explorer transExp(transform.Shape(), TopAbs_SOLID);
+                for (; origExp.More() && transExp.More(); origExp.Next(), transExp.Next()) {
                     i++;
-                    const TopoDS_Shape& currentShape = explorer.Current();
-                    namedSolids.emplace_back(TopoDS::Solid(currentShape), fullName + "-SOLID-" + std::to_string(i));
+                    std::string solidName = fullName + "-SOLID-" + std::to_string(i);
+                    if (solidNameMap) {
+                        auto it = solidNameMap->find((const void*)origExp.Current().TShape().get());
+                        if (it != solidNameMap->end() && !it->second.empty())
+                            solidName = it->second;
+                    }
+                    namedSolids.emplace_back(TopoDS::Solid(transExp.Current()), solidName);
                 }
             }
             break;
         case TopAbs_SOLID:
-            namedSolids.emplace_back(TopoDS::Solid(transform.Shape()), fullName);
+        {
+            std::string solidName = fullName;
+            if (solidNameMap) {
+                auto it = solidNameMap->find((const void*)shape.TShape().get());
+                if (it != solidNameMap->end() && !it->second.empty())
+                    solidName = it->second;
+            }
+            namedSolids.emplace_back(TopoDS::Solid(transform.Shape()), solidName);
             break;
+        }
         default:
             break;
         }
@@ -465,13 +512,14 @@ Step::Step_Status Step::load()
         if (cb_cancel) return;
         progress = 6;
         m_shape_tool = XCAFDoc_DocumentTool::ShapeTool(m_doc->Main());
+        m_solid_name_map = buildSolidNameMap(reader.ChangeReader().WS());
         TDF_LabelSequence topLevelShapes;
         m_shape_tool->GetFreeShapes(topLevelShapes);
         unsigned int id{ 1 };
         Standard_Integer topShapeLength = topLevelShapes.Length() + 1;
         for (Standard_Integer iLabel = 1; iLabel < topShapeLength; ++iLabel) {
             if (cb_cancel) return;
-            getNamedSolids(TopLoc_Location{}, "", id, m_shape_tool, topLevelShapes.Value(iLabel), m_name_solids);
+            getNamedSolids(TopLoc_Location{}, "", id, m_shape_tool, topLevelShapes.Value(iLabel), m_name_solids, false, &m_solid_name_map);
         }
         progress = 10;
         load_result = true;
@@ -534,7 +582,7 @@ Step::Step_Status Step::mesh(Model* model,
             if (cb_cancel) {
                 return;
             }
-            getNamedSolids(TopLoc_Location{}, "", id, m_shape_tool, topLevelShapes.Value(iLabel), namedSolids, isSplitCompound);
+            getNamedSolids(TopLoc_Location{}, "", id, m_shape_tool, topLevelShapes.Value(iLabel), namedSolids, isSplitCompound, &m_solid_name_map);
         }
 
         std::vector<stl_file> stl;

--- a/src/libslic3r/Format/STEP.hpp
+++ b/src/libslic3r/Format/STEP.hpp
@@ -7,6 +7,7 @@
 #include <boost/filesystem.hpp>
 #include <Message_ProgressIndicator.hxx>
 #include <atomic>
+#include <unordered_map>
 
 namespace fs = boost::filesystem;
 
@@ -118,6 +119,7 @@ private:
     Handle(TDocStd_Document) m_doc;
     Handle(XCAFDoc_ShapeTool) m_shape_tool;
     std::vector<NamedSolid> m_name_solids;
+    std::unordered_map<const void*, std::string> m_solid_name_map;
 };
 
 }; // namespace Slic3r


### PR DESCRIPTION
## Problem

When importing a STEP file that contains bodies (solids) living **directly inside the root Fusion 360 component** — rather than inside a named sub-component — those bodies were always imported with the name **\"SOLID\"**, regardless of their actual name in the STEP file.

Root cause: OCCT's XCAF layer only preserves names from `PRODUCT` entities. `MANIFOLD_SOLID_BREP` entity names are **not** propagated to XCAF labels for shapes that are not their own product. The existing `getNamedSolids()` function read names exclusively from XCAF labels, so any solid whose geometry came from a `MANIFOLD_SOLID_BREP` directly under an assembly product would silently lose its name.

## Fix

After `STEPCAFControl_Reader::Transfer()` completes, iterate all STEP entities via the transfer process (`TransientProcess`) to find every `StepShape_ManifoldSolidBrep`. For each one:
- Read the user-assigned name from the entity
- Resolve the corresponding `TopoDS_Shape` via `TransferBRep::ShapeResult`
- Store a `TShape*` → name mapping

`getNamedSolids()` now consults this map when naming solid shapes. When the XCAF label name is missing or generic, the correct `MANIFOLD_SOLID_BREP` name is used instead.

## Result

Bodies at any level of the assembly hierarchy are now imported with their correct STEP entity names.

| Before | After |
|--------|-------|
| Body at root component imported as `SOLID` | Imported with its actual name (e.g. `logo`, `bracket`) |
| Sub-component bodies unaffected | Sub-component bodies unaffected |

