### PR TITLE
Update Traditional Chinese translations

### DIFF
--- a/bbl/i18n/zh_TW/BambuStudio_zh_TW.po
+++ b/bbl/i18n/zh_TW/BambuStudio_zh_TW.po
@@ -4818,7 +4818,7 @@ msgid "Fan Speed: "
 msgstr "風扇速度: "
 
 msgid "AUX Fan Speed: "
-msgstr "輔助風扇速度："
+msgstr "輔助風扇速度： "
 
 msgid "Temperature: "
 msgstr "溫度: "

--- a/bbl/i18n/zh_TW/BambuStudio_zh_TW.po
+++ b/bbl/i18n/zh_TW/BambuStudio_zh_TW.po
@@ -2945,7 +2945,7 @@ msgstr "確定"
 
 #, c-format, boost-format
 msgid "Load %s to "
-msgstr "%s  進料至："
+msgstr "將 %s 進料至 "
 
 msgid "Changing fan speed during printing may affect print quality, please choose carefully."
 msgstr "在列印過程中改變風扇速度可能會影響列印質量，請謹慎選擇。"

--- a/bbl/i18n/zh_TW/BambuStudio_zh_TW.po
+++ b/bbl/i18n/zh_TW/BambuStudio_zh_TW.po
@@ -11147,7 +11147,7 @@ msgid "Heat is building up in small layers faster than it can dissipate. This ma
 msgstr "小層區域熱量累積速度超過散熱速度，可能導致下垂或細節丟失。"
 
 msgid "Ready to print — see suggestions"
-msgstr "準備列印 — — 檢視建議"
+msgstr "準備列印 — 檢視建議"
 
 msgid "Ready to print"
 msgstr "可以列印"

--- a/bbl/i18n/zh_TW/BambuStudio_zh_TW.po
+++ b/bbl/i18n/zh_TW/BambuStudio_zh_TW.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Slic3rPE\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-04-28 17:39+0800\n"
-"PO-Revision-Date: 2025-02-20 20:32+0800\n"
+"PO-Revision-Date: 2026-05-07 16:00+0800\n"
 "Last-Translator: Jiang Yue <maze1024@gmail.com>\n"
 "Language-Team: \n"
 "Language: zh_TW\n"
@@ -34,22 +34,22 @@ msgid "The filament model is unknown. A random filament preset will be used."
 msgstr "未知的材料型號，將使用隨機的材料預設。"
 
 msgid "Main Extruder"
-msgstr ""
+msgstr "主擠出機"
 
 msgid "Main extruder"
-msgstr ""
+msgstr "主擠出機"
 
 msgid "main extruder"
-msgstr ""
+msgstr "主擠出機"
 
 msgid "Auxiliary Extruder"
-msgstr ""
+msgstr "輔助擠出機"
 
 msgid "Auxiliary extruder"
-msgstr ""
+msgstr "輔助擠出機"
 
 msgid "auxiliary extruder"
-msgstr ""
+msgstr "輔助擠出機"
 
 msgid "Left Extruder"
 msgstr "左擠出機"
@@ -70,22 +70,22 @@ msgid "right extruder"
 msgstr "右側擠出機"
 
 msgid "Main Nozzle"
-msgstr ""
+msgstr "主噴嘴"
 
 msgid "Main nozzle"
-msgstr ""
+msgstr "主噴嘴"
 
 msgid "main nozzle"
-msgstr ""
+msgstr "主噴嘴"
 
 msgid "Auxiliary Nozzle"
-msgstr ""
+msgstr "輔助噴嘴"
 
 msgid "Auxiliary nozzle"
-msgstr ""
+msgstr "輔助噴嘴"
 
 msgid "auxiliary nozzle"
-msgstr ""
+msgstr "輔助噴嘴"
 
 msgid "Left Nozzle"
 msgstr "左噴嘴"
@@ -106,49 +106,49 @@ msgid "right nozzle"
 msgstr "右噴嘴"
 
 msgid "Main Hotend"
-msgstr ""
+msgstr "主熱端"
 
 msgid "Main hotend"
-msgstr ""
+msgstr "主熱端"
 
 msgid "main hotend"
-msgstr ""
+msgstr "主熱端"
 
 msgid "Auxiliary Hotend"
-msgstr ""
+msgstr "輔助熱端"
 
 msgid "Auxiliary hotend"
-msgstr ""
+msgstr "輔助熱端"
 
 msgid "auxiliary hotend"
-msgstr ""
+msgstr "輔助熱端"
 
 msgid "Left Hotend"
-msgstr ""
+msgstr "左熱端"
 
 msgid "Left hotend"
-msgstr ""
+msgstr "左熱端"
 
 msgid "left hotend"
-msgstr ""
+msgstr "左熱端"
 
 msgid "Right Hotend"
-msgstr ""
+msgstr "右側熱端"
 
 msgid "Right hotend"
-msgstr ""
+msgstr "右側熱端"
 
 msgid "right hotend"
-msgstr ""
+msgstr "右側熱端"
 
 msgid "main"
-msgstr ""
+msgstr "主"
 
 msgid "auxiliary"
-msgstr ""
+msgstr "輔助"
 
 msgid "Main"
-msgstr ""
+msgstr "主"
 
 msgid "Auxiliary"
 msgstr "附件"
@@ -188,7 +188,7 @@ msgid "Auto dynamic flow calibration is not supported for TPU filament."
 msgstr "TPU線材不支援自動動態流量校準。"
 
 msgid "Bambu TPU 85A is not supported for printing with 0.4 mm Standard or High Flow nozzles."
-msgstr ""
+msgstr "Bambu TPU 85A 不支援使用 0.4 mm 標準噴嘴或大流量噴嘴列印。"
 
 msgid "When using ABS/ASA/PETG HF on the right extruder, it can only be used as support material."
 msgstr "ABS/ASA/PETG HF在右擠出機列印時，僅能作為支撐材料使用。"
@@ -197,7 +197,7 @@ msgid "How to feed TPU filament."
 msgstr "TPU進料方式。"
 
 msgid "How to feed TPU filament on X2D."
-msgstr ""
+msgstr "X2D TPU 進料方式。"
 
 msgid "Using non-bambu filament may have printing quality issues."
 msgstr "使用非拓竹耗材可能會存在列印質量問題。"
@@ -237,7 +237,7 @@ msgstr "%s在使用 0.4，0.6，0.8mm 高流量噴嘴時會有堵頭風險，請
 
 #, c-format, boost-format
 msgid "%s may fail to load or unload due to the Filament Track Switch. If you wish to continue."
-msgstr ""
+msgstr "受耗材變軌器影響，%s 可能無法進料或退料。若您仍要繼續使用。"
 
 #, c-format, boost-format
 msgid "%s is not supported by %s extruder."
@@ -245,19 +245,19 @@ msgstr "%s 不支援在 %s 擠出機列印。"
 
 #, c-format, boost-format
 msgid "There may be critical print quality issues when printing '%s' with %s Bowden extruder. Use with caution!"
-msgstr ""
+msgstr "使用 %s 耗材在 %s 遠端擠出機列印時，可能會出現嚴重列印品質問題。請謹慎使用！"
 
 #, c-format, boost-format
 msgid "There may be critical print quality issues when printing '%s' with %s extruder. Use with caution!"
-msgstr ""
+msgstr "使用 %s 耗材在 %s 擠出機列印時，可能會出現嚴重列印品質問題。請謹慎使用！"
 
 #, c-format, boost-format
 msgid "There may be print quality issues when printing '%s' with %s Bowden extruder. Use with caution."
-msgstr ""
+msgstr "使用 %s 耗材在 %s 遠端擠出機列印時，可能會出現列印品質問題。請謹慎使用。"
 
 #, c-format, boost-format
 msgid "There may be print quality issues when printing '%s' with %s extruder. Use with caution."
-msgstr ""
+msgstr "使用 %s 耗材在 %s 擠出機列印時，可能會出現列印品質問題。請謹慎使用。"
 
 msgid "The toolhead and hotend rack may move. Please keep your hands away from the chamber."
 msgstr "工具頭和熱端架可能會運動，請勿將手伸入機箱。"
@@ -339,35 +339,35 @@ msgstr "空閒"
 
 #, c-format, boost-format
 msgid "%d ℃"
-msgstr ""
+msgstr "%d ℃"
 
 msgid "Filament Inlet A"
-msgstr ""
+msgstr "進料口 A"
 
 msgid "Filament Inlet B"
-msgstr ""
+msgstr "進料口 B"
 
 msgid "Filament Track Switch"
-msgstr ""
+msgstr "耗材變軌器"
 
 msgid "Suggested rearrangement"
-msgstr ""
+msgstr "建議重新擺料"
 
 msgid "How to save time?→"
-msgstr ""
+msgstr "為何可以節省時間？→"
 
 msgid "Filament Status:"
-msgstr ""
+msgstr "耗材狀態："
 
 msgid "Position adjustment required"
-msgstr ""
+msgstr "需要調整位置"
 
 msgctxt "FilamentTrack"
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 msgid "Unused"
-msgstr ""
+msgstr "未使用"
 
 msgid "Refresh"
 msgstr "重新整理"
@@ -377,26 +377,26 @@ msgstr "關閉"
 
 #, c-format, boost-format
 msgid "Based on the diagram below, rearrange the filaments on the printer for optimal results to save approximately %s."
-msgstr ""
+msgstr "請按照圖示調整AMS中耗材的擺放位置，採用最優排布可節省 %s。"
 
 msgid "Summary:"
-msgstr ""
+msgstr "總結："
 
 msgid "AMS on Filament Inlet A"
-msgstr ""
+msgstr "進料口 A 上的 AMS"
 
 msgid "AMS on Filament Inlet B"
-msgstr ""
+msgstr "進料口 B 上的 AMS"
 
 #, c-format, boost-format
 msgid "The No.%d slicing filament is matched to '%s'. Assigning it to '%s' can save printing time."
-msgstr ""
+msgstr "第 %d 個切片耗材已配對到「%s」。將它分配給「%s」可節省列印時間。"
 
 msgid "*Tips: If you have moved the spool position on the machine, please close this page and re‑match the filament."
-msgstr ""
+msgstr "*提示：如果您已移動機器上的料卷位置，請關閉此頁面並重新配對耗材。"
 
 msgid "Summary: This is currently the most suitable position for placement."
-msgstr ""
+msgstr "總結：目前已是最佳擺放。"
 
 msgid "?"
 msgstr "?"
@@ -468,7 +468,7 @@ msgid "Refreshing"
 msgstr "重新整理中"
 
 msgid "Hotend status abnormal, unavailable at present. Please upgrade the firmware and try again."
-msgstr ""
+msgstr "熱端狀態異常，目前不可用。請升級韌體後重試。"
 
 msgid "SN"
 msgstr "序列號"
@@ -478,10 +478,10 @@ msgstr "版本"
 
 #, c-format, boost-format
 msgid "Used Time: %s"
-msgstr ""
+msgstr "使用時間: %s"
 
 msgid "Dynamic nozzles are allocated on the current plate. Picking hotend is not supported."
-msgstr ""
+msgstr "當前盤存在動態分配噴嘴，不支援修改。"
 
 msgid "Hotend Rack"
 msgstr "熱端掛架"
@@ -493,7 +493,7 @@ msgid "Nozzle information needs to be read"
 msgstr "需要讀取噴嘴資訊"
 
 msgid "Note:"
-msgstr ""
+msgstr "注意："
 
 msgid "Supports Painting"
 msgstr "支撐繪製"
@@ -657,7 +657,7 @@ msgid "Toggle Wireframe"
 msgstr "顯示/隱藏線框"
 
 msgid "Shift + L"
-msgstr ""
+msgstr "Shift + L"
 
 msgid "Toggle non-manifold edges"
 msgstr "切換非流行邊"
@@ -1062,7 +1062,7 @@ msgid "Hexagon"
 msgstr "六邊形"
 
 msgid "Middle of geometry"
-msgstr ""
+msgstr "幾何中心"
 
 msgid "Snap global parameters"
 msgstr "按扣全域性引數"
@@ -1111,7 +1111,7 @@ msgid "Snap"
 msgstr "按扣"
 
 msgid "Thread"
-msgstr ""
+msgstr "螺紋"
 
 msgid "Tolerance"
 msgstr "容差"
@@ -1365,7 +1365,7 @@ msgid "Remove selection"
 msgstr "移除繪製"
 
 msgid "Recommend"
-msgstr ""
+msgstr "推薦"
 
 msgid "Old version"
 msgstr "舊版本"
@@ -1430,7 +1430,7 @@ msgid "The current style has been modified but not saved. Do you want to save it
 msgstr "當前樣式已被修改但未儲存。您想要儲存嗎？"
 
 msgid "Save current style"
-msgstr ""
+msgstr "儲存目前樣式"
 
 msgid "Add new style"
 msgstr "新增新樣式"
@@ -1439,7 +1439,7 @@ msgid "Only valid font can be added to style"
 msgstr "有效字型才能新增到樣式中"
 
 msgid "Add style to my list"
-msgstr ""
+msgstr "新增樣式到我的清單"
 
 msgid "Remove style"
 msgstr "刪除樣式"
