### PR TITLE
FIX: Global shortcuts interfering with text input

### DIFF
--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -647,7 +647,21 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
             });
 ;    }
     this->Bind(wxEVT_CHAR_HOOK, [this](wxKeyEvent &evt) {
+
+        // wxEVT_CHAR_HOOK on the top-level window will capture all key strokes sent to the application, even if a child widget would normally handle them.
+        // This can cause issues with global shortcuts which are also valid text entry (no modifier, Shift, or AltGr/Ctrl+Alt), or something the text editor would handle (like CTRL+A).
+        // Also wxWidgets isn't aware of ImGui text inputs at all, so we need to check if any ImGui widgets are expecting keyboard events.
+        // To do this we can check that current focus is not on a text editor control and use the ImGui functions provided for this purpose.
+        // However, our legacy behavior expects global CTRL/CMD shortcuts to work even when a text input has focus. Since it is highly unlikely that
+        // CTRL w/out ALT is used for text entry, we can skip those cases. The only issue is if the text/ImGui widget would normally handle any of our
+        // global shortucts, so ideally none of our globals should interfere with commonly-used text input shortcuts like CTRL+A, arrow keys, copy/cut/paste, etc.
+        if ((!evt.CmdDown() || evt.AltDown()) && (dynamic_cast<wxTextCtrl *>(wxWindow::FindFocus()) || wxGetApp().imgui()->want_keyboard())) {
+            evt.Skip();
+            return;
+        }
+
         const int key_code = evt.GetKeyCode();
+
 #ifdef __APPLE__
         if (evt.CmdDown() && (evt.GetKeyCode() == 'H')) {
             //call parent_menu hide behavior


### PR DESCRIPTION
As discussed in #10467, there is an overall issue with global shortcuts interfering with other inputs, specifically in text entry fields.  I wasn't aware of of this limitation in #10035 and inadvertently caused a bug, which this fixes.

But this also addresses that all global `CTRL/CMD` shortcuts were interfering in other ways, most notably with `AltGr` / `CTRL+ALT` modifiers as commonly used in "international" keyboard layouts. Eg. `CTRL + ALT + O` would attempt to open a new project (instead of typing `ó` on my layout).

Although most obvious in the text tool, this was also an issue in some of the other text fields with `MainFrame` as parent, for example when renaming an object in the tree, or property fields like the _Filename format_, _Post-processing scripts_ and _Notes_ text boxes (and all fields also, but most only accept numerals anyway).

Furthermore this opens up future global shortcut options so they're not limited to `CTRL/CMD` modifiers.

The top-level capture of input with `wxEVT_CHAR_HOOK` turns out to be somewhat common when handling global shortcuts and text entry. (Here is one nicely explained example, though it's not a Windows-only issue despite the title: https://blog.pcitron.fr/2012/09/11/application-wide-shortcuts-with-wxwidgets-on-windows/ )

And similar with ImGui, which even has specific functions for checking this kind of thing:
https://github.com/ocornut/imgui/blob/master/docs/FAQ.md#q-how-can-i-tell-whether-to-dispatch-mousekeyboard-to-dear-imgui-or-my-application

The proposed solution will detect when focus is in a wxWidgets text box widget, or when ImGui is expecting keyboard input in a text input, and skip processing the event.

As per the new code comments, I didn't want to change any current behavior where users may expect things like `CTRL+S` to always work. So there is an exception made for shortcuts which use the CTRL/CMD key w/out ALT.  This isn't ideal, but I think it is a reasonable workaround.

I'm currently waiting for Linux and Mac builds to finish so I can test on those platforms, but I wanted to get this up ASAP.  It's fundamentally a simple fix, so hopefully no issues.  If anyone else can try this on Linx/Mac as well, please report back.

Thanks,
-Max

---

Closes #10467
Closes #10605
Closes #10612
Closes #10586
Closes #10544
Closes #2843
