### PR TITLE
ENH: persist filament manager zoom level on close and restore on load

### DIFF
--- a/src/slic3r/GUI/DeviceWeb/DeviceWebHost.cpp
+++ b/src/slic3r/GUI/DeviceWeb/DeviceWebHost.cpp
@@ -11,6 +11,7 @@
 #include <wx/sizer.h>
 #include <boost/log/trivial.hpp>
 #include <chrono>
+#include <stdexcept>
 
 namespace Slic3r { namespace GUI {
 
@@ -51,6 +52,11 @@ void DeviceWebHost::EnsureBuilt()
 
     m_device_webview = new PrinterWebView(this);
     m_device_webview->SetMinSize(wxSize(FromDIP(320), FromDIP(260)));
+
+    // Restore saved zoom once the page has finished loading.
+    if (wxWebView* wv = GetWebView())
+        wv->Bind(wxEVT_WEBVIEW_LOADED, &DeviceWebHost::OnWebLoaded, this);
+
     m_device_web_bridge = std::make_unique<DeviceWebBridge>(m_device_webview->GetWebView());
     m_device_web_bridge->SetReportEnabledHandler([this]() {
         return CanReportToWeb();
@@ -222,6 +228,45 @@ void DeviceWebHost::on_sys_color_changed()
 
 void DeviceWebHost::msw_rescale()
 {
+}
+
+void DeviceWebHost::OnWebLoaded(wxWebViewEvent& evt)
+{
+    evt.Skip();
+
+    auto* config = wxGetApp().app_config;
+    if (!config || !config->has("filament_manager_zoom_factor"))
+        return;
+
+    wxWebView* wv = GetWebView();
+    if (!wv)
+        return;
+
+    try {
+        float zoom = std::stof(config->get("filament_manager_zoom_factor"));
+        if (zoom >= 0.25f && zoom <= 5.0f)
+            wv->SetZoomFactor(zoom);
+    } catch (const std::exception&) {
+        // Ignore malformed config values; browser default (1.0) will be used.
+    }
+}
+
+void DeviceWebHost::SaveZoom()
+{
+    wxWebView* wv = GetWebView();
+    if (!wv)
+        return;
+
+    float zoom = wv->GetZoomFactor();
+    if (zoom <= 0.0f)
+        return;
+
+    auto* config = wxGetApp().app_config;
+    if (!config)
+        return;
+
+    config->set("filament_manager_zoom_factor", std::to_string(zoom));
+    config->save();
 }
 
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/DeviceWeb/DeviceWebHost.hpp
+++ b/src/slic3r/GUI/DeviceWeb/DeviceWebHost.hpp
@@ -51,12 +51,17 @@ public:
         return nullptr;
     }
 
+    // Persist the current webview zoom level to AppConfig.
+    // Called from MainFrame's close handler so the level survives app restarts.
+    void SaveZoom();
+
 private:
     wxString BuildUrl(const std::string& path) const;
     // Deferred construction: build webview + bridge + manager + LoadUrl on first use.
     void EnsureBuilt();
     bool CanReportToWeb() const;
     bool CanBuildDeviceState() const;
+    void OnWebLoaded(wxWebViewEvent& evt);
 
 private:
     DeviceWebHostMode                 m_mode{ DeviceWebHostMode::AllForDebug };

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -490,6 +490,12 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
     // declare events
     Bind(wxEVT_CLOSE_WINDOW, [this](wxCloseEvent& event) {
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__<< ": mainframe received close_widow event";
+
+        // Persist the filament manager zoom level before any close veto can
+        // abort the shutdown, so the last-used zoom is always saved.
+        if (m_web_device)
+            m_web_device->SaveZoom();
+
         if (event.CanVeto() && m_plater->get_view3D_canvas3D()->get_gizmos_manager().is_in_editing_mode(true)) {
             // prevents to open the save dirty project dialog
             event.Veto();

--- a/src/slic3r/GUI/PrinterWebView.cpp
+++ b/src/slic3r/GUI/PrinterWebView.cpp
@@ -46,9 +46,6 @@ PrinterWebView::PrinterWebView(wxWindow *parent)
     }
     */
 
-    //Zoom
-    m_zoomFactor = 100;
-
     //Connect the idle events
     Bind(wxEVT_CLOSE_WINDOW, &PrinterWebView::OnClose, this);
 

--- a/src/slic3r/GUI/PrinterWebView.hpp
+++ b/src/slic3r/GUI/PrinterWebView.hpp
@@ -44,7 +44,6 @@ public:
 private:
 
     wxWebView* m_browser;
-    long m_zoomFactor;
 
     // DECLARE_EVENT_TABLE()
 };


### PR DESCRIPTION
Closes #10488

- Added functionality to save the current zoom level of the filament manager web view when the main frame is closed.
- Implemented restoration of the saved zoom level when the web view loads.
- Removed unused zoom factor variable from PrinterWebView.

Change-Id: I9eceac8c620802c615327c6abca0d01ff09dcef4