### PR TITLE
Add option for raft layer(s) filament selection

### DIFF
--- a/src/libslic3r/Flow.cpp
+++ b/src/libslic3r/Flow.cpp
@@ -233,6 +233,16 @@ Flow support_material_flow(const PrintObject *object, float layer_height)
         float(object->print()->config().nozzle_diameter.get_at(object->config().support_filament-1)),
         (layer_height > 0.f) ? layer_height : float(object->config().layer_height.value));
 }
+
+Flow raft_material_flow(const PrintObject *object, float layer_height)
+{
+    return Flow::new_from_config_width(
+        frSupportMaterial,
+        (object->config().support_line_width.value > 0) ? object->config().support_line_width : object->config().line_width,
+        float(object->print()->config().nozzle_diameter.get_at(object->config().raft_filament - 1)),
+        (layer_height > 0.f) ? layer_height : float(object->config().layer_height.value));
+}
+
 //BBS
 Flow support_transition_flow(const PrintObject* object)
 {
@@ -250,6 +260,17 @@ Flow support_material_1st_layer_flow(const PrintObject *object, float layer_heig
         // The width parameter accepted by new_from_config_width is of type ConfigOptionFloatOrPercent, the Flow class takes care of the percent to value substitution.
         (width.value > 0) ? width : object->config().line_width,
         float(print_config.nozzle_diameter.get_at(object->config().support_filament-1)),
+        (layer_height > 0.f) ? layer_height : float(print_config.initial_layer_print_height.value));
+}
+
+Flow raft_material_1st_layer_flow(const PrintObject *object, float layer_height)
+{
+    const PrintConfig &print_config = object->print()->config();
+    const auto &width = (print_config.initial_layer_line_width.value > 0) ? print_config.initial_layer_line_width : object->config().support_line_width;
+    return Flow::new_from_config_width(
+        frSupportMaterial,
+        (width.value > 0) ? width : object->config().line_width,
+        float(print_config.nozzle_diameter.get_at(object->config().raft_filament - 1)),
         (layer_height > 0.f) ? layer_height : float(print_config.initial_layer_print_height.value));
 }
 

--- a/src/libslic3r/Flow.hpp
+++ b/src/libslic3r/Flow.hpp
@@ -139,8 +139,10 @@ private:
 };
 
 extern Flow support_material_flow(const PrintObject* object, float layer_height = 0.f);
+extern Flow raft_material_flow(const PrintObject* object, float layer_height = 0.f);
 extern Flow support_transition_flow(const PrintObject *object); //BBS
 extern Flow support_material_1st_layer_flow(const PrintObject *object, float layer_height = 0.f);