@@ -1551,7 +1551,7 @@ msgid "Error:Detecting an incorrect mesh id or an unknown error, regenerating te
 msgstr "錯誤：檢測到不正確的網格id或未知錯誤，重新生成文字可能會導致不正確的結果。請拖動文字，儲存，然後重新編輯。"
 
 msgid "Warning:Due to functional upgrade, rotation information cannot be restored. Please drag or modify text,save it and reedit it will ok."
-msgstr ""
+msgstr "警告：由於功能升級，旋轉資訊無法還原。請拖曳或修改文字，儲存後再重新編輯即可。"
 
 msgid "Detected that text did not adhere to mesh surface. Please manually drag yellow square to mesh surface that needs to be adhered."
 msgstr "檢測到文字未貼合在網格表面。請手動將黃色方塊拖動到需要貼合的網格表面。"
@@ -1617,7 +1617,7 @@ msgstr "對齊"
 
 #. TRN - Input label. Be short as possible
 msgid "Text gap"
-msgstr ""
+msgstr "文字間距"
 
 #. TRN - Input label. Be short as possible
 msgid "Line gap"
@@ -1643,7 +1643,7 @@ msgid "There is already a text style with the same name."
 msgstr "已經存在同名的文字樣式。"
 
 msgid "There are spaces or illegal characters present."
-msgstr ""
+msgstr "存在空格或非法字元。"
 
 msgid "Head diameter"
 msgstr "Brim 直徑"
@@ -1860,7 +1860,7 @@ msgid "Change SVG Type"
 msgstr "改變SVG型別"
 
 msgid "Ctrl+"
-msgstr ""
+msgstr "Ctrl+"
 
 msgid "Notice"
 msgstr "通知"
@@ -2082,7 +2082,7 @@ msgid "Ongoing uploads"
 msgstr "正在進行的上傳"
 
 msgid "Install presets failed"
-msgstr ""
+msgstr "安裝預設失敗"
 
 msgid "Select a G-code file:"
 msgstr "選擇一個G-code檔案："
@@ -2245,7 +2245,7 @@ msgid "ksr FDMTest"
 msgstr "歐特克FDM測試"
 
 msgid "SVG"
-msgstr ""
+msgstr "SVG"
 
 msgid "Height range Modifier"
 msgstr "高度範圍修改器"
@@ -2396,10 +2396,10 @@ msgid "Add Primitive"
 msgstr "新增標準模型"
 
 msgid "Show Labels by Layer"
-msgstr ""
+msgstr "按逐層顯示標籤"
 
 msgid "Show Labels by Object"
-msgstr ""
+msgstr "按逐件顯示標籤"
 
 msgid "To objects"
 msgstr "拆分到物件"
@@ -2649,7 +2649,7 @@ msgid "Assembly"
 msgstr "組合體"
 
 msgid "Using variable layer height together with mixed color sublayer may result in poor color mixing quality."
-msgstr ""
+msgstr "同時使用可變層高和混色子層可能導致混色效果不佳。"
 
 msgid "Cut Connectors information"
 msgstr "切割連線件資訊"
@@ -2929,7 +2929,7 @@ msgid "Unload"
 msgstr "退料"
 
 msgid "AMS has not been initialized. Please initialize it before use."
-msgstr ""
+msgstr "AMS尚未初始化。請先初始化後再使用。"
 
 msgid "Choose an AMS slot then press \"Load\" or \"Unload\" button to automatically load or unload filaments."
 msgstr "選擇1個AMS槽位，然後點選進料/退料按鈕以自動進料/退料。"
@@ -2938,14 +2938,14 @@ msgid "Filament type is unknown which is required to perform this action. Please
 msgstr "執行此操作的耗材型別未知。請設定槽位資訊。"
 
 msgid "/"
-msgstr ""
+msgstr "/"
 
 msgid "Confirm"
 msgstr "確定"
 
 #, c-format, boost-format
 msgid "Load %s to "
-msgstr ""
+msgstr "%s  進料至："
 
 msgid "Changing fan speed during printing may affect print quality, please choose carefully."
 msgstr "在列印過程中改變風扇速度可能會影響列印質量，請謹慎選擇。"
@@ -2960,7 +2960,7 @@ msgid "Filter"
 msgstr "過濾"
 
 msgid "Enabling filtration redirects the right fan to filter gas, which may reduce cooling performance."
-msgstr ""
+msgstr "開啟過濾後右側風扇將用於過濾氣體，同時降低冷卻效果。"
 
 msgid "Enabling filtration during printing may reduce cooling and affect print qulity. Please choose carefully"
 msgstr "開啟過濾後會降低冷卻效果，同時可能會影響列印質量，請確認是否開啟"
@@ -2981,7 +2981,7 @@ msgid "Full Cooling"
 msgstr "強冷卻模式"
 
 msgid "Init"
-msgstr ""
+msgstr "初始化"
 
 msgid "Chamber"
 msgstr "腔體"
@@ -3014,7 +3014,7 @@ msgid "Heating mode is suitable for printing %s materials and circulates filters
 msgstr "腔溫保持模式適合列印%s材質，在機箱內部迴圈過濾腔內空氣。"
 
 msgid "Strong Cooling"
-msgstr ""
+msgstr "強冷卻模式"
 
 msgid "Fan"
 msgstr "風扇"
@@ -3033,14 +3033,14 @@ msgstr "左（輔助）"
 
 msgctxt "air_duct"
 msgid "Left(Heating)"
-msgstr ""
+msgstr "左側（加熱）"
 
 msgctxt "air_duct"
 msgid "Chamber"
 msgstr "腔體"
 
 msgid "Hotend"
-msgstr ""
+msgstr "熱端"
 
 msgid "Parts"
 msgstr "部件"
@@ -3052,7 +3052,7 @@ msgid "Nozzle1"
 msgstr "噴嘴1"
 
 msgid "MC Board"
-msgstr ""
+msgstr "MC 主機板"
 
 msgid "Heat"
 msgstr "加熱"
@@ -3079,22 +3079,22 @@ msgid "Purge old filament"
 msgstr "沖刷舊耗材絲"
 
 msgid "Switch"
-msgstr ""
+msgstr "切換"
 
 msgid "hotend"
-msgstr ""
+msgstr "熱端"
 
 msgid "Wait for AMS cooling"
-msgstr ""
+msgstr "等待 AMS 冷卻"
 
 msgid "Switch current filament at Filament Track Switch"
-msgstr ""
+msgstr "在耗材變軌器切換目前耗材"
 
 msgid "Pull back current filament at Filament Track Switch"
-msgstr ""
+msgstr "從耗材變軌器退回目前耗材"
 
 msgid "Switch track at Filament Track Switch"
-msgstr ""
+msgstr "切換耗材變軌器軌道"
 
 msgid "Confirm extruded"
 msgstr "確認擠出"
@@ -3195,7 +3195,7 @@ msgid "Text mesh ie empty."
 msgstr "文字網格為空。"
 
 msgid "Text"
-msgstr ""
+msgstr "文字"
 
 msgid "Error! Unable to create thread!"
 msgstr "發生錯誤，無法建立執行緒！"
@@ -3476,7 +3476,7 @@ msgstr "請輸入有效的數值（K的範圍為%.1f~%.1f，N的範圍為%.1f~%.
 
 #, c-format, boost-format
 msgid "Note: The hotend number on the %s is tied to the holder. When the hotend is moved to a new holder, its number will update automatically."
-msgstr ""
+msgstr "注意：%s上的熱端編號與刀架繫結。當熱端移動至新刀架時，其編號會自動更新。"
 
 msgid ""
 "The nozzle flow is not set. Please set the nozzle flow rate before editing the filament.\n"
@@ -3591,7 +3591,7 @@ msgstr "請從以下耗材中選擇"
 
 #, c-format, boost-format
 msgid "Select filament that installed to the %s"
-msgstr ""
+msgstr "請選擇安裝到%s的耗材絲"
 
 msgid "Left AMS"
 msgstr "左側AMS"
@@ -3692,32 +3692,32 @@ msgstr ""
 "*相同的耗材：相同的品牌、型別和顏色。"
 
 msgid "DRY"
-msgstr ""
+msgstr "乾燥"
 
 msgid "WET"
-msgstr ""
+msgstr "潮濕"
 
 #, c-format, boost-format
 msgid "Please select the filament installed on the %s."
-msgstr ""
+msgstr "請選擇安裝在%s上的耗材絲。"
 
 msgid "Please select the filament."
-msgstr ""
+msgstr "請選擇耗材。"
 
 msgid "Nozzle"
 msgstr "噴嘴"
 
 msgid "To learn about the filaments matching rules."
-msgstr ""
+msgstr "瞭解耗材配對規則。"
 
 msgid "External spools is not supported since Filament Track Switch has been installed. If you want to use external spool, please uninstall it."
-msgstr ""
+msgstr "已安裝耗材變軌器，因此不支援使用外部料卷。若要使用外部料卷，請先解除安裝耗材變軌器。"
 
 msgid "Select Filament && Hotends"
 msgstr "選擇材料預設和噴頭"
 
 msgid "Select Filament"
-msgstr ""
+msgstr "選擇耗材"
 
 msgid "AMS Settings"
 msgstr "AMS 設定"
@@ -3849,7 +3849,7 @@ msgid "Running post-processing scripts"
 msgstr "執行後處理指令碼"
 
 msgid "Updating preview with post-processed G-code"
-msgstr ""
+msgstr "正在使用後處理的 G-code 更新預覽"
 
 msgid "Successfully executed post-processing script"
 msgstr "成功執行後處理指令碼"
@@ -4050,6 +4050,8 @@ msgid ""
 "Interlocking beam width can't be zero when beam interlocking is enabled.\n"
 "Reset to 0.01 mm."
 msgstr ""
+"啟用梁互鎖時，互鎖梁寬度不能為零。\n"
+"重置為 0.01 毫米。"
 
 msgid ""
 "Fuzzy skin [Extrusion] and [Combined] modes require the Arachne wall generator.\n"
@@ -4058,6 +4060,11 @@ msgid ""
 "Yes - Enable Arachne wall generator\n"
 "No - Keep current wall generator and set fuzzy skin to [Displacement] mode"
 msgstr ""
+"絨毛表面的[擠出]和[組合]模式都需要啟用Arachne牆體生成器。\n"
+"\n"
+"是否自動更改這些設定？\n"
+"是 - 啟用Arachne牆體生成器\n"
+"否 - 停用Arachne牆體生成器並將絨毛表面設定為[位移]模式"
 
 msgid ""
 "Prime tower does not work when Adaptive Layer Height or Independent Support Layer Height is on.\n"
@@ -4332,34 +4339,34 @@ msgid "Purifying the chamber air"
 msgstr "腔體空氣淨化中"
 
 msgid "Measuring Rotary Attachment"
-msgstr ""
+msgstr "旋轉軸測量中"
 
 msgid "The toolhead moves above the purge chute"
-msgstr ""
+msgstr "工具頭移動到廢料滑梯上方"
 
 msgid "Cooling down the nozzle"
-msgstr ""
+msgstr "等待噴嘴降溫"
 
 msgid "The toolhead moves to the center of the heatbed"
-msgstr ""
+msgstr "工具頭移動到熱床中心"
 
 msgid "Active Arc Fitting"
-msgstr ""
+msgstr "動態圓弧擬合"
 
 msgid "Hotend Type Detection"
-msgstr ""
+msgstr "熱端型別檢測"
 
 msgid "Build plate alignment detection"
-msgstr ""
+msgstr "列印板偏移檢測"
 
 msgid "Heatbed surface foreign object detection"
-msgstr ""
+msgstr "熱床表面異物檢測"
 
 msgid "Heatbed underside foreign object detection"
-msgstr ""
+msgstr "熱床底部異物檢測"
 
 msgid "Pre-extrusion before printing"
-msgstr ""
+msgstr "列印前預擠出"
 
 msgid "Preparing AMS"
 msgstr "AMS準備中"
@@ -4436,7 +4443,7 @@ msgid "No Reminder Next Time"
 msgstr "下次不再提醒"
 
 msgid "Recheck"
-msgstr ""
+msgstr "重新檢測"
 
 msgid "Ignore. Don't Remind Next Time"
 msgstr "忽略，下次不再提醒"
@@ -4466,10 +4473,10 @@ msgid "Abort"
 msgstr "退出"
 
 msgid "Disable Purification for This Print"
-msgstr ""
+msgstr "關閉本次空氣淨化"
 
 msgid "Don't Remind Me"
-msgstr ""
+msgstr "不再提醒"
 
 msgid "Done"
 msgstr "完成"
@@ -4534,26 +4541,26 @@ msgid "Clear color"
 msgstr "清除顏色"
 
 msgid "L"
-msgstr ""
+msgstr "L"
 
 msgid "R"
-msgstr ""
+msgstr "R"
 
 #, c-format, boost-format
 msgid "%s %s:"
-msgstr ""
+msgstr "%s %s："
 
 msgid "Std"
-msgstr ""
+msgstr "標準"
 
 msgid "HF"
-msgstr ""
+msgstr "HF"
 
 msgid "L:"
-msgstr ""
+msgstr "L："
 
 msgid "R:"
-msgstr ""
+msgstr "R："
 
 msgid "Loading G-codes"
 msgstr "正在載入G-code"
@@ -4577,7 +4584,7 @@ msgid "Fan Speed"
 msgstr "風扇速度"
 
 msgid "AUX Fan Speed"
