### PR TITLE
fix: remove duplicate CMake sources, plug timer leak, debounce idle config save

### DIFF
--- a/src/libslic3r/Debounce.hpp
+++ b/src/libslic3r/Debounce.hpp
@@ -1,0 +1,35 @@
+#ifndef slic3r_Debounce_hpp_
+#define slic3r_Debounce_hpp_
+
+#include <chrono>
+
+namespace Slic3r {
+
+// Rate-limit a recurring action.
+//
+// Returns true and updates `last_tp` when at least `interval` has elapsed
+// since the last accepted call.  On the very first call (last_tp ==
+// time_point{}) the action is always accepted.
+//
+// Usage:
+//   static auto s_last = std::chrono::steady_clock::time_point{};
+//   if (debounce_elapsed(s_last, std::chrono::seconds(5)))
+//       do_expensive_thing();
+//
+// The function is intentionally free of wx / GUI dependencies so it can be
+// exercised by the plain libslic3r unit-test suite.
+inline bool debounce_elapsed(
+    std::chrono::steady_clock::time_point &last_tp,
+    std::chrono::steady_clock::duration    interval)
+{
+    const auto now = std::chrono::steady_clock::now();
+    if (now - last_tp >= interval) {
+        last_tp = now;
+        return true;
+    }
+    return false;
+}
+
+} // namespace Slic3r
+
+#endif // slic3r_Debounce_hpp_

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -70,10 +70,6 @@ set(SLIC3R_GUI_SOURCES
     GUI/Widgets/FilamentLoad.hpp
     GUI/Widgets/FanControl.cpp
     GUI/Widgets/FanControl.hpp
-    GUI/Widgets/Scrollbar.cpp
-    GUI/Widgets/Scrollbar.hpp
-    GUI/Widgets/ScrolledWindow.cpp
-    GUI/Widgets/ScrolledWindow.hpp
     GUI/Widgets/StepCtrl.cpp
     GUI/Widgets/StepCtrl.hpp
     GUI/Widgets/ProgressBar.cpp

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -22,6 +22,7 @@
 #include <iterator>
 #include <exception>
 #include <cstdlib>
+#include <chrono>
 #include <regex>
 #include <thread>
 #include <string_view>
@@ -56,6 +57,7 @@
 #include <wx/glcanvas.h>
 
 #include "libslic3r/Utils.hpp"
+#include "libslic3r/Debounce.hpp"
 #include "libslic3r/Model.hpp"
 #include "libslic3r/I18N.hpp"
 #include "libslic3r/LogSink.hpp"
@@ -2799,6 +2801,10 @@ int GUI_App::OnExit()
     m_fila_debug_sink = nullptr;
 #endif
 
+    // Flush any config changes that were deferred by the idle-handler debounce.
+    if (app_config && app_config->dirty())
+        app_config->save();
+
     return wxApp::OnExit();
 }
 
@@ -3395,8 +3401,13 @@ bool GUI_App::on_init_inner()
         if (! plater_)
             return;
 
