### PR TITLE
Add camera fullscreen view

### DIFF
--- a/resources/images/camera_fullscreen.svg
+++ b/resources/images/camera_fullscreen.svg
@@ -1,0 +1,10 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.2 3.5H3.5V6.2" stroke="#6B6B6B" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.8 3.5H16.5V6.2" stroke="#6B6B6B" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.5 13.8V16.5H13.8" stroke="#6B6B6B" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.5 13.8V16.5H6.2" stroke="#6B6B6B" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.1 7.1L4.1 4.1" stroke="#6B6B6B" stroke-width="1.4" stroke-linecap="round"/>
+<path d="M12.9 7.1L15.9 4.1" stroke="#6B6B6B" stroke-width="1.4" stroke-linecap="round"/>
+<path d="M12.9 12.9L15.9 15.9" stroke="#6B6B6B" stroke-width="1.4" stroke-linecap="round"/>
+<path d="M7.1 12.9L4.1 15.9" stroke="#6B6B6B" stroke-width="1.4" stroke-linecap="round"/>
+</svg>

--- a/resources/images/camera_fullscreen_hover.svg
+++ b/resources/images/camera_fullscreen_hover.svg
@@ -1,0 +1,10 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.2 3.5H3.5V6.2" stroke="#00AE42" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.8 3.5H16.5V6.2" stroke="#00AE42" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.5 13.8V16.5H13.8" stroke="#00AE42" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.5 13.8V16.5H6.2" stroke="#00AE42" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.1 7.1L4.1 4.1" stroke="#00AE42" stroke-width="1.6" stroke-linecap="round"/>
+<path d="M12.9 7.1L15.9 4.1" stroke="#00AE42" stroke-width="1.6" stroke-linecap="round"/>
+<path d="M12.9 12.9L15.9 15.9" stroke="#00AE42" stroke-width="1.6" stroke-linecap="round"/>
+<path d="M7.1 12.9L4.1 15.9" stroke="#00AE42" stroke-width="1.6" stroke-linecap="round"/>
+</svg>

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -320,6 +320,10 @@ void AppConfig::set_defaults()
         set_bool("enable_high_low_temp_mixed_printing", false);
     }
 
+    if (get("camera_fullscreen_active_monitor_only").empty()){
+        set_bool("camera_fullscreen_active_monitor_only", true);
+    }
+
     if (get("ignore_ext_filament_in_filament_map").empty()){
         set_bool("ignore_ext_filament_in_filament_map", false);
     }

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -662,6 +662,8 @@ if (APPLE)
             GUI/Mouse3DHandlerMac.mm
             GUI/InstanceCheckMac.mm
             GUI/InstanceCheckMac.h
+            GUI/CameraFullscreenMac.mm
+            GUI/CameraFullscreenMac.hpp
             GUI/wxMediaCtrl2.mm
             GUI/wxMediaCtrl2.h
             GUI/wxMediaCtrl3.h

--- a/src/slic3r/GUI/CameraFullscreenMac.hpp
+++ b/src/slic3r/GUI/CameraFullscreenMac.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifdef __APPLE__
+
+class wxWindow;
+
+namespace Slic3r { namespace GUI {
+
+using CameraFullscreenEscapeCallback = void (*)(void *);
+
+void *install_camera_fullscreen_escape_monitor(CameraFullscreenEscapeCallback callback, void *context);
+void  uninstall_camera_fullscreen_escape_monitor(void *monitor);
+void *enter_camera_fullscreen_presentation(wxWindow *window);
+void  apply_camera_fullscreen_frame(wxWindow *window);
+void  restore_camera_fullscreen_presentation(void *presentation);
+
+}} // namespace Slic3r::GUI
+
+#endif