-msgstr ""
+msgstr "輔助風扇速度"
 
 msgid "Flow"
 msgstr "流量"
@@ -4655,7 +4662,7 @@ msgid "Fan Speed (%)"
 msgstr "風扇速度（%）"
 
 msgid "AUX  Fan Speed (%)"
-msgstr ""
+msgstr "輔助風扇速度 (%)"
 
 msgid "Temperature (°C)"
 msgstr "溫度（℃）"
@@ -4664,7 +4671,7 @@ msgid "Volumetric flow rate (mm³/s)"
 msgstr "體積流量速度（mm³/s）"
 
 msgid "Nozzles"
-msgstr ""
+msgstr "噴嘴"
 
 msgid "Travel"
 msgstr "空駛"
@@ -4811,7 +4818,7 @@ msgid "Fan Speed: "
 msgstr "風扇速度: "
 
 msgid "AUX Fan Speed: "
-msgstr ""
+msgstr "輔助風扇速度："
 
 msgid "Temperature: "
 msgstr "溫度: "
@@ -4838,6 +4845,8 @@ msgid ""
 "An object is placed in the left/right nozzle-only area or exceeds the printable height of the left nozzle.\n"
 "Please ensure the filaments used by this object are not arranged to other nozzles."
 msgstr ""
+"物件被放置在僅限左/右噴嘴的區域，或超出左噴嘴的可列印高度。\n"
+"請確認此物件使用的耗材沒有被安排到其他噴嘴。"
 
 msgid ""
 "An object is laid over the boundary of plate or exceeds the height limit.\n"
@@ -4895,7 +4904,7 @@ msgid "Increase/decrease edit area"
 msgstr "增加/減小編輯區域"
 
 msgid "The variable layer height profile has been reset because some layer heights exceed the allowed range of the current nozzle."
-msgstr ""
+msgstr "由於部分層高超出目前噴嘴允許的範圍，可變層高設定檔已重設。"
 
 msgid "Sequence"
 msgstr "順序"
@@ -4921,18 +4930,22 @@ msgstr "請透過將物體完全移動到盤上或移出盤來解決問題，並
 #, boost-format
 msgid "Assembly's bounding box is too large ( max size >= %1% in ) which may cause rendering issues.\n"
 msgstr ""
+"組件的邊界框過大（最大尺寸 >= %1% 英吋），可能導致渲染問題。\n"
 
 #, boost-format
 msgid "Assembly's bounding box is too large ( max size >= %1% mm ) which may cause rendering issues.\n"
 msgstr ""
+"組件的邊界框過大（最大尺寸 >= %1% mm），可能導致渲染問題。\n"
 
 #, boost-format
 msgid "Following objects are too far ( distance >= %1% in ) from the original of the world coordinate system:\n"
 msgstr ""
+"以下物件距離世界座標系原點太遠（距離 >= %1% 英吋）：\n"
 
 #, boost-format
 msgid "Following objects are too far ( distance >= %1% mm ) from the original of the world coordinate system:\n"
 msgstr ""
+"以下物件距離世界座標系原點太遠（距離 >= %1% mm）：\n"
 
 #, c-format, boost-format
 msgid "The position or size of some models exceeds the %s's printable range."
@@ -5036,36 +5049,36 @@ msgid "Click to Collapse"
 msgstr "點選摺疊"
 
 msgid "Overview"
-msgstr ""
+msgstr "整體檢視"
 
 msgid "Select Plate"
 msgstr "選擇盤"
 
 msgid "Change camera perspective"
-msgstr ""
+msgstr "改變相機視角"
 
 msgid "Go to Wiki"
-msgstr ""
+msgstr "檢視Wiki"
 
 #, boost-format
 msgid "Current assembly rate: %1%%%, volume rate: %2%%%"
-msgstr ""
+msgstr "當前裝配率： %1%%%，體積率： %2%%%"
 
 msgctxt "Camera"
 msgid "Top"
-msgstr ""
+msgstr "頂部"
 
 msgctxt "Camera"
 msgid "Bottom"
-msgstr ""
+msgstr "底部"
 
 msgctxt "Camera"
 msgid "Front"
-msgstr ""
+msgstr "前面"
 
 msgctxt "Camera"
 msgid "Back"
-msgstr ""
+msgstr "背面"
 
 msgctxt "Camera"
 msgid "Isometric"
@@ -5111,19 +5124,19 @@ msgid "Size:"
 msgstr "尺寸："
 
 msgid "Isolated objects detected"
-msgstr ""
+msgstr "已檢測到孤立物件"
 
 msgid "Click to move them closer to the main body."
-msgstr ""
+msgstr "點選即可將它們移近主體。"
 
 msgid "Move closer"
-msgstr ""
+msgstr "移近"
 
 msgid "The main assembly bounding box is too far from the world origin. Reset assembly relationships and move to origin?"
-msgstr ""
+msgstr "主裝配邊界框距離世界原點太遠。是否重置裝配關係並移至原點？"
 
 msgid "Reset to origin"
-msgstr ""
+msgstr "重置到原點"
 
 #, c-format, boost-format
 msgid "Conflicts of gcode paths have been found at layer %d. Please separate the conflicted objects farther (%s <-> %s)."
@@ -5186,7 +5199,7 @@ msgid "Jump to: Prime tower"
 msgstr "轉跳到：擦料塔"
 
 msgid "Enable Clumping Detection"
-msgstr ""
+msgstr "啟用觸碰裹頭檢測"
 
 msgid "Click here to regroup"
 msgstr "點選此處重新分組"
@@ -5315,7 +5328,7 @@ msgid "Project"
 msgstr "專案"
 
 msgid "Filament Manager"
-msgstr ""
+msgstr "耗材管理器"
 
 msgid "Yes"
 msgstr "是"
@@ -5460,7 +5473,7 @@ msgid "Isometric View"
 msgstr "等軸測檢視"
 
 msgid "Fit Camera"
-msgstr ""
+msgstr "適配相機"
 
 msgid "Start a new window"
 msgstr "開啟新視窗"
@@ -5619,10 +5632,10 @@ msgid "Reset to default window layout"
 msgstr "重置為預設視窗布局"
 
 msgid "Show Labels of printing by layer in 3D scene"
-msgstr ""
+msgstr "在3D場景中顯示按逐層列印的標籤"
 
 msgid "Show Labels of printing by object in 3D scene"
-msgstr ""
+msgstr "在 3D 場景中顯示按逐件列印的標籤"
 
 msgid "Show &Overhang"
 msgstr "顯示懸空高亮"
@@ -5688,7 +5701,7 @@ msgid "Max flowrate"
 msgstr "最大流速"
 
 msgid "VFA"
-msgstr ""
+msgstr "VFA"
 
 msgid "More..."
 msgstr "更多..."
@@ -5739,7 +5752,7 @@ msgid "Reload the plater from disk"
 msgstr "從磁碟重新載入平臺"
 
 msgid "Export &Toolpaths as OBJ"
-msgstr ""
+msgstr "將刀具路徑匯出為 OBJ(&T)"
 
 msgid "Open &Studio"
 msgstr "開啟Studio"
@@ -5758,7 +5771,7 @@ msgid "&File"
 msgstr "檔案"
 
 msgid "&View"
-msgstr ""
+msgstr "檢視(&V)"
 
 msgid "&Help"
 msgstr "幫助"
@@ -5911,7 +5924,7 @@ msgid "The live streaming feature relies on Bambu Studio to run,and the stream w
 msgstr "直播功能依賴 Bambu Studio 執行，關閉軟體後直播將在一段時間後結束。"
 
 msgid "Printer Preview"
-msgstr ""
+msgstr "印表機預覽"
 
 msgid "Playing..."
 msgstr "正在播放中……"
@@ -6050,7 +6063,7 @@ msgid "Downloading %d%%..."
 msgstr "下載中 %d%%..."
 
 msgid "Air Management"
-msgstr ""
+msgstr "空調系統"
 
 msgid "Reconnecting the printer, the operation cannot be completed immediately, please try again later."
 msgstr "重新連線印表機，該操作無法立即完成，請稍後再試。"
@@ -6329,10 +6342,10 @@ msgid "Current extruder is busy changing filament"
 msgstr "當前擠出機正在換料"
 
 msgid "\"Load\" or \"Unload\" is not supported for external spool while using Filament Track Switch."
-msgstr ""
+msgstr "使用線材軌道開關時，不支援對外部線軸執行“載入”或“解除安裝”操作。"
 
 msgid "The Filament Track Switch has not been setup. Please setup on printer."
-msgstr ""
+msgstr "耗材變軌器尚未設定。請在印表機上進行設定。"
 
 msgid "Current slot has alread been loaded"
 msgstr "當前槽位已載入"
@@ -6369,7 +6382,7 @@ msgstr "層： %d/%d"
 
 #, c-format, boost-format
 msgid "(%d)"
-msgstr ""
+msgstr "(%d)"
 
 msgid "Auto homing"
 msgstr "自動回中"
@@ -6396,7 +6409,7 @@ msgid "Please select an AMS slot before calibration"
 msgstr "請先選擇一個AMS槽位後進行校準"
 
 msgid "Cannot read filament info: the filament is loaded to the toolhead, please unload the filament and try again."
-msgstr ""
+msgstr "無法讀取耗材絲資訊：耗材絲已經載入到工具頭，請退出耗材絲後再重試。"
 
 msgid "This only takes effect during printing"
 msgstr "僅在列印過程中生效"
@@ -6423,7 +6436,7 @@ msgid "Can't start this without storage."
 msgstr "沒有外部儲存就無法啟動"
 
 msgid "Cannot switch extruder when the printer is not at FDM mode"
-msgstr ""
+msgstr "當前印表機不在3D列印模式，無法切換擠出機"
 
 msgid "Rate the Print Profile"
 msgstr "評價列印配置檔案"
@@ -6549,7 +6562,7 @@ msgid "Number of triangular facets"
 msgstr "三角面數量"
 
 msgid "0"
-msgstr ""
+msgstr "0"
 
 msgid "Don't show again"
 msgstr "不再顯示"
@@ -6593,13 +6606,13 @@ msgid "Collapse"
 msgstr "收起"
 
 msgid "View details"
-msgstr ""
+msgstr "檢視詳細資訊"
 
 msgid "Execute"
 msgstr "執行"
 
 msgid "Do not execute"
-msgstr ""
+msgstr "不執行"
 
 #, c-format, boost-format
 msgid "%s info"
@@ -6725,7 +6738,7 @@ msgstr[0] "%1$d物件有塗色。"
 #, c-format, boost-format
 msgid "%1$d Object has fuzzy skin."
 msgid_plural "%1$d Objects have fuzzy skin."
-msgstr[0] ""
+msgstr[0] "%1$d 個物件有絨毛表面。"
 
 #, c-format, boost-format
 msgid "%1$d object was loaded as a part of cut object."
@@ -6751,7 +6764,7 @@ msgid "Error:"
 msgstr "錯誤："
 
 msgid "Open link for more info"
-msgstr ""
+msgstr "開啟連結獲取更多資訊"
 
 msgid "Warning:"
 msgstr "警告："
@@ -6882,16 +6895,16 @@ msgid "Detects air printing caused by nozzle clogging or filament grinding."
 msgstr "檢測由噴嘴堵塞引起的空打。"
 
 msgid "Foreign Object Detection"
-msgstr ""
+msgstr "異物檢測"
 
 msgid "Checks for any objects on the build plate at the start of a print to avoid collisions."
-msgstr ""
+msgstr "列印開始時，檢測列印板上是否有異物，避免列印過程中出現碰撞。"
 
 msgid "Printed Part Displacement Detection"
-msgstr ""
+msgstr "列印件位移檢測"
 
 msgid "Monitors the printed part during printing and alerts immediately if it shifts or collapses."
-msgstr ""
+msgstr "檢測列印中的列印件狀態，若發生移動或倒塌則立即提醒。"
 
 msgid "Ensures the build plate type and placement are correct."
 msgstr "確保盤的型別及放置位置正確。"
@@ -6969,7 +6982,7 @@ msgid "Please change the nozzle settings on the printer."
 msgstr "如需修改噴嘴資訊，請去印表機操作。"
 
 msgid "View wiki"
-msgstr ""
+msgstr "檢視 Wiki"
 
 msgid "Brass"
 msgstr "黃銅"
@@ -6981,7 +6994,7 @@ msgid "TPU High flow"
 msgstr "TPU高流量"
 
 msgid "No wiki link available for this printer."
-msgstr ""
+msgstr "此印表機沒有可用的 Wiki 連結。"
 
 msgid "Unavailable while heating maintenance function is on."
 msgstr "因其他加熱維護功能已開啟，本功能暫不可用。"
@@ -7044,6 +7057,7 @@ msgstr "%s噴嘴不可以列印%s"
 #, boost-format
 msgid "Mixing %1% with %2% in printing is not recommended.\n"
 msgstr ""
+"不建議在列印中混用 %1% 與 %2%。\n"
 
 msgid " nozzle"
 msgstr "噴嘴"
@@ -7068,14 +7082,14 @@ msgstr "請更換噴嘴型別或重新分配耗材，然後重試。"
 
 #, c-format, boost-format
 msgid "Risk of nozzle clumping detected with the current high-temperature filament (%s). We recommend enabling clumping detection (via probing). This feature uses a quick probing sequence to check for nozzle buildup during the print and utilizes the prime tower to absorb oozing before resuming."
