### PR TITLE
FIX: Fix crash when clicking 'View all object settings'

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectTable.cpp
+++ b/src/slic3r/GUI/GUI_ObjectTable.cpp
@@ -2575,6 +2575,8 @@ bool ObjectGridTable::OnCellLeftClick(int row, int col, ConfigOptionType &type)
 void ObjectGridTable::OnSelectCell(int row, int col)
 {
     m_selected_cells.clear();
+    if (!m_panel->m_side_window)
+        return;
     m_panel->m_side_window->Freeze();
     if (row == 0 || col == col_filaments) {
         m_panel->m_object_settings->UpdateAndShow(row, false, false, false, nullptr, nullptr, std::string());


### PR DESCRIPTION
`ObjectGridTable::OnSelectCell()` might get triggered without a valid `m_side_window` existing, guard against running the rest of the callback when `m_side_window` is `NULL`.

Verified on the latest Flatpak beta build (2.6.1) with wxWidgets 3.2.9.

Closes: #9423 #10015 #10178