### PR TITLE
Fix: AMSMaterialsSetting calls non-existent get_extruder_id_by_ams_id (re-apply post-fix to PR #10106)

### DIFF
--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -1165,12 +1165,14 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
     // Request PA calibration history if not loaded yet — needed for k-profile dropdown
     if (obj->GetCalib()->IsVersionInited() && !obj->GetCalib()->IsPAHistoryReady()) {
         PACalibExtruderInfo cali_info;
-        int ext_id = obj->get_extruder_id_by_ams_id(std::to_string(ams_id));
-        cali_info.nozzle_diameter        = obj->GetExtderSystem()->GetNozzleDiameter(ext_id);
-        cali_info.use_extruder_id        = false;
-        cali_info.use_nozzle_volume_type = false;
-        CalibUtils::emit_get_PA_calib_infos(cali_info);
-        m_pa_data_pending = true;
+        int ext_id = obj->GetFilaSystem()->GetExtruderIdByAmsId(std::to_string(ams_id));
+        if (ext_id > 0) {
+            cali_info.nozzle_diameter = obj->GetExtderSystem()->GetNozzleDiameter(ext_id);
+            cali_info.use_extruder_id = false;
+            cali_info.use_nozzle_volume_type = false;
+            CalibUtils::emit_get_PA_calib_infos(cali_info);
+            m_pa_data_pending = true;
+        }
     } else {
         m_pa_data_pending = false;
     }


### PR DESCRIPTION
## Summary

`AMSMaterialsSetting::Popup()` at `src/slic3r/GUI/AMSMaterialsSetting.cpp:1168` calls `obj->get_extruder_id_by_ams_id(...)` on a `MachineObject*`. That method does not exist anywhere in the tree — `git grep` for the symbol returns exactly one hit (the call site itself), and `MachineObject`'s class definition in `DeviceManager.hpp` does not declare it. Every other call site in the codebase uses `obj->GetFilaSystem()->GetExtruderIdByAmsId(...)` against the `DevFilaSystem` interface.

## How it got here

```
2026-03-28  b29fe53fe  maziggy:   PR #10106 introduces the broken call
2026-05-07  33b62edc1  xin.zhang: "FIX: post fix to PR #10106"
                                    ↳ replaces the broken call with
                                      `obj->GetFilaSystem()->GetExtruderIdByAmsId(...)`
                                      and adds an `if (ext_id > 0)` guard.
2026-03-28  01781493c  maziggy:   DUPLICATE cherry-pick of #10106 with the
                                  same author + author-date + title as
                                  b29fe53fe — re-introduces the broken
                                  call AFTER xin.zhang's post-fix.
```

The post-fix landed on master and was then clobbered by the duplicate cherry-pick. Both `master` HEAD and the release tag `v02.07.00.55` (published 2026-05-14) currently contain the broken line. `git merge-base --is-ancestor 33b62edc1 origin/master` confirms the post-fix is still in history — just no longer reaches the file content at this line.

## The fix

This PR re-applies xin.zhang's `33b62edc1` verbatim:

```diff
-        int ext_id = obj->get_extruder_id_by_ams_id(std::to_string(ams_id));
-        cali_info.nozzle_diameter        = obj->GetExtderSystem()->GetNozzleDiameter(ext_id);
-        cali_info.use_extruder_id        = false;
-        cali_info.use_nozzle_volume_type = false;
-        CalibUtils::emit_get_PA_calib_infos(cali_info);
-        m_pa_data_pending = true;
+        int ext_id = obj->GetFilaSystem()->GetExtruderIdByAmsId(std::to_string(ams_id));
+        if (ext_id > 0) {
+            cali_info.nozzle_diameter = obj->GetExtderSystem()->GetNozzleDiameter(ext_id);
+            cali_info.use_extruder_id = false;
+            cali_info.use_nozzle_volume_type = false;
+            CalibUtils::emit_get_PA_calib_infos(cali_info);
+            m_pa_data_pending = true;
+        }
```

## Why this is safe

- Behaviour matches every other call site in the tree against the same DevFilaSystem API (`AMSDryControl.cpp:1575`, `AMSMaterialsSetting.cpp:597` + `:1025`, `CalibrationWizardPresetPage.cpp:1549`, `SelectMachine.cpp:6005`).
- The `if (ext_id > 0)` guard prevents `GetNozzleDiameter` being called with a sentinel/negative value when no extruder matches the ams_id.
- This is exactly the patch your team applied as the post-fix to PR #10106 — just being re-applied because a duplicate cherry-pick of the original undid it.

## Test plan

- [ ] CI build green (this fixes a compile-time symbol-resolution issue if anything in the build pipeline doesn't have private patches that work around it)
- [ ] Manual: open AMS Materials Setting dialog, confirm PA calibration history loads as before (same behaviour as the previously-merged post-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)