-msgstr ""
+msgstr "當前盤使用高溫材料（%s）列印，存在裹頭風險，建議開啟裹頭觸碰檢測功能（透過探針），列印過程中，該功能會快速檢測噴嘴積料，並啟用小型擦料塔吸收溢料後繼續列印。"
 
 #, c-format, boost-format
 msgid "High-shrinkage filament(s) detected: %s. These materials may cause dimensional deviation after cooling. If your model requires precise fitting or assembly, please refer to the Wiki guide for shrinkage testing."
-msgstr ""
+msgstr "檢測到高收縮率耗材：%s。這些材料在冷卻後可能會導致尺寸偏差。如果您的模型需要精確的配合或裝配，請參閱 Wiki 指南進行收縮率測試。"
 
 msgid "Printing mixed-color filament on a single-extruder printer requires frequent filament changes and flushing, which may significantly increase waste and the risk of nozzle / waste-chute clogging."
-msgstr ""
+msgstr "在單擠出頭印表機上使用混色耗材需要頻繁換料和沖刷，這可能會顯著增加廢料量以及噴嘴/廢料槽堵塞的風險。"
 
 #, boost-format
 msgid " plate %1%: "
@@ -7109,10 +7123,10 @@ msgid "Filament changes"
 msgstr "材料切換"
 
 msgid "Filament switcher detected. All AMS filaments are now available for both extruders. The slicer will auto-assign for optimal printing. "
-msgstr ""
+msgstr "檢測到你已安裝耗材變軌器，所有AMS中材料均能在左右頭自由使用，切片過程中直接按照最優結果左右分配。 "
 
 msgid "A filament switcher is detected but not calibrated and thus currently unavailable. Please calibrate it on the printer and synchronize before use. "
-msgstr ""
+msgstr "檢測到你安裝的耗材變軌器未標定，暫時無法使用，請先去印表機標定後再同步使用。 "
 
 msgid "Learn more"
 msgstr "更多資訊檢視Wiki"
@@ -7145,15 +7159,15 @@ msgid "Sync printer information"
 msgstr "同步印表機資訊"
 
 msgid "Do you want to sync the preset printer with the connected printer, "
-msgstr ""
+msgstr "是否將預設機型同步為當前已連線印表機型， "
 
 #, c-format, boost-format
 msgid "Current connected printer (Device page): %s (%s)"
-msgstr ""
+msgstr "當前連線的印表機（裝置頁面）：%s（%s）"
 
 #, c-format, boost-format
 msgid "Current printer preset (Prepare page): %s"
-msgstr ""
+msgstr "當前印表機預設（準備頁面）：%s"
 
 msgid "Sync now"
 msgstr "立即同步"
@@ -7167,7 +7181,7 @@ msgstr "同步擠出機資訊"
 msgid ""
 "Tips:\n"
 "Curve planning enhancement support detected on your printer. The software has automatically disabled arc fitting to ensure this feature functions correctly."
-msgstr ""
+msgstr "檢測到您的印表機支援曲線規劃增強功能，軟體已為您自動關閉切片圓弧擬合，以確保該功能正常生效。"
 
 msgid "Click to edit preset"
 msgstr "點選編輯配置"
@@ -7206,25 +7220,25 @@ msgid "Set filaments to use"
 msgstr "配置可選擇的材料"
 
 msgid "Add Mixed Filament"
-msgstr ""
+msgstr "新增混色耗材"
 
 msgid "Mixed Filament"
-msgstr ""
+msgstr "混色耗材"
 
 msgid "Add mixed filament"
-msgstr ""
+msgstr "新增混色耗材"
 
 msgid "Remove last mixed filament"
-msgstr ""
+msgstr "刪除最後一個混色耗材"
 
 msgid "Mixed filament has invalid or mismatched components. Please re-edit affected entries."
-msgstr ""
+msgstr "不支援不同型別的耗材進行混色列印，請到軟體左側的耗材列表處理帶！的混色耗材。"
 
 msgid "Search plate, object and part."
 msgstr "搜尋盤、模型和零件。"
 
 msgid "The target mixed filament uses this physical filament as a component. Merging will remove this physical filament and may invalidate the mixed filament. Continue?"
-msgstr ""
+msgstr "該物理耗材已被混色耗材引用。合併後該物理耗材將被移除，可能導致相關混色耗材失效。是否繼續？"
 
 #, c-format, boost-format
 msgid "After completing your operation, %s project will be closed and create a new project."
@@ -7247,10 +7261,10 @@ msgid "Filament type and color information have been synchronized, but slot info
 msgstr "耗材型別和顏色資訊已同步，但不包括槽位資訊。"
 
 msgid "Mixed filament has broken component references"
-msgstr ""
+msgstr "混色耗材引用了不存在的耗材"
 
 msgid "Edit / Delete / Merge"
-msgstr ""
+msgstr "編輯 / 刪除 / 合併"
 
 #, boost-format
 msgid "Do you want to save changes to \"%1%\"?"
@@ -7285,6 +7299,7 @@ msgstr "開啟傳統模式延時攝影可能導致表面瑕疵，建議修改為
 
 msgid "\n"
 msgstr ""
+"\n"
 
 msgid "(Path to modify: 'Process'-'Others'-'Special Mode'-'Timelapsed')"
 msgstr "（修改路徑：“工藝”-”其他“-”特殊模式“-”延時攝影“）"
@@ -7354,10 +7369,10 @@ msgid "The name may show garbage characters!"
 msgstr "此名稱可能顯示亂碼字元！"
 
 msgid "The following shells are not closed and may cause issues:"
-msgstr ""
+msgstr "以下殼層未封閉，可能造成問題："
 
 msgid "Unclosed Shell Warning"
-msgstr ""
+msgstr "未封閉殼層警告"
 
 #, boost-format
 msgid "Failed loading file \"%1%\". An invalid configuration was found."
@@ -7509,14 +7524,14 @@ msgid " (unsupported)"
 msgstr " （不支援）"
 
 msgid "Multicolour simulation currently supports only a single filament material."
-msgstr ""
+msgstr "多色模擬目前僅支援單一耗材材料。"
 
 #, c-format, boost-format
 msgid "You have selected multiple materials: %s"
 msgstr "你已選擇多種材料：%s"
 
 msgid "Note: Unsupported materials will use the selected reference material for simulation."
-msgstr ""
+msgstr "注意：不支援的材料將使用所選參考材料進行模擬。"
 
 msgid "True multi-material support will be added in a future update."
 msgstr "真正的多材料支援將在後續更新中加入。"
@@ -7555,7 +7570,7 @@ msgid "⚠ Unsupported Materials Detected"
 msgstr "⚠ 檢測到不支援的材料"
 
 msgid "Some of your selected materials are not directly supported by Helio:"
-msgstr ""
+msgstr "你選擇的部分材料未被 Helio 直接支援："
 
 msgid "Option 1: Proceed with a reference material"
 msgstr "選項 1：繼續使用參考材料"
@@ -7570,19 +7585,19 @@ msgid "Change your filament selection to use a supported material, then try agai
 msgstr "將耗材更換為受支援的材料，然後重試。"
 
 msgid "Option 3: Refresh supported materials list"
-msgstr ""
+msgstr "選項 3：重新整理支援的材料列表"
 
 msgid "Re-download the supported printers and materials list from Helio, then re-check compatibility."
-msgstr ""
+msgstr "從 Helio 重新下載支援的印表機和材料列表，然後重新檢查相容性。"
 
 msgid "Refresh & Retry"
-msgstr ""
+msgstr "重新整理並重試"
 
 msgid "Syncing Data"
-msgstr ""
+msgstr "同步資料"
 
 msgid "Refreshing printer and material data..."
-msgstr ""
+msgstr "正在重新整理印表機和材料資料……"
 
 msgid "A Helio simulation or optimization task is in progress."
 msgstr "Helio 模擬或最佳化任務正在進行中。"
@@ -7614,9 +7629,11 @@ msgid ""
 "Your printer '%s' is not officially supported by Helio.\n"
 "Select a reference printer:"
 msgstr ""
+"您的印表機 \"%s\" 未被 Helio 官方支援。\n"
+"請選擇一個參考印表機："
 
 msgid "Unsupported Printer"
-msgstr ""
+msgstr "不支援的印表機"
 
 msgid "The current printer preset cannot be sliced using Helio."
 msgstr "當前印表機預設無法使用 Helio 功能。"
@@ -7646,9 +7663,12 @@ msgid ""
 "\n"
 "Please choose an officially supported material. "
 msgstr ""
+"Helio 不支援材料 %s.\n"
+"\n"
+"請選擇官方支援的材料。 "
 
 msgid "View supported materials"
-msgstr ""
+msgstr "檢視支援的材料"
 
 #, c-format, boost-format
 msgid "Helio does not support materials %s"
@@ -7887,6 +7907,8 @@ msgid ""
 "Failed to export the sliced file.\n"
 "Please check whether the file is occupied by another program or if there is enough disk space."
 msgstr ""
+"儲存切片檔案失敗。\n"
+"請檢查其他程式是否打開了該檔案，以及磁碟空間是否足夠。"
 
 msgid "Export sliced file"
 msgstr "匯出切片檔案"
@@ -7927,10 +7949,12 @@ msgid ""
 "Security Warning: This 3MF file contains post-processing script commands that will run automatically during slicing and may pose security risks!\n"
 "Please verify the file source and script contents before continuing."
 msgstr ""
+"安全警告：此 3MF 檔案包含後處理指令碼命令，會在切片期間自動執行，可能造成安全風險！\n"
+"請在繼續前確認檔案來源與指令碼內容。"
 
 #, c-format, boost-format
 msgid "The calibration filament is currently assigned to a different extruder than the one selected in the PA Calibration dialog (%s). This may lead to incorrect calibration results. You can change the assignment in the filament grouping settings."
-msgstr ""
+msgstr "當前校準耗材分配到的擠出機與 PA 校準對話方塊 (%s) 中選擇的擠出機不同。這可能會導致校準結果不準確。您可以在耗材分組設定中更改分配情況。"
 
 msgid "It is not recommended to use PVA filaments with 0.2mm nozzles."
 msgstr "不建議使用0.2毫米噴嘴來列印PVA材料"
@@ -7961,7 +7985,7 @@ msgid "Auto arrange"
 msgstr "自動擺盤"
 
 msgid "Detail view wiki->"
-msgstr ""
+msgstr "詳見wiki->"
 
 #, c-format, boost-format
 msgid "Printer not connected. Please go to the device page to connect %s before syncing."
@@ -7993,6 +8017,8 @@ msgid ""
 "While printing by Object, the extruder may collide skirt.\n"
 "Thus, it is recommended to reset the skirt layer to 1 to avoid that."
 msgstr ""
+"逐件列印時，擠出機可能會與裙邊碰撞。\n"
+"因此，建議將裙邊層數重設為 1 以避免此問題。"
 
 msgid "Prime Tower:"
 msgstr "擦料塔："
@@ -8255,13 +8281,13 @@ msgid "When enabled, the last used color scheme (e.g., Line Type, Speed) will be
 msgstr "啟用後，將在下次啟動Studio後切片自動應用上次切片時使用的顏色方案（如走線型別、速度）。"
 
 msgid "Display overview"
-msgstr ""
+msgstr "顯示整體檢視"
 
 msgid "Show assembly BVH primary bounds"
-msgstr ""
+msgstr "顯示裝配體BVH的主要邊界"
 
 msgid "Display the BVH primary bounding box wireframe in assembly view."
-msgstr ""
+msgstr "在裝配檢視中顯示 BVH 主邊界框線框。"
 
 msgid "Improve rendering performance by lod"
 msgstr "透過lod提高渲染效能"
@@ -8481,16 +8507,16 @@ msgid "trace"
 msgstr "跟蹤"
 
 msgid "Host Setting"
-msgstr ""
+msgstr "主機設定"
 
 msgid "DEV host: api-dev.bambu-lab.com/v1"
-msgstr ""
+msgstr "DEV 主機：api-dev.bambu-lab.com/v1"
 
 msgid "QA  host: api-qa.bambu-lab.com/v1"
-msgstr ""
+msgstr "QA  主機：api-qa.bambu-lab.com/v1"
 
 msgid "PRE host: api-pre.bambu-lab.com/v1"
-msgstr ""
+msgstr "PRE 主機：api-pre.bambu-lab.com/v1"
 
 msgid "Product host"
 msgstr "正式環境"
@@ -8541,7 +8567,7 @@ msgid "Project-inside presets"
 msgstr "專案預設"
 
 msgid "System"
-msgstr ""
+msgstr "系統"
 
 msgid "Unsupported presets"
 msgstr "不支援的預設"
@@ -8568,7 +8594,7 @@ msgid "The selected preset is null!"
 msgstr "選擇的預設為空！"
 
 msgid "End"
-msgstr ""
+msgstr "結束"
 
 msgid "Customize"
 msgstr "自定義"
@@ -8607,7 +8633,7 @@ msgid "First layer filament sequence"
 msgstr "首層耗材列印順序"
 
 msgid "The filament list contains mixed filaments. Custom filament sequence will not take effect."
-msgstr ""
+msgstr "耗材列表包含混合耗材。自定義耗材列印順序將不會生效。"
 
 msgid "Same as Global Bed Type"
 msgstr "跟隨全域性列印板型別"