--- a/src/slic3r/GUI/CameraFullscreenMac.mm
+++ b/src/slic3r/GUI/CameraFullscreenMac.mm
@@ -1,0 +1,103 @@
+#include "CameraFullscreenMac.hpp"
+
+#ifdef __APPLE__
+
+#import <Cocoa/Cocoa.h>
+
+#include <wx/window.h>
+
+namespace Slic3r { namespace GUI {
+
+namespace {
+
+constexpr unsigned short EscapeKeyCode = 53;
+
+struct CameraFullscreenEscapeMonitor
+{
+    id monitor{ nil };
+    CameraFullscreenEscapeCallback callback{ nullptr };
+    void *context{ nullptr };
+};
+
+struct CameraFullscreenPresentationState
+{
+    NSApplicationPresentationOptions presentation_options{ NSApplicationPresentationDefault };
+};
+
+NSWindow *camera_fullscreen_window(wxWindow *window)
+{
+    if (!window || !window->GetHandle())
+        return nil;
+
+    NSView *view = (NSView *) window->GetHandle();
+    return [view window];
+}
+
+} // namespace
+
+void *install_camera_fullscreen_escape_monitor(CameraFullscreenEscapeCallback callback, void *context)
+{
+    auto *state = new CameraFullscreenEscapeMonitor;
+    state->callback = callback;
+    state->context = context;
+    state->monitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown handler:^NSEvent *(NSEvent *event) {
+        if ([event keyCode] == EscapeKeyCode) {
+            if (state->callback)
+                state->callback(state->context);
+            return nil;
+        }
+        return event;
+    }];
+    return state;
+}
+
+void uninstall_camera_fullscreen_escape_monitor(void *monitor)
+{
+    auto *state = static_cast<CameraFullscreenEscapeMonitor *>(monitor);
+    if (!state)
+        return;
+    if (state->monitor)
+        [NSEvent removeMonitor:state->monitor];
+    delete state;
+}
+
+void *enter_camera_fullscreen_presentation(wxWindow *window)
+{
+    auto *state = new CameraFullscreenPresentationState;
+    state->presentation_options = [NSApp presentationOptions];
+
+    NSApplicationPresentationOptions fullscreen_options = state->presentation_options;
+    fullscreen_options &= ~(NSApplicationPresentationHideDock | NSApplicationPresentationHideMenuBar);
+    fullscreen_options |= NSApplicationPresentationAutoHideDock | NSApplicationPresentationAutoHideMenuBar;
+    [NSApp setPresentationOptions:fullscreen_options];
+
+    apply_camera_fullscreen_frame(window);
+    return state;
+}
+
+void apply_camera_fullscreen_frame(wxWindow *window)
+{
+    NSWindow *ns_window = camera_fullscreen_window(window);
+    if (!ns_window)
+        return;
+
+    NSScreen *screen = [ns_window screen] ?: [NSScreen mainScreen];
+    if (!screen)
+        return;
+
+    [ns_window setFrame:[screen frame] display:YES animate:NO];
+}
+
+void restore_camera_fullscreen_presentation(void *presentation)
+{
+    auto *state = static_cast<CameraFullscreenPresentationState *>(presentation);
+    if (!state)
+        return;
+
+    [NSApp setPresentationOptions:state->presentation_options];
+    delete state;
+}
+
+}} // namespace Slic3r::GUI
+
+#endif

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1764,6 +1764,21 @@ bool MainFrame::can_change_view() const
     }
 }
 
+bool MainFrame::can_toggle_camera_fullscreen() const
+{
+    StatusPanel *status_panel = m_monitor ? m_monitor->get_status_panel() : nullptr;
+    if (!status_panel) return false;
+    if (status_panel->is_camera_fullscreen()) return true;
+    return m_tabpanel && m_tabpanel->GetSelection() == TabPosition::tpMonitor && status_panel->can_show_camera_fullscreen();
+}
+
+void MainFrame::toggle_camera_fullscreen()
+{
+    StatusPanel *status_panel = m_monitor ? m_monitor->get_status_panel() : nullptr;
+    if (!status_panel || !can_toggle_camera_fullscreen()) return;
+    status_panel->toggle_camera_fullscreen();
+}
+
 bool MainFrame::can_clone() const {
     return can_select() && !m_plater->is_selection_empty();
 }
