### PR TITLE
Add Traditional Chinese language entry

### DIFF
--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -780,6 +780,7 @@ bool has_filaments(const std::vector<string>& model_filaments);
 static std::vector<wxLanguage> s_supported_languages = {
     wxLANGUAGE_ENGLISH,
     wxLANGUAGE_CHINESE_SIMPLIFIED,
+    wxLANGUAGE_CHINESE_TRADITIONAL,
     wxLANGUAGE_GERMAN,
     wxLANGUAGE_FRENCH,
     wxLANGUAGE_SPANISH,

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -144,6 +144,9 @@ wxBoxSizer *PreferencesDialog::create_item_language_combobox(
         if (vlist[i] == wxLocale::GetLanguageInfo(wxLANGUAGE_CHINESE_SIMPLIFIED)) {
             language_name = wxString::FromUTF8("\xe4\xb8\xad\xe6\x96\x87\x28\xe7\xae\x80\xe4\xbd\x93\x29");
         }
+        else if (vlist[i] == wxLocale::GetLanguageInfo(wxLANGUAGE_CHINESE_TRADITIONAL)) {
+            language_name = wxString::FromUTF8("\xe4\xb8\xad\xe6\x96\x87\x28\xe7\xb9\x81\xe9\xab\x94\x29");
+        }
         else if (vlist[i] == wxLocale::GetLanguageInfo(wxLANGUAGE_SPANISH)) {
             language_name = wxString::FromUTF8("\x45\x73\x70\x61\xc3\xb1\x6f\x6c");
         }


### PR DESCRIPTION
This adds Traditional Chinese to the supported language list so the existing zh_TW translation can appear in the language selector.

The zh_TW translation files were added in #9705, and this follows up on the maintainer note that the language entry would be added later.

Testing:
- Not run locally; macOS build is currently blocked by local dependency build issues unrelated to this one-line language entry change.