@@ -8804,7 +8830,7 @@ msgid "To ensure print quality, the drying temperature will be lowered during pr
 msgstr "為保證列印質量，列印過程中會適當降低烘乾溫度。"
 
 msgid "Select timelapse storage location"
-msgstr ""
+msgstr "選擇延時攝影儲存位置"
 
 msgid ""
 "This checks the flatness of heatbed. Leveling makes extruded height uniform.\n"
@@ -8834,7 +8860,7 @@ msgid "Nozzles and filaments of the same type share the same PA profile"
 msgstr "同型別噴嘴與耗材共用PA配置檔案"
 
 msgid "If the filament/nozzle of the main extruder hasn't changed, the last calibration value will be reused. The auxiliary extruder will use the system default value."
-msgstr ""
+msgstr "如果主擠出機的耗材/噴嘴未更換，將複用上次的校準值。輔助擠出機將使用系統預設值。"
 
 msgid "send completed"
 msgstr "傳送完成"
@@ -8844,11 +8870,11 @@ msgstr "錯誤程式碼"
 
 #, c-format, boost-format
 msgid "Recommended filament arrangement saves %s->"
-msgstr ""
+msgstr "如果按照推薦擺料可省 %s->"
 
 #, c-format, boost-format
 msgid "The current firmware supports a maximum of %s materials. You can either reduce the number of materials to %s or fewer on the Preparation Page, or try updating the firmware. If you are still restricted after the update, please wait for subsequent firmware support."
-msgstr ""
+msgstr "目前韌體最多支援 %s 種材料。你可以在準備頁面將材料數量減少到 %s 種或更少，或嘗試更新韌體。如果更新後仍受限制，請等待後續韌體支援。"
 
 #, c-format, boost-format
 msgid "Filament %s does not match the filament in AMS slot %s. Please update the printer firmware to support AMS slot assignment."
@@ -8898,47 +8924,47 @@ msgid "This process determines the dynamic flow values to improve overall print 
 msgstr "此過程確定動態流量校準的最佳係數，從而提升列印質量。"
 
 msgid "Internal"
-msgstr ""
+msgstr "內部"
 
 #, c-format, boost-format
 msgid "%s space less than 10MB. Timelapse may not save properly. You can turn it off or"
-msgstr ""
+msgstr "%s空間不足10MB，延時攝影可能無法正常儲存，可選擇關閉，或者"
 
 msgid "Clean up files"
-msgstr ""
+msgstr "清理檔案"
 
 msgid "Low internal storage. This timelapse will overwrite the oldest video files."
-msgstr ""
+msgstr "機記憶體儲空間不足，本次延時攝影將覆蓋最早的影片檔案。"
 
 msgid "Low external storage. This timelapse will overwrite the oldest video files."
-msgstr ""
+msgstr "外部儲存空間不足，本次延時攝影將覆蓋最早的影片檔案。"
 
 msgid "Insufficient external storage for time-lapse photography. Connect to computer to delete files, or use a larger memory card."
-msgstr ""
+msgstr "外部儲存空間不足，無法進行延時攝影，請將儲存裝置連線至電腦，手動刪除不需要的檔案，或更換大容量記憶體卡。"
 
 msgid "Storage Space Not Enough"
-msgstr ""
+msgstr "儲存空間不足"
 
 msgid "Confirm & Print"
-msgstr ""
+msgstr "好的，發起列印"
 
 msgid "Cancel Timelapse & Print"
-msgstr ""
+msgstr "取消延時攝影，繼續列印"
 
 msgid "Clean Up"
-msgstr ""
+msgstr "清理"
 
 msgid "Auto: If the filament/nozzle of the main extruder hasn't changed, the last calibration value will be reused. The auxiliary extruder will use the system default value."
-msgstr ""
+msgstr "自動：如果主擠出機的耗材/噴嘴未更改，將複用上次的校準值。輔助擠出機將使用系統預設值。"
 
 msgid "On: Before each print starts, calibration will be performed for the main extruder. The auxiliary extruder will use the system default value."
-msgstr ""
+msgstr "開啟：每次列印開始前，主擠出機都會進行校準；輔助擠出機會使用系統預設值。"
 
 msgid "Off: Prioritize using the value from your manual flow calibration."
-msgstr ""
+msgstr "關閉：優先使用手動校準流量的值。"
 
 msgid "Before each print starts, calibration will be performed for the main extruder. The auxiliary extruder will use the system default value."
-msgstr ""
+msgstr "開啟：每次列印開始前，主擠出機都會進行校準；輔助擠出機會使用系統預設值。"
 
 msgid "Preparing print job"
 msgstr "正在準備列印任務"
@@ -9021,13 +9047,13 @@ msgid "The current nozzle diameter (%.1fmm) doesn't match with the slicing file 
 msgstr "當前噴嘴直徑（%.1fmm）和切片檔案（%.1fmm）不一致，無法發起列印。請確保印表機上安裝噴嘴直徑和機器設定中一致，並在切片時設定對應的噴嘴直徑。"
 
 msgid "The Filament Track Switch installed on the printer does not match the slicing file. Please re-slice to avoid print quality issues."
-msgstr ""
+msgstr "印表機上安裝的耗材變軌器與切片檔案不相符。請重新切片以避免列印品質問題。"
 
 msgid "This print requires a Filament Track Switch. Please install it first."
-msgstr ""
+msgstr "此列印件需要耗材變軌器。請先安裝它。"
 
 msgid "The Filament Track Switch has not been setup. Please setup it first."
-msgstr ""
+msgstr "耗材變軌器尚未設定。請先完成設定。"
 
 #, c-format, boost-format
 msgid "Failed to send nozzle auto-mapping request to printer { code: %d }. Please try to refresh the printer information. If it still does not recover, you can try to rebind the printer and check the network connection."
@@ -9056,19 +9082,19 @@ msgid "The hardness of current material (%s) exceeds the hardness of %s (%s). It
 msgstr "當前材料（%s）的硬度高於 %s（%s）的硬度，可能導致噴嘴磨損，進而造成材料洩漏和流動不穩定。使用時請務必小心。"
 
 msgid "Some filaments may switch between extruders during printing. Manual K-value calibration cannot be applied throughout the entire print, which may affect print quality. Enabling Flow Dynamics Calibration is recommended."
-msgstr ""
+msgstr "某些耗材在列印過程中可能會在擠出機之間切換。手動 K 值校準無法套用到整個列印過程，這可能會影響列印品質。建議啟用動態校準。"
 
 msgid "Cool"
-msgstr ""
+msgstr "冷卻"
 
 msgid "Engineering"
-msgstr ""
+msgstr "工程"
 
 msgid "High Temp"
-msgstr ""
+msgstr "高溫"
 
 msgid "Cool(Supertack)"
-msgstr ""
+msgstr "冷卻（Supertack）"
 
 msgid "Click here if you can't connect to the printer"
 msgstr "如果您無法連線印表機，請點選這裡"
@@ -9128,7 +9154,7 @@ msgid "You have selected both external and AMS filaments for an extruder. You wi
 msgstr "您在一個擠出機中同時選擇了使用外掛和AMS耗材，這將需要您在列印過程中手動進行換料，請謹慎選擇。"
 
 msgid "TPU 90A/TPU 85A are too soft. It is recommended to perform manual flow calibration on the 'Calibration' page. If 'Dynamic Flow Calibration' is set to auto/on, the system will use the previous calibration value and skip the flow calibration process."
-msgstr ""
+msgstr "TPU 90A/TPU85A硬度過低，建議在‘校準’頁面進行手動流量校準。若使用自動/開啟動態流量校準，將使用上一次的校準值，跳過流量校準。"
 
 msgid "Set dynamic flow calibration to 'OFF' to enable custom dynamic flow value."
 msgstr "您可以將動態流量校準設定為'關閉'來啟用自定義的動態流量校準值"
@@ -9156,11 +9182,11 @@ msgstr "嘗試連線"
 
 msgctxt "sendtoprint"
 msgid "Cache"
-msgstr ""
+msgstr "快取模型"
 
 msgctxt "sendtoprint"
 msgid "External"
-msgstr ""
+msgstr "外部儲存"
 
 msgid "Upload file timeout, please check if the firmware version supports it."
 msgstr "上傳檔案超時，請檢查韌體版本是否支援。"
@@ -9336,7 +9362,7 @@ msgid "Click to reset all settings to the last saved preset."
 msgstr "點選以將所有設定還原到最後一次儲存的版本。"
 
 msgid "Support interface speed"
-msgstr ""
+msgstr "支撐面"
 
 msgid "Prime tower is required for nozzle changing. There may be flaws on the model without prime tower. Are you sure you want to disable prime tower?"
 msgstr "切換噴嘴需要擦料塔，否則列印件上可能會有瑕疵。您確定要關閉擦料塔嗎？"
@@ -9393,19 +9419,19 @@ msgstr ""
 
 #, c-format, boost-format
 msgid "When using %s to support %s, We recommend the following settings:"
-msgstr ""
+msgstr "當使用%s作為支撐料支撐%s時，我們推薦配置以下引數："
 
 msgid "When using PLA to support TPU, We recommend the following settings:"
-msgstr ""
+msgstr "當使用PLA作為支撐材料支撐TPU時，我們推薦配置以下引數："
 
 msgid "When using soluble material for the support interface, We recommend the following settings:"
-msgstr ""
+msgstr "當使用可溶性材料作為支撐接觸面時，我們推薦配置以下引數："
 
 msgid "When using support material for the support interface, We recommend the following settings:"
-msgstr ""
+msgstr "當使用支撐材料作為支撐接觸面時，我們推薦配置以下引數："
 
 msgid "Do you want to apply these settings?"
-msgstr ""
+msgstr "是否應用這些配置？"
 
 msgid ""
 "Layer height is too small.\n"
@@ -9622,19 +9648,19 @@ msgid "Part cooling fan"
 msgstr "部件冷卻風扇"
 
 msgid "Initial layer fan"
-msgstr ""
+msgstr "起始層風扇"
 
 msgid "Set the part cooling fan speed for the first few layers. Set to 0 to keep the fan off for better bed adhesion"
-msgstr ""
+msgstr "為前幾層設定部件冷卻風扇速度。設定為 0 可保持風扇關閉以獲得更好的列印平臺附著力"
 
 msgid "Linear ramp up to"
-msgstr ""
+msgstr "線性提速至"
 
 msgid "Fan speed will linearly increase from the initial layer speed to the layer-time-based speed over the specified number of layers"
-msgstr ""
+msgstr "風扇轉速將在指定的層數內,從起始層速度線性提升至基於層時間的風扇速度"
 
 msgid "At"
-msgstr ""
+msgstr "在"
 
 msgid "layers"
 msgstr "層"
@@ -9655,19 +9681,19 @@ msgid "Auxiliary part cooling fan"
 msgstr "輔助部件冷卻風扇"
 
 msgid "Set the auxiliary fan speed for the first few layers"
-msgstr ""
+msgstr "為前幾層設定輔助風扇速度"
 
 msgid "Linear ramp up"
-msgstr ""
+msgstr "線性提速"
 
 msgid "Auxiliary fan speed will linearly increase from the initial layer speed to the target speed over the specified number of layers"
-msgstr ""
+msgstr "輔助風扇轉速將在指定的層數內,從起始層速度線性提升至目標速度"
 
 msgid "At layer"
-msgstr ""
+msgstr "在"
 
 msgid "ramp up to"
-msgstr ""
+msgstr "提速至"
 
 msgid "Exhaust fan"
 msgstr "排風扇"
@@ -9807,7 +9833,7 @@ msgstr "設定"
 
 #, c-format, boost-format
 msgid "%s: %s"
-msgstr ""
+msgstr "%s：%s"
 
 msgid "No modifications need to be copied."
 msgstr "沒有需要複製的引數修改。"
@@ -9817,11 +9843,11 @@ msgstr "複製引數"
 
 #, c-format, boost-format
 msgid "Modify paramters of %s"
-msgstr ""
+msgstr "修改%s的引數"
 
 #, c-format, boost-format
 msgid "Do you want to modify the following parameters of the %s to that of the %s?"
-msgstr ""
+msgstr "是否要將%s下的引數修改為與%s相同的值？"
 
 msgid "No available nozzles for current preset"
 msgstr "當前預設無可用噴嘴"
@@ -10116,7 +10142,7 @@ msgid "Reset mapped extruders."
 msgstr "重置匹配的耗材絲。"
 
 msgid "—> "
-msgstr ""
+msgstr "—> "
 
 msgid ""
 "Synchronizing AMS filaments will discard your modified but unsaved filament presets.\n"
@@ -10245,7 +10271,7 @@ msgid "OK"
 msgstr "確認"
 
 msgid "Extruder of Bowden type does not support 0.2 diameter nozzle. We can only proceed with single-head printing."
-msgstr ""
+msgstr "遠端擠出機不支援0.2毫米直徑的噴嘴，因此只能進行單頭列印。"
 
 msgid "Studio would re-calculate your flushing volumes everytime the filaments color changed or filaments changed. You could disable the auto-calculate in Bambu Studio > Preferences"
 msgstr "Studio 將會在每一次更換耗材或顏色時重新計算您的沖刷體積，您可以在Bambu Studio > 偏好設定 中關閉自動計算"