@@ -3106,6 +3121,17 @@ void MainFrame::init_menubar_as_editor()
     if (m_plater) {
         viewMenu = new wxMenu();
         add_common_view_menu_items(viewMenu, this, std::bind(&MainFrame::can_change_view, this));
+        viewMenu->AppendSeparator();
+
+        wxMenuItem *camera_fullscreen_item = append_menu_item(
+            viewMenu, wxID_ANY, _L("Enter Camera Full Screen"), _L("Show the Device camera in full screen"),
+            [this](wxCommandEvent &) { toggle_camera_fullscreen(); }, "", nullptr);
+        Bind(wxEVT_UPDATE_UI, [this, camera_fullscreen_item](wxUpdateUIEvent &evt) {
+            StatusPanel *status_panel = m_monitor ? m_monitor->get_status_panel() : nullptr;
+            const bool active = status_panel && status_panel->is_camera_fullscreen();
+            camera_fullscreen_item->SetItemLabel(active ? _L("Exit Camera Full Screen") : _L("Enter Camera Full Screen"));
+            evt.Enable(can_toggle_camera_fullscreen());
+        }, camera_fullscreen_item->GetId());
         viewMenu->AppendSeparator();
 
         //BBS perspective view

--- a/src/slic3r/GUI/MainFrame.hpp
+++ b/src/slic3r/GUI/MainFrame.hpp
@@ -134,6 +134,8 @@ class MainFrame : public DPIFrame
     //bool can_eject() const;
     bool can_slice() const;
     bool can_change_view() const;
+    bool can_toggle_camera_fullscreen() const;
+    void toggle_camera_fullscreen();
     bool can_select() const;
     bool can_deselect() const;
     bool can_clone() const;

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1326,6 +1326,7 @@ wxWindow* PreferencesDialog::create_general_page()
     auto item_step_mesh_setting = create_item_checkbox(_L("Show the step mesh parameter setting dialog."), page, _L("If enabled,a parameter settings dialog will appear during STEP file import."), 50, "enable_step_mesh_setting");
     auto item_beta_version_update = create_item_checkbox(_L("Support beta version update."), page, _L("With this option enabled, you can receive beta version updates."), 50, "enable_beta_version_update");
     auto item_mix_print_high_low_temperature = create_item_checkbox(_L("Remove the restriction on mixed printing of high and low temperature filaments."), page, _L("With this option enabled, you can print materials with a large temperature difference together."), 50, "enable_high_low_temp_mixed_printing");
+    auto item_camera_fullscreen_active_monitor_only = create_item_checkbox(_L("Open full screen camera view on active monitor only."), page, _L("When enabled, the camera full screen view opens only on the monitor that contains Bambu Studio."), 50, "camera_fullscreen_active_monitor_only");
     auto item_restore_hide_pop_ups = create_item_button(_L("Clear my choice for synchronizing printer preset after loading the file."), _L("Clear"), page, {}, []() {
         wxGetApp().app_config->erase("app", "sync_after_load_file_show_flag");
     });
@@ -1494,6 +1495,7 @@ wxWindow* PreferencesDialog::create_general_page()
     sizer_page->Add(item_beta_version_update, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_auto_transfer_when_switch_preset, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_mix_print_high_low_temperature, 0, wxTOP, FromDIP(3));
+    sizer_page->Add(item_camera_fullscreen_active_monitor_only, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_restore_hide_pop_ups, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_restore_hide_3mf_info, 0, wxTOP, FromDIP(3));
     sizer_page->Add(_3d_settings, 0, wxTOP | wxEXPAND, FromDIP(20));

--- a/src/slic3r/GUI/StatusPanel.cpp
+++ b/src/slic3r/GUI/StatusPanel.cpp
@@ -8,6 +8,9 @@
 #include "BitmapCache.hpp"
 #include "GUI_App.hpp"
 #include "MainFrame.hpp"
+#ifdef __APPLE__
+#include "CameraFullscreenMac.hpp"
+#endif
 
 #include "MsgDialog.hpp"
 #include "slic3r/Utils/Http.hpp"
@@ -18,7 +21,11 @@
 #include "CalibUtils.hpp"
 #include "BBLUtil.hpp"
 #include <slic3r/GUI/Widgets/ProgressDialog.hpp>
+#include <wx/accel.h>
 #include <wx/display.h>
+#include <wx/dcbuffer.h>
+#include <wx/dcgraph.h>
+#include <wx/frame.h>
 #include <wx/mstream.h>
 #include <wx/sstream.h>
 #include <wx/zstream.h>
@@ -51,6 +58,9 @@
 
 #include "ThermalPreconditioningDialog.hpp"
 
+#include <algorithm>
+#include <functional>
+
 namespace Slic3r { namespace GUI {
 
 #define TEMP_THRESHOLD_VAL 2
@@ -78,6 +88,370 @@ static const wxColour BUTTON_HOVER_COL   = wxColour(0, 174, 66);
 
 static const wxColour DISCONNECT_TEXT_COL = wxColour(171, 172, 172);
 static const wxColour NORMAL_TEXT_COL     = wxColour(48, 58, 60);
+
+class CameraFullscreenCloseButton : public wxPanel
+{
+public:
+    CameraFullscreenCloseButton(wxWindow *parent, std::function<void()> close_cb, std::function<void(bool)> hover_cb)
+        : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE)
+        , m_close_cb(std::move(close_cb))
+        , m_hover_cb(std::move(hover_cb))
+    {
+        SetBackgroundStyle(wxBG_STYLE_PAINT);
+        SetCursor(wxCursor(wxCURSOR_HAND));
+        Bind(wxEVT_PAINT, &CameraFullscreenCloseButton::on_paint, this);
+        Bind(wxEVT_ENTER_WINDOW, &CameraFullscreenCloseButton::on_enter, this);
+        Bind(wxEVT_LEAVE_WINDOW, &CameraFullscreenCloseButton::on_leave, this);
+        Bind(wxEVT_LEFT_UP, &CameraFullscreenCloseButton::on_left_up, this);
+    }
+
+    void set_alpha(int alpha)
+    {
+        m_alpha = std::clamp(alpha, 0, 255);
+        Refresh();
+    }
+
+private:
+    void on_paint(wxPaintEvent &)
+    {
+        wxAutoBufferedPaintDC paint_dc(this);
+        paint_dc.SetBackground(wxBrush(wxColour(0, 0, 0, 0)));
+        paint_dc.Clear();
+
+        if (m_alpha <= 0) return;
+
+        wxGCDC       dc(paint_dc);
+        const wxSize size       = GetClientSize();
+        const int    inset      = FromDIP(1);
+        const int    x_pad      = FromDIP(14);
+        const int    line_width = FromDIP(2);
+        const int    bg_alpha   = m_hover ? std::min(255, m_alpha + 35) : m_alpha;
+
+        dc.SetPen(*wxTRANSPARENT_PEN);
+        dc.SetBrush(wxBrush(wxColour(18, 18, 18, bg_alpha)));
+        dc.DrawEllipse(inset, inset, size.x - 2 * inset, size.y - 2 * inset);
+
+        dc.SetPen(wxPen(wxColour(255, 255, 255, std::min(255, bg_alpha + 20)), line_width, wxPENSTYLE_SOLID));
+        dc.DrawLine(x_pad, x_pad, size.x - x_pad, size.y - x_pad);
+        dc.DrawLine(size.x - x_pad, x_pad, x_pad, size.y - x_pad);
+    }
+
+    void on_enter(wxMouseEvent &event)
+    {
+        m_hover = true;
+        if (m_hover_cb) m_hover_cb(true);
+        Refresh();
+        event.Skip();
+    }
+
+    void on_leave(wxMouseEvent &event)
+    {
+        m_hover = false;
+        if (m_hover_cb) m_hover_cb(false);
+        Refresh();
+        event.Skip();
+    }
+
+    void on_left_up(wxMouseEvent &)
+    {
+        if (m_close_cb) m_close_cb();
+    }
+
+    std::function<void()>     m_close_cb;
+    std::function<void(bool)> m_hover_cb;
+    int                       m_alpha{0};
+    bool                      m_hover{false};
+};
+
+class CameraFullscreenFrame : public wxFrame
+{
+public:
+    explicit CameraFullscreenFrame(StatusBasePanel *owner)
+        : wxFrame(owner, wxID_ANY, _L("Camera Full Screen"), wxDefaultPosition, wxDefaultSize, wxBORDER_NONE | wxFRAME_NO_TASKBAR)
+        , m_owner(owner)
+    {
+        SetBackgroundColour(*wxBLACK);
+        EnableFullScreenView(true);
+
+        m_hide_timer.SetOwner(this, wxWindow::NewControlId());
+        m_fade_timer.SetOwner(this, wxWindow::NewControlId());
+
+        auto *root_sizer = new wxBoxSizer(wxVERTICAL);
+        m_video_host     = new wxPanel(this, wxID_ANY);
+        m_video_host->SetBackgroundColour(*wxBLACK);
+        m_video_sizer = new wxBoxSizer(wxVERTICAL);
+        m_video_host->SetSizer(m_video_sizer);
+        root_sizer->Add(m_video_host, 1, wxEXPAND);
+        SetSizer(root_sizer);
+
+        m_close_button = new CameraFullscreenCloseButton(
+            m_video_host,
+            [this] { request_close(); },
+            [this](bool hover) { on_close_hover_changed(hover); });
+        m_close_button->Hide();
+
+        Bind(wxEVT_CLOSE_WINDOW, &CameraFullscreenFrame::on_close, this);
+        m_escape_accel_id = wxWindow::NewControlId();
+        Bind(wxEVT_MENU, &CameraFullscreenFrame::on_escape_accelerator, this, m_escape_accel_id);
+        Bind(wxEVT_CHAR_HOOK, &CameraFullscreenFrame::on_char_hook, this);
+        Bind(wxEVT_KEY_DOWN, &CameraFullscreenFrame::on_char_hook, this);
+        Bind(wxEVT_SIZE, &CameraFullscreenFrame::on_size, this);
+        Bind(wxEVT_MOTION, &CameraFullscreenFrame::on_mouse_motion, this);
+        Bind(wxEVT_TIMER, &CameraFullscreenFrame::on_hide_timer, this, m_hide_timer.GetId());
+        Bind(wxEVT_TIMER, &CameraFullscreenFrame::on_fade_timer, this, m_fade_timer.GetId());
+        wxAcceleratorEntry entries[1];
+        entries[0].Set(wxACCEL_NORMAL, WXK_ESCAPE, m_escape_accel_id);
+        SetAcceleratorTable(wxAcceleratorTable(1, entries));
+#ifdef __APPLE__
+        m_escape_monitor = install_camera_fullscreen_escape_monitor(
+            [](void *context) {
+                auto *frame = static_cast<CameraFullscreenFrame *>(context);
+                frame->CallAfter([frame] { frame->request_close(); });
+            },
+            this);
+#endif
+        m_video_host->Bind(wxEVT_KEY_DOWN, &CameraFullscreenFrame::on_char_hook, this);
+        m_video_host->Bind(wxEVT_MOTION, &CameraFullscreenFrame::on_mouse_motion, this);
+        m_close_button->Bind(wxEVT_CHAR_HOOK, &CameraFullscreenFrame::on_char_hook, this);
+        m_close_button->Bind(wxEVT_KEY_DOWN, &CameraFullscreenFrame::on_char_hook, this);
+
+        wxDisplay display(wxDisplay::GetFromWindow(owner));
+        if (display.IsOk()) SetSize(display.GetGeometry());
+    }
+
+    ~CameraFullscreenFrame() override
+    {
+#ifdef __APPLE__
+        restore_camera_fullscreen_presentation(m_presentation_state);
+        uninstall_camera_fullscreen_escape_monitor(m_escape_monitor);
+#endif
+    }
+
+    wxWindow *video_parent() const { return m_video_host; }
+
+    void show_camera_view(bool active_monitor_only)
+    {
+        m_native_fullscreen = false;
+        if (active_monitor_only) {
+#ifdef __APPLE__
+            m_presentation_state = enter_camera_fullscreen_presentation(this);
+#endif
+            SetSize(display_geometry_for(m_owner ? static_cast<wxWindow *>(m_owner) : this));
+            Show();
+#ifdef __APPLE__
+            apply_camera_fullscreen_frame(this);
+#else
+            ShowFullScreen(true, wxFULLSCREEN_ALL);
+            m_native_fullscreen = true;
+#endif
+        } else {
+#ifdef __APPLE__
+            Show();
+            ShowFullScreen(true, wxFULLSCREEN_ALL);
+            m_native_fullscreen = true;
+#else
+            SetSize(all_display_geometry());
+            Show();
+#endif
+        }
+
+        Raise();
+        SetFocus();
+    }
+
+    void exit_camera_view()
+    {
+        if (m_native_fullscreen) ShowFullScreen(false);
+#ifdef __APPLE__
+        restore_camera_fullscreen_presentation(m_presentation_state);
+        m_presentation_state = nullptr;
+#endif
+    }
+
+    void attach_media(wxMediaCtrl3 *media_ctrl)
+    {
+        m_media_ctrl = media_ctrl;
+        m_video_sizer->Add(m_media_ctrl, 1, wxEXPAND);
+        m_media_ctrl->Bind(wxEVT_CHAR_HOOK, &CameraFullscreenFrame::on_char_hook, this);
+        m_media_ctrl->Bind(wxEVT_KEY_DOWN, &CameraFullscreenFrame::on_char_hook, this);
+        m_media_ctrl->Bind(wxEVT_MOTION, &CameraFullscreenFrame::on_mouse_motion, this);
+        Layout();
+        position_close_button();
+        CallAfter([this] { show_close_button(); });
+    }
+
+    void detach_media()
+    {
+        if (!m_media_ctrl) return;
+        m_media_ctrl->Unbind(wxEVT_CHAR_HOOK, &CameraFullscreenFrame::on_char_hook, this);
+        m_media_ctrl->Unbind(wxEVT_KEY_DOWN, &CameraFullscreenFrame::on_char_hook, this);
+        m_media_ctrl->Unbind(wxEVT_MOTION, &CameraFullscreenFrame::on_mouse_motion, this);
+        m_video_sizer->Detach(m_media_ctrl);
+        m_media_ctrl = nullptr;
+    }
+
+    void clear_owner() { m_owner = nullptr; }
+
+private:
+    void on_close(wxCloseEvent &event)
+    {
+        if (m_owner) {
+            m_owner->close_camera_fullscreen();
+            return;
+        }
+        event.Skip();
+    }
+
+    void on_escape_accelerator(wxCommandEvent &)
+    {
+        request_close();
+    }
+
+    void on_char_hook(wxKeyEvent &event)
+    {
+        if (event.GetKeyCode() == WXK_ESCAPE) {
+            request_close();
+            return;
+        }
+        event.Skip();
+    }
+
+    void on_size(wxSizeEvent &event)
+    {
+        event.Skip();
+        position_close_button();
+    }
+
+    void on_mouse_motion(wxMouseEvent &event)
+    {
+        show_close_button();
+        event.Skip();
+    }
+
+    void on_hide_timer(wxTimerEvent &)
+    {
+        if (m_close_hover) return;
+        m_fade_elapsed_ms  = 0;
+        m_fade_start_alpha = m_close_alpha;
+        m_fade_timer.Start(30);
+    }
+
+    void on_fade_timer(wxTimerEvent &)
+    {
+        if (m_close_hover) {
+            m_fade_timer.Stop();
+            return;
+        }
+
+        m_fade_elapsed_ms += 30;
+        if (m_fade_elapsed_ms >= 300) {
+            m_fade_timer.Stop();
+            m_close_alpha = 0;
+            m_close_button->set_alpha(m_close_alpha);
+            m_close_button->Hide();
+            return;
+        }
+
+        m_close_alpha = m_fade_start_alpha * (300 - m_fade_elapsed_ms) / 300;
+        m_close_button->set_alpha(m_close_alpha);
+    }
+
+    void on_close_hover_changed(bool hover)
+    {
+        m_close_hover = hover;
+        if (hover) {
+            show_close_button(false);
+        } else {
+            start_hide_timer();
+        }
+    }
+
+    void request_close()
+    {
+        if (m_owner) {
+            m_owner->close_camera_fullscreen();
+        } else {
+            Close();
+        }
+    }
+
+    static wxRect display_geometry_for(wxWindow *window)
+    {
+        const int display_index = window ? wxDisplay::GetFromWindow(window) : wxNOT_FOUND;
+        if (display_index != wxNOT_FOUND) {
+            wxDisplay display(static_cast<unsigned int>(display_index));
+            if (display.IsOk()) return display.GetGeometry();
+        }
+
+        wxDisplay primary_display(static_cast<unsigned int>(0));
+        return primary_display.IsOk() ? primary_display.GetGeometry() : wxGetClientDisplayRect();
+    }
+
+    static wxRect all_display_geometry()
+    {
+        wxRect             geometry;
+        bool               has_geometry  = false;
+        const unsigned int display_count = wxDisplay::GetCount();
+        for (unsigned int i = 0; i < display_count; ++i) {
+            wxDisplay display(i);
+            if (!display.IsOk()) continue;
+            if (!has_geometry) {
+                geometry     = display.GetGeometry();
+                has_geometry = true;
+            } else {
+                geometry.Union(display.GetGeometry());
+            }
+        }
+
+        return has_geometry ? geometry : wxGetClientDisplayRect();
+    }
+
+    void show_close_button(bool reset_idle_timer = true)
+    {
+        if (!m_close_button) return;
+        m_fade_timer.Stop();
+        m_close_alpha = m_close_hover ? 225 : 185;
+        m_close_button->set_alpha(m_close_alpha);
+        if (!m_close_button->IsShown()) m_close_button->Show();
+        position_close_button();
+        m_close_button->Raise();
+        if (reset_idle_timer && !m_close_hover) start_hide_timer();
+    }
+
+    void start_hide_timer()
+    {
+        m_hide_timer.Stop();
+        m_hide_timer.StartOnce(3000);
+    }
+
+    void position_close_button()
+    {
+        if (!m_video_host || !m_close_button) return;
+        const int    button_size = FromDIP(44);
+        const int    margin      = FromDIP(24);
+        const wxSize host_size   = m_video_host->GetClientSize();
+        m_close_button->SetSize(wxSize(button_size, button_size));
+        m_close_button->SetPosition(wxPoint(std::max(margin, host_size.x - button_size - margin), margin));
+    }
+
+    StatusBasePanel             *m_owner{nullptr};
+    wxPanel                     *m_video_host{nullptr};
+    wxBoxSizer                  *m_video_sizer{nullptr};
+    wxMediaCtrl3                *m_media_ctrl{nullptr};
+    CameraFullscreenCloseButton *m_close_button{nullptr};
+    wxTimer m_hide_timer;
+    wxTimer m_fade_timer;
+#ifdef __APPLE__
+    void *m_escape_monitor{nullptr};
+    void *m_presentation_state{nullptr};
+#endif
+    wxWindowID m_escape_accel_id{ wxID_ANY };
+    int m_close_alpha{ 0 };
+    int m_fade_start_alpha{ 0 };
+    int m_fade_elapsed_ms{ 0 };
+    bool m_close_hover{ false };
+    bool m_native_fullscreen{ false };
+};
 static const wxColour NORMAL_FAN_TEXT_COL = wxColour(107, 107, 107);
 static const wxColour WARNING_INFO_BG_COL = wxColour(255, 111, 0);
 static const wxColour STAGE_TEXT_COL      = wxColour(107, 107, 107);
@@ -1456,7 +1830,64 @@ StatusBasePanel::StatusBasePanel(wxWindow *parent, wxWindowID id, const wxPoint 
     this->Layout();
 }
 
-StatusBasePanel::~StatusBasePanel() { delete m_media_play_ctrl; }
+StatusBasePanel::~StatusBasePanel()
+{
+    close_camera_fullscreen();
+    delete m_media_play_ctrl;
+}
+
+bool StatusBasePanel::can_show_camera_fullscreen() const { return m_media_ctrl != nullptr && IsShownOnScreen(); }
+
+bool StatusBasePanel::is_camera_fullscreen() const { return m_camera_fullscreen_frame != nullptr; }
+
+void StatusBasePanel::toggle_camera_fullscreen()
+{
+    if (is_camera_fullscreen()) {
+        close_camera_fullscreen();
+    } else {
+        show_camera_fullscreen();
+    }
+}
+
+void StatusBasePanel::show_camera_fullscreen()
+{
+    if (!can_show_camera_fullscreen() || m_camera_fullscreen_frame || !m_camera_media_sizer) return;
+
+    m_camera_fullscreen_frame = new CameraFullscreenFrame(this);
+    m_camera_media_sizer->Detach(m_media_ctrl);
+    m_media_ctrl->Reparent(m_camera_fullscreen_frame->video_parent());
+    m_camera_fullscreen_frame->attach_media(m_media_ctrl);
+
+    Layout();
+    Refresh();
+
+    const bool active_monitor_only = wxGetApp().app_config == nullptr || wxGetApp().app_config->get_bool("camera_fullscreen_active_monitor_only");
+    m_camera_fullscreen_frame->show_camera_view(active_monitor_only);
+}
+
+void StatusBasePanel::close_camera_fullscreen()
+{
+    if (!m_camera_fullscreen_frame) return;
+
+    CameraFullscreenFrame *frame = m_camera_fullscreen_frame;
+    m_camera_fullscreen_frame    = nullptr;
+    frame->clear_owner();
+    frame->detach_media();
+
+    m_media_ctrl->Reparent(this);
+    m_camera_media_sizer->Insert(1, m_media_ctrl, 1, wxEXPAND | wxALL, 0);
+    Layout();
+    Refresh();
+
+    frame->exit_camera_view();
+    frame->Destroy();
+}
+
+void StatusBasePanel::on_camera_fullscreen(wxMouseEvent &event)
+{
+    toggle_camera_fullscreen();
+    event.Skip();
+}
 
 void StatusBasePanel::init_bitmaps()
 {
@@ -1544,6 +1975,10 @@ wxBoxSizer *StatusBasePanel::create_monitoring_page()
     m_bitmap_vcamera_img->SetMinSize(wxSize(FromDIP(38), FromDIP(24)));
     m_bitmap_vcamera_img->Hide();
 
+    m_camera_fullscreen_button = new CameraItem(m_panel_monitoring_title, "camera_fullscreen", "camera_fullscreen_hover");
+    m_camera_fullscreen_button->SetMinSize(wxSize(FromDIP(38), FromDIP(24)));
+    m_camera_fullscreen_button->SetBackgroundColour(STATUS_TITLE_BG);
+
     m_setting_button = new CameraItem(m_panel_monitoring_title, "camera_setting", "camera_setting_hover");
     m_setting_button->SetMinSize(wxSize(FromDIP(38), FromDIP(24)));
     m_setting_button->SetBackgroundColour(STATUS_TITLE_BG);
@@ -1552,12 +1987,14 @@ wxBoxSizer *StatusBasePanel::create_monitoring_page()
     m_bitmap_timelapse_img->SetToolTip(_L("Timelapse"));
     m_bitmap_recording_img->SetToolTip(_L("Video"));
     m_bitmap_vcamera_img->SetToolTip(_L("Go Live"));
+    m_camera_fullscreen_button->SetToolTip(_L("Enter Camera Full Screen"));
     m_setting_button->SetToolTip(_L("Camera Setting"));
 
     bSizer_monitoring_title->Add(m_bitmap_sdcard_img, 0, wxALIGN_CENTER_VERTICAL | wxALL, FromDIP(5));
     bSizer_monitoring_title->Add(m_bitmap_timelapse_img, 0, wxALIGN_CENTER_VERTICAL | wxALL, FromDIP(5));
     bSizer_monitoring_title->Add(m_bitmap_recording_img, 0, wxALIGN_CENTER_VERTICAL | wxALL, FromDIP(5));
     bSizer_monitoring_title->Add(m_bitmap_vcamera_img, 0, wxALIGN_CENTER_VERTICAL | wxALL, FromDIP(5));
+    bSizer_monitoring_title->Add(m_camera_fullscreen_button, 0, wxALIGN_CENTER_VERTICAL | wxALL, FromDIP(5));
     bSizer_monitoring_title->Add(m_setting_button, 0, wxALIGN_CENTER_VERTICAL | wxALL, FromDIP(5));
 
     bSizer_monitoring_title->Add(FromDIP(13), 0, 0);
@@ -1577,6 +2014,7 @@ wxBoxSizer *StatusBasePanel::create_monitoring_page()
 
     sizer->Add(m_media_ctrl, 1, wxEXPAND | wxALL, 0);
     sizer->Add(m_media_play_ctrl, 0, wxEXPAND | wxALL, 0);
+    m_camera_media_sizer = sizer;
     //    media_ctrl_panel->SetSizer(bSizer_monitoring);
     //    media_ctrl_panel->Layout();
     //
@@ -2449,6 +2887,8 @@ StatusPanel::StatusPanel(wxWindow *parent, wxWindowID id, const wxPoint &pos, co
 
     m_setting_button->Connect(wxEVT_LEFT_DOWN, wxMouseEventHandler(StatusPanel::on_camera_enter), NULL, this);
     m_setting_button->Connect(wxEVT_LEFT_DCLICK, wxMouseEventHandler(StatusPanel::on_camera_enter), NULL, this);
+    m_camera_fullscreen_button->Connect(wxEVT_LEFT_DOWN, wxMouseEventHandler(StatusBasePanel::on_camera_fullscreen), NULL, this);
+    m_camera_fullscreen_button->Connect(wxEVT_LEFT_DCLICK, wxMouseEventHandler(StatusBasePanel::on_camera_fullscreen), NULL, this);
     m_tempCtrl_bed->Connect(wxEVT_KILL_FOCUS, wxFocusEventHandler(StatusPanel::on_bed_temp_kill_focus), NULL, this);
     m_tempCtrl_bed->Connect(wxEVT_SET_FOCUS, wxFocusEventHandler(StatusPanel::on_bed_temp_set_focus), NULL, this);
     m_tempCtrl_nozzle->Connect(wxEVT_KILL_FOCUS, wxFocusEventHandler(StatusPanel::on_nozzle_temp_kill_focus), NULL, this);
@@ -2514,6 +2954,10 @@ StatusPanel::~StatusPanel()
 
     m_setting_button->Disconnect(wxEVT_LEFT_DOWN, wxMouseEventHandler(StatusPanel::on_camera_enter), NULL, this);
     m_setting_button->Disconnect(wxEVT_LEFT_DCLICK, wxMouseEventHandler(StatusPanel::on_camera_enter), NULL, this);
+    if (m_camera_fullscreen_button) {
+        m_camera_fullscreen_button->Disconnect(wxEVT_LEFT_DOWN, wxMouseEventHandler(StatusBasePanel::on_camera_fullscreen), NULL, this);
+        m_camera_fullscreen_button->Disconnect(wxEVT_LEFT_DCLICK, wxMouseEventHandler(StatusBasePanel::on_camera_fullscreen), NULL, this);
+    }
     m_tempCtrl_bed->Disconnect(wxEVT_KILL_FOCUS, wxFocusEventHandler(StatusPanel::on_bed_temp_kill_focus), NULL, this);
     m_tempCtrl_bed->Disconnect(wxEVT_SET_FOCUS, wxFocusEventHandler(StatusPanel::on_bed_temp_set_focus), NULL, this);
     m_tempCtrl_nozzle->Disconnect(wxEVT_KILL_FOCUS, wxFocusEventHandler(StatusPanel::on_nozzle_temp_kill_focus), NULL, this);
@@ -5006,6 +5450,7 @@ bool StatusPanel::is_stage_list_info_changed(MachineObject *obj)
 void StatusPanel::set_default()
 {
     BOOST_LOG_TRIVIAL(trace) << "status_panel: set_default";
+    close_camera_fullscreen();
     obj                           = nullptr;
     last_subtask                  = nullptr;
     last_tray_exist_bits          = -1;
@@ -5083,6 +5528,7 @@ void StatusPanel::rescale_camera_icons()
     if (!m_setting_button || !m_media_play_ctrl || !m_bitmap_vcamera_img || !m_bitmap_sdcard_img || !m_bitmap_recording_img || !m_bitmap_timelapse_img) return;
 
     m_setting_button->msw_rescale();
+    if (m_camera_fullscreen_button) m_camera_fullscreen_button->msw_rescale();
 
     m_bitmap_sdcard_state_abnormal = ScalableBitmap(this, wxGetApp().dark_mode() ? "sdcard_state_abnormal_dark" : "sdcard_state_abnormal", 20);
     m_bitmap_sdcard_state_normal   = ScalableBitmap(this, wxGetApp().dark_mode() ? "sdcard_state_normal_dark" : "sdcard_state_normal", 20);

--- a/src/slic3r/GUI/StatusPanel.hpp
+++ b/src/slic3r/GUI/StatusPanel.hpp
@@ -50,6 +50,7 @@ namespace GUI {
 // Previous definitions
 class MessageDialog;
 class wgtDeviceNozzleRack;
+class CameraFullscreenFrame;
 
 enum CameraRecordingStatus {
     RECORDING_NONE,
@@ -427,8 +428,10 @@ protected:
     CameraRecordingStatus m_state_recording{CameraRecordingStatus::RECORDING_NONE};
     CameraTimelapseStatus m_state_timelapse{CameraTimelapseStatus::TIMELAPSE_NONE};
 
-
     CameraItem *m_setting_button;
+    CameraItem *m_camera_fullscreen_button{ nullptr };
+    wxBoxSizer *m_camera_media_sizer{ nullptr };
+    CameraFullscreenFrame *m_camera_fullscreen_frame{ nullptr };
 
     wxBitmap m_bitmap_camera;
     ScalableBitmap m_bitmap_sdcard_state_normal;
@@ -629,10 +632,16 @@ public:
 
     void jump_to_Rack();
 
+    bool can_show_camera_fullscreen() const;
+    bool is_camera_fullscreen() const;
+    void toggle_camera_fullscreen();
+    void close_camera_fullscreen();
+    void on_camera_fullscreen(wxMouseEvent& event);
+
 private:
     void on_ams_rack_switch(wxCommandEvent& event);
+    void show_camera_fullscreen();
 };
-
 
 class StatusPanel : public StatusBasePanel
 {


### PR DESCRIPTION
Fixes #7272 

I added a full screen camera view feature. This includes:

- A Settings option to view only on the current monitor (default) or on all monitors (blanking non-default monitors).
- ESC key to exit
  - MacOS required special handling, I didn't add anything extra for Windows or Linux
- Close button in upper right corner to exit full screen view (fades out after 5s, reappears on mouse movement).
- Menu item to 'Enter Camera Full Screen' under the View menu
- ~~Localized to all supported languages~~

Note to maintainers:

I only tested it on MacOS as I don't have a Windows machine or Linux desktop available.

**Please test on Windows and Linux.**

<hr>

This is what the Settings dialog looks like now (see last entry):

<br>

<img width="601" height="368" alt="Screenshot 2026-05-01 at 4 04 01 AM" src="https://github.com/user-attachments/assets/073007a7-1031-4fe6-908b-9d9cb54d805e" />

<br>

This is the new camera view toolbar:

<br>

<img width="388" height="225" alt="Screenshot 2026-05-01 at 4 03 10 AM" src="https://github.com/user-attachments/assets/55d0d644-8894-4d41-9b28-7b5cb38420ba" />

<br>

This is the full screen view:

<br>

<img width="2560" height="1440" alt="Screenshot 2026-05-01 at 4 05 43 AM" src="https://github.com/user-attachments/assets/ecefe1e3-2f01-4844-99b6-f05eee68d111" />
