### PR TITLE
FIX: avoid debug asserts in multifilament project loading

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1201,12 +1201,12 @@ StringObjectException Print::check_multi_filament_valid(const Print& print)
         bool enable_mix_printing = !print.need_check_multi_filaments_compatibility();
 
         for (const auto &objectID_t : print.print_object_ids()) {
-            std::set<int> obj_used_extruder_ids;
+            std::set<unsigned int> obj_used_extruder_ids;
             auto                     print_object = print.get_object(objectID_t);// current object
             if (print_object){
                 auto object_extruders_t = print_object->object_extruders(); // object used extruder
-                for (int extruder : object_extruders_t) {
-                    assert(extruder > 0);
+                for (unsigned int extruder : object_extruders_t) {
+                    // object_extruders() returns 0-based filament indexes; 0 is the first filament.
                     obj_used_extruder_ids.insert(extruder);
                 }
             }


### PR DESCRIPTION
## Summary
- Fix a debug-build assertion when loading by-object multifilament projects that use filament slot 1.
- Treat `PrintObject::object_extruders()` values as 0-based filament indexes in by-object multifilament validation.

## Details
`PrintObject::object_extruders()` returns 0-based filament indexes, so `0` is valid and represents the first filament. The by-object branch in `Print::check_multi_filament_valid()` incorrectly asserted that each returned extruder index was greater than zero, causing debug builds to abort while loading valid multifilament `.3mf` projects.

The fix removes that invalid assertion and uses an unsigned local set matching the returned index type.

## Testing
- `git diff --check master...HEAD`

## Notes
- No regression test was added; the existing FFF print test target is currently stale and fails to build on unrelated API drift.