@@ -10290,52 +10316,52 @@ msgstr "引數配置包發生變更"
 
 msgctxt "WebView"
 msgid "Back"
-msgstr ""
+msgstr "返回"
 
 msgid "Open in browser"
-msgstr ""
+msgstr "在瀏覽器中開啟"
 
 msgid "View Source"
-msgstr ""
+msgstr "檢視原始碼"
 
 msgid "View Text"
-msgstr ""
+msgstr "檢視文字"
 
 msgid "Handle Navigation"
-msgstr ""
+msgstr "處理導覽"
 
 msgid "Handle New Windows"
-msgstr ""
+msgstr "處理新視窗"
 
 msgid "Edit Mode"
-msgstr ""
+msgstr "編輯模式"
 
 msgid "Run Script"
-msgstr ""
+msgstr "執行指令碼"
 
 msgid "Add user script"
-msgstr ""
+msgstr "新增使用者指令碼"
 
 msgid "Set custom user agent"
-msgstr ""
+msgstr "設定自訂使用者代理"
 
 msgid "Clear Selection"
-msgstr ""
+msgstr "清除選取"
 
 msgid "Delete Selection"
-msgstr ""
+msgstr "刪除選取"
 
 msgid "Custom Scheme Example"
-msgstr ""
+msgstr "自訂 Scheme 範例"
 
 msgid "Memory File System Example"
-msgstr ""
+msgstr "記憶體檔案系統範例"
 
 msgid "Enable Context Menu"
-msgstr ""
+msgstr "啟用內容選單"
 
 msgid "Enable Dev Tools"
-msgstr ""
+msgstr "啟用開發者工具"
 
 msgid "Toolbar"
 msgstr "工具欄"
@@ -10371,16 +10397,16 @@ msgid "Zoom View"
 msgstr "縮放視角"
 
 msgid "Shift+A"
-msgstr ""
+msgstr "Shift+A"
 
 msgid "Shift+R"
-msgstr ""
+msgstr "Shift+R"
 
 msgid "Auto orientates selected objects or all objects.If there are selected objects, it just orientates the selected ones.Otherwise, it will orientates all objects in the current disk."
 msgstr "自動調整選定零件/所有零件的方向,有選定零件時調整選定零件的朝向,沒有選擇零件時調整當前盤所有零件的朝向"
 
 msgid "Shift+Tab"
-msgstr ""
+msgstr "Shift+Tab"
 
 msgid "Collapse/Expand the sidebar"
 msgstr "收起/展開 側邊欄"
@@ -10449,25 +10475,25 @@ msgid "Camera view - Behind"
 msgstr "攝像機視角 - 後面"
 
 msgid "Camera view - Left"
-msgstr ""
+msgstr "相機視角 - 左側"
 
 msgid "Camera view - Right"
-msgstr ""
+msgstr "相機視角 - 右側"
 
 msgid "Camera view - Isometric"
 msgstr "攝像機視角 - 等軸測"
 
 msgid "Camera view - Fit to scene or selection"
-msgstr ""
+msgstr "相機視角 - 適配場景或選取項"
 
 msgid "Shift+E"
-msgstr ""
+msgstr "Shift+E"
 
 msgid "Select all objects"
 msgstr "選擇所有物件"
 
 msgid "Shift+D"
-msgstr ""
+msgstr "Shift+D"
 
 msgid "Gizmo move"
 msgstr "線框移動"
@@ -10707,10 +10733,10 @@ msgid "Software Service Terms && Conditions"
 msgstr "軟體服務條款與條件"
 
 msgid "^"
-msgstr ""
+msgstr "^"
 
 msgid "Helio Additive"
-msgstr ""
+msgstr "Helio Additive"
 
 msgid "Helio Additive Privacy Agreement"
 msgstr "Helio Additive 隱私協議"
@@ -10784,7 +10810,7 @@ msgid "You're nearly there! Now that Helio is activated, your first optimization
 msgstr "就快完成了！現在 Helio 已啟用，你的首次最佳化只需幾分鐘即可獲得更快、更可靠的列印！（現稱為“Enhance/增強”或“Enhancement/增強效果”）"
 
 msgid "Add an object to the build plate, select a material and printer that Helio supports, then slice."
-msgstr ""
+msgstr "將物件新增到列印板上，選擇 Helio 支援的材料與印表機，然後進行切片。"
 
 msgid "Supported printers and materials"
 msgstr "支援的印表機與材料"
@@ -10824,12 +10850,14 @@ msgid "Terms of Use"
 msgstr "使用條款"
 
 msgid "Experimental: Enable multi-material support"
-msgstr ""
+msgstr "實驗性：啟用多材料支援"
 
 msgid ""
 "When enabled, Helio uses the V3 API with per-slot material mapping for true multi-material prints.\n"
 "When disabled, the original V2 single-material API is used."
 msgstr ""
+"啟用後，Helio 將使用 V3 API ，按每個槽位材料對映來實現真正的多材料列印。\n"
+"停用後，將使用原先的 V2 單材料 API。"
 
 msgid "Activation Successful"
 msgstr "啟用成功"
@@ -10892,7 +10920,7 @@ msgid "Environment Settings"
 msgstr "環境設定"
 
 msgid "Optional. Uses the chamber temperature from Filament settings when available; you can override it here."
-msgstr ""
+msgstr "選填。可用時會使用耗材設定中的腔室溫度；你也可以在此覆寫。"
 
 msgid "Uses the chamber temperature from Filament settings when available; otherwise estimates it from the build plate temperature."
 msgstr "若可用，則使用耗材設定中的腔體溫度；否則根據熱床溫度進行估算。"
@@ -11023,7 +11051,7 @@ msgid "Failed to obtain Helio PAT. The number of issued PATs has reached the upp
 msgstr "獲取 Helio-PAT 失敗。已達到發行 PAT 的上限。請關注 Helio 官方網站的資訊。可點選重新整理重新獲取。"
 
 msgid "HELIO ADDITIVE"
-msgstr ""
+msgstr "HELIO ADDITIVE"
 
 msgid "Print Time Improvement"
 msgstr "列印時間最佳化"
@@ -11119,7 +11147,7 @@ msgid "Heat is building up in small layers faster than it can dissipate. This ma
 msgstr "小層區域熱量累積速度超過散熱速度，可能導致下垂或細節丟失。"
 
 msgid "Ready to print — see suggestions"
-msgstr ""
+msgstr "準備列印 — — 檢視建議"
 
 msgid "Ready to print"
 msgstr "可以列印"
@@ -11289,7 +11317,7 @@ msgid "Maybe parts of the object at these height are too thin, or the object has
 msgstr "部分模型在這些高度可能過薄，或者模型存在面片錯誤"
 
 msgid "Flush volumes matrix do not match to the correct size!"
-msgstr ""
+msgstr "沖刷量矩陣大小不正確！"
 
 msgid "No object can be printed. Maybe too small"
 msgstr "沒有可列印的物件。可能是因為尺寸過小。"
@@ -11357,7 +11385,7 @@ msgid "Overhang wall"
 msgstr "懸空牆"
 
 msgid "Floating vertical shell"
-msgstr ""
+msgstr "懸空垂直殼層"
 
 msgid "Internal solid infill"
 msgstr "內部實心填充"
@@ -11710,7 +11738,7 @@ msgid "Avoid crossing wall"
 msgstr "避免跨越外牆"
 
 msgid "Detour and avoid traveling across wall which may cause blob on surface (when travel length greater than Travel distance threshold)"
-msgstr ""
+msgstr "空駛時繞過外牆以避免在模型外觀面產生半點（對距離大於空駛距離閾值的空駛）"
 
 msgid "Smoothing wall speed along Z(experimental)"
 msgstr "平滑z方向外牆速度（實驗）"
@@ -11812,10 +11840,10 @@ msgid "Force part cooling fan to be at this speed when printing bridge or overha
 msgstr "當列印橋接和超過設定閾值的懸垂時，強制部件冷卻風扇為設定的速度值。強制冷卻能夠使懸垂和橋接獲得更好的列印質量"
 
 msgid "Ironing fan speed"
-msgstr ""
+msgstr "熨燙風扇速度"
 
 msgid "This part cooling fan speed is applied when ironing. Setting this parameter to a lower than regular speed reduces possible nozzle clogging due to the low volumetric flow rate, making the interface smoother. Set to -1 to disable it."
-msgstr ""
+msgstr "此部件冷卻風扇速度應用於熨燙時。將此引數設定為低於常規的速度可減少因低流量比例可能導致的噴嘴堵頭，從而使表面更平滑。設定為 -1 可停用。"
 
 msgid "Pre start fan time"
 msgstr "風扇預啟動時間"
@@ -11902,7 +11930,7 @@ msgstr "mm/s"
 
 #, c-format, boost-format
 msgid "Speed of 100%% overhang wall which has 0 overlap with the lower layer."
-msgstr ""
+msgstr "與下層 0 重疊的 100%% 懸垂牆速度。"
 
 msgid "Slow down by height"
 msgstr "隨高度降速"
@@ -12045,7 +12073,7 @@ msgid "The default acceleration of both normal printing and travel except initia
 msgstr "除首層之外的預設的列印和空駛的加速度"
 
 msgid "The acceleration of travel except initial layer"
-msgstr ""
+msgstr "除首層外的空駛加速度"
 
 msgid "Short travel"
 msgstr "短程移動"
@@ -12067,7 +12095,7 @@ msgid "Initial layer travel"
 msgstr "首層空駛"
 
 msgid "The acceleration of travel of initial layer"
-msgstr ""
+msgstr "首層空駛加速度"
 
 msgid "Default filament profile"
 msgstr "預設耗材配置"
@@ -12100,19 +12128,19 @@ msgid "For the first"
 msgstr "在最初的"
 
 msgid "Set special auxiliary cooling fan for the first certain layers."
-msgstr ""
+msgstr "為起始幾層設定特殊的輔助冷卻風扇速度。"
 
 msgid "Full fan speed at layer"
 msgstr "滿速風扇在"
 
 msgid "Auxiliary fan speed will be ramped up linearly from layer \"For the first\" to maximum at layer \"Full fan speed at layer\". \"Full fan speed at layer\" will be ignored if lower than \"For the first\", in which case the fan will be running at maximum allowed speed at layer \"For the first\" + 1."
-msgstr ""
+msgstr "輔助風扇轉速將從”起始層“風扇線性遞增至層的全風扇轉速。“全風扇速度層”如果低於“初始層”，則將被忽略，此時風扇將在”起始層“ + 1層處以全風扇轉速執行。"
 
 msgid "Set special cooling fan for the first certain layers.The part cooling fan of the first layer used to be closed to get better build plate adhesion and used for auto cooling function"
 msgstr "為前幾層設定專用冷卻風扇。首層的部件冷卻風扇通常關閉，以獲得更好的列印平臺附著力，同時用於自動冷卻功能"
 
 msgid "Part cooling fan speed for the first few layers. Set to 0 to disable the part cooling fan on the initial layers for better bed adhesion"
-msgstr ""
+msgstr "起始層部件冷卻風扇速度。設定為 0 將在起始層停用部件冷卻風扇，以獲得更好的熱床附著力"
 
 msgid "Special auxiliary cooling fan speed, effective only for the first x layers"
 msgstr "該值僅用於輔助散熱風扇，在前x層生效。"
@@ -12220,10 +12248,10 @@ msgid "Density of top surface infill, 100% means a fully solid filled top layer.
 msgstr "頂面的填充密度，100%表示頂層完全實心填充。較低值會產生有紋理的頂層表面，0%時只有頂層牆體被建立。此設定用於美觀或功能性目的，不用於解決諸如過量擠出等問題。"
 
 msgid "Monotonic line travel extend"
-msgstr ""
+msgstr "單調線空駛延伸"
 
 msgid "Enable this option to extend the travel distance between lines, improving the adhesion between the monotonic line infill and the walls.(percent to line width)"
-msgstr ""
+msgstr "啟用此選項可延伸線條之間的連線長度，從而改善單調線條填充與牆之間的結合。（佔線寬的百分比）"
 
 msgid "Bottom surface pattern"
 msgstr "底面圖案"
@@ -12347,13 +12375,13 @@ msgid "Pressure advance(Klipper) AKA Linear advance factor(Marlin). Useless for 
 msgstr "壓力提前補償（Klipper）也稱為線性提前補償因子（Marlin）。對於Bambu印表機無效。"
 
 msgid "Filament notes"
-msgstr ""
+msgstr "耗材備註"
 
 msgid "You can put your notes regarding the filament here."
 msgstr "您可以把材料的註釋放在這裡。"
 
 msgid "Process notes"
-msgstr ""
+msgstr "製程備註"
 
 msgid "You can put your notes regarding the process here."
 msgstr "您可以把工藝的註釋放在這裡。"
@@ -12398,16 +12426,16 @@ msgid "filament mapping mode"
 msgstr "耗材絲匹配模式"
 
 msgid "Auto For Flush"
-msgstr ""
+msgstr "自動用於沖刷"
 
 msgid "Auto For Match"
-msgstr ""
+msgstr "自動用於配對"
 
 msgid "Manual"
 msgstr "手動"
 
 msgid "Nozzle Manual"
-msgstr ""
+msgstr "噴嘴手動"
 
 msgid "Flush temperature"
 msgstr "沖刷溫度"
@@ -12520,10 +12548,10 @@ msgid "Filament category"
 msgstr "材料類別"
 
 msgid "Metal stickiness"
