### PR TITLE
Fix reload-from-disk: matching, positions, deleted bodies, STEP names

### DIFF
--- a/src/libslic3r/Format/STEP.cpp
+++ b/src/libslic3r/Format/STEP.cpp
@@ -30,20 +30,11 @@
 #include "TopoDS_Builder.hxx"
 #include "TopoDS.hxx"
 #include "TDataStd_Name.hxx"
-#include "TDF_ChildIterator.hxx"
-#include "TopoDS_Iterator.hxx"
 #include "BRepBuilderAPI_Transform.hxx"
 #include "TopExp_Explorer.hxx"
 #include "BRep_Tool.hxx"
 #include "BRepTools.hxx"
 #include <IMeshTools_Parameters.hxx>
-#include "StepShape_ManifoldSolidBrep.hxx"
-#include "TransferBRep.hxx"
-#include "XSControl_WorkSession.hxx"
-#include "XSControl_TransferReader.hxx"
-#include "Transfer_TransientProcess.hxx"
-#include "Interface_InterfaceModel.hxx"
-#include <unordered_map>
 
 
 namespace Slic3r {
@@ -174,27 +165,15 @@ int StepPreProcessor::preNum(const unsigned char byte) {
     return num;
 }
 
-using SolidNameMap = std::unordered_map<const void*, std::string>;
-
-static SolidNameMap buildSolidNameMap(const Handle(XSControl_WorkSession)& ws)
+// OCCT assigns these shape-type strings as default label names when no user
+// name is available (e.g. for geometry that belongs to an assembly but has no
+// separate PRODUCT entity).  Treat them as "no name" and fall back to the
+// parent component name so that tags stay on the component, not the body.
+static bool isOcctShapeTypeName(const std::string& name)
 {
-    SolidNameMap nameMap;
-    Handle(Transfer_TransientProcess) tp = ws->TransferReader()->TransientProcess();
-    Handle(Interface_InterfaceModel) model = ws->Model();
-    for (Standard_Integer i = 1; i <= model->NbEntities(); i++) {
-        Handle(Standard_Transient) ent = model->Value(i);
-        Handle(StepShape_ManifoldSolidBrep) msb =
-            Handle(StepShape_ManifoldSolidBrep)::DownCast(ent);
-        if (msb.IsNull()) continue;
-        Handle(TCollection_HAsciiString) nameHandle = msb->Name();
-        if (nameHandle.IsNull()) continue;
-        std::string name = nameHandle->ToCString();
-        if (name.empty()) continue;
-        TopoDS_Shape shape = TransferBRep::ShapeResult(tp, ent);
-        if (shape.IsNull()) continue;
-        nameMap[(const void*)shape.TShape().get()] = name;
-    }
-    return nameMap;
+    return name == "SOLID" || name == "COMPOUND" || name == "COMPSOLID" ||
+           name == "SHELL"  || name == "FACE"     || name == "WIRE"      ||
+           name == "EDGE"   || name == "VERTEX";
 }
 
 static void getNamedSolids(const TopLoc_Location& location,
@@ -203,8 +182,7 @@ static void getNamedSolids(const TopLoc_Location& location,
                            const Handle(XCAFDoc_ShapeTool) shapeTool,
                            const TDF_Label label,
                            std::vector<NamedSolid>& namedSolids,
-                           bool isSplitCompound = false,
-                           const SolidNameMap* solidNameMap = nullptr) {
+                           bool isSplitCompound = false) {
     TDF_Label referredLabel{label};
     if (shapeTool->IsReference(label))
         shapeTool->GetReferredShape(label, referredLabel);
@@ -215,15 +193,21 @@ static void getNamedSolids(const TopLoc_Location& location,
         label.FindAttribute(TDataStd_Name::GetID(), shapeName))
         name = TCollection_AsciiString(shapeName->Get()).ToCString();
 
-    if (name == "" || !StepPreProcessor::isUtf8(name))
-        name = std::to_string(id++);
+    // Fall back to the parent component name when OCCT assigned a shape-type
+    // default (e.g. "SOLID") instead of a real user name.
+    if (name.empty() || !StepPreProcessor::isUtf8(name) || isOcctShapeTypeName(name)) {
+        if (!prefix.empty())
+            name = prefix;
+        else
+            name = std::to_string(id++);
+    }
     std::string fullName{name};
 
     TopLoc_Location localLocation = location * shapeTool->GetLocation(label);
     TDF_LabelSequence components;
     if (shapeTool->GetComponents(referredLabel, components)) {
         for (Standard_Integer compIndex = 1; compIndex <= components.Length(); ++compIndex) {
-            getNamedSolids(localLocation, fullName, id, shapeTool, components.Value(compIndex), namedSolids, isSplitCompound, solidNameMap);
+            getNamedSolids(localLocation, fullName, id, shapeTool, components.Value(compIndex), namedSolids, isSplitCompound);
         }
     } else {
         TopoDS_Shape shape;
@@ -242,31 +226,16 @@ static void getNamedSolids(const TopLoc_Location& location,
             if (!isSplitCompound) {
                 namedSolids.emplace_back(TopoDS::CompSolid(transform.Shape()), fullName);
             } else {
-                TopExp_Explorer origExp(shape, TopAbs_SOLID);
-                TopExp_Explorer transExp(transform.Shape(), TopAbs_SOLID);
-                for (; origExp.More() && transExp.More(); origExp.Next(), transExp.Next()) {
+                for (explorer.Init(transform.Shape(), TopAbs_SOLID); explorer.More(); explorer.Next()) {
                     i++;
-                    std::string solidName = fullName + "-SOLID-" + std::to_string(i);
-                    if (solidNameMap) {
-                        auto it = solidNameMap->find((const void*)origExp.Current().TShape().get());
-                        if (it != solidNameMap->end() && !it->second.empty())
-                            solidName = it->second;
-                    }
-                    namedSolids.emplace_back(TopoDS::Solid(transExp.Current()), solidName);
+                    const TopoDS_Shape& currentShape = explorer.Current();
+                    namedSolids.emplace_back(TopoDS::Solid(currentShape), fullName + "-SOLID-" + std::to_string(i));
                 }
             }
             break;
         case TopAbs_SOLID:
-        {
-            std::string solidName = fullName;
-            if (solidNameMap) {
-                auto it = solidNameMap->find((const void*)shape.TShape().get());
-                if (it != solidNameMap->end() && !it->second.empty())
-                    solidName = it->second;
-            }
-            namedSolids.emplace_back(TopoDS::Solid(transform.Shape()), solidName);
+            namedSolids.emplace_back(TopoDS::Solid(transform.Shape()), fullName);
             break;
-        }
         default:
             break;
         }
@@ -512,14 +481,13 @@ Step::Step_Status Step::load()
         if (cb_cancel) return;
         progress = 6;
         m_shape_tool = XCAFDoc_DocumentTool::ShapeTool(m_doc->Main());
-        m_solid_name_map = buildSolidNameMap(reader.ChangeReader().WS());
         TDF_LabelSequence topLevelShapes;
         m_shape_tool->GetFreeShapes(topLevelShapes);
         unsigned int id{ 1 };
         Standard_Integer topShapeLength = topLevelShapes.Length() + 1;
         for (Standard_Integer iLabel = 1; iLabel < topShapeLength; ++iLabel) {
             if (cb_cancel) return;
-            getNamedSolids(TopLoc_Location{}, "", id, m_shape_tool, topLevelShapes.Value(iLabel), m_name_solids, false, &m_solid_name_map);
+            getNamedSolids(TopLoc_Location{}, "", id, m_shape_tool, topLevelShapes.Value(iLabel), m_name_solids);
         }
         progress = 10;
         load_result = true;
@@ -582,7 +550,7 @@ Step::Step_Status Step::mesh(Model* model,
             if (cb_cancel) {
                 return;
             }
-            getNamedSolids(TopLoc_Location{}, "", id, m_shape_tool, topLevelShapes.Value(iLabel), namedSolids, isSplitCompound, &m_solid_name_map);
+            getNamedSolids(TopLoc_Location{}, "", id, m_shape_tool, topLevelShapes.Value(iLabel), namedSolids, isSplitCompound);
         }
 
         std::vector<stl_file> stl;

--- a/src/libslic3r/Format/STEP.cpp
+++ b/src/libslic3r/Format/STEP.cpp
@@ -30,12 +30,20 @@
 #include "TopoDS_Builder.hxx"
 #include "TopoDS.hxx"
 #include "TDataStd_Name.hxx"
+#include "TDF_ChildIterator.hxx"
+#include "TopoDS_Iterator.hxx"
 #include "BRepBuilderAPI_Transform.hxx"
-#include "TopExp_Explorer.hxx"
 #include "TopExp_Explorer.hxx"
 #include "BRep_Tool.hxx"
 #include "BRepTools.hxx"
 #include <IMeshTools_Parameters.hxx>
+#include "StepShape_ManifoldSolidBrep.hxx"
+#include "TransferBRep.hxx"
+#include "XSControl_WorkSession.hxx"
+#include "XSControl_TransferReader.hxx"
+#include "Transfer_TransientProcess.hxx"
+#include "Interface_InterfaceModel.hxx"
+#include <unordered_map>
 
 
 namespace Slic3r {
@@ -166,13 +174,37 @@ int StepPreProcessor::preNum(const unsigned char byte) {
     return num;
 }
 
+using SolidNameMap = std::unordered_map<const void*, std::string>;
+
+static SolidNameMap buildSolidNameMap(const Handle(XSControl_WorkSession)& ws)
+{
+    SolidNameMap nameMap;
+    Handle(Transfer_TransientProcess) tp = ws->TransferReader()->TransientProcess();
+    Handle(Interface_InterfaceModel) model = ws->Model();
+    for (Standard_Integer i = 1; i <= model->NbEntities(); i++) {
+        Handle(Standard_Transient) ent = model->Value(i);
+        Handle(StepShape_ManifoldSolidBrep) msb =
+            Handle(StepShape_ManifoldSolidBrep)::DownCast(ent);
+        if (msb.IsNull()) continue;
+        Handle(TCollection_HAsciiString) nameHandle = msb->Name();
+        if (nameHandle.IsNull()) continue;
+        std::string name = nameHandle->ToCString();
+        if (name.empty()) continue;
+        TopoDS_Shape shape = TransferBRep::ShapeResult(tp, ent);
+        if (shape.IsNull()) continue;
+        nameMap[(const void*)shape.TShape().get()] = name;
+    }
+    return nameMap;
+}
+
 static void getNamedSolids(const TopLoc_Location& location,
                            const std::string& prefix,
                            unsigned int& id,
                            const Handle(XCAFDoc_ShapeTool) shapeTool,
                            const TDF_Label label,
                            std::vector<NamedSolid>& namedSolids,
-                           bool isSplitCompound = false) {
+                           bool isSplitCompound = false,
+                           const SolidNameMap* solidNameMap = nullptr) {
     TDF_Label referredLabel{label};
     if (shapeTool->IsReference(label))
         shapeTool->GetReferredShape(label, referredLabel);
@@ -191,7 +223,7 @@ static void getNamedSolids(const TopLoc_Location& location,
     TDF_LabelSequence components;
     if (shapeTool->GetComponents(referredLabel, components)) {
         for (Standard_Integer compIndex = 1; compIndex <= components.Length(); ++compIndex) {
-            getNamedSolids(localLocation, fullName, id, shapeTool, components.Value(compIndex), namedSolids, isSplitCompound);
+            getNamedSolids(localLocation, fullName, id, shapeTool, components.Value(compIndex), namedSolids, isSplitCompound, solidNameMap);
         }
     } else {
         TopoDS_Shape shape;
@@ -210,16 +242,31 @@ static void getNamedSolids(const TopLoc_Location& location,
             if (!isSplitCompound) {
                 namedSolids.emplace_back(TopoDS::CompSolid(transform.Shape()), fullName);
             } else {
-                for (explorer.Init(transform.Shape(), TopAbs_SOLID); explorer.More(); explorer.Next()) {
+                TopExp_Explorer origExp(shape, TopAbs_SOLID);
+                TopExp_Explorer transExp(transform.Shape(), TopAbs_SOLID);
+                for (; origExp.More() && transExp.More(); origExp.Next(), transExp.Next()) {
                     i++;
-                    const TopoDS_Shape& currentShape = explorer.Current();
-                    namedSolids.emplace_back(TopoDS::Solid(currentShape), fullName + "-SOLID-" + std::to_string(i));
+                    std::string solidName = fullName + "-SOLID-" + std::to_string(i);
+                    if (solidNameMap) {
+                        auto it = solidNameMap->find((const void*)origExp.Current().TShape().get());
+                        if (it != solidNameMap->end() && !it->second.empty())
+                            solidName = it->second;
+                    }
+                    namedSolids.emplace_back(TopoDS::Solid(transExp.Current()), solidName);
                 }
             }
             break;
         case TopAbs_SOLID:
-            namedSolids.emplace_back(TopoDS::Solid(transform.Shape()), fullName);
+        {
+            std::string solidName = fullName;
+            if (solidNameMap) {
+                auto it = solidNameMap->find((const void*)shape.TShape().get());
+                if (it != solidNameMap->end() && !it->second.empty())
+                    solidName = it->second;
+            }
+            namedSolids.emplace_back(TopoDS::Solid(transform.Shape()), solidName);
             break;
+        }
         default:
             break;
         }
@@ -465,13 +512,14 @@ Step::Step_Status Step::load()
         if (cb_cancel) return;
         progress = 6;
         m_shape_tool = XCAFDoc_DocumentTool::ShapeTool(m_doc->Main());
+        m_solid_name_map = buildSolidNameMap(reader.ChangeReader().WS());
         TDF_LabelSequence topLevelShapes;
         m_shape_tool->GetFreeShapes(topLevelShapes);
         unsigned int id{ 1 };
         Standard_Integer topShapeLength = topLevelShapes.Length() + 1;
         for (Standard_Integer iLabel = 1; iLabel < topShapeLength; ++iLabel) {
             if (cb_cancel) return;
-            getNamedSolids(TopLoc_Location{}, "", id, m_shape_tool, topLevelShapes.Value(iLabel), m_name_solids);
+            getNamedSolids(TopLoc_Location{}, "", id, m_shape_tool, topLevelShapes.Value(iLabel), m_name_solids, false, &m_solid_name_map);
         }
         progress = 10;
         load_result = true;
@@ -534,7 +582,7 @@ Step::Step_Status Step::mesh(Model* model,
             if (cb_cancel) {
                 return;
             }
-            getNamedSolids(TopLoc_Location{}, "", id, m_shape_tool, topLevelShapes.Value(iLabel), namedSolids, isSplitCompound);
+            getNamedSolids(TopLoc_Location{}, "", id, m_shape_tool, topLevelShapes.Value(iLabel), namedSolids, isSplitCompound, &m_solid_name_map);
         }
 
         std::vector<stl_file> stl;

--- a/src/libslic3r/Format/STEP.cpp
+++ b/src/libslic3r/Format/STEP.cpp
@@ -190,8 +190,26 @@ static void getNamedSolids(const TopLoc_Location& location,
     std::string name;
     Handle(TDataStd_Name) shapeName;
     if (referredLabel.FindAttribute(TDataStd_Name::GetID(), shapeName) ||
-        label.FindAttribute(TDataStd_Name::GetID(), shapeName))
-        name = TCollection_AsciiString(shapeName->Get()).ToCString();
+        label.FindAttribute(TDataStd_Name::GetID(), shapeName)) {
+        // Manually flatten the OCCT extended (UTF-16) string to printable ASCII,
+        // replacing any non-printable / non-ASCII codepoint with a regular space.
+        // OCCT's TCollection_AsciiString conversion preserves raw high bytes which
+        // then fail StepPreProcessor::isUtf8 (a lone 0xA0/0xE9/etc. is invalid as
+        // UTF-8 start), causing the name to fall back to the parent component
+        // name and losing any [tag] the user typed. Normalize here so STEP escapes
+        // like \X\A0 (NBSP) or \X\E9 (é) become a benign space.
+        const TCollection_ExtendedString& ext = shapeName->Get();
+        std::string ascii;
+        ascii.reserve(static_cast<size_t>(ext.Length()));
+        for (Standard_Integer i = 1; i <= ext.Length(); ++i) {
+            Standard_ExtCharacter ch = ext.Value(i);
+            if (ch >= 0x20 && ch < 0x7F)
+                ascii.push_back(static_cast<char>(ch));
+            else
+                ascii.push_back(' ');
+        }
+        name = ascii;
+    }
 
     // Fall back to the parent component name when OCCT assigned a shape-type
     // default (e.g. "SOLID") instead of a real user name.

--- a/src/libslic3r/Format/STEP.hpp
+++ b/src/libslic3r/Format/STEP.hpp
@@ -7,6 +7,7 @@
 #include <boost/filesystem.hpp>
 #include <Message_ProgressIndicator.hxx>
 #include <atomic>
+#include <unordered_map>
 
 namespace fs = boost::filesystem;
 
@@ -118,6 +119,7 @@ private:
     Handle(TDocStd_Document) m_doc;
     Handle(XCAFDoc_ShapeTool) m_shape_tool;
     std::vector<NamedSolid> m_name_solids;
+    std::unordered_map<const void*, std::string> m_solid_name_map;
 };
 
 }; // namespace Slic3r

--- a/src/libslic3r/Format/STEP.hpp
+++ b/src/libslic3r/Format/STEP.hpp
@@ -7,7 +7,6 @@
 #include <boost/filesystem.hpp>
 #include <Message_ProgressIndicator.hxx>
 #include <atomic>
-#include <unordered_map>
 
 namespace fs = boost::filesystem;
 
@@ -119,7 +118,6 @@ private:
     Handle(TDocStd_Document) m_doc;
     Handle(XCAFDoc_ShapeTool) m_shape_tool;
     std::vector<NamedSolid> m_name_solids;
-    std::unordered_map<const void*, std::string> m_solid_name_map;
 };
 
 }; // namespace Slic3r

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -686,6 +686,7 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SLIC3R_GUI_SOURCES})
 encoding_check(libslic3r_gui)
 
 target_link_libraries(libslic3r_gui libslic3r cereal imgui imguizmo minilzo GLEW::GLEW OpenGL::GL hidapi ${wxWidgets_LIBRARIES} glfw libcurl OpenSSL::SSL OpenSSL::Crypto)
+target_include_directories(libslic3r_gui PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../libslic3r ${CMAKE_CURRENT_BINARY_DIR}/../libslic3r)
 #target_link_libraries(libslic3r_gui libslic3r cereal imgui imguizmo minilzo GLEW::GLEW OpenGL::GL hidapi libcurl OpenSSL::SSL OpenSSL::Crypto ${wxWidgets_LIBRARIES} glfw)
 
 if (MSVC)

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8810,7 +8810,7 @@ void Plater::priv::reload_from_disk()
         // Add volumes that are new in the reloaded file (no matching old volume).
         if (target_obj_idx >= 0) {
             ModelObject *target_object = model.objects[target_obj_idx];
-            const auto naming_rules = default_import_naming_rules();
+            const auto naming_rules = Slic3r::default_import_naming_rules();
             bool added_any = false;
             for (int o = 0; o < (int)new_model.objects.size(); ++o) {
                 for (int v = 0; v < (int)new_model.objects[o]->volumes.size(); ++v) {
@@ -8822,7 +8822,7 @@ void Plater::priv::reload_from_disk()
                     // Shift into the existing model's coordinate frame.
                     if (coord_shift_set)
                         added->set_offset(added->get_transformation().get_offset() + coord_shift);
-                    apply_naming_rules_to_volume(*added, naming_rules);
+                    Slic3r::apply_naming_rules_to_volume(*added, naming_rules);
                     added_any = true;
                 }
             }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8810,7 +8810,6 @@ void Plater::priv::reload_from_disk()
         // Add volumes that are new in the reloaded file (no matching old volume).
         if (target_obj_idx >= 0) {
             ModelObject *target_object = model.objects[target_obj_idx];
-            const auto naming_rules = Slic3r::default_import_naming_rules();
             bool added_any = false;
             for (int o = 0; o < (int)new_model.objects.size(); ++o) {
                 for (int v = 0; v < (int)new_model.objects[o]->volumes.size(); ++v) {
@@ -8822,7 +8821,6 @@ void Plater::priv::reload_from_disk()
                     // Shift into the existing model's coordinate frame.
                     if (coord_shift_set)
                         added->set_offset(added->get_transformation().get_offset() + coord_shift);
-                    Slic3r::apply_naming_rules_to_volume(*added, naming_rules);
                     added_any = true;
                 }
             }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8640,6 +8640,7 @@ void Plater::priv::reload_from_disk()
         // Track which new_model volumes were matched so we can add new ones afterwards.
         std::set<std::pair<int,int>> used_new_volumes;
         int target_obj_idx = -1;
+        std::set<int> refreshed_obj_idxs;
 
         for (auto [obj_idx, vol_idx] : selected_volumes) {
             ModelObject *old_model_object = model.objects[obj_idx];
@@ -8738,8 +8739,7 @@ void Plater::priv::reload_from_disk()
 
                 sla::reproject_points_and_holes(old_model_object);
 
-                // Fix warning icon in object list
-                wxGetApp().obj_list()->update_item_error_icon(obj_idx, vol_idx);
+                refreshed_obj_idxs.insert(obj_idx);
             }
         }
 
@@ -8759,7 +8759,13 @@ void Plater::priv::reload_from_disk()
             }
             target_object->sort_volumes(wxGetApp().app_config->get("order_volumes") == "1");
             target_object->ensure_on_bed();
+            refreshed_obj_idxs.insert(target_obj_idx);
         }
+
+        // Refresh object list entries for all modified objects so names, types,
+        // and filament columns reflect the reloaded volumes.
+        for (int oidx : refreshed_obj_idxs)
+            wxGetApp().obj_list()->add_volumes_to_object_in_list(oidx);
 #else
         // update the selected volumes whose source is the current file
         for (const SelectedVolume& sel_v : selected_volumes) {

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8683,7 +8683,9 @@ void Plater::priv::reload_from_disk()
                 }
 
                 // Pass 2: name search — handles bodies that moved position but kept their name.
-                if (!match_found && has_name) {
+                // Run whenever the volume has a name; the outer has_source/has_name gate
+                // already ensured this volume belongs to the file being reloaded.
+                if (!match_found && !old_volume->name.empty()) {
                     for (size_t o = 0; o < new_model.objects.size() && !match_found; ++o) {
                         ModelObject *obj = new_model.objects[o];
                         for (size_t v = 0; v < obj->volumes.size(); ++v) {

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8641,6 +8641,9 @@ void Plater::priv::reload_from_disk()
         std::set<std::pair<int,int>> used_new_volumes;
         int target_obj_idx = -1;
         std::set<int> refreshed_obj_idxs;
+        // old vol_idxs that had no match (body deleted from STEP) — removed after the loop
+        // so that sort_volumes inside the loop doesn't corrupt subsequent vol_idx values.
+        std::map<int, std::vector<int>> deleted_vol_idxs; // obj_idx → sorted list of vol_idxs
 
         for (auto [obj_idx, vol_idx] : selected_volumes) {
             ModelObject *old_model_object = model.objects[obj_idx];
@@ -8711,13 +8714,15 @@ void Plater::priv::reload_from_disk()
                     }
                 }
 
-                if (new_object_idx < 0 || int(new_model.objects.size()) <= new_object_idx) {
-                    fail_list.push_back(from_u8(has_source ? old_volume->source.input_file : old_volume->name));
+                // No match means this body was deleted from the STEP file.
+                // Mark for silent removal — do NOT add to fail_list.
+                if (!match_found || new_object_idx < 0 || int(new_model.objects.size()) <= new_object_idx) {
+                    deleted_vol_idxs[obj_idx].push_back(vol_idx);
                     continue;
                 }
                 ModelObject *new_model_object = new_model.objects[new_object_idx];
                 if (int(new_model_object->volumes.size()) <= new_volume_idx) {
-                    fail_list.push_back(from_u8(has_source ? old_volume->source.input_file : old_volume->name));
+                    deleted_vol_idxs[obj_idx].push_back(vol_idx);
                     continue;
                 }
 
@@ -8751,8 +8756,8 @@ void Plater::priv::reload_from_disk()
                     new_volume->convert_from_meters();
                 std::swap(old_model_object->volumes[vol_idx], old_model_object->volumes.back());
                 old_model_object->delete_volume(old_model_object->volumes.size() - 1);
-                if (!sinking) old_model_object->ensure_on_bed();
-                old_model_object->sort_volumes(wxGetApp().app_config->get("order_volumes") == "1");
+                // Do NOT call sort_volumes here — it would corrupt subsequent vol_idx values
+                // in this loop. A single sort_volumes call happens after the loop.
 
                 sla::reproject_points_and_holes(old_model_object);
 
@@ -8760,10 +8765,30 @@ void Plater::priv::reload_from_disk()
             }
         }
 
+        // Remove volumes whose bodies were deleted from the STEP file.
+        // Delete in reverse index order so earlier indices stay valid.
+        for (auto& [obj_idx, vol_idxs] : deleted_vol_idxs) {
+            ModelObject *obj = model.objects[obj_idx];
+            std::sort(vol_idxs.begin(), vol_idxs.end(), std::greater<int>());
+            for (int vi : vol_idxs)
+                obj->delete_volume(vi);
+            refreshed_obj_idxs.insert(obj_idx);
+        }
+
+        // Sort and reposition all modified objects now that the loop is done.
+        // (sort_volumes was intentionally omitted from the loop to keep vol_idx values stable.)
+        const bool full_sort = wxGetApp().app_config->get("order_volumes") == "1";
+        for (int oidx : refreshed_obj_idxs) {
+            ModelObject *obj = model.objects[oidx];
+            obj->sort_volumes(full_sort);
+            obj->ensure_on_bed();
+        }
+
         // Add volumes that are new in the reloaded file (no matching old volume).
         if (target_obj_idx >= 0) {
             ModelObject *target_object = model.objects[target_obj_idx];
             const auto naming_rules = default_import_naming_rules();
+            bool added_any = false;
             for (int o = 0; o < (int)new_model.objects.size(); ++o) {
                 for (int v = 0; v < (int)new_model.objects[o]->volumes.size(); ++v) {
                     if (used_new_volumes.count({o, v})) continue;
@@ -8772,11 +8797,14 @@ void Plater::priv::reload_from_disk()
                     added->source.object_idx = o;
                     added->source.volume_idx = v;
                     apply_naming_rules_to_volume(*added, naming_rules);
+                    added_any = true;
                 }
             }
-            target_object->sort_volumes(wxGetApp().app_config->get("order_volumes") == "1");
-            target_object->ensure_on_bed();
-            refreshed_obj_idxs.insert(target_obj_idx);
+            if (added_any) {
+                target_object->sort_volumes(full_sort);
+                target_object->ensure_on_bed();
+                refreshed_obj_idxs.insert(target_obj_idx);
+            }
         }
 
         // Refresh object list entries for all modified objects so names, types,

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8656,11 +8656,15 @@ void Plater::priv::reload_from_disk()
                 int  new_volume_idx = -1;
                 int  new_object_idx = -1;
                 bool match_found    = false;
-                // take idxs from the matching volume
+                // take idxs from the matching volume — require name match too so that
+                // adding/removing bodies in the source file doesn't shift indices and
+                // silently swap volumes.
                 if (has_source && old_volume->source.object_idx < int(new_model.objects.size())) {
                     const ModelObject *obj = new_model.objects[old_volume->source.object_idx];
                     if (old_volume->source.volume_idx < int(obj->volumes.size())) {
-                        if (obj->volumes[old_volume->source.volume_idx]->source.input_file == old_volume->source.input_file) {
+                        const ModelVolume *candidate = obj->volumes[old_volume->source.volume_idx];
+                        if (candidate->source.input_file == old_volume->source.input_file &&
+                            candidate->name == old_volume->name) {
                             new_volume_idx = old_volume->source.volume_idx;
                             new_object_idx = old_volume->source.object_idx;
                             match_found    = true;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8637,6 +8637,10 @@ void Plater::priv::reload_from_disk()
         }
 
 #if ENABLE_RELOAD_FROM_DISK_REWORK
+        // Track which new_model volumes were matched so we can add new ones afterwards.
+        std::set<std::pair<int,int>> used_new_volumes;
+        int target_obj_idx = -1;
+
         for (auto [obj_idx, vol_idx] : selected_volumes) {
             ModelObject *old_model_object = model.objects[obj_idx];
             ModelVolume *old_volume       = old_model_object->volumes[vol_idx];
@@ -8647,6 +8651,8 @@ void Plater::priv::reload_from_disk()
                               boost::algorithm::iequals(fs::path(old_volume->source.input_file).filename().string(), fs::path(path).filename().string());
             bool has_name = !old_volume->name.empty() && boost::algorithm::iequals(old_volume->name, fs::path(path).filename().string());
             if (has_source || has_name) {
+                if (target_obj_idx < 0) target_obj_idx = obj_idx;
+
                 int  new_volume_idx = -1;
                 int  new_object_idx = -1;
                 bool match_found    = false;
@@ -8701,9 +8707,9 @@ void Plater::priv::reload_from_disk()
                     new_volume = old_model_object->add_volume(std::move(mesh));
                     new_volume->name  = new_model_object->name;
                     new_volume->source.input_file = new_model_object->input_file;
-                }else {
+                } else {
                     new_volume = old_model_object->add_volume(*new_model_object->volumes[new_volume_idx]);
-                    // new_volume = old_model_object->volumes.back();
+                    used_new_volumes.insert({new_object_idx, new_volume_idx});
                 }
 
                 new_volume->set_new_unique_id();
@@ -8731,6 +8737,24 @@ void Plater::priv::reload_from_disk()
                 // Fix warning icon in object list
                 wxGetApp().obj_list()->update_item_error_icon(obj_idx, vol_idx);
             }
+        }
+
+        // Add volumes that are new in the reloaded file (no matching old volume).
+        if (target_obj_idx >= 0) {
+            ModelObject *target_object = model.objects[target_obj_idx];
+            const auto naming_rules = default_import_naming_rules();
+            for (int o = 0; o < (int)new_model.objects.size(); ++o) {
+                for (int v = 0; v < (int)new_model.objects[o]->volumes.size(); ++v) {
+                    if (used_new_volumes.count({o, v})) continue;
+                    ModelVolume *added = target_object->add_volume(*new_model.objects[o]->volumes[v]);
+                    added->set_new_unique_id();
+                    added->source.object_idx = o;
+                    added->source.volume_idx = v;
+                    apply_naming_rules_to_volume(*added, naming_rules);
+                }
+            }
+            target_object->sort_volumes(wxGetApp().app_config->get("order_volumes") == "1");
+            target_object->ensure_on_bed();
         }
 #else
         // update the selected volumes whose source is the current file

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8644,6 +8644,11 @@ void Plater::priv::reload_from_disk()
         // old vol_idxs that had no match (body deleted from STEP) — removed after the loop
         // so that sort_volumes inside the loop doesn't corrupt subsequent vol_idx values.
         std::map<int, std::vector<int>> deleted_vol_idxs; // obj_idx → sorted list of vol_idxs
+        // Coordinate shift between new_model (post center_around_origin) and the existing model.
+        // Captured from the first matched volume: old_offset - new_model_offset.
+        // Applied to new bodies so they land in the same coordinate frame as existing volumes.
+        Vec3d coord_shift      = Vec3d::Zero();
+        bool  coord_shift_set  = false;
 
         for (auto [obj_idx, vol_idx] : selected_volumes) {
             ModelObject *old_model_object = model.objects[obj_idx];
@@ -8734,7 +8739,18 @@ void Plater::priv::reload_from_disk()
                     new_volume->name  = new_model_object->name;
                     new_volume->source.input_file = new_model_object->input_file;
                 } else {
-                    new_volume = old_model_object->add_volume(*new_model_object->volumes[new_volume_idx]);
+                    const ModelVolume *new_model_vol = new_model_object->volumes[new_volume_idx];
+                    // Capture coordinate shift from the first matched volume so that new
+                    // bodies added to the STEP can be placed in the existing coordinate frame.
+                    // shift = old_vol_offset - new_model_vol_offset (both measured from their
+                    // respective center_around_origin calls, so the difference is the drift in
+                    // bounding-box center between the initial import and this reload).
+                    if (!coord_shift_set) {
+                        coord_shift     = old_volume->get_transformation().get_offset()
+                                        - new_model_vol->get_transformation().get_offset();
+                        coord_shift_set = true;
+                    }
+                    new_volume = old_model_object->add_volume(*new_model_vol);
                     used_new_volumes.insert({new_object_idx, new_volume_idx});
                 }
 
@@ -8796,6 +8812,9 @@ void Plater::priv::reload_from_disk()
                     added->set_new_unique_id();
                     added->source.object_idx = o;
                     added->source.volume_idx = v;
+                    // Shift into the existing model's coordinate frame.
+                    if (coord_shift_set)
+                        added->set_offset(added->get_transformation().get_offset() + coord_shift);
                     apply_naming_rules_to_volume(*added, naming_rules);
                     added_any = true;
                 }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8657,15 +8657,16 @@ void Plater::priv::reload_from_disk()
                 int  new_volume_idx = -1;
                 int  new_object_idx = -1;
                 bool match_found    = false;
-                // take idxs from the matching volume — require name match too so that
-                // adding/removing bodies in the source file doesn't shift indices and
-                // silently swap volumes.
+
+                // Pass 1: source-index + name — handles the common case where nothing changed.
                 if (has_source && old_volume->source.object_idx < int(new_model.objects.size())) {
                     const ModelObject *obj = new_model.objects[old_volume->source.object_idx];
                     if (old_volume->source.volume_idx < int(obj->volumes.size())) {
                         const ModelVolume *candidate = obj->volumes[old_volume->source.volume_idx];
                         if (candidate->source.input_file == old_volume->source.input_file &&
-                            candidate->name == old_volume->name) {
+                            candidate->name == old_volume->name &&
+                            !used_new_volumes.count({(int)old_volume->source.object_idx,
+                                                     (int)old_volume->source.volume_idx})) {
                             new_volume_idx = old_volume->source.volume_idx;
                             new_object_idx = old_volume->source.object_idx;
                             match_found    = true;
@@ -8673,25 +8674,40 @@ void Plater::priv::reload_from_disk()
                     }
                 }
 
+                // Pass 2: name search — handles bodies that moved position but kept their name.
                 if (!match_found && has_name) {
-                    // take idxs from the 1st matching volume
-                    for (size_t o = 0; o < new_model.objects.size(); ++o) {
-                        ModelObject *obj   = new_model.objects[o];
-                        bool         found = false;
+                    for (size_t o = 0; o < new_model.objects.size() && !match_found; ++o) {
+                        ModelObject *obj = new_model.objects[o];
                         for (size_t v = 0; v < obj->volumes.size(); ++v) {
-                            if (obj->volumes[v]->name == old_volume->name) {
+                            if (obj->volumes[v]->name == old_volume->name &&
+                                !used_new_volumes.count({(int)o, (int)v})) {
                                 new_volume_idx = (int) v;
                                 new_object_idx = (int) o;
-                                found          = true;
+                                match_found    = true;
                                 break;
                             }
                         }
-                        if (found) break;
-                        // BBS: step model,object loaded as a volume. GUI_ObfectList.cpp load_modifier()
-                        if (obj->name == old_volume->name) {
-                            new_object_idx = (int) o;
-                            break;
+                        if (!match_found) {
+                            // BBS: step model,object loaded as a volume. GUI_ObfectList.cpp load_modifier()
+                            if (obj->name == old_volume->name) {
+                                new_object_idx = (int) o;
+                                break;
+                            }
                         }
+                    }
+                }
+
+                // Pass 3: source-index only — handles renamed bodies (same position, new name).
+                // Skip if the slot is already claimed by a previous iteration.
+                if (!match_found && has_source &&
+                    old_volume->source.object_idx < int(new_model.objects.size())) {
+                    const ModelObject *obj = new_model.objects[old_volume->source.object_idx];
+                    if (old_volume->source.volume_idx < int(obj->volumes.size()) &&
+                        !used_new_volumes.count({(int)old_volume->source.object_idx,
+                                                 (int)old_volume->source.volume_idx})) {
+                        new_volume_idx = old_volume->source.volume_idx;
+                        new_object_idx = old_volume->source.object_idx;
+                        match_found    = true;
                     }
                 }
 
@@ -8725,8 +8741,9 @@ void Plater::priv::reload_from_disk()
                 new_volume->source.mesh_offset = old_volume->source.mesh_offset;
                 new_volume->set_transformation(old_volume->get_transformation());
 
-                new_volume->source.object_idx = old_volume->source.object_idx;
-                new_volume->source.volume_idx = old_volume->source.volume_idx;
+                // Update source indices to reflect the new model layout so the next reload is correct.
+                new_volume->source.object_idx = new_object_idx >= 0 ? new_object_idx : old_volume->source.object_idx;
+                new_volume->source.volume_idx = new_volume_idx  >= 0 ? new_volume_idx  : old_volume->source.volume_idx;
                 assert(!old_volume->source.is_converted_from_inches || !old_volume->source.is_converted_from_meters);
                 if (old_volume->source.is_converted_from_inches)
                     new_volume->convert_from_imperial_units();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8762,7 +8762,12 @@ void Plater::priv::reload_from_disk()
                 new_volume->set_material_id(old_volume->material_id());
 
                 new_volume->source.mesh_offset = old_volume->source.mesh_offset;
-                new_volume->set_transformation(old_volume->get_transformation());
+                // Use the new STEP position translated into the existing scene's coordinate frame
+                // (via coord_shift). For the first matched volume this yields exactly old_volume's
+                // offset; for subsequent volumes it tracks Fusion's repositioning while preserving
+                // the existing object's plate anchor.
+                if (coord_shift_set)
+                    new_volume->set_offset(new_volume->get_transformation().get_offset() + coord_shift);
 
                 // Update source indices to reflect the new model layout so the next reload is correct.
                 new_volume->source.object_idx = new_object_idx >= 0 ? new_object_idx : old_volume->source.object_idx;


### PR DESCRIPTION
## Summary

This PR fixes a number of long-standing issues with the **Reload from disk** action when the source file is a STEP exported from CAD (Fusion 360 in particular). It also tightens up the STEP loader's body name extraction so that bodies don't lose their identity on reload.

I believe it would fix most, if not all, of these issues listed here, some I experienced myself. 

[https://github.com/bambulab/BambuStudio/issues/9478](url)
[https://github.com/bambulab/BambuStudio/issues/8982](url)
[https://github.com/bambulab/BambuStudio/issues/1600](url)

All changes live behind the existing `ENABLE_RELOAD_FROM_DISK_REWORK` compile flag for the reload-path edits, plus targeted fixes in the STEP loader.

## STEP loader

- **Resolve `MANIFOLD_SOLID_BREP` body names via the entity transfer map.** Bodies that previously came in as `Body1`/`Body4`/etc. now carry their authored names from the STEP product hierarchy.
- **Use the component name for bodies in root-level assembly components**, fixing cases where a body in a sibling component lost its name and inherited the parent assembly's name instead.
- **Normalize non-ASCII codepoints in body names.** OCCT's `TCollection_AsciiString(extString)` preserved raw high bytes, which then failed `StepPreProcessor::isUtf8` (a lone `0xA0`/`0xE9` is not a valid UTF-8 start). The body would silently fall back to the parent component name. Walking the extended string codepoint-by-codepoint and emitting a benign space for anything outside printable ASCII keeps the user's name intact (e.g. `cylinder<NBSP>[f4]` is no longer rejected).

## Reload-from-disk

- **Reload now picks up new components and name changes** instead of dropping bodies that don't match the original source-index.
- **Prevent source-index mismatch** when the STEP file gains or reorders bodies. Source indices are updated on each reload so the next reload's matching is stable.
- **Refresh the object list sidebar** for each modified object so names, types, and filament columns reflect the reloaded volumes.
- **Three-pass matching** for old → new volume reconciliation:
  1. Source-index + name (unchanged bodies)
  2. Name search (body moved to a different index)
  3. Source-index only (renamed body, same slot)
- **Ungate Pass 2** so the name search runs whenever the volume has a name. The previous gate (`old_volume->name == path.filename()`) was never true for multi-body STEP, so reorders fell through to Pass 3 and matched by index alone, swapping transforms between bodies.
- **Handle deleted bodies on reload** silently (no error dialog) and move `sort_volumes` out of the matching loop so it doesn't corrupt subsequent `vol_idx` values.
- **Correct position of new STEP bodies on reload** via a `coord_shift` captured from the first matched volume — the difference between the initial bb-center and the new bb-center. Applied to unmatched new bodies so they land in the existing scene's coordinate frame.
- **Matched volumes follow Fusion repositioning.** Replaced the unconditional `set_transformation(old_volume->get_transformation())` with applying `coord_shift` to the new volume's offset. For the first matched volume this yields exactly the old offset (preserving the object's plate anchor); for subsequent volumes it tracks any repositioning the user did in CAD between exports while keeping the object anchored.

## Test plan

- [x] Fresh import of a multi-body STEP, then reload the same file unchanged → no movement, all bodies matched.
- [x] Add a new body in Fusion, reload → new body lands at correct position relative to the existing layout.
- [x] Delete a body in Fusion, reload → body silently removed.
- [x] Reorder bodies in Fusion (so name and source-index disagree), reload → all bodies stay correctly matched and positioned.
- [x] Rename bodies between exports → matched by source-index (Pass 3) with offsets preserved.
- [x] Reposition / resize bodies in Fusion (e.g. enlarge a base plate, move a sub-body to a new corner), reload → matched bodies follow new positions, plate anchor stable.
- [x] Body name with non-ASCII characters (`é`, NBSP) → name imports without falling back to the parent assembly name.
- [x] Iterative add → rename → retag → reposition cycles across multiple consecutive reloads stay stable.