-        if (app_config->dirty())
-            app_config->save();
+        if (app_config->dirty()) {
+            // Debounce: avoid synchronous disk writes on every idle event.
+            // Save at most once per 5 seconds; OnExit() flushes any remaining dirty state.
+            static auto s_last_config_save = std::chrono::steady_clock::time_point{};
+            if (Slic3r::debounce_elapsed(s_last_config_save, std::chrono::seconds(5)))
+                app_config->save();
+        }
 
         // BBS
         //this->obj_manipul()->update_if_dirty();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -997,6 +997,12 @@ void Sidebar::priv::show_fila_switch_msg(bool ready)
 
 Sidebar::priv::~priv()
 {
+    // Stop and delete the printer-sync timer to prevent resource leak
+    if (timer_sync_printer) {
+        timer_sync_printer->Stop();
+        delete timer_sync_printer;
+        timer_sync_printer = nullptr;
+    }
     // BBS
     //delete object_manipulation;
     delete object_settings;

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(${_TEST_NAME}_tests
     test_png_io.cpp
     test_timeutils.cpp
     test_indexed_triangle_set.cpp
+    test_debounce.cpp
     ../libnest2d/printer_parts.cpp
 	)
 

--- a/tests/libslic3r/test_debounce.cpp
+++ b/tests/libslic3r/test_debounce.cpp
@@ -1,0 +1,83 @@
+#include <catch2/catch.hpp>
+
+#include "libslic3r/Debounce.hpp"
+
+#include <thread>
+
+using namespace Slic3r;
+using namespace std::chrono;
+
+// ---------------------------------------------------------------------------
+// debounce_elapsed() — unit tests
+// ---------------------------------------------------------------------------
+
+SCENARIO("debounce_elapsed: first call always fires", "[Debounce]") {
+    GIVEN("A default-initialised time_point (epoch)") {
+        steady_clock::time_point last{};
+        WHEN("debounce_elapsed is called with a 5-second interval") {
+            const bool fired = debounce_elapsed(last, seconds(5));
+            THEN("It returns true") {
+                REQUIRE(fired);
+            }
+            THEN("last_tp is updated to a non-epoch value") {
+                REQUIRE(last != steady_clock::time_point{});
+            }
+        }
+    }
+}
+
+SCENARIO("debounce_elapsed: second immediate call is suppressed", "[Debounce]") {
+    GIVEN("A time_point primed by a first accepted call") {
+        steady_clock::time_point last{};
+        debounce_elapsed(last, seconds(5)); // prime
+        WHEN("debounce_elapsed is called again immediately") {
+            const bool fired = debounce_elapsed(last, seconds(5));
+            THEN("It returns false") {
+                REQUIRE_FALSE(fired);
+            }
+        }
+    }
+}
+
+SCENARIO("debounce_elapsed: call fires again after interval expires", "[Debounce]") {
+    GIVEN("A time_point set to 10 seconds in the past") {
+        // Simulate 'last' being 10 seconds old without sleeping.
+        steady_clock::time_point last = steady_clock::now() - seconds(10);
+        WHEN("debounce_elapsed is called with a 5-second interval") {
+            const bool fired = debounce_elapsed(last, seconds(5));
+            THEN("It returns true") {
+                REQUIRE(fired);
+            }
+            THEN("last_tp is updated") {
+                REQUIRE(last >= steady_clock::now() - milliseconds(100));
+            }
+        }
+    }
+}
+
+SCENARIO("debounce_elapsed: zero interval fires every time", "[Debounce]") {
+    GIVEN("A time_point primed by a first call") {
+        steady_clock::time_point last{};
+        debounce_elapsed(last, seconds(0));
+        WHEN("debounce_elapsed is called immediately again with zero interval") {
+            const bool fired = debounce_elapsed(last, seconds(0));
+            THEN("It returns true") {
+                REQUIRE(fired);
+            }
+        }
+    }
+}
+
+SCENARIO("debounce_elapsed: last_tp is not modified on suppressed calls", "[Debounce]") {
+    GIVEN("A time_point primed by a first accepted call") {
+        steady_clock::time_point last{};
+        debounce_elapsed(last, seconds(5));
+        const auto snapshot = last;
+        WHEN("A suppressed call is made") {
+            debounce_elapsed(last, seconds(5));
+            THEN("last_tp is unchanged") {
+                REQUIRE(last == snapshot);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes three small independent issues from the static analysis in #10289.

**F-010 — duplicate sources in `CMakeLists.txt`**
`Scrollbar.cpp` and `ScrolledWindow.cpp` were listed twice in `SLIC3R_GUI_SOURCES`. Removed the redundant entries.

**F-006 — `timer_sync_printer` leak in `Sidebar::priv::~priv()`**
`timer_sync_printer` is heap-allocated (`= new wxTimer()`) but the destructor never deleted it. Added `Stop()` + `delete` + null-out.

**F-015 — unbounded `app_config->save()` in idle handler**
The idle handler called `app_config->save()` on every dirty idle event — on a busy loop this means a synchronous disk write at idle frequency. Added a 5-second rate limit via `std::chrono::steady_clock`. `OnExit()` flushes any remaining dirty state so no settings are lost on clean shutdown.

---

**Tests**

Extracted the rate-limit logic into `src/libslic3r/Debounce.hpp` (pure C++, no wx dependency) and added `tests/libslic3r/test_debounce.cpp` with 5 Catch2 scenarios covering first call, suppression, interval expiry, zero interval, and no mutation on suppressed calls.

```
All tests passed (7 assertions in 5 test cases)
```

Build verified on Linux/GCC: `cmake --build build --target BambuStudio -j$(nproc)` completes without new warnings or errors.

Ref: #10289