-msgstr ""
+msgstr "對金屬粘性"
 
 msgid "Indicates how strongly the filament tends to stick to the metal nozzle and leave residue. \"None\" means untested or custom filament, behaves the same as Low. Low: e.g. PLA - retraction can be safely skipped in infill areas. Medium: moderate stickiness - use with caution. High: e.g. PETG - retraction should not be skipped to avoid oozing artifacts on outer walls."
-msgstr ""
+msgstr "指示了耗材有多容易粘在金屬噴嘴上並留下殘留物。“無”表示未經測試或自定義耗材，表現與“低”相同。低：例如 PLA - 在填充區域可以安全地跳過回抽。中：粘性適中 - 謹慎使用。高：例如 PETG - 不應跳過回抽，以避免在外壁出現漏料痕跡。"
 
 msgid "Density"
 msgstr "密度"
@@ -12589,46 +12617,46 @@ msgid "Support material is commonly used to print support and support interface"
 msgstr "支撐材料通常用於列印支撐體和支撐接觸面"
 
 msgid "Is mixed filament"
-msgstr ""
+msgstr "是否為混色耗材"
 
 msgid "Whether this filament slot is a mixed filament composed of multiple physical filaments"
-msgstr ""
+msgstr "該耗材槽位是否為由多種物理耗材混合而成的混色耗材"
 
 msgid "Mixed filament components"
-msgstr ""
+msgstr "混色耗材元件"
 
 msgid "Comma-separated 1-based indices of component filaments, e.g. \"1,3\""
-msgstr ""
+msgstr "以逗號分隔、從 1 開始的組成耗材索引，例如 \"1,3\""
 
 msgid "Mixed filament sublayer ratios"
-msgstr ""
+msgstr "混色耗材子層比例"
 
 msgid "Comma-separated ratio values summing to 1.0, e.g. \"0.7,0.3\""
-msgstr ""
+msgstr "以逗號分隔且總和為 1.0 的比例值，例如 \"0.7,0.3\""
 
 msgid "Mixed filament gradient"
-msgstr ""
+msgstr "混色耗材漸變"
 
 msgid "Enable Z-direction gradient mode for mixed filament sub-layers. When enabled, the sub-layer ratios vary linearly across layers."
-msgstr ""
+msgstr "啟用混色耗材子層的 Z 方向漸變模式。啟用後，子層比例隨層數線性變化。"
 
 msgid "Mixed filament gradient range"
-msgstr ""
+msgstr "混色耗材漸變範圍"
 
 msgid "Start and end ratios for the first component in gradient mode. Comma-separated pair, e.g. \"0.10,0.90\" means 10% to 90%."
-msgstr ""
+msgstr "漸層模式下第一個組成耗材的起始與結束比例。以逗號分隔的一組值，例如 \"0.10,0.90\" 表示 10% 到 90%。"
 
 msgid "Filament printable"
 msgstr "主體耗材可列印性"
 
 msgid "The filament is printable in extruder"
-msgstr ""
+msgstr "此耗材可在擠出機中列印"
 
 msgid "Filament-extruder compatibility"
-msgstr ""
+msgstr "耗材-擠出機相容性"
 
 msgid "A single 32-bit int encoding the compatibility level of a filament across all extruders (up to 10). Every 3 bits represent one extruder (bits [3*i, 3*i+2] for extruder i). 0: printable, 1: error, 2: critical warning, 3: warning, 4-7: reserved"
-msgstr ""
+msgstr "以單一 32 位元整數編碼耗材在所有擠出機（最多 10 個）上的相容性等級。每 3 個位元代表一個擠出機（擠出機 i 使用位元 [3*i, 3*i+2]）。0：可列印，1：錯誤，2：嚴重警告，3：警告，4-7：保留"
 
 msgid "Filament change"
 msgstr "耗材絲更換"
@@ -12640,10 +12668,10 @@ msgid "The volume of material required to prime the extruder for a hotend change
 msgstr "換熱端所需的擦料塔上的清理量。"
 
 msgid "Preheat temperature delta"
-msgstr ""
+msgstr "預熱溫度差"
 
 msgid "Temperature delta applied during pre-heating before tool change."
-msgstr ""
+msgstr "工具切換前預熱期間套用的溫度差。"
 
 msgid "Wipe tower cooling"
 msgstr "擦料塔冷卻"
@@ -12676,7 +12704,7 @@ msgid "Interface layer purge length"
 msgstr "擦拭塔沖刷長度"
 
 msgid "Purge length for prime tower interface layer (where different materials meet)."
-msgstr ""
+msgstr "換料塔介面層（不同材料交會處）的沖刷長度。"
 
 msgid "Interface layer print temperature"
 msgstr "接觸層列印溫度"
@@ -12688,10 +12716,10 @@ msgid "°C"
 msgstr "°C"
 
 msgid "Enable tower interface features"
-msgstr ""
+msgstr "啟用料塔接觸層最佳化"
 
 msgid "When enabled, use dedicated temperature, pre-extrusion and purge settings for prime tower interface layers (where different materials meet), to improve multi-material tool change quality."
-msgstr ""
+msgstr "啟用後，對料塔介面層（不同材料交會處）使用專用的溫度、預擠出和沖刷設定，以提高多材料工具更換品質。"
 
 msgid "Softening temperature"
 msgstr "軟化溫度"
@@ -12785,13 +12813,13 @@ msgid "Cross Hatch"
 msgstr "交叉層疊"
 
 msgid "Zig Zag"
-msgstr ""
+msgstr "鋸齒"
 
 msgid "Cross Zag"
-msgstr ""
+msgstr "交叉鋸齒"
 
 msgid "Locked Zag"
-msgstr ""
+msgstr "鎖定鋸齒"
 
 msgid "2D Lattice"
 msgstr "二維晶格"
@@ -12827,16 +12855,16 @@ msgid "Acceleration of initial layer. Using a lower value can improve build plat
 msgstr "首層加速度。使用較低值可以改善和列印板的粘接。"
 
 msgid "Enable accel_to_decel"
-msgstr ""
+msgstr "啟用 accel_to_decel"
 
 msgid "Klipper's max_accel_to_decel will be adjusted automatically"
-msgstr ""
+msgstr "將自動調整 Klipper 的 max_accel_to_decel"
 
 msgid "accel_to_decel"
-msgstr ""
+msgstr "accel_to_decel"
 
 msgid "Klipper's max_accel_to_decel will be adjusted to this percent of acceleration"
-msgstr ""
+msgstr "Klipper 的 max_accel_to_decel 將調整為加速度的此百分比"
 
 msgid "Default jerk"
 msgstr "預設抖動"
@@ -12908,13 +12936,13 @@ msgid "The average distance between the random points introduced on each line se
 msgstr "產生絨毛表面時，插入的隨機點之間的平均距離"
 
 msgid "Apply fuzzy skin to first layer"
-msgstr ""
+msgstr "絨毛表面應用至首層"
 
 msgid "Whether to apply fuzzy skin on the first layer."
-msgstr ""
+msgstr "是否在第一層應用絨毛表面效果。"
 
 msgid "Fuzzy skin noise type"
-msgstr ""
+msgstr "絨毛噪聲型別"
 
 msgid ""
 "Noise type to use for fuzzy skin generation:\n"
@@ -12924,30 +12952,36 @@ msgid ""
 "Ridged Multifractal: Ridged noise with sharp, jagged features. Creates marble-like textures.\n"
 "Voronoi: Divides the surface into voronoi cells, and displaces each one by a random amount. Creates a patchwork texture."
 msgstr ""
+"用於生成絨毛效果的噪聲型別：\n"
+"經典：經典的均勻隨機噪聲。\n"
+"柏林噪聲：能產生更均勻紋理的柏林噪聲。\n"
+"雲狀噪聲：類似柏林噪聲，但更聚集。\n"
+"脊狀多重分形：具有鋒利鋸齒特性的脊狀噪聲，呈現大理石般紋理。\n"
+"維諾圖：將表面劃分為維諾單元，每個單元依隨機量位移，形成拼貼紋理。"
 
 msgid "Classic"
 msgstr "經典"
 
 msgid "Fuzzy skin feature size"
-msgstr ""
+msgstr "絨毛表面特徵尺寸"
 
 msgid "The base size of the coherent noise features, in mm. Higher values will result in larger features."
-msgstr ""
+msgstr "連貫噪聲紋理的基礎尺寸，單位為毫米。數值越大，紋理起伏越大。"
 
 msgid "Fuzzy skin noise octaves"
-msgstr ""
+msgstr "絨毛表面噪聲八度數"
 
 msgid "The number of octaves of coherent noise to use. Higher values increase the detail of the noise, but also increase computation time."
-msgstr ""
+msgstr "所用連貫噪聲的八度層數。數值越大，噪聲細節越豐富，但計算時間也會增加。"
 
 msgid "Fuzzy skin noise persistence"
-msgstr ""
+msgstr "絨毛表面噪聲持續度"
 
 msgid "The decay rate for higher octaves of the coherent noise. Lower values will result in smoother noise."
-msgstr ""
+msgstr "高分八度噪聲的衰減率。數值越小，噪聲越平滑。"
 
 msgid "Fuzzy skin generator mode"
-msgstr ""
+msgstr "絨毛表面生成器模式"
 
 msgid ""
 "Displacement: Pattern is formed by shifting the nozzle sideways from the original path.\n"
@@ -12955,15 +12989,19 @@ msgid ""
 "Combined: Displacement + Extrusion. Similar look to Displacement but fills gaps between perimeters.\n"
 "Note: Extrusion and Combined only work when fuzzy skin thickness is not greater than the printed line width."
 msgstr ""
+"位移：透過讓噴嘴相對原始路徑左右偏移形成紋理。\n"
+"擠出：透過改變擠出量形成紋理（噴嘴走線保持平直）。\n"
+"組合：位移 + 擠出。觀感接近位移模式，且能填補圈與圈之間的間隙。\n"
+"說明：擠出與組合模式僅在「絨毛表面厚度」不大於「實際列印線寬」時生效。"
 
 msgid "Displacement"
-msgstr ""
+msgstr "位移"
 
 msgid "Extrusion"
-msgstr ""
+msgstr "擠出"
 
 msgid "Combined"
-msgstr ""
+msgstr "組合"
 
 msgid "Filter out tiny gaps"
 msgstr "過濾掉微小間隙"
@@ -13005,10 +13043,10 @@ msgid "Enable this to enable the camera on printer to check the quality of first
 msgstr "開啟這個設定將開啟印表機上的攝像頭用於檢查首層列印質量。"
 
 msgid "Print loops in clockwise"
-msgstr ""
+msgstr "順時針列印環形走線"
 
 msgid "Print in clockwise when enabled, or counterclockwise when not enabled, not work for spiral vase mode"
-msgstr ""
+msgstr "啟用時順時針列印，未啟用時逆時針列印，不適用於旋轉花瓶模式"
 
 msgid "Enable clumping detection"
 msgstr "開啟觸碰裹頭檢測"
@@ -13491,7 +13529,7 @@ msgid "Reduce infill retraction"
 msgstr "減小填充回抽"
 
 msgid "Controls whether retraction is skipped when traveling within the infill area. \"Auto\" enables this optimization for filaments with low metal stickiness (e.g. PLA) and disables it for medium/high metal stickiness filaments (e.g. PETG) to avoid oozing artifacts. \"Enabled\" always skips retraction in infill areas regardless of filament type. \"Disabled\" always retracts normally."
-msgstr ""
+msgstr "控制在填充區域內移動時是否跳過回抽。“自動”會為金屬粘性較低的耗材（例如 PLA）啟用此最佳化，併為金屬粘性中/高的耗材（例如 PETG）停用此最佳化，以避免漏料。“啟用”始終在填充區域跳過回抽，無論耗材型別。“停用”始終正常回抽。"
 
 msgid "Filename format"
 msgstr "檔名格式"
@@ -14211,10 +14249,10 @@ msgid "Describe how long the nozzle will move along the last path when retractin
 msgstr "表示回抽時擦拭的移動距離。"
 
 msgid "Mixed color sublayer"
-msgstr ""
+msgstr "混色子層"
 
 msgid "Enable mixed color sublayer splitting. When enabled, layers containing mixed color filaments will be split into sub-layers to achieve color mixing effects."
-msgstr ""
+msgstr "啟用混色分層。啟用後，使用混色耗材的層將被拆分為子層，以實現混色效果。"
 
 msgid "The wiping tower can be used to clean up the residue on the nozzle and stabilize the chamber pressure inside the nozzle, in order to avoid appearance defects when printing objects."
 msgstr "擦料塔可以用來清理噴嘴上的殘留料和讓噴嘴內部的腔壓達到穩定狀態，以避免列印物體時出現外觀瑕疵。"
@@ -14244,76 +14282,76 @@ msgid "Scarf seam will be applied on circles for better dimensional accuracy."
 msgstr "應用斜拼接縫以獲得更準確的尺寸"
 
 msgid "Circle Compensation Speed"
-msgstr ""
+msgstr "圓形補償速度"
 
 msgid "circle_compensation_speed"
-msgstr ""
+msgstr "circle_compensation_speed"
 
 msgid "Counter Coef 1"
-msgstr ""
+msgstr "輪廓係數 1"
 
 msgid "counter_coef_1"
