### PR TITLE
ENH: Add user-configurable default infill pattern in Preferences

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -316,6 +316,10 @@ void AppConfig::set_defaults()
         set("auto_calculate_flush","all");
     }
 
+    if (get("default_infill_pattern").empty()){
+        set("default_infill_pattern", "grid");
+    }
+
     if (get("enable_high_low_temp_mixed_printing").empty()){
         set_bool("enable_high_low_temp_mixed_printing", false);
     }

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -780,8 +780,13 @@ void ConfigManipulation::apply_null_fff_config(DynamicPrintConfig *config, std::
         }
         else if (k == "detect_overhang_wall")
             config->set_key_value(k, new ConfigOptionBool(false));
-        else if (k == "sparse_infill_pattern")
-            config->set_key_value(k, new ConfigOptionEnum<InfillPattern>(ipGrid));
+        else if (k == "sparse_infill_pattern") {
+            InfillPattern default_pattern = ipGrid;
+            std::string pref = wxGetApp().app_config->get("default_infill_pattern");
+            if (!pref.empty())
+                ConfigOptionEnum<InfillPattern>::from_string(pref, default_pattern);
+            config->set_key_value(k, new ConfigOptionEnum<InfillPattern>(default_pattern));
+        }
     }
 }
 

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1406,6 +1406,27 @@ wxWindow* PreferencesDialog::create_general_page()
     auto item_user_sync        = create_item_checkbox(_L("Auto sync user presets(Printer/Filament/Process)"), page, _L("If enabled, auto sync user presets with cloud after Bambu Studio startup or presets modified."), 50, "sync_user_preset");
     auto item_system_sync        = create_item_checkbox(_L("Auto check for system presets updates"), page, _L("If enabled, auto check whether there are system presets updates after Bambu Studio startup."), 50, "sync_system_preset");
 
+    std::vector<wxString> InfillPatternLabels = {
+        _L("Concentric"), _L("Rectilinear"), _L("Grid"), _L("Line"), _L("Cubic"),
+        _L("Triangles"), _L("Tri-hexagon"), _L("Gyroid"), _L("Honeycomb"),
+        _L("Adaptive Cubic"), _L("Aligned Rectilinear"), _L("3D Honeycomb"),
+        _L("Hilbert Curve"), _L("Archimedean Chords"), _L("Octagram Spiral"),
+        _L("Support Cubic"), _L("Lightning"), _L("Cross Hatch"),
+        _L("Zig Zag"), _L("Cross Zag"), _L("Locked Zag"), _L("2D Lattice")
+    };
+    std::vector<std::string> InfillPatternValues = {
+        "concentric", "zig-zag", "grid", "line", "cubic",
+        "triangles", "tri-hexagon", "gyroid", "honeycomb",
+        "adaptivecubic", "alignedrectilinear", "3dhoneycomb",
+        "hilbertcurve", "archimedeanchords", "octagramspiral",
+        "supportcubic", "lightning", "crosshatch",
+        "zigzag", "crosszag", "lockedzag", "2dlattice"
+    };
+    auto item_default_infill_pattern = create_item_combobox(
+        _L("Default infill pattern"), page,
+        _L("The infill pattern used for new configurations and when resolving conflicts between objects. Does not override patterns already set in existing presets or projects."),
+        "default_infill_pattern", InfillPatternLabels, InfillPatternValues, nullptr, FromDIP(150), FromDIP(160));
+
 #ifdef _WIN32
     auto title_associate_file = create_item_title(_L("Associate Files To Bambu Studio"), page, _L("Associate Files To Bambu Studio"));
 
@@ -1519,6 +1540,7 @@ wxWindow* PreferencesDialog::create_general_page()
     sizer_page->Add(title_presets, 0, wxTOP | wxEXPAND, FromDIP(20));
     sizer_page->Add(item_user_sync, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_system_sync, 0, wxTOP, FromDIP(3));
+    sizer_page->Add(item_default_infill_pattern, 0, wxTOP, FromDIP(3));
 #ifdef _WIN32
     sizer_page->Add(title_associate_file, 0, wxTOP| wxEXPAND, FromDIP(20));
     sizer_page->Add(item_associate_3mf, 0, wxTOP, FromDIP(3));

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5861,6 +5861,24 @@ void Tab::load_current_preset()
             wxGetApp().obj_list()->update_objects_list_filament_column(1);
     }
     if (m_type == Preset::TYPE_PRINT) {
+        // Apply user's preferred default infill pattern if the preset still uses its parent's value
+        const Preset *parent = m_presets->get_selected_preset_parent();
+        if (parent) {
+            auto *edited_opt = m_config->option<ConfigOptionEnum<InfillPattern>>("sparse_infill_pattern");
+            auto *parent_opt = parent->config.option<ConfigOptionEnum<InfillPattern>>("sparse_infill_pattern");
+            if (edited_opt && parent_opt && edited_opt->value == parent_opt->value) {
+                std::string pref = wxGetApp().app_config->get("default_infill_pattern");
+                InfillPattern preferred;
+                if (!pref.empty() && ConfigOptionEnum<InfillPattern>::from_string(pref, preferred) && preferred != edited_opt->value) {
+                    auto *new_opt = new ConfigOptionEnum<InfillPattern>(preferred);
+                    m_config->set_key_value("sparse_infill_pattern", new_opt);
+                    // Also update the selected preset so the dirty check won't flag this as a user modification
+                    m_presets->get_selected_preset().config.set_key_value("sparse_infill_pattern",
+                        new ConfigOptionEnum<InfillPattern>(preferred));
+                }
+            }
+        }
+
         if (auto tab = wxGetApp().plate_tab) {
             tab->m_config->apply(*m_config);
             tab->update_extruder_variants();


### PR DESCRIPTION
Right now, the sparse infill pattern defaults to Grid, and there's no way to change that without editing each preset manually. If you prefer Gyroid or Honeycomb (or anything else), you have to re-select it every time you switch presets or start fresh. This gets old fast.

This PR adds a "Default infill pattern" dropdown under Preferences > Presets. Pick your preferred pattern once and it gets applied automatically.

<img width="380" height="116" alt="image" src="https://github.com/user-attachments/assets/c5ded51e-b509-4941-8796-65b744b19826" />

It's intentionally conservative about when it kicks in:
- Only overrides the infill pattern if the preset still has the same value as its parent/system preset (i.e., you haven't touched it yourself)
- Also replaces the hardcoded `ipGrid` fallback used when resolving conflicts between multiple objects
- If you've manually changed the infill pattern in a preset, your choice is preserved — the override won't stomp on it

**What changed:**
- **AppConfig.cpp**: new `default_infill_pattern` setting, defaults to `"grid"` for backwards compat
- **Preferences.cpp**: combobox with all available infill patterns
- **ConfigManipulation.cpp**: reads the preference instead of always falling back to `ipGrid`
- **Tab.cpp**: applies the preferred pattern on preset load when the current value still matches the parent

**To test:**
1. Open Preferences, scroll to Presets, pick a different default (e.g., Honeycomb).
2. Switch process presets. This should show your chosen pattern.
3. Manually change infill in a preset, switch away, and back. Your manual change should stick.
4. Add objects with conflicting infill settings. Your preferred default should be used as the tie-breaker.


Fixes: #2496, #6875, #2354, and probably many other