+extern Flow raft_material_1st_layer_flow(const PrintObject *object, float layer_height = 0.f);
 extern Flow support_material_interface_flow(const PrintObject *object, float layer_height = 0.f);
 
 }

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4327,14 +4327,19 @@ GCode::LayerResult GCode::process_layer(
                 ExtrusionRole   role               = support_layer.support_fills.role();
                 bool            has_support        = role == erMixed || role == erSupportMaterial || role == erSupportTransition;
                 bool            has_interface      = role == erMixed || role == erSupportMaterialInterface;
-                // Extruder ID of the support base. -1 if "don't care".
-                unsigned int    support_extruder   = object.config().support_filament.value - 1;
-                // Shall the support be printed with the active extruder, preferably with non-soluble, to avoid tool changes?
-                bool            support_dontcare   = object.config().support_filament.value == 0;
+                const bool raft_layer_uses_raft_filament = object.slicing_parameters().raft_layer_uses_raft_filament(support_layer.id());
+                const ConfigOptionInt &base_filament      = raft_layer_uses_raft_filament ?
+                    object.config().raft_filament : object.config().support_filament;
+                const ConfigOptionInt &interface_filament = raft_layer_uses_raft_filament ?
+                    object.config().raft_filament : object.config().support_interface_filament;
+                // Extruder ID of the support or raft base. -1 if "don't care".
+                unsigned int    support_extruder   = base_filament.value - 1;
+                // Shall the support / raft base be printed with the active extruder, preferably with non-soluble, to avoid tool changes?
+                bool            support_dontcare   = base_filament.value == 0;
                 // Extruder ID of the support interface. -1 if "don't care".
-                unsigned int    interface_extruder = object.config().support_interface_filament.value - 1;
+                unsigned int    interface_extruder = interface_filament.value - 1;
                 // Shall the support interface be printed with the active extruder, preferably with non-soluble, to avoid tool changes?
-                bool            interface_dontcare = object.config().support_interface_filament.value == 0;
+                bool            interface_dontcare = interface_filament.value == 0;
 
                 // BBS: apply wiping overridden extruders
                 WipingExtrusions& wiping_extrusions = const_cast<LayerTools&>(layer_tools).wiping_extrusions();

--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -878,9 +878,14 @@ void ToolOrdering::collect_extruders(const PrintObject &object, const std::vecto
             if (er == erSupportMaterialInterface) has_interface = true;
             if (has_support && has_interface) break;
         }
-        unsigned int extruder_support   = object.config().support_filament.value;
-        unsigned int extruder_interface = object.config().support_interface_filament.value;
-        bool         interface_not_for_body = object.config().support_interface_not_for_body;
+        const bool raft_layer_uses_raft_filament = object.slicing_parameters().raft_layer_uses_raft_filament(support_layer->id());
+        unsigned int extruder_support   = raft_layer_uses_raft_filament ?
+            object.config().raft_filament.value :
+            object.config().support_filament.value;
+        unsigned int extruder_interface = raft_layer_uses_raft_filament ?
+            object.config().raft_filament.value :
+            object.config().support_interface_filament.value;
+        bool         interface_not_for_body = !raft_layer_uses_raft_filament && object.config().support_interface_not_for_body;
         if (has_support) {
             auto has_reusable_layer_extruder = [&]() -> bool {
                 for (unsigned int extruder_id : layer_tools.extruders) {
@@ -2836,14 +2841,13 @@ bool WipingExtrusions::is_support_overriddable(const ExtrusionRole role, const P
     if (!object.config().flush_into_support)
         return false;
 
+    const bool has_raft_filament_layer = object.slicing_parameters().raft_layers() > 0;
     if (role == erMixed) {
-        return object.config().support_filament == 0 || object.config().support_interface_filament == 0;
-    }
-    else if (role == erSupportMaterial || role == erSupportTransition) {
-        return object.config().support_filament == 0;
-    }
-    else if (role == erSupportMaterialInterface) {
-        return object.config().support_interface_filament == 0;
+        return object.config().support_filament == 0 || (has_raft_filament_layer && object.config().raft_filament == 0) || object.config().support_interface_filament == 0;
+    } else if (role == erSupportMaterial || role == erSupportTransition) {
+        return object.config().support_filament == 0 || (has_raft_filament_layer && object.config().raft_filament == 0);
+    } else if (role == erSupportMaterialInterface) {
+        return object.config().support_interface_filament == 0 || (has_raft_filament_layer && object.config().raft_filament == 0);
     }
 
     return false;
@@ -2954,8 +2958,13 @@ float WipingExtrusions::mark_wiping_extrusions(const Print& print, unsigned int 
                     if (this_support_layer == nullptr)
                         break;
 
-                    bool support_overriddable = object_config.support_filament == 0;
-                    bool support_intf_overriddable = object_config.support_interface_filament == 0;
+                    const bool raft_layer_uses_raft_filament = object->slicing_parameters().raft_layer_uses_raft_filament(this_support_layer->id());
+                    bool support_overriddable = raft_layer_uses_raft_filament ?
+                        object_config.raft_filament == 0 :
+                        object_config.support_filament == 0;
+                    bool support_intf_overriddable = raft_layer_uses_raft_filament ?
+                        object_config.raft_filament == 0 :
+                        object_config.support_interface_filament == 0;
                     if (!support_overriddable && !support_intf_overriddable)
                         break;
 

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -4262,6 +4262,9 @@ void ModelInstance::get_arrange_polygon(void *ap, const Slic3r::DynamicPrintConf
     // get per-object support extruders
     auto op                 = object->get_config_value<ConfigOptionBool>(config_global, "enable_support");
     bool is_support_enabled = op && op->getBool();
+    auto raft_layers_op     = object->get_config_value<ConfigOptionInt>(config_global, "raft_layers");
+    bool has_raft           = raft_layers_op && raft_layers_op->getInt() > 0;
+    bool has_raft_base      = raft_layers_op && raft_layers_op->getInt() > 1;
     if (is_support_enabled) {
         auto op1 = object->get_config_value<ConfigOptionInt>(config_global, "support_filament");
         auto op2 = object->get_config_value<ConfigOptionInt>(config_global, "support_interface_filament");
@@ -4269,6 +4272,16 @@ void ModelInstance::get_arrange_polygon(void *ap, const Slic3r::DynamicPrintConf
         // id==0 means follow previous material, so need not be recorded
         if (op1 && (extruder_id = op1->getInt()) > 0) ret.extrude_id_filament_types.insert({extruder_id, get_filament_name(extruder_id)});
         if (op2 && (extruder_id = op2->getInt()) > 0) ret.extrude_id_filament_types.insert({extruder_id, get_filament_name(extruder_id)});
+    }
+    if (has_raft) {
+        auto op = object->get_config_value<ConfigOptionInt>(config_global, "raft_filament");
+        int  extruder_id;
+        if (op && (extruder_id = op->getInt()) > 0) ret.extrude_id_filament_types.insert({extruder_id, get_filament_name(extruder_id)});
+    }
+    if (has_raft_base) {
+        auto op = object->get_config_value<ConfigOptionInt>(config_global, "support_interface_filament");
+        int  extruder_id;
+        if (op && (extruder_id = op->getInt()) > 0) ret.extrude_id_filament_types.insert({extruder_id, get_filament_name(extruder_id)});
     }
 
     if (ret.extrude_id_filament_types.empty()) // the default extruder

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1033,7 +1033,7 @@ static std::vector<std::string> s_Preset_print_options {
     "accel_to_decel_enable", "accel_to_decel_factor", "skirt_loops", "skirt_distance",
     "skirt_height", "draft_shield",
     "brim_width", "brim_object_gap", "brim_type", "enable_support", "support_type", "support_threshold_angle", "enforce_support_layers",
-    "raft_layers", "raft_first_layer_density", "raft_first_layer_expansion", "raft_contact_distance", "raft_expansion",
+    "raft_layers", "raft_filament", "raft_first_layer_density", "raft_first_layer_expansion", "raft_contact_distance", "raft_expansion",
     "support_base_pattern", "support_base_pattern_spacing", "support_expansion", "support_style",
     // BBS
     "print_extruder_id", "print_extruder_variant", "independent_support_layer_height",

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -243,7 +243,7 @@ DynamicPrintConfig PresetBundle::construct_full_config(
     // BBS: add logic for settings check between different system presets
     out.erase("different_settings_to_system");
 
-    static const char *keys[] = {"support_filament", "support_interface_filament"};
+    static const char *keys[] = {"support_filament", "raft_filament", "support_interface_filament"};
     for (size_t i = 0; i < sizeof(keys) / sizeof(keys[0]); ++i) {
         std::string key = std::string(keys[i]);
         auto       *opt = dynamic_cast<ConfigOptionInt *>(out.option(key, false));
@@ -2815,9 +2815,13 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
 
         auto& print_config = this->prints.get_edited_preset().config;
         auto  support_filament_opt = print_config.option<ConfigOptionInt>("support_filament");
+        auto  raft_filament_opt = print_config.option<ConfigOptionInt>("raft_filament");
         auto support_interface_filament_opt = print_config.option<ConfigOptionInt>("support_interface_filament");
         if (support_filament_opt->value > ams_filament_color_types.size())
             support_filament_opt->value = 0;
+
+        if (raft_filament_opt->value > ams_filament_color_types.size())
+            raft_filament_opt->value = 0;
 
         if (support_interface_filament_opt->value > ams_filament_color_types.size())
             support_interface_filament_opt->value = 0;
@@ -3444,7 +3448,7 @@ DynamicPrintConfig PresetBundle::full_fff_config(bool apply_extruder, std::optio
     out.erase("different_settings_to_system");
     out.erase("filament_map_2");
 
-    static const char *keys[] = { "support_filament", "support_interface_filament" };
+    static const char *keys[] = { "support_filament", "raft_filament", "support_interface_filament" };
     for (size_t i = 0; i < sizeof(keys) / sizeof(keys[0]); ++ i) {
         std::string key = std::string(keys[i]);
         auto *opt = dynamic_cast<ConfigOptionInt*>(out.option(key, false));

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -476,22 +476,23 @@ std::vector<unsigned int> Print::support_material_extruders() const
     // BBS
     auto num_extruders = (unsigned int)m_config.filament_diameter.size();
 
+    auto collect_support_extruder = [&extruders, &support_uses_current_extruder, num_extruders](const ConfigOptionInt &filament) {
+        assert(filament >= 0);
+        if (filament == 0)
+            support_uses_current_extruder = true;
+        else {
+            unsigned int i = (unsigned int)filament - 1;
+            extruders.emplace_back((i >= num_extruders) ? 0 : i);
+        }
+    };
+
     for (PrintObject *object : m_objects) {
-        if (object->has_support_material()) {
-        	assert(object->config().support_filament >= 0);
-            if (object->config().support_filament == 0)
-                support_uses_current_extruder = true;
-            else {
-            	unsigned int i = (unsigned int)object->config().support_filament - 1;
-                extruders.emplace_back((i >= num_extruders) ? 0 : i);
-            }
-        	assert(object->config().support_interface_filament >= 0);
-            if (object->config().support_interface_filament == 0)
-                support_uses_current_extruder = true;
-            else {
-            	unsigned int i = (unsigned int)object->config().support_interface_filament - 1;
-                extruders.emplace_back((i >= num_extruders) ? 0 : i);
-            }
+        if (object->has_support())
+            collect_support_extruder(object->config().support_filament);
+        if (object->has_raft())
+            collect_support_extruder(object->config().raft_filament);
+        if (object->has_support() || (object->has_raft() && object->config().raft_layers > 1)) {
+            collect_support_extruder(object->config().support_interface_filament);
         }
     }
 
@@ -1223,12 +1224,18 @@ StringObjectException Print::check_multi_filament_valid(const Print& print)
 
             if (print_object->has_support_material()) { // extruder used by supports
                 auto num_extruders                 = (unsigned int) print_config.filament_diameter.size();
-                assert(print_object->config().support_filament >= 0);
-                if (print_object->config().support_filament >= 1 && (unsigned int)print_object->config().support_filament < num_extruders + 1)
-                    obj_used_extruder_ids.insert((unsigned int) print_object->config().support_filament - 1);//0-based extruder id
+                auto add_feature_extruder = [&obj_used_extruder_ids, num_extruders](const ConfigOptionInt &filament) {
+                    assert(filament >= 0);
+                    if (filament >= 1 && (unsigned int)filament < num_extruders + 1)
+                        obj_used_extruder_ids.insert((unsigned int)filament - 1);//0-based extruder id
+                };
+                if (print_object->has_support())
+                    add_feature_extruder(print_object->config().support_filament);
+                if (print_object->has_raft())
+                    add_feature_extruder(print_object->config().raft_filament);
                 assert(print_object->config().support_interface_filament >= 0);
-                if (print_object->config().support_interface_filament >= 1 && (unsigned int)print_object->config().support_interface_filament < num_extruders + 1)
-                    obj_used_extruder_ids.insert((unsigned int) print_object->config().support_interface_filament - 1);
+                if (print_object->has_support() || (print_object->has_raft() && print_object->config().raft_layers > 1))
+                    add_feature_extruder(print_object->config().support_interface_filament);
             }
             std::vector<std::string> filament_types;
             filament_types.reserve(obj_used_extruder_ids.size());
@@ -1594,10 +1601,8 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
             double initial_layer_print_height = m_config.initial_layer_print_height.value;
             double first_layer_min_nozzle_diameter;
             if (object->has_raft()) {
-                // if we have raft layers, only support material extruder is used on first layer
-                size_t first_layer_extruder = object->config().raft_layers == 1
-                    ? object->config().support_interface_filament-1
-                    : object->config().support_filament-1;
+                // If we have raft layers, the first print layer is printed with raft_filament.
+                size_t first_layer_extruder = object->config().raft_filament - 1;
                 first_layer_min_nozzle_diameter = (first_layer_extruder == size_t(-1)) ?
                     min_nozzle_diameter :
                     m_config.nozzle_diameter.get_at(first_layer_extruder);
@@ -3002,9 +3007,12 @@ std::vector<FilamentUsageType> Print::get_filament_usage_type() const
         model_filaments.insert(obj_filaments.begin(), obj_filaments.end());
 
         int support_fil = obj->config().support_filament - 1;
+        int raft_fil = obj->config().raft_filament - 1;
         int support_interface_fil = obj->config().support_interface_filament - 1;
-        if (support_fil >= 0) support_filaments.insert(support_fil);
-        if (support_interface_fil >= 0) support_filaments.insert(support_interface_fil);
+        if (obj->has_support() && support_fil >= 0) support_filaments.insert(support_fil);
+        if (obj->has_raft() && raft_fil >= 0) support_filaments.insert(raft_fil);
+        if ((obj->has_support() || (obj->has_raft() && obj->config().raft_layers > 1)) && support_interface_fil >= 0)
+            support_filaments.insert(support_interface_fil);
     }
 
     for (int idx = 0; idx < m_config.filament_type.size(); ++idx) {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4326,6 +4326,15 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionInt(0));
 
+    def = this->add("raft_filament", coInt);
+    def->gui_type = ConfigOptionDef::GUIType::i_enum_open;
+    def->label    = L("Filament for raft");
+    def->category = L("Support");
+    def->tooltip  = L("Filament to print raft. \"Default\" means no specific filament for raft and current filament is used");
+    def->min      = 0;
+    def->mode     = comSimple;
+    def->set_default_value(new ConfigOptionInt(0));
+
     def = this->add("resolution", coFloat);
     def->label = L("Resolution");
     def->tooltip = L("G-code path is generated after simplifying the contour of model to avoid too many points and gcode lines "
@@ -5118,9 +5127,9 @@ void PrintConfigDef::init_fff_params()
 
     def = this->add("support_filament", coInt);
     def->gui_type = ConfigOptionDef::GUIType::i_enum_open;
-    def->label    = L("Support/raft base");
+    def->label    = L("Support base");
     def->category = L("Support");
-    def->tooltip = L("Filament to print support base and raft. \"Default\" means no specific filament for support and current filament is used");
+    def->tooltip = L("Filament to print support base. \"Default\" means no specific filament for support and current filament is used");
     def->min = 0;
     def->mode = comSimple;
     def->set_default_value(new ConfigOptionInt(0));

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -920,6 +920,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionPercent,             raft_first_layer_density))
     ((ConfigOptionFloat,               raft_first_layer_expansion))
     ((ConfigOptionInt,                 raft_layers))
+    ((ConfigOptionInt,                 raft_filament))
     ((ConfigOptionEnum<SeamPosition>,  seam_position))
     ((ConfigOptionBool,                seam_placement_away_from_overhangs))
     ((ConfigOptionFloat,               slice_closing_radius))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1137,6 +1137,7 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "mmu_segmented_region_max_width"
             || opt_key == "mmu_segmented_region_interlocking_depth"
             || opt_key == "raft_layers"
+            || opt_key == "raft_filament"
             || opt_key == "raft_contact_distance"
             || opt_key == "slice_closing_radius"
             || opt_key == "slicing_mode"
@@ -3051,6 +3052,7 @@ PrintObjectConfig PrintObject::object_config_from_model_object(const PrintObject
     }
     // Clamp invalid extruders to the default extruder (with index 1).
     clamp_exturder_to_default(config.support_filament,           num_extruders);
+    clamp_exturder_to_default(config.raft_filament,              num_extruders);
     clamp_exturder_to_default(config.support_interface_filament, num_extruders);
     return config;
 }

--- a/src/libslic3r/Slicing.cpp
+++ b/src/libslic3r/Slicing.cpp
@@ -67,35 +67,39 @@ SlicingParameters SlicingParameters::create_from_config(
 {
     coordf_t initial_layer_print_height                      = (print_config.initial_layer_print_height.value <= 0) ? 
         object_config.layer_height.value : print_config.initial_layer_print_height.value;
-    // If object_config.support_filament == 0 resp. object_config.support_interface_filament == 0,
+    // If an explicit support / raft filament is not selected,
     // print_config.nozzle_diameter.get_at(size_t(-1)) returns the 0th nozzle diameter,
-    // which is consistent with the requirement that if support_filament == 0 resp. support_interface_filament == 0,
-    // support will not trigger tool change, but it will use the current nozzle instead.
+    // which is consistent with the requirement that default support / raft material
+    // will not trigger tool change, but it will use the current nozzle instead.
     // In that case all the nozzles have to be of the same diameter.
-    coordf_t support_material_extruder_dmr           = print_config.nozzle_diameter.get_at(object_config.support_filament.value - 1);
-    coordf_t support_material_interface_extruder_dmr = print_config.nozzle_diameter.get_at(object_config.support_interface_filament.value - 1);
-    bool     soluble_interface                       = object_config.support_top_z_distance.value == 0.;
+    coordf_t raft_material_extruder_dmr = print_config.nozzle_diameter.get_at(object_config.raft_filament.value - 1);
+    bool     soluble_interface          = object_config.support_top_z_distance.value == 0.;
 
     SlicingParameters params;
-    params.layer_height = object_config.layer_height.value;
-    params.first_print_layer_height = initial_layer_print_height;
+    params.layer_height              = object_config.layer_height.value;
+    params.first_print_layer_height  = initial_layer_print_height;
     params.first_object_layer_height = initial_layer_print_height;
-    params.object_print_z_min = 0.;
-    params.object_print_z_max = object_height;
-    params.base_raft_layers = object_config.raft_layers.value;
-    params.soluble_interface = soluble_interface;
+    params.object_print_z_min        = 0.;
+    params.object_print_z_max        = object_height;
+    params.base_raft_layers          = object_config.raft_layers.value;
+    params.soluble_interface         = soluble_interface;
 
     // Miniumum/maximum of the minimum layer height over all extruders.
-    params.min_layer_height = MIN_LAYER_HEIGHT;
-    params.max_layer_height = std::numeric_limits<double>::max();
-    if (object_config.enable_support.value || params.base_raft_layers > 0 || object_config.enforce_support_layers > 0) {
-        // Has some form of support. Add the support layers to the minimum / maximum layer height limits.
-        params.min_layer_height = std::max(
-            min_layer_height_from_nozzle(print_config, object_config.support_filament), 
-            min_layer_height_from_nozzle(print_config, object_config.support_interface_filament));
-        params.max_layer_height = std::min(
-            max_layer_height_from_nozzle(print_config, object_config.support_filament), 
-            max_layer_height_from_nozzle(print_config, object_config.support_interface_filament));
+    params.min_layer_height     = MIN_LAYER_HEIGHT;
+    params.max_layer_height     = std::numeric_limits<double>::max();
+    auto add_layer_height_limit = [&params, &print_config](int idx_nozzle) {
+        params.min_layer_height = std::max(params.min_layer_height, min_layer_height_from_nozzle(print_config, idx_nozzle));
+        params.max_layer_height = std::min(params.max_layer_height, max_layer_height_from_nozzle(print_config, idx_nozzle));
+    };
+    if (object_config.enable_support.value || object_config.enforce_support_layers > 0) {
+        // Has support. Add the support layers to the minimum / maximum layer height limits.
+        add_layer_height_limit(object_config.support_filament);
+        add_layer_height_limit(object_config.support_interface_filament);
+        params.max_suport_layer_height = params.max_layer_height;
+    }
+    if (params.base_raft_layers > 0) {
+        // Has raft. Raft layers use raft_filament.
+        add_layer_height_limit(object_config.raft_filament);
         params.max_suport_layer_height = params.max_layer_height;
     }
     if (object_extruders.empty()) {
@@ -110,27 +114,26 @@ SlicingParameters SlicingParameters::create_from_config(
     params.min_layer_height = std::min(params.min_layer_height, params.layer_height);
     params.max_layer_height = std::max(params.max_layer_height, params.layer_height);
 
-    params.gap_raft_object    = soluble_interface ? 0 : object_config.raft_contact_distance.value;
-    //BBS
-    params.gap_object_support = object_config.support_bottom_z_distance.value; 
+    params.gap_raft_object = soluble_interface ? 0 : object_config.raft_contact_distance.value;
+    // BBS
+    params.gap_object_support = object_config.support_bottom_z_distance.value;
     params.gap_support_object = object_config.support_top_z_distance.value;
-    if (params.gap_object_support <= 0)
-        params.gap_object_support = params.gap_support_object;
+    if (params.gap_object_support <= 0) params.gap_object_support = params.gap_support_object;
 
     if (!print_config.independent_support_layer_height) {
-        params.gap_raft_object = std::round(params.gap_raft_object / object_config.layer_height + EPSILON) * object_config.layer_height;
+        params.gap_raft_object    = std::round(params.gap_raft_object / object_config.layer_height + EPSILON) * object_config.layer_height;
         params.gap_object_support = std::round(params.gap_object_support / object_config.layer_height + EPSILON) * object_config.layer_height;
         params.gap_support_object = std::round(params.gap_support_object / object_config.layer_height + EPSILON) * object_config.layer_height;
     }
 
     if (params.base_raft_layers > 0) {
-		params.interface_raft_layers = (params.base_raft_layers + 1) / 2;
+        params.interface_raft_layers = (params.base_raft_layers + 1) / 2;
         params.base_raft_layers -= params.interface_raft_layers;
         // Use as large as possible layer height for the intermediate raft layers.
-        params.base_raft_layer_height       = std::max(params.layer_height, 0.75 * support_material_extruder_dmr);
-        params.interface_raft_layer_height  = std::max(params.layer_height, 0.75 * support_material_interface_extruder_dmr);
+        params.base_raft_layer_height       = std::max(params.layer_height, 0.75 * raft_material_extruder_dmr);
+        params.interface_raft_layer_height  = std::max(params.layer_height, 0.75 * raft_material_extruder_dmr);
         params.first_object_layer_bridging  = false;
-        params.contact_raft_layer_height    = std::max(params.layer_height, 0.75 * support_material_interface_extruder_dmr);
+        params.contact_raft_layer_height    = std::max(params.layer_height, 0.75 * raft_material_extruder_dmr);
         params.first_object_layer_height    = params.layer_height;
     }
 

--- a/src/libslic3r/Slicing.hpp
+++ b/src/libslic3r/Slicing.hpp
@@ -37,6 +37,7 @@ struct SlicingParameters
     // Has any raft layers?
     bool        has_raft() const { return raft_layers() > 0; }
     size_t      raft_layers() const { return base_raft_layers + interface_raft_layers; }
+    bool        raft_layer_uses_raft_filament(size_t support_layer_id) const { return support_layer_id < raft_layers(); }
 
     // Is the 1st object layer height fixed, or could it be varied?
     bool        first_object_layer_height_fixed()  const { return ! has_raft() || first_object_layer_bridging; }

--- a/src/libslic3r/Support/SupportCommon.cpp
+++ b/src/libslic3r/Support/SupportCommon.cpp
@@ -458,6 +458,25 @@ SupportGeneratorLayersPtr generate_raft_base(
             if (base_interfaces)
                 base_interfaces->polygons = diff(base_interfaces->polygons, brim);
         }
+
+        if (slicing_params.raft_layers() == 1) {
+            Polygons first_layer_raft;
+            auto     append_layer_polygons = [&first_layer_raft](const SupportGeneratorLayer *layer) {
+                if (layer != nullptr && !layer->polygons.empty()) polygons_append(first_layer_raft, layer->polygons);
+            };
+            append_layer_polygons(contacts);
+            append_layer_polygons(interfaces);
+            append_layer_polygons(base_interfaces);
+            append_layer_polygons(columns_base);
+            if (!first_layer_raft.empty()) {
+                SupportGeneratorLayer &new_layer = layer_storage.allocate(SupporLayerType::sltRaftInterface);
+                raft_layers.push_back(&new_layer);
+                new_layer.print_z  = slicing_params.first_print_layer_height;
+                new_layer.height   = slicing_params.first_print_layer_height;
+                new_layer.bottom_z = 0.;
+                new_layer.polygons = union_(first_layer_raft);
+            }
+        }
     }
 
     return raft_layers;
@@ -1498,18 +1517,15 @@ void generate_support_toolpaths(
     const coordf_t link_max_length_factor = 0.;
 
     // Insert the raft base layers.
-    auto n_raft_layers = std::min<size_t>(support_layers.size(), std::max(0, int(slicing_params.raft_layers()) - 1));
+    auto n_raft_layers = std::min(support_layers.size(), raft_layers.size());
 
-    tbb::parallel_for(tbb::blocked_range<size_t>(0, n_raft_layers),
-        [&support_layers, &raft_layers, &intermediate_layers, &config, &support_params, &slicing_params,
-            &bbox_object, link_max_length_factor]
-            (const tbb::blocked_range<size_t>& range) {
-        for (size_t support_layer_id = range.begin(); support_layer_id < range.end(); ++ support_layer_id)
-        {
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, n_raft_layers), [&support_layers, &raft_layers, &intermediate_layers, &config, &support_params, &slicing_params, &bbox_object,
+                                                                     link_max_length_factor](const tbb::blocked_range<size_t> &range) {
+        for (size_t support_layer_id = range.begin(); support_layer_id < range.end(); ++support_layer_id) {
             assert(support_layer_id < raft_layers.size());
-            SupportLayer               &support_layer = *support_layers[support_layer_id];
+            SupportLayer &support_layer = *support_layers[support_layer_id];
             assert(support_layer.support_fills.entities.empty());
-            SupportGeneratorLayer      &raft_layer    = *raft_layers[support_layer_id];
+            SupportGeneratorLayer &raft_layer = *raft_layers[support_layer_id];
 
             std::unique_ptr<Fill> filler_interface = std::unique_ptr<Fill>(Fill::new_from_type(support_params.raft_interface_fill_pattern));
             std::unique_ptr<Fill> filler_support   = std::unique_ptr<Fill>(Fill::new_from_type(support_params.base_fill_pattern));
@@ -1519,58 +1535,61 @@ void generate_support_toolpaths(
             // Print the tree supports cutting through the raft with the exception of the 1st layer, where a full support layer will be printed below
             // both the raft and the trees.
             // Trim the raft layers with the tree polygons.
-            const Polygons &tree_polygons =
-                support_layer_id > 0 && support_layer_id < intermediate_layers.size() && is_approx(intermediate_layers[support_layer_id]->print_z, support_layer.print_z) ?
-                intermediate_layers[support_layer_id]->polygons : Polygons();
+            const Polygons &tree_polygons = support_layer_id > 0 && support_layer_id < intermediate_layers.size() &&
+                                                    is_approx(intermediate_layers[support_layer_id]->print_z, support_layer.print_z) ?
+                                                intermediate_layers[support_layer_id]->polygons :
+                                                Polygons();
 
             // Print the support base below the support columns, or the support base for the support columns plus the contacts.
             if (support_layer_id > 0) {
-                const Polygons &to_infill_polygons = (support_layer_id < slicing_params.base_raft_layers) ?
-                    raft_layer.polygons :
-                    //FIXME misusing contact_polygons for support columns.
-                    ((raft_layer.contact_polygons == nullptr) ? Polygons() : *raft_layer.contact_polygons);
+                const Polygons &to_infill_polygons = (support_layer_id < slicing_params.base_raft_layers) ? raft_layer.polygons :
+                                                                                                            // FIXME misusing contact_polygons for support columns.
+                                                         ((raft_layer.contact_polygons == nullptr) ? Polygons() : *raft_layer.contact_polygons);
+                const bool      is_raft_base_layer = support_layer_id < slicing_params.base_raft_layers;
+                const Flow     &base_flow          = is_raft_base_layer ? support_params.raft_material_flow : support_params.support_material_flow;
+                const double    base_density       = is_raft_base_layer ? support_params.raft_density : support_params.support_density;
                 // Trees may cut through the raft layers down to a print bed.
-                Flow flow(float(support_params.support_material_flow.width()), float(raft_layer.height), support_params.support_material_flow.nozzle_diameter());
+                Flow flow(float(base_flow.width()), float(raft_layer.height), base_flow.nozzle_diameter());
                 assert(!raft_layer.bridging);
-                if (! to_infill_polygons.empty()) {
-                    Fill *filler = filler_support.get();
-                    filler->angle = support_params.raft_angle_base;
-                    filler->spacing = support_params.support_material_flow.spacing();
-                    filler->link_max_length = coord_t(scale_(filler->spacing * link_max_length_factor / support_params.support_density));
+                if (!to_infill_polygons.empty()) {
+                    Fill *filler            = filler_support.get();
+                    filler->angle           = support_params.raft_angle_base;
+                    filler->spacing         = base_flow.spacing();
+                    filler->link_max_length = coord_t(scale_(filler->spacing * link_max_length_factor / base_density));
                     fill_expolygons_with_sheath_generate_paths(
                         // Destination
                         support_layer.support_fills.entities,
                         // Regions to fill
                         tree_polygons.empty() ? to_infill_polygons : diff(to_infill_polygons, tree_polygons),
                         // Filler and its parameters
-                        filler, float(support_params.support_density),
+                        filler, float(base_density),
                         // Extrusion parameters
-                        ExtrusionRole::erSupportMaterial, flow,
-                        support_params, support_params.with_sheath, false);
+                        ExtrusionRole::erSupportMaterial, flow, support_params, support_params.with_sheath, false);
                 }
-                if (! tree_polygons.empty())
-                    tree_supports_generate_paths(support_layer.support_fills.entities, tree_polygons, flow, support_params);
+                if (!tree_polygons.empty()) tree_supports_generate_paths(support_layer.support_fills.entities, tree_polygons, flow, support_params);
             }
 
-            Fill *filler = filler_interface.get();
-            Flow  flow = support_params.first_layer_flow;
+            Fill *filler  = filler_interface.get();
+            Flow  flow    = support_params.raft_first_layer_flow;
             float density = 0.f;
             if (support_layer_id == 0) {
                 // Base flange.
-                filler->angle = support_params.raft_angle_1st_layer;
-                filler->spacing = support_params.first_layer_flow.spacing();
-                density       = float(config.raft_first_layer_density.value * 0.01);
+                filler->angle   = support_params.raft_angle_1st_layer;
+                filler->spacing = support_params.raft_first_layer_flow.spacing();
+                density         = float(config.raft_first_layer_density.value * 0.01);
             } else if (support_layer_id >= slicing_params.base_raft_layers) {
                 filler->angle = support_params.raft_interface_angle(support_layer.interface_id());
                 // We don't use $base_flow->spacing because we need a constant spacing
                 // value that guarantees that all layers are correctly aligned.
                 filler->spacing = support_params.support_material_flow.spacing();
-                assert(! raft_layer.bridging);
-                flow          = Flow(float(support_params.raft_interface_flow.width()), float(raft_layer.height), support_params.raft_interface_flow.nozzle_diameter());
-                density       = float(support_params.raft_interface_density);
+                assert(!raft_layer.bridging);
+                flow    = Flow(float(support_params.raft_interface_flow.width()), float(raft_layer.height), support_params.raft_interface_flow.nozzle_diameter());
+                density = float(support_params.raft_interface_density);
             } else
                 continue;
-            filler->link_max_length = coord_t(scale_(filler->spacing * link_max_length_factor / density));
+            filler->link_max_length  = coord_t(scale_(filler->spacing * link_max_length_factor / density));
+            const ExtrusionRole role = slicing_params.raft_layer_uses_raft_filament(support_layer_id) ? ExtrusionRole::erSupportMaterial :
+                                                                                                        ExtrusionRole::erSupportMaterialInterface;
             fill_expolygons_with_sheath_generate_paths(
                 // Destination
                 support_layer.support_fills.entities,
@@ -1579,7 +1598,7 @@ void generate_support_toolpaths(
                 // Filler and its parameters
                 filler, density,
                 // Extrusion parameters
-                (support_layer_id < slicing_params.base_raft_layers) ? ExtrusionRole::erSupportMaterial : ExtrusionRole::erSupportMaterialInterface, flow,
+                role, flow,
                 // sheath at first layer
                 support_params, support_layer_id == 0, support_layer_id == 0);
         }
@@ -1690,19 +1709,23 @@ void generate_support_toolpaths(
                 // save the polygons to extrude in topo contact layer into polys to iron
                 if (support_params.enable_support_ironing && !top_contact_layer.empty())
                     layer_cache.polys_to_iron = top_contact_layer.polygons_to_extrude();
-                loop_interface_processor.generate(top_contact_layer, support_params.support_material_interface_flow);
+                const bool  raft_contact_uses_raft_filament = raft_layer && slicing_params.raft_layer_uses_raft_filament(support_layer_id);
+                const bool  raft_contact_is_first_layer     = raft_contact_uses_raft_filament && support_layer_id == 0;
+                const Flow &top_contact_flow                = raft_contact_is_first_layer     ? support_params.raft_first_layer_flow :
+                                                              raft_contact_uses_raft_filament ? support_params.raft_interface_flow :
+                                                                                                support_params.support_material_interface_flow;
+                loop_interface_processor.generate(top_contact_layer, top_contact_flow);
                 // If no loops are allowed, we treat the contact layer exactly as a generic interface layer.
                 // Merge interface_layer into top_contact_layer, as the top_contact_layer is not synchronized and therefore it will be used
                 // to trim other layers.
-                if (top_contact_layer.could_merge(interface_layer) && ! raft_layer)
-                    top_contact_layer.merge(std::move(interface_layer));
+                if (top_contact_layer.could_merge(interface_layer) && !raft_layer) top_contact_layer.merge(std::move(interface_layer));
             }
             if ((config.support_interface_top_layers == 0 || config.support_interface_bottom_layers == 0) && support_params.can_merge_support_regions) {
                 if (base_layer.could_merge(bottom_contact_layer))
                     base_layer.merge(std::move(bottom_contact_layer));
-                else if (base_layer.empty() && ! bottom_contact_layer.empty() && ! bottom_contact_layer.layer->bridging)
+                else if (base_layer.empty() && !bottom_contact_layer.empty() && !bottom_contact_layer.layer->bridging)
                     base_layer = std::move(bottom_contact_layer);
-            } else if (bottom_contact_layer.could_merge(top_contact_layer) && ! raft_layer)
+            } else if (bottom_contact_layer.could_merge(top_contact_layer) && !raft_layer)
                 top_contact_layer.merge(std::move(bottom_contact_layer));
             else if (bottom_contact_layer.could_merge(interface_layer))
                 bottom_contact_layer.merge(std::move(interface_layer));
@@ -1722,25 +1745,35 @@ void generate_support_toolpaths(
             // Top and bottom contacts, interface layers.
             enum class InterfaceLayerType { TopContact, BottomContact, RaftContact, Interface, InterfaceAsBase };
             auto extrude_interface = [&](SupportGeneratorLayerExtruded &layer_ex, InterfaceLayerType interface_layer_type) {
-                if (! layer_ex.empty() && ! layer_ex.polygons_to_extrude().empty()) {
-                    bool interface_as_base = interface_layer_type == InterfaceLayerType::InterfaceAsBase;
-                    bool raft_contact      = interface_layer_type == InterfaceLayerType::RaftContact;
-                    //FIXME Bottom interfaces are extruded with the briding flow. Some bridging layers have its height slightly reduced, therefore
-                    // the bridging flow does not quite apply. Reduce the flow to area of an ellipse? (A = pi * a * b)
-                    auto *filler = raft_contact ? filler_raft_contact : filler_interface.get();
-                    auto interface_flow = layer_ex.layer->bridging ?
-                        Flow::bridging_flow(layer_ex.layer->height, support_params.support_material_bottom_interface_flow.nozzle_diameter()) :
-                        (raft_contact ? &support_params.raft_interface_flow :
-                         interface_as_base ? &support_params.support_material_flow : &support_params.support_material_interface_flow)
-                            ->with_height(float(layer_ex.layer->height));
+                if (!layer_ex.empty() && !layer_ex.polygons_to_extrude().empty()) {
+                    bool interface_as_base               = interface_layer_type == InterfaceLayerType::InterfaceAsBase;
+                    bool raft_contact                    = interface_layer_type == InterfaceLayerType::RaftContact;
+                    bool raft_contact_uses_raft_filament = raft_contact && slicing_params.raft_layer_uses_raft_filament(support_layer_id);
+                    bool raft_contact_is_first_layer     = raft_contact_uses_raft_filament && support_layer_id == 0;
+                    // FIXME Bottom interfaces are extruded with the briding flow. Some bridging layers have its height slightly reduced, therefore
+                    //  the bridging flow does not quite apply. Reduce the flow to area of an ellipse? (A = pi * a * b)
+                    auto       *filler         = raft_contact ? filler_raft_contact : filler_interface.get();
+                    const Flow *default_flow   = raft_contact_is_first_layer ? &support_params.raft_first_layer_flow :
+                                                 raft_contact                ? &support_params.raft_interface_flow :
+                                                 interface_as_base           ? &support_params.support_material_flow :
+                                                                               &support_params.support_material_interface_flow;
+                    auto        interface_flow = layer_ex.layer->bridging ?
+                                                     Flow::bridging_flow(layer_ex.layer->height, support_params.support_material_bottom_interface_flow.nozzle_diameter()) :
+                                                     default_flow->with_height(float(layer_ex.layer->height));
                     // If zero interface layers are configured, use the same angle as for the base layers.
-                    filler->angle  = interface_as_base ? angles[support_layer_id % angles.size()] :
-                                     raft_contact      ? support_params.raft_interface_angle(support_layer.interface_id()) :
-                                                         interface_angles[support_layer_id % interface_angles.size()]; // Use interface angle for the interface layers.
-                    double density = raft_contact ? support_params.raft_interface_density : interface_as_base ? support_params.support_density : support_params.interface_density;
-                    filler->spacing = raft_contact ? support_params.raft_interface_flow.spacing() :
-                        interface_as_base ? support_params.support_material_flow.spacing() : support_params.support_material_interface_flow.spacing();
+                    filler->angle           = interface_as_base ? angles[support_layer_id % angles.size()] :
+                                              raft_contact      ? support_params.raft_interface_angle(support_layer.interface_id()) :
+                                                                  interface_angles[support_layer_id % interface_angles.size()]; // Use interface angle for the interface layers.
+                    double density          = raft_contact_is_first_layer ? config.raft_first_layer_density.value * 0.01 :
+                                              raft_contact                ? support_params.raft_interface_density :
+                                              interface_as_base           ? support_params.support_density :
+                                                                            support_params.interface_density;
+                    filler->spacing         = raft_contact_is_first_layer ? support_params.raft_first_layer_flow.spacing() :
+                                              raft_contact                ? support_params.raft_interface_flow.spacing() :
+                                              interface_as_base           ? support_params.support_material_flow.spacing() :
+                                                                            support_params.support_material_interface_flow.spacing();
                     filler->link_max_length = coord_t(scale_(filler->spacing * link_max_length_factor / density));
+                    ExtrusionRole role = raft_contact_uses_raft_filament ? ExtrusionRole::erSupportMaterial : ExtrusionRole::erSupportMaterialInterface;
                     fill_expolygons_generate_paths(
                         // Destination
                         layer_ex.extrusions,
@@ -1749,7 +1782,7 @@ void generate_support_toolpaths(
                         // Filler and its parameters
                         filler, float(density),
                         // Extrusion parameters
-                        ExtrusionRole::erSupportMaterialInterface, interface_flow);
+                        role, interface_flow);
                 }
             };
             const bool top_interfaces = config.support_interface_top_layers.value != 0;

--- a/src/libslic3r/Support/SupportParameters.hpp
+++ b/src/libslic3r/Support/SupportParameters.hpp
@@ -63,10 +63,12 @@ struct SupportParameters {
                 }
             }
 	    }
-        this->first_layer_flow = Slic3r::support_material_1st_layer_flow(&object, float(slicing_params.first_print_layer_height));
-        this->support_material_flow = Slic3r::support_material_flow(&object, float(slicing_params.layer_height));
+        this->first_layer_flow                = Slic3r::support_material_1st_layer_flow(&object, float(slicing_params.first_print_layer_height));
+        this->raft_first_layer_flow           = Slic3r::raft_material_1st_layer_flow(&object, float(slicing_params.first_print_layer_height));
+        this->support_material_flow           = Slic3r::support_material_flow(&object, float(slicing_params.layer_height));
+        this->raft_material_flow              = Slic3r::raft_material_flow(&object, float(slicing_params.layer_height));
         this->support_material_interface_flow = Slic3r::support_material_interface_flow(&object, float(slicing_params.layer_height));
-    	this->raft_interface_flow                = support_material_interface_flow;
+        this->raft_interface_flow             = this->raft_material_flow;
 
         // Calculate a minimum support layer height as a minimum over all extruders, but not smaller than 10um.
         this->support_layer_height_min = scaled<coord_t>(0.01);
@@ -115,10 +117,12 @@ struct SupportParameters {
         this->interface_angle = Geometry::deg2rad(float(object_config.support_angle.value + 90.));
         this->interface_spacing = object_config.support_interface_spacing.value + this->support_material_interface_flow.spacing();
         this->interface_density = std::min(1., this->support_material_interface_flow.spacing() / this->interface_spacing);
-	    double raft_interface_spacing = object_config.support_interface_spacing.value + this->raft_interface_flow.spacing();
-	    this->raft_interface_density = std::min(1., this->raft_interface_flow.spacing() / raft_interface_spacing);
+        double raft_interface_spacing = object_config.support_interface_spacing.value + this->raft_interface_flow.spacing();
+        this->raft_interface_density = std::min(1., this->raft_interface_flow.spacing() / raft_interface_spacing);
         this->support_spacing = object_config.support_base_pattern_spacing.value + this->support_material_flow.spacing();
         this->support_density = std::min(1., this->support_material_flow.spacing() / this->support_spacing);
+        this->raft_spacing = object_config.support_base_pattern_spacing.value + this->raft_material_flow.spacing();
+        this->raft_density = std::min(1., this->raft_material_flow.spacing() / this->raft_spacing);
         if (object_config.support_interface_top_layers.value == 0) {
             // No interface layers allowed, print everything with the base support pattern.
             this->interface_spacing = this->support_spacing;
@@ -265,7 +269,9 @@ struct SupportParameters {
     size_t                  num_top_interface_layers_only() const { return std::max(0, int(this->num_top_interface_layers) - int(this->num_top_base_interface_layers)); }
     size_t                  num_bottom_interface_layers_only() const { return this->num_bottom_interface_layers - this->num_bottom_base_interface_layers; }
     Flow 		first_layer_flow;
+    Flow 		raft_first_layer_flow;
     Flow 		support_material_flow;
+    Flow 		raft_material_flow;
     Flow 		support_material_interface_flow;
     Flow 		support_material_bottom_interface_flow;
 	// Flow at raft inteface & contact layers.
@@ -289,6 +295,8 @@ struct SupportParameters {
     coordf_t 				raft_interface_density;
     coordf_t 				support_spacing;
     coordf_t 				support_density;
+    coordf_t 				raft_spacing;
+    coordf_t 				raft_density;
     SupportMaterialStyle    support_style = smsDefault;
     SupportMaterialPattern  support_base_pattern = smpDefault;
 

--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -1320,8 +1320,12 @@ void TreeSupport::create_tree_support_layers()
     if (m_raft_layers > 0) { //create raft layers
         coordf_t raft_print_z = 0.f;
         coordf_t raft_slice_z = 0.f;
-        if (m_slicing_params.base_raft_layers > 0)
-        {
+        if (m_slicing_params.raft_layers() == 1) {
+            coordf_t height = m_slicing_params.first_print_layer_height;
+            raft_print_z += height;
+            raft_slice_z = raft_print_z - height / 2;
+            m_object->add_tree_support_layer(layer_id++, height, raft_print_z, raft_slice_z);
+        } else if (m_slicing_params.base_raft_layers > 0) {
             // Do not add the raft contact layer, 1st layer should use first_print_layer_height
             coordf_t height = m_slicing_params.first_print_layer_height;
             raft_print_z += height;
@@ -1336,7 +1340,8 @@ void TreeSupport::create_tree_support_layers()
             m_object->add_tree_support_layer(layer_id++, height, raft_print_z, raft_slice_z);
         }
         // Insert the interface layers.
-        for (size_t i = 0; i < m_slicing_params.interface_raft_layers; i++) {
+        size_t first_interface_layer = m_slicing_params.raft_layers() == 1 ? 1 : 0;
+        for (size_t i = first_interface_layer; i < m_slicing_params.interface_raft_layers; i++) {
             coordf_t height = m_slicing_params.interface_raft_layer_height;
             raft_print_z += height;
             raft_slice_z = raft_print_z - height / 2;
@@ -1588,22 +1593,23 @@ void TreeSupport::generate_toolpaths()
         coordf_t expand_offset = (layer_nr == 0 ? m_object_config->raft_first_layer_expansion.value : 0.);
         auto raft_areas1 = offset_ex(raft_areas, scale_(expand_offset));
 
-        Flow support_flow = Flow(support_extrusion_width, ts_layer->height, nozzle_diameter);
+        const Flow &raft_base_flow = layer_nr == 0 ?
+            m_support_params.raft_first_layer_flow : m_support_params.raft_material_flow;
+        Flow support_flow(float(raft_base_flow.width()), ts_layer->height, raft_base_flow.nozzle_diameter());
         Fill* filler_raft = Fill::new_from_type(ipRectilinear);
         filler_raft->angle = layer_nr == 0 ? PI/2 : 0;
         filler_raft->spacing = support_flow.spacing();
 
         FillParams fill_params;
-        coordf_t raft_density = std::min(1., support_flow.spacing() / (object_config.support_base_pattern_spacing.value + support_flow.spacing()));
+        coordf_t raft_density = m_support_params.raft_density;
         fill_params.density = layer_nr == 0 ? object_config.raft_first_layer_density * 0.01 : raft_density;
         fill_params.dont_adjust = true;
 
         // wall of first layer raft
         if (layer_nr == 0) {
-            Flow flow = Flow(support_extrusion_width, ts_layer->height, nozzle_diameter);
             extrusion_entities_append_loops(ts_layer->support_fills.entities, to_polygons(raft_areas1), erSupportMaterial,
-                        float(flow.mm3_per_mm()), float(flow.width()), float(flow.height()));
-            raft_areas1 = offset_ex(raft_areas1, -flow.scaled_spacing() / 2.);
+                float(support_flow.mm3_per_mm()), float(support_flow.width()), float(support_flow.height()));
+            raft_areas1 = offset_ex(raft_areas1, -support_flow.scaled_spacing() / 2.);
         }
         fill_expolygons_generate_paths(ts_layer->support_fills.entities, raft_areas1,
             filler_raft, fill_params, erSupportMaterial, support_flow);
@@ -1630,17 +1636,20 @@ void TreeSupport::generate_toolpaths()
     {
         SupportLayer *ts_layer = m_object->get_support_layer(layer_nr);
 
-        Flow support_flow(support_extrusion_width, ts_layer->height, nozzle_diameter);
-        Fill* filler_interface = Fill::new_from_type(ipRectilinear);
-        filler_interface->angle = PI / 2;  // interface should be perpendicular to base
-        filler_interface->spacing = support_flow.spacing();
+        const bool raft_layer_uses_raft_filament = m_slicing_params.raft_layer_uses_raft_filament(layer_nr);
+        const bool  raft_layer_is_first_layer     = raft_layer_uses_raft_filament && layer_nr == 0;
+        const Flow &raft_flow                     = raft_layer_is_first_layer ? m_support_params.raft_first_layer_flow : m_support_params.raft_interface_flow;
+        Flow        support_flow(float(raft_flow.width()), ts_layer->height, raft_flow.nozzle_diameter());
+        Fill       *filler_interface = Fill::new_from_type(ipRectilinear);
+        filler_interface->angle      = PI / 2; // interface should be perpendicular to base
+        filler_interface->spacing    = support_flow.spacing();
 
         FillParams fill_params;
-        fill_params.density = interface_density;
+        fill_params.density     = raft_layer_is_first_layer ? object_config.raft_first_layer_density * 0.01 : m_support_params.raft_interface_density;
         fill_params.dont_adjust = true;
 
-        fill_expolygons_generate_paths(ts_layer->support_fills.entities, raft_interface_areas,
-            filler_interface, fill_params, erSupportMaterialInterface, support_flow);
+        fill_expolygons_generate_paths(ts_layer->support_fills.entities, raft_interface_areas, filler_interface, fill_params,
+            raft_layer_uses_raft_filament ? erSupportMaterial : erSupportMaterialInterface, support_flow);
 
         if (m_support_params.enable_support_ironing && !raft_interface_areas.empty()
             && layer_nr == m_slicing_params.base_raft_layers + m_slicing_params.interface_raft_layers-1) {

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -712,7 +712,7 @@ void ConfigManipulation::update_print_fff_config(DynamicPrintConfig* config, con
     }
 
     // BBS
-    static const char* filament_slot_keys[] = { "support_filament", "support_interface_filament",
+    static const char* filament_slot_keys[] = { "support_filament", "raft_filament", "support_interface_filament",
         "wall_filament", "sparse_infill_filament", "solid_infill_filament"};
     for (int i = 0; i < sizeof(filament_slot_keys) / sizeof(filament_slot_keys[0]); i++) {
         std::string key = std::string(filament_slot_keys[i]);
@@ -950,7 +950,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     //toggle_field("support_material_synchronize_layers", have_support_soluble);
 
     toggle_field("inner_wall_line_width", have_perimeters || have_skirt || have_brim);
-    toggle_field("support_filament", have_support_material || have_skirt);
+    toggle_field("support_filament", config->opt_bool("enable_support") || have_skirt);
+    toggle_field("raft_filament", have_raft);
 
     toggle_line("raft_contact_distance", have_raft && !have_support_soluble);
 

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -10607,14 +10607,18 @@ void GLCanvas3D::_load_print_object_toolpaths(const PrintObject& print_object, c
                 if (ctxt.has_support) {
                     const SupportLayer *support_layer = dynamic_cast<const SupportLayer*>(layer);
                     if (support_layer) {
-                        for (const ExtrusionEntity *extrusion_entity : support_layer->support_fills.entities)
+                        const bool raft_layer_uses_raft_filament = support_layer->object()->slicing_parameters().raft_layer_uses_raft_filament(support_layer->id());
+                        for (const ExtrusionEntity *extrusion_entity : support_layer->support_fills.entities) {
+                            const bool is_base_role = extrusion_entity->role() == erSupportMaterial || extrusion_entity->role() == erSupportTransition;
+                            const ConfigOptionInt &filament = raft_layer_uses_raft_filament ?
+                                support_layer->object()->config().raft_filament :
+                                (is_base_role ? support_layer->object()->config().support_filament :
+                                                support_layer->object()->config().support_interface_filament);
                             _3DScene::extrusionentity_to_verts(extrusion_entity, float(layer->print_z), copy,
 	                            volume(idx_layer,
-		                            (extrusion_entity->role() == erSupportMaterial ||
-                                     extrusion_entity->role() == erSupportTransition) ?
-			                            support_layer->object()->config().support_filament :
-			                            support_layer->object()->config().support_interface_filament,
+		                            filament,
 		                            2));
+                        }
                     }
                 }
             }

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -86,7 +86,7 @@ std::map<std::string, std::vector<SimpleSettingData>>  SettingsFactory::OBJECT_C
                     }},
     { L("Support"), {{"brim_type", "",1},{"brim_width", "",2},{"brim_object_gap", "",3},
                     {"enable_support", "",4},{"support_type", "",5},{"support_threshold_angle", "",6},{"support_on_build_plate_only", "",7},
-                    {"support_filament", "",8},{"support_interface_filament", "",9},{"support_expansion", "",24},{"support_style", "",25},
+                    {"support_filament", "",8},{"raft_filament", "",9},{"support_interface_filament", "",10},{"support_expansion", "",24},{"support_style", "",25},
                     {"tree_support_branch_angle", "",10}, {"tree_support_wall_count", "",11},{"tree_support_branch_diameter_angle", "",11},//tree support
                     {"support_top_z_distance", "",13},{"support_bottom_z_distance", "",12},{"support_base_pattern", "",14},{"support_base_pattern_spacing", "",15},
                     {"support_interface_top_layers", "",16},{"support_interface_bottom_layers", "",17},{"support_interface_spacing", "",18},{"support_bottom_interface_spacing", "",19},

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -714,7 +714,7 @@ void ObjectList::update_filament_values_for_items(const size_t filaments_count)
         }
         m_objects_model->SetExtruder(extruder, item);
 
-        static const char *keys[] = {"support_filament", "support_interface_filament"};
+        static const char *keys[] = {"support_filament", "raft_filament", "support_interface_filament"};
         for (auto key : keys)
             if (object->config.has(key) && object->config.opt_int(key) > filaments_count)
                 object->config.erase(key);
@@ -769,7 +769,7 @@ void ObjectList::update_filament_values_for_items_when_delete_filament(const siz
         }
         m_objects_model->SetExtruder(extruder, item);
 
-        static const char *keys[] = {"support_filament", "support_interface_filament",
+        static const char *keys[] = {"support_filament", "raft_filament", "support_interface_filament",
             "sparse_infill_filament", "solid_infill_filament", "wall_filament"};
         for (auto key : keys) {
             if (object->config.has(key)) {

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -333,7 +333,7 @@ void PartPlate::set_spiral_vase_mode(bool spiral_mode, bool as_global)
 				m_config.set_key_value(key, new ConfigOptionBool(true));
 				set_vase_mode_related_object_config();
 			}
-		}
+        }
 		else
 			m_config.set_key_value(key, new ConfigOptionBool(false));
 	}
@@ -386,7 +386,7 @@ void PartPlate::calc_bounding_boxes() const {
 			exclude_bb.max(2) = m_depth;
 			exclude_bb.min(2) = GROUND_Z;
 			m_exclude_bounding_box.emplace_back(exclude_bb);
-		}
+        }
 	}
 }
 
@@ -1130,11 +1130,14 @@ std::vector<int> PartPlate::get_extruders(bool conside_custom_gcode) const
 	const DynamicPrintConfig& glb_config = wxGetApp().preset_bundle->prints.get_edited_preset().config;
 	int glb_support_intf_extr = glb_config.opt_int("support_interface_filament");
 	int glb_support_extr = glb_config.opt_int("support_filament");
+	int glb_raft_extr = glb_config.opt_int("raft_filament");
 	int glb_wall_extr = glb_config.opt_int("wall_filament");
 	int glb_sparse_infill_extr = glb_config.opt_int("sparse_infill_filament");
 	int glb_solid_infill_extr = glb_config.opt_int("solid_infill_filament");
 	bool glb_support = glb_config.opt_bool("enable_support");
-    glb_support |= glb_config.opt_int("raft_layers") > 0;
+	int glb_raft_layers = glb_config.opt_int("raft_layers");
+	bool glb_raft = glb_raft_layers > 0;
+	bool glb_raft_has_interface = glb_raft_layers > 1;
 
 	for (int obj_idx = 0; obj_idx < m_model->objects.size(); obj_idx++) {
 		if (!contain_instance_totally(obj_idx, 0))
@@ -1195,37 +1198,60 @@ std::vector<int> PartPlate::get_extruders(bool conside_custom_gcode) const
         }
 
 		bool obj_support = false;
+		bool obj_raft = false;
+		bool obj_raft_has_interface = false;
 		const ConfigOption* obj_support_opt = mo->config.option("enable_support");
-        const ConfigOption *obj_raft_opt    = mo->config.option("raft_layers");
+		const ConfigOption *obj_raft_opt    = mo->config.option("raft_layers");
 		if (obj_support_opt != nullptr || obj_raft_opt != nullptr) {
-            if (obj_support_opt != nullptr)
+			if (obj_support_opt != nullptr)
 				obj_support = obj_support_opt->getBool();
-            if (obj_raft_opt != nullptr)
-				obj_support |= obj_raft_opt->getInt() > 0;
-        }
-		else
+			if (obj_raft_opt != nullptr) {
+				int obj_raft_layers = obj_raft_opt->getInt();
+				obj_raft = obj_raft_layers > 0;
+				obj_raft_has_interface = obj_raft_layers > 1;
+			}
+		}
+		else {
 			obj_support = glb_support;
+			obj_raft = glb_raft;
+			obj_raft_has_interface = glb_raft_has_interface;
+		}
 
-		if (!obj_support)
+		if (!obj_support && !obj_raft)
 			continue;
 
-		int obj_support_intf_extr = 0;
-		const ConfigOption* support_intf_extr_opt = mo->config.option("support_interface_filament");
-		if (support_intf_extr_opt != nullptr)
-			obj_support_intf_extr = support_intf_extr_opt->getInt();
-		if (obj_support_intf_extr != 0)
-			plate_extruders.push_back(obj_support_intf_extr);
-		else if (glb_support_intf_extr != 0)
-			plate_extruders.push_back(glb_support_intf_extr);
+		if (obj_raft) {
+			int obj_raft_extr = 0;
+			const ConfigOption* raft_extr_opt = mo->config.option("raft_filament");
+			if (raft_extr_opt != nullptr)
+				obj_raft_extr = raft_extr_opt->getInt();
+			if (obj_raft_extr != 0)
+				plate_extruders.push_back(obj_raft_extr);
+			else if (glb_raft_extr != 0)
+				plate_extruders.push_back(glb_raft_extr);
+		}
 
-		int obj_support_extr = 0;
-		const ConfigOption* support_extr_opt = mo->config.option("support_filament");
-		if (support_extr_opt != nullptr)
-			obj_support_extr = support_extr_opt->getInt();
-		if (obj_support_extr != 0)
-			plate_extruders.push_back(obj_support_extr);
-		else if (glb_support_extr != 0)
-			plate_extruders.push_back(glb_support_extr);
+		if (obj_support || obj_raft_has_interface) {
+			int obj_support_intf_extr = 0;
+			const ConfigOption* support_intf_extr_opt = mo->config.option("support_interface_filament");
+			if (support_intf_extr_opt != nullptr)
+				obj_support_intf_extr = support_intf_extr_opt->getInt();
+			if (obj_support_intf_extr != 0)
+				plate_extruders.push_back(obj_support_intf_extr);
+			else if (glb_support_intf_extr != 0)
+				plate_extruders.push_back(glb_support_intf_extr);
+		}
+
+		if (obj_support) {
+			int obj_support_extr = 0;
+			const ConfigOption* support_extr_opt = mo->config.option("support_filament");
+			if (support_extr_opt != nullptr)
+				obj_support_extr = support_extr_opt->getInt();
+			if (obj_support_extr != 0)
+				plate_extruders.push_back(obj_support_extr);
+			else if (glb_support_extr != 0)
+				plate_extruders.push_back(glb_support_extr);
+		}
 	}
 
 	if (conside_custom_gcode) {
@@ -1270,11 +1296,14 @@ std::vector<int> PartPlate::get_extruders_under_cli(bool conside_custom_gcode, D
     // if 3mf file
     int glb_support_intf_extr = full_config.opt_int("support_interface_filament");
     int  glb_support_extr       = full_config.opt_int("support_filament");
+    int  glb_raft_extr          = full_config.opt_int("raft_filament");
     int  glb_wall_extr          = full_config.opt_int("wall_filament");
     int  glb_sparse_infill_extr = full_config.opt_int("sparse_infill_filament");
     int  glb_solid_infill_extr  = full_config.opt_int("solid_infill_filament");
     bool glb_support = full_config.opt_bool("enable_support");
-    glb_support |= full_config.opt_int("raft_layers") > 0;
+    int  glb_raft_layers        = full_config.opt_int("raft_layers");
+    bool glb_raft                = glb_raft_layers > 0;
+    bool glb_raft_has_interface  = glb_raft_layers > 1;
 
     for (std::set<std::pair<int, int>>::iterator it = obj_to_instance_set.begin(); it != obj_to_instance_set.end(); ++it)
     {
@@ -1350,37 +1379,60 @@ std::vector<int> PartPlate::get_extruders_under_cli(bool conside_custom_gcode, D
             }
 
             bool obj_support = false;
+            bool obj_raft = false;
+            bool obj_raft_has_interface = false;
             const ConfigOption* obj_support_opt = object->config.option("enable_support");
             const ConfigOption *obj_raft_opt    = object->config.option("raft_layers");
             if (obj_support_opt != nullptr || obj_raft_opt != nullptr) {
                 if (obj_support_opt != nullptr)
                     obj_support = obj_support_opt->getBool();
-                if (obj_raft_opt != nullptr)
-                    obj_support |= obj_raft_opt->getInt() > 0;
+                if (obj_raft_opt != nullptr) {
+                    int obj_raft_layers = obj_raft_opt->getInt();
+                    obj_raft = obj_raft_layers > 0;
+                    obj_raft_has_interface = obj_raft_layers > 1;
+                }
             }
-            else
+            else {
                 obj_support = glb_support;
+                obj_raft = glb_raft;
+                obj_raft_has_interface = glb_raft_has_interface;
+            }
 
-            if (!obj_support)
+            if (!obj_support && !obj_raft)
                 continue;
 
-            int obj_support_intf_extr = 0;
-            const ConfigOption* support_intf_extr_opt = object->config.option("support_interface_filament");
-            if (support_intf_extr_opt != nullptr)
-                obj_support_intf_extr = support_intf_extr_opt->getInt();
-            if (obj_support_intf_extr != 0)
-                plate_extruders.push_back(obj_support_intf_extr);
-            else if (glb_support_intf_extr != 0)
-                plate_extruders.push_back(glb_support_intf_extr);
+            if (obj_raft) {
+                int obj_raft_extr = 0;
+                const ConfigOption* raft_extr_opt = object->config.option("raft_filament");
+                if (raft_extr_opt != nullptr)
+                    obj_raft_extr = raft_extr_opt->getInt();
+                if (obj_raft_extr != 0)
+                    plate_extruders.push_back(obj_raft_extr);
+                else if (glb_raft_extr != 0)
+                    plate_extruders.push_back(glb_raft_extr);
+            }
 
-            int obj_support_extr = 0;
-            const ConfigOption* support_extr_opt = object->config.option("support_filament");
-            if (support_extr_opt != nullptr)
-                obj_support_extr = support_extr_opt->getInt();
-            if (obj_support_extr != 0)
-                plate_extruders.push_back(obj_support_extr);
-            else if (glb_support_extr != 0)
-                plate_extruders.push_back(glb_support_extr);
+            if (obj_support || obj_raft_has_interface) {
+                int obj_support_intf_extr = 0;
+                const ConfigOption* support_intf_extr_opt = object->config.option("support_interface_filament");
+                if (support_intf_extr_opt != nullptr)
+                    obj_support_intf_extr = support_intf_extr_opt->getInt();
+                if (obj_support_intf_extr != 0)
+                    plate_extruders.push_back(obj_support_intf_extr);
+                else if (glb_support_intf_extr != 0)
+                    plate_extruders.push_back(glb_support_intf_extr);
+            }
+
+            if (obj_support) {
+                int obj_support_extr = 0;
+                const ConfigOption* support_extr_opt = object->config.option("support_filament");
+                if (support_extr_opt != nullptr)
+                    obj_support_extr = support_extr_opt->getInt();
+                if (obj_support_extr != 0)
+                    plate_extruders.push_back(obj_support_extr);
+                else if (glb_support_extr != 0)
+                    plate_extruders.push_back(glb_support_extr);
+            }
         }
     }
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2397,6 +2397,7 @@ Sidebar::Sidebar(Plater *parent)
     : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(42 * wxGetApp().em_unit(), -1)), p(new priv(parent))
 {
     Choice::register_dynamic_list("support_filament", &dynamic_filament_list);
+    Choice::register_dynamic_list("raft_filament", &dynamic_filament_list);
     Choice::register_dynamic_list("support_interface_filament", &dynamic_filament_list);
     Choice::register_dynamic_list("wall_filament", &dynamic_filament_list);
     Choice::register_dynamic_list("sparse_infill_filament", &dynamic_filament_list);
@@ -6876,7 +6877,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
         // These values are necessary to construct SlicingParameters by the Canvas3D variable layer height editor.
         "layer_height", "initial_layer_print_height", "min_layer_height", "max_layer_height",
         "brim_width", "wall_loops", "wall_filament", "sparse_infill_density", "sparse_infill_filament", "top_shell_layers",
-        "enable_support", "support_filament", "support_interface_filament",
+        "enable_support", "support_filament", "raft_filament", "support_interface_filament",
         "support_top_z_distance", "support_bottom_z_distance", "raft_layers",
         "best_object_pos",  "master_extruder_id"
         }))
@@ -21538,7 +21539,7 @@ void Plater::on_filaments_delete(size_t num_filaments, size_t filament_id, int r
     sidebar().obj_list()->update_objects_list_filament_column_when_delete_filament(filament_id, num_filaments, replace_filament_id);
 
     // update global support filament
-    static const char *keys[] = {"support_filament", "support_interface_filament"};
+    static const char *keys[] = {"support_filament", "raft_filament", "support_interface_filament"};
     for (auto key : keys)
         if (p->config->has(key)) {
             if(p->config->opt_int(key) == filament_id + 1)
@@ -21723,7 +21724,7 @@ void Plater::on_config_change(const DynamicPrintConfig &config)
             update_scheduled = true;
         }
         // BBS
-        else if (opt_key == "support_interface_filament" || opt_key == "support_filament" || opt_key == "wall_filament" || opt_key == "sparse_infill_filament" ||
+        else if (opt_key == "support_interface_filament" || opt_key == "support_filament" || opt_key == "raft_filament" || opt_key == "wall_filament" || opt_key == "sparse_infill_filament" ||
                  opt_key == "solid_infill_filament") {
             update_scheduled = true;
         }

--- a/src/slic3r/GUI/PresetHints.cpp
+++ b/src/slic3r/GUI/PresetHints.cpp
@@ -132,6 +132,7 @@ std::string PresetHints::maximum_volumetric_flow_description(const PresetBundle 
     bool infill_extruder_active                     = feature_extruder_active(print_config.opt_int("sparse_infill_filament"));
     bool solid_infill_extruder_active               = feature_extruder_active(print_config.opt_int("solid_infill_filament"));
     bool support_material_extruder_active           = feature_extruder_active(print_config.opt_int("support_filament"));
+    bool raft_material_extruder_active              = feature_extruder_active(print_config.opt_int("raft_filament"));
     bool support_material_interface_extruder_active = feature_extruder_active(print_config.opt_int("support_interface_filament"));
 
     // Current filament values
@@ -178,7 +179,7 @@ std::string PresetHints::maximum_volumetric_flow_description(const PresetBundle 
             if (! bridging)
                 test_flow(frInfill, top_surface_line_width, top_surface_speed, L("top surface"));
         }
-        if (! bridging && support_material_extruder_active)
+        if (! bridging && (support_material_extruder_active || raft_material_extruder_active))
             test_flow(frSupportMaterial, support_line_width, support_speed, L("support"));
         if (support_material_interface_extruder_active)
             test_flow(frSupportMaterialInterface, support_line_width, support_interface_speed, L("support interface"));

--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -39,6 +39,7 @@ void normalize_pasted_object_filament_config(ModelObject &object, size_t filamen
     auto normalize_pasted_filament_overrides = [filaments_count](auto &config) {
         static const char *keys[] = {
             "support_filament",
+            "raft_filament",
             "support_interface_filament",
             "wall_filament",
             "sparse_infill_filament",

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3125,6 +3125,7 @@ void TabPrint::build()
 
         optgroup = page->new_optgroup(L("Raft"), L"param_raft");
         optgroup->append_single_option_line("raft_layers");
+        optgroup->append_single_option_line("raft_filament", "support#support-filament");
         optgroup->append_single_option_line("raft_contact_distance");
 
         optgroup = page->new_optgroup(L("Support filament"), L"param_support_filament");


### PR DESCRIPTION
In the current version of BambuStudio, the filament selection option for raft and support base is combined.

I regularly have trouble getting PVA to adhere to my high temperature plate, but have no problem getting it to adhere to PLA.

This PR splits the raft filament and support base filament into separate selectors, and prints the raft base in the selected filament. This lets the user print a PLA raft and a PVA support base on top of it (although any filament can be chosen for the raft).

Here is what the Support dialog looks like with this change:
<br>
<img width="382" height="223" alt="Screenshot 2026-05-01 at 3 52 50 AM" src="https://github.com/user-attachments/assets/c62ee2ff-dfc6-49e2-9bfc-2d38201c4252" />
<br>
This is an image of a 1-layer raft using the selected PLA filament:
<br>
<img width="1038" height="619" alt="Screenshot 2026-05-01 at 3 53 18 AM" src="https://github.com/user-attachments/assets/0ec866d9-0180-48bd-8fd3-a48a493eed48" />
<br>
This is what the support base looks like on top of the raft:
<br>
<img width="1012" height="611" alt="Screenshot 2026-05-01 at 3 53 39 AM" src="https://github.com/user-attachments/assets/b6b1c656-e14f-4195-acca-048fdb239818" />
