### PR TITLE
FIX: Fix FilamentMapMode declaration

### DIFF
--- a/src/slic3r/GUI/FilamentMapDialog.hpp
+++ b/src/slic3r/GUI/FilamentMapDialog.hpp
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include "CapsuleButton.hpp"
+#include "libslic3r/PrintConfig.hpp"
 
 class Button;
 


### PR DESCRIPTION
```
/run/build/BambuStudio/src/slic3r/GUI/FilamentMapDialog.hpp:30:13: error: ‘FilamentMapMode’ was not declared in this scope; did you mean ‘FilamentMapPanel’?
   30 | std::vector<FilamentMapMode> resolve_available_auto_modes(Print *print_obj, const std::vector<FilamentMapMode> &requested_modes, bool machine_synced);
      |             ^~~~~~~~~~~~~~~
      |             FilamentMapPanel
```