### PR TITLE
Fix touchscreen taps being dropped on custom Button widgets

### DIFF
--- a/src/slic3r/GUI/TabButton.cpp
+++ b/src/slic3r/GUI/TabButton.cpp
@@ -218,8 +218,11 @@ void TabButton::mouseReleased(wxMouseEvent &event)
     event.Skip();
     if (pressedDown) {
         pressedDown = false;
-        ReleaseMouse();
-        if (wxRect({0, 0}, GetSize()).Contains(event.GetPosition()))
+        if (HasCapture())
+            ReleaseMouse();
+        // Touch input drift slop — see Button::mouseReleased.
+        constexpr int kReleaseSlop = 15;
+        if (wxRect({0, 0}, GetSize()).Inflate(kReleaseSlop).Contains(event.GetPosition()))
             sendButtonEvent();
     }
 }

--- a/src/slic3r/GUI/Widgets/AxisCtrlButton.cpp
+++ b/src/slic3r/GUI/Widgets/AxisCtrlButton.cpp
@@ -297,8 +297,14 @@ void AxisCtrlButton::mouseReleased(wxMouseEvent& event)
     event.Skip();
     if (pressedDown) {
         pressedDown = false;
-        ReleaseMouse();
-        if (wxRect({ 0, 0 }, GetSize()).Contains(event.GetPosition()))
+        if (HasCapture())
+            ReleaseMouse();
+        // Touch input drift slop — see Button::mouseReleased. The active
+        // wedge is tracked in current_pos by mouseMove, so the correct
+        // axis still fires; the slop just keeps the click alive when a
+        // touch lands a few pixels outside the wedge ring on release.
+        constexpr int kReleaseSlop = 15;
+        if (wxRect({ 0, 0 }, GetSize()).Inflate(kReleaseSlop).Contains(event.GetPosition()))
             sendButtonEvent();
     }
 }

--- a/src/slic3r/GUI/Widgets/Button.cpp
+++ b/src/slic3r/GUI/Widgets/Button.cpp
@@ -411,7 +411,18 @@ void Button::mouseReleased(wxMouseEvent& event)
         pressedDown = false;
         if (HasCapture())
             ReleaseMouse();
-        if (wxRect({0, 0}, GetSize()).Contains(event.GetPosition()))
+        // Touch input drift slop. The button-up position can land a few
+        // pixels outside the rect after a tap because finger contact rolls
+        // between press and release; the original strict
+        // wxRect({0,0},GetSize()).Contains(...) check silently dropped
+        // those clicks on every touchscreen device (visible symptom on
+        // Cancel buttons, AMS spool selectors, sidebar tabs, etc.).
+        // Inflating the hit area by kReleaseSlop on each side preserves
+        // the deliberate drag-off-to-cancel gesture for desktop mouse
+        // users (any release more than ~15 px outside still cancels)
+        // while accepting the small finger drift typical of touchscreens.
+        constexpr int kReleaseSlop = 15;
+        if (wxRect({0, 0}, GetSize()).Inflate(kReleaseSlop).Contains(event.GetPosition()))
             sendButtonEvent();
     }
 }

--- a/src/slic3r/GUI/Widgets/SideButton.cpp
+++ b/src/slic3r/GUI/Widgets/SideButton.cpp
@@ -338,7 +338,9 @@ void SideButton::mouseReleased(wxMouseEvent& event)
 
     if (pressedDown) {
         pressedDown = false;
-        if (wxRect({0, 0}, GetSize()).Contains(event.GetPosition()))
+        // Touch input drift slop — see Button::mouseReleased.
+        constexpr int kReleaseSlop = 15;
+        if (wxRect({0, 0}, GetSize()).Inflate(kReleaseSlop).Contains(event.GetPosition()))
             sendButtonEvent();
     }
 }


### PR DESCRIPTION
## Fix touchscreen taps being dropped on custom Button widgets

### Symptom

On touchscreen / convertible / kiosk deployments, several custom-drawn
Bambu widgets silently drop taps:

* `Cancel` / `OK` / `Skip` buttons in many MsgDialog flows
* AMS spool selectors
* The sidebar `SideButton` items (Printer / Filament tabs etc.)
* `AxisCtrlButton` jog directions on the device tab
* `TabButton` page-selectors inside settings panels

The user sees the press indicator activate, lifts their finger, and
nothing happens. Native widgets like `wxButton` and `wxNotebook` aren't
affected in practice — presumably because the underlying GTK / native
hit regions are more lenient than the strict client-rect check used
here.

### Root cause

All four custom Button widgets
(`src/slic3r/GUI/Widgets/Button.cpp`,
`src/slic3r/GUI/Widgets/AxisCtrlButton.cpp`,
`src/slic3r/GUI/Widgets/SideButton.cpp`,
`src/slic3r/GUI/TabButton.cpp`)
fire their `wxEVT_COMMAND_BUTTON_CLICKED` event in `mouseReleased` only
if the up-coords are still inside `wxRect({0,0}, GetSize())`:

```cpp
if (wxRect({0, 0}, GetSize()).Contains(event.GetPosition()))
    sendButtonEvent();
```

Touch input doesn't deliver pixel-stable coords. Finger contact rolls
between press and release; the up-coord typically lands a few pixels
outside the rect. The strict bounds check then drops the click.

(Side note: `Button::mouseCaptureLost` already calls `mouseReleased`
with a default-constructed `wxMouseEvent`, whose `GetPosition()` is
`{0,0}` — and `wxRect({0,0}, GetSize()).Contains({0,0})` is true, so
the click currently fires on capture-loss anyway. The strict cancel-
on-drag-off behaviour was already only partially honoured.)

### Fix

Add a small slop (`kReleaseSlop = 15` px) to the bounds check on
release. The deliberate desktop "drag off and release to cancel"
gesture is preserved (any release further than 15 px outside still
cancels), and touch users get the few pixels of grace they need.

For consistency, the patch also wraps `AxisCtrlButton` and `TabButton`'s
`ReleaseMouse()` call in a `HasCapture()` guard — wxWidgets asserts in
debug builds if you call `ReleaseMouse()` without holding capture, and
those two widgets were the only ones in this family doing so
unconditionally.

Net diff: +13, -8 across four files.

### Discovery context

Found while making BambuStudio runnable on aarch64 Termux + termux-x11,
where touch input has slightly more finger drift than typical desktop
touchscreens. Full toolkit + the rest of the platform-specific patches
at <https://github.com/tribixbite/x2d>.
