### PR TITLE
Fix: add distance threshold to reduce_infill_retraction optimization (#3423)

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7083,9 +7083,11 @@ bool GCode::needs_retraction(const Polyline &travel, ExtrusionRole role, LiftTyp
         }
         // rirDisabled: should_reduce remains false
         if (should_reduce && !is_perimeter(role) && m_layer != nullptr && m_config.sparse_infill_density.value > 0 &&
+            travel.length() < scale_(FILAMENT_CONFIG(retraction_minimum_travel)) &&
             m_retract_when_crossing_perimeters.travel_inside_internal_regions_no_wall_crossing(*m_layer, travel))
             // Skip retraction if travel is contained in an internal slice *and*
-            // internal infill is enabled (so that stringing is entirely not visible).
+            // internal infill is enabled (so that stringing is entirely not visible) *and*
+            // travel distance is shorter than retraction_minimum_travel (to prevent oozing on long moves).
             //FIXME any_internal_region_slice_contains() is potentionally very slow, it shall test for the bounding boxes first.
             return false;
     }


### PR DESCRIPTION
## Problem

The infill retraction bypass in `needs_retraction()` (GCode.cpp) skips retraction for **any** travel move that stays inside an infill region without crossing a perimeter wall — regardless of travel distance.

On small prints this is fine. On larger parts a single travel move can span 30–50 mm across infill with no retraction, causing:
- Stringing across infill surfaces
- Nozzle drag / scraping on infill
- Support knock-offs (the core issue reported in #3423)

This affects BambuStudio, OrcaSlicer, and PrusaSlicer equally — none of them have a distance threshold on this optimization.

## Root cause

```cpp
// GCode.cpp — needs_retraction()
    m_config.sparse_infill_density.value > 0 &&
    m_retract_when_crossing_perimeters.travel_inside_internal_regions_no_wall_crossing(*m_layer, travel))
    return false;  // no distance check — skips retraction for ANY length
```

## Fix

Reuse the existing `retraction_minimum_travel` threshold (already used at the top of `needs_retraction()`) for the infill bypass as well:

```cpp
    m_config.sparse_infill_density.value > 0 &&
    travel.length() < scale_(FILAMENT_CONFIG(retraction_minimum_travel)) &&
    m_retract_when_crossing_perimeters.travel_inside_internal_regions_no_wall_crossing(*m_layer, travel))
    return false;
```

- Short hops (< `retraction_minimum_travel`): unretracted — no speed regression
- Long moves (≥ `retraction_minimum_travel`): retracted — eliminates stringing and drag

No new settings needed. `retraction_minimum_travel` already has the correct semantics and is already exposed in the UI.

## Testing

The current workaround (disabling *Reduce infill retractions*) confirms the issue is in this code path — enabling it with this fix should produce equivalent quality to disabling it, while preserving the speed benefit for short infill hops.

Closes #3423