-msgstr ""
+msgstr "counter_coef_1"
 
 msgid "Contour Coef 2"
-msgstr ""
+msgstr "輪廓係數 2"
 
 msgid "counter_coef_2"
-msgstr ""
+msgstr "counter_coef_2"
 
 msgid "Contour Coef 3"
-msgstr ""
+msgstr "輪廓係數 3"
 
 msgid "counter_coef_3"
-msgstr ""
+msgstr "counter_coef_3"
 
 msgid "Hole Coef 1"
-msgstr ""
+msgstr "孔洞係數 1"
 
 msgid "hole_coef_1"
-msgstr ""
+msgstr "hole_coef_1"
 
 msgid "Hole Coef 2"
-msgstr ""
+msgstr "孔洞係數 2"
 
 msgid "hole_coef_2"
-msgstr ""
+msgstr "hole_coef_2"
 
 msgid "Hole Coef 3"
-msgstr ""
+msgstr "孔洞係數 3"
 
 msgid "hole_coef_3"
-msgstr ""
+msgstr "hole_coef_3"
 
 msgid "Contour limit min"
-msgstr ""
+msgstr "輪廓下限"
 
 msgid "counter_limit_min"
-msgstr ""
+msgstr "counter_limit_min"
 
 msgid "Contour limit max"
-msgstr ""
+msgstr "輪廓上限"
 
 msgid "counter_limit_max"
-msgstr ""
+msgstr "counter_limit_max"
 
 msgid "Hole limit min"
-msgstr ""
+msgstr "孔洞下限"
 
 msgid "hole_limit_min"
-msgstr ""
+msgstr "hole_limit_min"
 
 msgid "Hole limit max"
-msgstr ""
+msgstr "孔洞上限"
 
 msgid "hole_limit_max"
-msgstr ""
+msgstr "hole_limit_max"
 
 msgid "Diameter limit"
 msgstr "直徑限制"
 
 msgid "diameter_limit"
-msgstr ""
+msgstr "diameter_limit"
 
 msgid "Purging volumes"
 msgstr "沖刷體積"
@@ -14442,10 +14480,10 @@ msgid "invalid value "
 msgstr "無效值"
 
 msgid "--use-firmware-retraction is only supported by Marlin, Klipper, Smoothie, RepRapFirmware, Repetier and Machinekit firmware"
-msgstr ""
+msgstr "--use-firmware-retraction 僅支援 Marlin、Klipper、Smoothie、RepRapFirmware、Repetier 和 Machinekit 韌體"
 
 msgid "--use-firmware-retraction is not compatible with --wipe"
-msgstr ""
+msgstr "--use-firmware-retraction 與 --wipe 不相容"
 
 #, c-format, boost-format
 msgid " doesn't work at 100%% density "
@@ -14536,7 +14574,7 @@ msgid "Loading of a model file failed."
 msgstr "載入模型檔案失敗。"
 
 msgid "Meshing of a model file failed or no valid shape."
-msgstr ""
+msgstr "模型檔案網格化失敗，或沒有有效形狀。"
 
 msgid "The supplied file couldn't be read because it's empty"
 msgstr "無法讀取提供的檔案，因為該檔案為空。"
@@ -14932,7 +14970,7 @@ msgstr ""
 "- 不同耗材品牌和系列（品牌 = Bambu，系列 = Basic，啞光）\n"
 
 msgid "(Aux) does not support automatic flow calibration."
-msgstr ""
+msgstr "（輔助）不支援自動流量校準。"
 
 msgid "- Note: The hotend's number is tied to the holder. When the hotend is moved to a new holder, its number will update automatically.\n"
 msgstr "- 注意：熱端編號與刀架繫結。當熱端移動到新到架時，其編號將自動更新。\n"
@@ -14998,7 +15036,7 @@ msgstr "正在連線印表機"
 
 #, c-format, boost-format
 msgid "Calibration only supports cases where the %s and %s diameters are identical."
-msgstr ""
+msgstr "只支援%s/%s噴嘴直徑相同的情況下發起校準。"
 
 msgid "From k Value"
 msgstr "起始k值"
@@ -15074,7 +15112,7 @@ msgid "PA Calibration"
 msgstr "PA標定"
 
 msgid "Extruder type"
-msgstr ""
+msgstr "擠出機型別"
 
 msgid "PA Tower"
 msgstr "PA塔"
@@ -15513,7 +15551,7 @@ msgid "Create Based on Current Printer"
 msgstr "基於當前印表機建立"
 
 msgid "wiki"
-msgstr ""
+msgstr "wiki"
 
 msgid "Import Preset"
 msgstr "匯入預設"
@@ -15887,11 +15925,11 @@ msgid "TPU 90A/TPU 85A is too soft and does not support automatic Flow Dynamics 
 msgstr "TPU 90A/TPU 85A硬度過低，不支援自動流量校準。"
 
 msgid "The number of printer extruders and the printer selected for calibration does not match."
-msgstr ""
+msgstr "印表機擠出機數量與選擇用於校準的印表機不符。"
 
 #, c-format, boost-format
 msgid "The type of %sextruder is bowden which does not support automatic Flow Dynamics calibration."
-msgstr ""
+msgstr "%s擠出機是遠端擠出機，不支援自動動態流量校準。"
 
 #, c-format, boost-format
 msgid "The nozzle diameter of %sextruder is 0.2mm which does not support automatic Flow Dynamics calibration."
@@ -15942,7 +15980,7 @@ msgid "HTTPS CA file is optional. It is only needed if you use HTTPS with a self
 msgstr "HTTPS CA檔案是可選的。只有在使用自簽名證書進行HTTPS連線時才需要。"
 
 msgid "Certificate files (*.crt, *.pem)|*.crt;*.pem|All files|*.*"
-msgstr ""
+msgstr "憑證檔案 (*.crt, *.pem)|*.crt;*.pem|所有檔案|*.*"
 
 msgid "Open CA certificate file"
 msgstr "開啟CA證書檔案"
@@ -16223,7 +16261,7 @@ msgid "Failed to parse response"
 msgstr "解析響應失敗"
 
 msgid "Failed to create GCodeV3"
-msgstr ""
+msgstr "建立 GCodeV3 失敗"
 
 msgid "Helio simulation task failed"
 msgstr "Helio模擬任務失敗"
@@ -16423,7 +16461,7 @@ msgid "Management user presets"
 msgstr "管理使用者預設"
 
 msgid "No content"
-msgstr ""
+msgstr "沒有內容"
 
 #, c-format, boost-format
 msgid "Printer presets (%d/%d)"
@@ -16442,20 +16480,20 @@ msgid "%u Selected"
 msgstr "已選擇 %u項"
 
 msgid "Please select the preset to be deleted"
-msgstr ""
+msgstr "請選擇要刪除的預設"
 
 #, c-format, boost-format
 msgid "%d %s Preset will be deleted."
 msgstr "%d個%s預設將被刪除。"
 
 msgid "Enable smart filament assign: Assign one filament to multiple nozzles to maximize savings"
-msgstr ""
+msgstr "啟用智慧耗材分配：一個耗材可分配至多個噴嘴，以最大限度節省用料"
 
 msgid "Filament grouping"
 msgstr "耗材分組"
 
 msgid "Fila Saving"
-msgstr ""
+msgstr "省料"
 
 msgid "Filament-Saving Mode"
 msgstr "省料模式"
@@ -16464,26 +16502,26 @@ msgid "Convenience Mode"
 msgstr "便捷模式"
 
 msgid "Quality Mode"
-msgstr ""
+msgstr "品質模式"
 
 msgid "Custom Mode"
 msgstr "自定義模式"
 
 #, c-format, boost-format
 msgid "Generates filament grouping for the %s and %s based on the most filament-saving principles to minimize waste"
-msgstr ""
+msgstr "根據最節省耗材的原則，生成%s/%s的耗材分組方案，幫助減少耗材浪費"
 
 #, c-format, boost-format
 msgid "Generates filament grouping for the %s and %s based on the printer's actual filament status, reducing the need for manual filament adjustment"
-msgstr ""
+msgstr "根據印表機實際耗材狀態，生成%s/%s的耗材分組方案，幫助減少對實際耗材的手動調整操作"
 
 #, c-format, boost-format
 msgid "Generates filament grouping for the %s and %s based on quality optimization principles"
-msgstr ""
+msgstr "依據品質最佳化原則，為 %s 和 %s 產生耗材分組方案"
 
 #, c-format, boost-format
 msgid "Manually assign filament to the %s or %s"
-msgstr ""
+msgstr "手動分配耗材給%s或%s"
 
 msgid "Global settings"
 msgstr "全域性設定"
@@ -16512,7 +16550,7 @@ msgstr "設定噴嘴數量"
 
 #, c-format, boost-format
 msgid "Generates filament grouping for the %s and %s based on the quality of prints, prioritizing print quality over filament saving"
-msgstr ""
+msgstr "依據列印品質，為 %s 和 %s 產生耗材分組方案，優先列印品質而非節省耗材"
 
 msgid "Skip Objects"
 msgstr "零件跳過"
@@ -16521,7 +16559,7 @@ msgid "Zoom Out"
 msgstr "縮小"
 
 msgid "100 %"
-msgstr ""
+msgstr "100 %"
 
 msgid "Zoom In"
 msgstr "放大"
@@ -16531,11 +16569,11 @@ msgstr "載入跳過零件資訊失敗。請重試。"
 
 #, c-format, boost-format
 msgid "%d%%"
-msgstr ""
+msgstr "%d%%"
 
 #, c-format, boost-format
 msgid "%d"
-msgstr ""
+msgstr "%d"
 
 #, c-format, boost-format
 msgid "/%d Selected"
@@ -16564,13 +16602,13 @@ msgid "This action cannot be undone. Continue?"
 msgstr "此操作無法撤銷，是否繼續？"
 
 msgid "Skipping objects."
-msgstr ""
+msgstr "正在跳過物件。"
 
 msgid "Continue"
 msgstr "繼續"
 
 msgid "Null Color"
-msgstr ""
+msgstr "無色彩"
 
 msgid "Multiple Color"
 msgstr "多色"
@@ -16732,7 +16770,7 @@ msgid "  Please plug in the power and then use the drying function."
 msgstr "  請插上電源後使用烘乾功能。"
 
 msgid "  The high drying temperature may cause AMS blockage. Please unload the filament manually before proceeding."
-msgstr ""
+msgstr "  烘乾的高溫可能造成AMS堵塞，請手動退回耗材後再操作。"
 
 msgid "System is busy"
 msgstr "系統正忙"
@@ -16895,59 +16933,59 @@ msgid "Print Outcome: "
 msgstr "列印結果： "
 
 msgid "Edit Mixed Filament"
-msgstr ""
+msgstr "編輯混色耗材"
 
 msgid "Effect Preview"
-msgstr ""
+msgstr "效果預覽"
 
 msgid "Select Mixed Materials"
-msgstr ""
+msgstr "選擇混色材料"
 
 msgid "+ Add Material"
-msgstr ""
+msgstr "新增耗材"
 
 msgid "- Delete Material"
-msgstr ""
+msgstr "刪除耗材"
 
 msgid "Ratio"
 msgstr "比例"
 
 msgid "Gradient Effect"
-msgstr ""
+msgstr "漸變效果"
 
 msgid "Mixing Recommendations"
-msgstr ""
+msgstr "混色推薦"
 
 msgid "-- Select --"
-msgstr ""
+msgstr "-- 請選擇 --"
 
 msgid "Gradient effect requires 'Mixed color sublayer' to be enabled. Enable it now?"
-msgstr ""
+msgstr "漸變效果需要啟用「混色子層」功能，是否立即啟用？"
 
 msgid "Mixed Color Sublayer"
-msgstr ""
+msgstr "混色子層"
 
 #, c-format, boost-format
 msgid "Slot %s (%s)"
-msgstr ""
+msgstr "槽位 %s（%s）"
 
 msgid "cannot be mixed. Please select the same filament type."
-msgstr ""
+msgstr "無法混合，請選擇相同型別的耗材。"
 
 msgid "Please select a filament for all components"
-msgstr ""
+msgstr "請為所有組分選擇耗材"
 
 msgid "Cannot mix different filament types"
-msgstr ""
+msgstr "無法混合不同型別的耗材"
 
 msgid "Maximum 3 materials for mixing"
-msgstr ""
+msgstr "最多支援 3 種材料混合"
 
 msgid "Maximum number of components reached"
-msgstr ""
+msgstr "已達到最大組分數量"
 
 msgid "Remove the third material"
-msgstr ""
+msgstr "移除第三種材料"
 
 #: resources/data/hints.ini: [hint:How to use keyboard shortcuts]
 msgid ""


### PR DESCRIPTION
This updates the Traditional Chinese zh_TW translation.

The update fills previously untranslated strings in BambuStudio_zh_TW.po and keeps gettext formatting valid. Most of the translations are based on the existing Simplified Chinese translations and converted/adapted for Traditional Chinese, with newly added strings translated from the English source text where needed.

This is a follow-up to #10386, which added Traditional Chinese to the supported language list.

Testing:
- msgfmt --statistics --check-format -o /tmp/BambuStudio_zh_TW.mo bbl/i18n/zh_TW/BambuStudio_zh_TW.po
- 5265 translated messages
- 0 untranslated
- 0 fuzzy

Thanks for reviewing.