### PR TITLE
feat(webview): translate Online Models URLs to public web + add Share menu

### DIFF
--- a/resources/images/share.svg
+++ b/resources/images/share.svg
@@ -1,0 +1,14 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- 3-dots-and-lines share glyph, OS-agnostic. Sized to visually
+       match the weight and extent of the refresh icon next to it in
+       the online-models toolbar. -->
+
+  <!-- Connector lines: drawn first so the dots overpaint the joins. -->
+  <path d="M3.2 8 L12.8 13.7 M12.8 2.3 L3.2 8"
+        stroke="#00AE42" stroke-width="1.9" stroke-linecap="round"/>
+
+  <!-- Three dots, radius 2.7, edges of the box. -->
+  <circle cx="13.3" cy="2.3"  r="2.7" fill="#00AE42"/>
+  <circle cx="2.7"  cy="8"    r="2.7" fill="#00AE42"/>
+  <circle cx="13.3" cy="13.7" r="2.7" fill="#00AE42"/>
+</svg>

--- a/resources/images/share_copy_link.svg
+++ b/resources/images/share_copy_link.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="4.5" y="4.5" width="8" height="9.5" rx="1.5" stroke="#262E30" stroke-width="1.2" fill="none"/>
+<path d="M3.5 11.5h-0.5a1.5 1.5 0 0 1-1.5-1.5v-7a1.5 1.5 0 0 1 1.5-1.5h6a1.5 1.5 0 0 1 1.5 1.5v0.5" stroke="#262E30" stroke-width="1.2" fill="none"/>
+</svg>

--- a/resources/images/share_native.svg
+++ b/resources/images/share_native.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 1.5v9" stroke="#262E30" stroke-width="1.2" stroke-linecap="round"/>
+<path d="M5 4.5L8 1.5L11 4.5" stroke="#262E30" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+<path d="M4 7.5h-1a1.5 1.5 0 0 0-1.5 1.5v4a1.5 1.5 0 0 0 1.5 1.5h10a1.5 1.5 0 0 0 1.5-1.5v-4a1.5 1.5 0 0 0-1.5-1.5h-1" stroke="#262E30" stroke-width="1.2" stroke-linecap="round" fill="none"/>
+</svg>

--- a/resources/images/share_open_link.svg
+++ b/resources/images/share_open_link.svg
@@ -1,0 +1,6 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="8" cy="8" r="6.4" stroke="#262E30" stroke-width="1.2"/>
+<ellipse cx="8" cy="8" rx="3" ry="6.4" stroke="#262E30" stroke-width="1.2"/>
+<line x1="1.6" y1="8" x2="14.4" y2="8" stroke="#262E30" stroke-width="1.2"/>
+<line x1="8" y1="1.6" x2="8" y2="14.4" stroke="#262E30" stroke-width="1.2"/>
+</svg>

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -294,6 +294,8 @@ set(SLIC3R_GUI_SOURCES
     GUI/Monitor.hpp
     GUI/WebViewDialog.cpp
     GUI/WebViewDialog.hpp
+    GUI/SystemShare.hpp
+    GUI/SystemShare.cpp
     GUI/PrinterWebView.cpp
     GUI/PrinterWebView.hpp
     GUI/WebDownPluginDlg.hpp
@@ -666,6 +668,7 @@ if (APPLE)
             GUI/InstanceCheckMac.h
             GUI/CameraFullscreenMac.mm
             GUI/CameraFullscreenMac.hpp
+            GUI/SystemShare_mac.mm
             GUI/wxMediaCtrl2.mm
             GUI/wxMediaCtrl2.h
             GUI/wxMediaCtrl3.h
@@ -679,6 +682,7 @@ else ()
             GUI/wxMediaCtrl2.h
             GUI/wxMediaCtrl3.cpp
             GUI/wxMediaCtrl3.h
+            GUI/SystemShare_fallback.cpp
         )
 endif ()
 

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -654,6 +654,7 @@ if (WIN32)
             GUI/dark_mode/UAHMenuBar.hpp
             GUI/dark_mode.hpp
             GUI/dark_mode.cpp
+            GUI/SystemShare_win.cpp
         )
 endif ()
 
@@ -682,13 +683,13 @@ else ()
             GUI/wxMediaCtrl2.h
             GUI/wxMediaCtrl3.cpp
             GUI/wxMediaCtrl3.h
-            GUI/SystemShare_fallback.cpp
         )
 endif ()
 
 if (UNIX AND NOT APPLE)
     list(APPEND SLIC3R_GUI_SOURCES
         GUI/Printer/gstbambusrc.c
+        GUI/SystemShare_fallback.cpp
     )
 endif ()
 

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -694,6 +694,7 @@ if (WIN32)
             GUI/dark_mode/UAHMenuBar.hpp
             GUI/dark_mode.hpp
             GUI/dark_mode.cpp
+            GUI/SystemShare_win.cpp
         )
 endif ()
 
@@ -724,13 +725,13 @@ else ()
             GUI/wxMediaCtrl2.h
             GUI/wxMediaCtrl3.cpp
             GUI/wxMediaCtrl3.h
-            GUI/SystemShare_fallback.cpp
         )
 endif ()
 
 if (UNIX AND NOT APPLE)
     list(APPEND SLIC3R_GUI_SOURCES
         GUI/Printer/gstbambusrc.c
+        GUI/SystemShare_fallback.cpp
     )
 endif ()
 

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -310,6 +310,8 @@ set(SLIC3R_GUI_SOURCES
     GUI/Monitor.hpp
     GUI/WebViewDialog.cpp
     GUI/WebViewDialog.hpp
+    GUI/SystemShare.hpp
+    GUI/SystemShare.cpp
     GUI/PrinterWebView.cpp
     GUI/PrinterWebView.hpp
     GUI/WebDownPluginDlg.hpp
@@ -708,6 +710,7 @@ if (APPLE)
             GUI/CameraFullscreenMac.hpp
             GUI/MacIME.mm
             GUI/MacIME.hpp
+            GUI/SystemShare_mac.mm
             GUI/wxMediaCtrl2.mm
             GUI/wxMediaCtrl2.h
             GUI/wxMediaCtrl3.h
@@ -721,6 +724,7 @@ else ()
             GUI/wxMediaCtrl2.h
             GUI/wxMediaCtrl3.cpp
             GUI/wxMediaCtrl3.h
+            GUI/SystemShare_fallback.cpp
         )
 endif ()
 

--- a/src/slic3r/GUI/SystemShare.cpp
+++ b/src/slic3r/GUI/SystemShare.cpp
@@ -1,0 +1,63 @@
+#include "SystemShare.hpp"
+
+#include <wx/clipbrd.h>
+#include <wx/dataobj.h>
+#include <wx/menu.h>
+#include <wx/utils.h>
+#include <wx/window.h>
+
+#include "I18N.hpp"
+#include "wxExtensions.hpp"
+
+namespace Slic3r { namespace GUI { namespace SystemShare {
+
+// Cross-platform action menu for sharing a URL. Three items:
+//   * Open Link  -- launches the user's default browser
+//   * Copy Link  -- writes the URL to the clipboard
+//   * Share...   -- drills into the OS-native share UI when available
+//                   (NSSharingServicePicker on macOS, DataTransferManager
+//                   on Windows). Omitted on platforms without a native
+//                   share surface (e.g. Linux).
+//
+// Icons are macOS Mail-style: globe for Open Link, doc-on-doc for Copy
+// Link, square-with-up-arrow for Share. Loaded via the codebase's
+// append_menu_item helper which handles bitmap scaling and dark-mode
+// recoloring.
+void ShareUrl(wxWindow *anchor, const wxString &url, const wxString &title)
+{
+    if (url.IsEmpty()) return;
+
+    wxMenu *menu = new wxMenu();
+    const int id_open   = wxNewId();
+    const int id_copy   = wxNewId();
+    const int id_native = wxNewId();
+
+    append_menu_item(menu, id_open, _L("Open Link"), wxEmptyString,
+        [url](wxCommandEvent &) { wxLaunchDefaultBrowser(url); },
+        "share_open_link", nullptr, []() { return true; }, anchor);
+
+    append_menu_item(menu, id_copy, _L("Copy Link"), wxEmptyString,
+        [url](wxCommandEvent &) {
+            if (wxTheClipboard->Open()) {
+                wxTheClipboard->SetData(new wxTextDataObject(url));
+                wxTheClipboard->Close();
+            }
+        },
+        "share_copy_link", nullptr, []() { return true; }, anchor);
+
+    if (HasNativePicker()) {
+        menu->AppendSeparator();
+        append_menu_item(menu, id_native, _L("Share..."), wxEmptyString,
+            [anchor, url, title](wxCommandEvent &) {
+                OpenNativePicker(anchor, url, title);
+            },
+            "share_native", nullptr, []() { return true; }, anchor);
+    }
+
+    if (anchor)
+        anchor->PopupMenu(menu);
+
+    delete menu;
+}
+
+}}} // namespace Slic3r::GUI::SystemShare

--- a/src/slic3r/GUI/SystemShare.hpp
+++ b/src/slic3r/GUI/SystemShare.hpp
@@ -1,0 +1,50 @@
+#ifndef slic3r_GUI_SystemShare_hpp_
+#define slic3r_GUI_SystemShare_hpp_
+
+#include <wx/string.h>
+
+class wxWindow;
+
+namespace Slic3r { namespace GUI {
+
+// Cross-platform "share this URL" entry point. Renders a small action menu
+// (modeled on macOS Mail's link context menu) with: Open in browser, Copy
+// link, and -- when available -- "Share via System..." which drills into
+// the OS-native share UI:
+//   * macOS:   NSSharingServicePicker (Messages, Mail, AirDrop, Notes,
+//              installed share extensions like Slack/Telegram, etc.)
+//   * Windows: DataTransferManager (system share flyout)
+//   * Linux:   no native picker; the "Share via System..." item is omitted.
+//
+// `anchor` is the wx widget the share UI should appear relative to (the
+// button or area that triggered the share). The cross-platform action menu
+// pops up at the cursor; the OS-native picker (when invoked from "Share via
+// System...") anchors to `anchor`.
+//
+// `url` is the URL to share. It should be a public, shareable URL --
+// callers must translate any internal/embedded URLs to their public-web
+// form before invoking this (see WebViewPanel::TranslateMakerWorldEmbeddedUrl).
+//
+// `title` is a human-readable title used by the OS share menu when the
+// target supports it (e.g. Messages will show the title alongside the
+// link, Mail can prefill the subject). Pass an empty string when no title
+// is available.
+namespace SystemShare {
+
+void ShareUrl(wxWindow *anchor, const wxString &url, const wxString &title);
+
+// Platform shim: opens the OS-native share UI directly (no pre-menu).
+// Implemented per-platform; on Linux this is a no-op. Called by ShareUrl
+// when the user picks "Share via System..." from the cross-platform menu.
+// Public so the menu code in SystemShare.cpp can invoke it; not intended
+// for callers outside the SystemShare unit.
+void OpenNativePicker(wxWindow *anchor, const wxString &url, const wxString &title);
+
+// Returns true if OpenNativePicker is meaningful on this platform.
+bool HasNativePicker();
+
+}
+
+}} // namespace Slic3r::GUI
+
+#endif // slic3r_GUI_SystemShare_hpp_

--- a/src/slic3r/GUI/SystemShare_fallback.cpp
+++ b/src/slic3r/GUI/SystemShare_fallback.cpp
@@ -1,0 +1,19 @@
+#include "SystemShare.hpp"
+
+class wxWindow;
+
+namespace Slic3r { namespace GUI { namespace SystemShare {
+
+// Used on Linux (no native share UI) and on Windows until the WinRT
+// DataTransferManager implementation lands. ShareUrl in SystemShare.cpp
+// detects HasNativePicker() == false and omits the "Share via System..."
+// menu item, so the user sees only Open in browser + Copy link.
+
+bool HasNativePicker() { return false; }
+
+void OpenNativePicker(wxWindow * /*anchor*/, const wxString & /*url*/, const wxString & /*title*/)
+{
+    // No-op. Cannot be reached unless HasNativePicker() returns true.
+}
+
+}}} // namespace Slic3r::GUI::SystemShare

--- a/src/slic3r/GUI/SystemShare_mac.mm
+++ b/src/slic3r/GUI/SystemShare_mac.mm
@@ -1,0 +1,74 @@
+#include "SystemShare.hpp"
+
+#ifdef __APPLE__
+
+#import <Cocoa/Cocoa.h>
+#import <AppKit/NSSharingService.h>
+
+#include <wx/window.h>
+
+namespace Slic3r { namespace GUI { namespace SystemShare {
+
+bool HasNativePicker() { return true; }
+
+// macOS share menu via NSSharingServicePicker. The picker shows everything
+// the user has configured: Messages, Mail, AirDrop, Notes, Reminders, Safari
+// Reading List, plus any installed share extensions (Things, Drafts, Slack,
+// Telegram, etc.) -- the same menu users get from Safari's share button or
+// the Finder share menu.
+//
+// We pass two items:
+//   1. NSURL  -- the canonical share payload. Most targets pick this up.
+//   2. NSString (the title) -- some targets (Mail subject, Messages preview)
+//      use this when present.
+//
+// The picker anchors to the wx widget that triggered the share so the
+// popover arrow points at the right control.
+void OpenNativePicker(wxWindow *anchor, const wxString &url, const wxString &title)
+{
+    if (url.IsEmpty()) return;
+
+    NSString *ns_url = [NSString stringWithUTF8String:url.utf8_str().data()];
+    NSURL    *url_obj = [NSURL URLWithString:ns_url];
+    if (!url_obj) return;
+
+    NSMutableArray *items = [NSMutableArray arrayWithObject:url_obj];
+    if (!title.IsEmpty()) {
+        NSString *ns_title = [NSString stringWithUTF8String:title.utf8_str().data()];
+        if (ns_title) [items addObject:ns_title];
+    }
+
+    // BambuStudio's Objective-C++ files compile under MRR (no -fobjc-arc),
+    // so [[NSSharingServicePicker alloc] init...] returns a +1 retained
+    // object that the caller owns. The system retains the picker for the
+    // popover lifetime, but we still need to release our own reference or
+    // we leak one picker per share invocation. -autorelease defers the
+    // release to the next autorelease pool drain, which is after the
+    // popover's internal refcount goes to zero.
+    NSSharingServicePicker *picker = [[[NSSharingServicePicker alloc] initWithItems:items] autorelease];
+
+    NSView    *anchor_view = nil;
+    NSRect     anchor_rect = NSZeroRect;
+    NSRectEdge edge        = NSMinYEdge;
+    if (anchor && anchor->GetHandle()) {
+        anchor_view = (NSView *) anchor->GetHandle();
+        anchor_rect = [anchor_view bounds];
+    }
+
+    if (anchor_view) {
+        [picker showRelativeToRect:anchor_rect ofView:anchor_view preferredEdge:edge];
+    } else {
+        // Fall back to anchoring on the key window's content view so the
+        // picker still appears even if the wx widget wasn't backed by a
+        // realized NSView at trigger time.
+        NSWindow *key = [NSApp keyWindow];
+        NSView   *content = key ? [key contentView] : nil;
+        if (content) {
+            [picker showRelativeToRect:[content bounds] ofView:content preferredEdge:edge];
+        }
+    }
+}
+
+}}} // namespace Slic3r::GUI::SystemShare
+
+#endif // __APPLE__

--- a/src/slic3r/GUI/SystemShare_win.cpp
+++ b/src/slic3r/GUI/SystemShare_win.cpp
@@ -1,0 +1,278 @@
+#include "SystemShare.hpp"
+
+#ifdef _WIN32
+
+// The Windows native share UI is the system "Share" flyout that's been
+// available since Windows 10 1607. It's reached programmatically via the
+// WinRT `Windows.ApplicationModel.DataTransfer.DataTransferManager` class
+// plus the `IDataTransferManagerInterop` COM bridge that lets a plain Win32
+// HWND drive what was originally a UWP-only API.
+//
+// Since the WinRT headers (winrt/windows.applicationmodel.datatransfer.h)
+// only ship with the Windows 10 SDK, the body of this file is gated on
+// HAS_WIN10SDK -- the same gate used by Utils/FixModelByWin10.cpp. When the
+// gate is off, HasNativePicker() returns false and SystemShare.cpp omits
+// the "Share..." menu item. This matches the Linux / no-SDK path served by
+// SystemShare_fallback.cpp, but lets a Windows build that DOES have the
+// SDK get the full system share flyout.
+//
+// Activation pattern follows Utils/FixModelByWin10.cpp: dynamic-load
+// ComBase.dll, look up RoInitialize / RoGetActivationFactory at runtime,
+// activate by class-name HSTRING. This avoids hard-linking to the WinRT
+// runtime so that older Windows installs still load BambuStudio.exe even
+// if they can't reach this code path.
+
+#ifdef HAS_WIN10SDK
+
+#ifndef NOMINMAX
+#  define NOMINMAX
+#endif
+
+#include <windows.h>
+#include <roapi.h>
+#include <wrl/client.h>
+#include <wrl/event.h>
+#include <wrl/wrappers/corewrappers.h>
+
+#include <winrt/windows.applicationmodel.datatransfer.h>
+#include <winrt/windows.foundation.h>
+#include <shobjidl.h> // IDataTransferManagerInterop
+
+#include <wx/window.h>
+
+namespace ABI_DT  = ABI::Windows::ApplicationModel::DataTransfer;
+namespace ABI_F   = ABI::Windows::Foundation;
+using Microsoft::WRL::ComPtr;
+using Microsoft::WRL::Callback;
+
+namespace Slic3r { namespace GUI { namespace SystemShare {
+
+// Forward decls of the runtime entry points we look up dynamically. Same
+// shape as Utils/FixModelByWin10.cpp -- by going through GetProcAddress we
+// don't add a load-time dependency on combase.dll's WinRT entry points.
+extern "C" {
+    typedef HRESULT (__stdcall *PFRoInitialize)(int);
+    typedef HRESULT (__stdcall *PFRoUninitialize)();
+    typedef HRESULT (__stdcall *PFRoGetActivationFactory)(HSTRING, REFIID, void **);
+    typedef HRESULT (__stdcall *PFWindowsCreateString)(LPCWSTR, UINT32, HSTRING *);
+    typedef HRESULT (__stdcall *PFWindowsDeleteString)(HSTRING);
+}
+
+namespace {
+
+// Lazy-load the WinRT entry points the first time we share. Returns false
+// if combase.dll isn't on the system or any required symbol is missing.
+struct WinRtEntry {
+    HMODULE                     dll{ nullptr };
+    PFRoInitialize              RoInitialize{ nullptr };
+    PFRoUninitialize            RoUninitialize{ nullptr };
+    PFRoGetActivationFactory    RoGetActivationFactory{ nullptr };
+    PFWindowsCreateString       WindowsCreateString{ nullptr };
+    PFWindowsDeleteString       WindowsDeleteString{ nullptr };
+    bool                        ok{ false };
+
+    bool ensure_loaded() {
+        if (ok) return true;
+        if (!dll) dll = LoadLibraryW(L"ComBase.dll");
+        if (!dll) return false;
+        RoInitialize           = (PFRoInitialize)           GetProcAddress(dll, "RoInitialize");
+        RoUninitialize         = (PFRoUninitialize)         GetProcAddress(dll, "RoUninitialize");
+        RoGetActivationFactory = (PFRoGetActivationFactory) GetProcAddress(dll, "RoGetActivationFactory");
+        WindowsCreateString    = (PFWindowsCreateString)    GetProcAddress(dll, "WindowsCreateString");
+        WindowsDeleteString    = (PFWindowsDeleteString)    GetProcAddress(dll, "WindowsDeleteString");
+        ok = RoInitialize && RoUninitialize && RoGetActivationFactory
+             && WindowsCreateString && WindowsDeleteString;
+        return ok;
+    }
+};
+
+WinRtEntry &winrt() { static WinRtEntry e; return e; }
+
+} // anonymous namespace
+
+// HasNativePicker decides whether the SystemShare cross-platform menu
+// includes the "Share..." item. Returning false here causes the menu to
+// fall back to the Open Link / Copy Link pair only. We consult
+// ensure_loaded() so that older Windows installs lacking ComBase.dll's
+// WinRT entry points (or any of the specific symbols we depend on) hide
+// the menu item entirely instead of advertising a feature that would
+// silently no-op when invoked.
+//
+// ensure_loaded() is idempotent and caches its result, so the lazy load
+// happens once at the first share-affordance state check; subsequent
+// calls are O(1).
+bool HasNativePicker() { return winrt().ensure_loaded(); }
+
+namespace {
+
+// RAII wrapper for HSTRING.
+struct HStringHolder {
+    HSTRING h{ nullptr };
+    HRESULT make(LPCWSTR s) {
+        if (!winrt().ensure_loaded()) return E_FAIL;
+        return winrt().WindowsCreateString(s, (UINT32) wcslen(s), &h);
+    }
+    ~HStringHolder() {
+        if (h && winrt().WindowsDeleteString) winrt().WindowsDeleteString(h);
+    }
+};
+
+// IDataTransferManagerInterop GUID. Defined in shobjidl.h on recent SDKs;
+// repeated here so the build works on slightly older SDKs that lack the
+// definition but still ship the header.
+const GUID IID_IDataTransferManagerInterop_local = {
+    0x3A3DCD6C, 0x3EAB, 0x43DC,
+    {0xBC, 0xDE, 0x45, 0x67, 0x1C, 0xE8, 0x00, 0xC8}
+};
+
+} // namespace
+
+void OpenNativePicker(wxWindow *anchor, const wxString &url, const wxString &title)
+{
+    if (url.IsEmpty()) return;
+    if (!winrt().ensure_loaded()) return;
+
+    // Find the parent HWND. wxWindow::GetHandle() returns the underlying
+    // HWND on Windows. The share flyout anchors to the top-level window.
+    HWND hwnd = anchor ? (HWND) anchor->GetHandle() : nullptr;
+    if (!hwnd) hwnd = GetActiveWindow();
+    if (!hwnd) return;
+
+    // Initialize WinRT for this thread (idempotent; safe to call repeatedly).
+    HRESULT init_hr = winrt().RoInitialize(RO_INIT_SINGLETHREADED);
+    const bool initialized = SUCCEEDED(init_hr) || init_hr == RPC_E_CHANGED_MODE
+                             || init_hr == S_FALSE;
+
+    // Resolve the DataTransferManager statics via the interop COM bridge.
+    HStringHolder cls_static;
+    if (FAILED(cls_static.make(L"Windows.ApplicationModel.DataTransfer.DataTransferManager")))
+        return;
+
+    ComPtr<IDataTransferManagerInterop> interop;
+    HRESULT hr = winrt().RoGetActivationFactory(cls_static.h,
+                                                IID_IDataTransferManagerInterop_local,
+                                                reinterpret_cast<void **>(interop.GetAddressOf()));
+    if (FAILED(hr) || !interop) {
+        if (initialized) winrt().RoUninitialize();
+        return;
+    }
+
+    // Bind the manager to our HWND.
+    ComPtr<ABI_DT::IDataTransferManager> dtm;
+    hr = interop->GetForWindow(hwnd, IID_PPV_ARGS(&dtm));
+    if (FAILED(hr) || !dtm) {
+        if (initialized) winrt().RoUninitialize();
+        return;
+    }
+
+    // Hook the DataRequested event. The handler runs when the user actually
+    // commits the share (picks a target). It fills the data package with the
+    // URI + title.
+    //
+    // Capture url/title by value so they survive the async callback.
+    std::wstring wurl   = url.ToStdWstring();
+    std::wstring wtitle = title.ToStdWstring();
+    if (wtitle.empty()) wtitle = wurl;
+
+    // We hand both the cookie returned by add_DataRequested and the DTM
+    // pointer itself into the lambda by shared_ptr so the handler can
+    // unregister itself when it fires. Without that, every SystemShare
+    // call appends a new handler to the DTM's internal list (DTM is a
+    // per-HWND singleton; add_DataRequested is additive). Subsequent
+    // shares would invoke every handler in registration order, each
+    // overwriting the previous one's data package on the request -- not
+    // user-visible-broken (the last write wins) but a leak that grows
+    // linearly with the number of shares.
+    auto cookie = std::make_shared<EventRegistrationToken>();
+    auto dtm_for_handler = dtm;
+    auto handler = Callback<ABI_F::ITypedEventHandler<
+        ABI_DT::DataTransferManager *, ABI_DT::DataRequestedEventArgs *>>(
+        [wurl, wtitle, cookie, dtm_for_handler](ABI_DT::IDataTransferManager *,
+                                                ABI_DT::IDataRequestedEventArgs *args) -> HRESULT {
+            // Unregister ourselves first thing -- whatever the handler does
+            // below, this invocation is the last for this share request, so
+            // we don't want to stay subscribed. By the time the handler
+            // fires, add_DataRequested has returned and cookie has been
+            // populated by the OS.
+            if (dtm_for_handler)
+                dtm_for_handler->remove_DataRequested(*cookie);
+
+            if (!args) return E_INVALIDARG;
+            ComPtr<ABI_DT::IDataRequest> request;
+            HRESULT hr = args->get_Request(&request);
+            if (FAILED(hr) || !request) return hr;
+            ComPtr<ABI_DT::IDataPackage> data;
+            hr = request->get_Data(&data);
+            if (FAILED(hr) || !data) return hr;
+            ComPtr<ABI_DT::IDataPackagePropertySet> props;
+            hr = data->get_Properties(&props);
+            if (FAILED(hr) || !props) return hr;
+
+            HStringHolder h_title;
+            if (SUCCEEDED(h_title.make(wtitle.c_str())))
+                props->put_Title(h_title.h);
+
+            // Set the URI as the canonical share payload.
+            ComPtr<ABI_F::IUriRuntimeClassFactory> uri_factory;
+            HStringHolder cls_uri;
+            if (FAILED(cls_uri.make(L"Windows.Foundation.Uri")))
+                return S_OK; // best-effort
+            HRESULT fr = winrt().RoGetActivationFactory(cls_uri.h,
+                            __uuidof(ABI_F::IUriRuntimeClassFactory),
+                            reinterpret_cast<void **>(uri_factory.GetAddressOf()));
+            if (SUCCEEDED(fr) && uri_factory) {
+                HStringHolder h_url;
+                if (SUCCEEDED(h_url.make(wurl.c_str()))) {
+                    ComPtr<ABI_F::IUriRuntimeClass> uri_obj;
+                    if (SUCCEEDED(uri_factory->CreateUri(h_url.h, &uri_obj)) && uri_obj) {
+                        data->SetWebLink(uri_obj.Get());
+                    }
+                }
+            }
+            return S_OK;
+        });
+
+    HRESULT add_hr = E_FAIL;
+    if (handler) {
+        add_hr = dtm->add_DataRequested(handler.Get(), cookie.get());
+    }
+
+    // Show the share UI. Returns asynchronously; the system handles the
+    // popup. We don't remove the handler here -- DataRequested fires
+    // synchronously inside ShowShareUIForWindow as the system populates
+    // the data package, regardless of whether the user later commits to
+    // a target or dismisses the flyout. The handler removes itself on
+    // fire, so the registration list doesn't grow over the process
+    // lifetime.
+    HRESULT show_hr = E_FAIL;
+    if (SUCCEEDED(add_hr))
+        show_hr = interop->ShowShareUIForWindow(hwnd);
+
+    // If ShowShareUIForWindow itself failed (bad HWND, system share UI
+    // unavailable, etc.) the handler will never fire, so we must
+    // unregister explicitly to avoid leaking it to the next share call.
+    if (SUCCEEDED(add_hr) && FAILED(show_hr)) {
+        dtm->remove_DataRequested(*cookie);
+    }
+
+    // Note: do NOT call RoUninitialize() here. The flyout is async and
+    // will reach back into WinRT after we return. Leaving WinRT initialized
+    // for the lifetime of the process is safe and matches what
+    // FixModelByWin10.cpp does.
+}
+
+}}} // namespace Slic3r::GUI::SystemShare
+
+#else // !HAS_WIN10SDK
+
+// Without the Win10 SDK at compile time we can't talk to
+// DataTransferManager. Surface the same fallback shape as Linux: no
+// "Share..." menu item, just Open Link / Copy Link.
+namespace Slic3r { namespace GUI { namespace SystemShare {
+bool HasNativePicker() { return false; }
+void OpenNativePicker(wxWindow *, const wxString &, const wxString &) {}
+}}}
+
+#endif // HAS_WIN10SDK
+
+#endif // _WIN32

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -585,6 +585,17 @@ void WebViewPanel::OnOpenInBrowser(wxCommandEvent& WXUNUSED(evt))
     if (IsBlankWebUrl(current_url))
         return;
 
+    // For the "Online Models" tab the embedded URL is the slicer-only
+    // /studio/webview view, which hides comments, designer profile,
+    // version-specific print profiles, and link rendering in descriptions.
+    // Translate to the public-web equivalent (e.g. /models/{id}) so the user
+    // lands on the actual MakerWorld page.
+    //
+    // For "makerlab" we don't translate yet; embedded MakerLab URLs don't
+    // have an obvious 1:1 public mapping.
+    if (m_contentname == "online")
+        current_url = TranslateMakerWorldEmbeddedUrl(current_url);
+
     wxLaunchDefaultBrowser(current_url);
     UpdateOnlineToolbarState();
 }
@@ -1242,6 +1253,136 @@ std::string UrlDecode(const std::string &str)
             strTemp += str[i];
     }
     return strTemp;
+}
+
+// Translate the slicer-embedded MakerWorld view URL to the equivalent public-web
+// URL. The embedded view (loaded as e.g. https://makerworld.com/en/studio/webview
+// ?modelid=12345&from=bambustudio) is a Studio-only iframe shape that hides
+// comments, designer profile, hyperlinks in descriptions, version selection and
+// per-version print profiles. The public-web shape (e.g.
+// https://makerworld.com/en/models/12345) shows all of that. This translation
+// powers the "Open in browser" toolbar button so users see the full model page
+// instead of a duplicate of what's already in the slicer.
+//
+// Returns the input unchanged when no public-web equivalent is known (e.g.
+// agree-terms / sign-in / sign-out auth redirects, makerlab sub-tools); the
+// caller can decide whether to launch as-is or skip.
+wxString WebViewPanel::TranslateMakerWorldEmbeddedUrl(const wxString &embedded_url)
+{
+    if (embedded_url.IsEmpty()) return embedded_url;
+
+    std::string url = embedded_url.ToStdString();
+
+    // Drop #fragment and utm_* tracking params before pattern matching. Both
+    // are noise in any context this function returns into (Open in browser,
+    // Share to system picker, copy link), and we want pass-through URLs (the
+    // ones the recognizer below doesn't match) to be cleaned too.
+    {
+        const size_t hash_pos = url.find('#');
+        if (hash_pos != std::string::npos) url.erase(hash_pos);
+
+        const size_t q_pos = url.find('?');
+        if (q_pos != std::string::npos) {
+            const std::string params = url.substr(q_pos + 1);
+            std::string filtered;
+            size_t start = 0;
+            while (start <= params.size()) {
+                const size_t end = params.find('&', start);
+                const size_t len = (end == std::string::npos)
+                                       ? params.size() - start
+                                       : end - start;
+                const std::string param = params.substr(start, len);
+                const bool is_utm = param.size() > 4
+                                    && param.compare(0, 4, "utm_") == 0;
+                if (!param.empty() && !is_utm) {
+                    if (!filtered.empty()) filtered += '&';
+                    filtered += param;
+                }
+                if (end == std::string::npos) break;
+                start = end + 1;
+            }
+            url = filtered.empty()
+                      ? url.substr(0, q_pos)
+                      : url.substr(0, q_pos + 1) + filtered;
+        }
+    }
+
+    // Find the host root: everything up to and including the first '/' after
+    // the host. We keep the original scheme+host+lang prefix (e.g.
+    // "https://makerworld.com/en/" or "https://makerworld.com.cn/zh-CN/") so
+    // that region- and language-localized embedded URLs translate to the same
+    // region/language on the public web.
+    const size_t scheme_end = url.find("://");
+    if (scheme_end == std::string::npos) return wxString::FromUTF8(url.c_str());
+    const size_t host_start = scheme_end + 3;
+    const size_t host_end = url.find('/', host_start);
+    if (host_end == std::string::npos) return wxString::FromUTF8(url.c_str());
+
+    // Bail out early if this isn't a MakerWorld URL we recognize. We don't
+    // attempt to translate makerlab/, store/, sign-in/, sign-out/, etc.
+    if (url.find("/studio/webview") == std::string::npos &&
+        url.find("/studio/print-history") == std::string::npos)
+        return wxString::FromUTF8(url.c_str());
+
+    // Lang prefix: "/en/", "/zh-CN/", or empty if no lang segment. The first
+    // path segment after the host is the language unless it's "studio" itself
+    // (in which case the URL has no lang prefix and we land at scheme+host+/).
+    std::string base; // scheme+host(+lang)+slash
+    {
+        const bool first_seg_is_studio =
+            url.compare(host_end + 1, 7, "studio/") == 0;
+        if (first_seg_is_studio) {
+            base = url.substr(0, host_end + 1);
+        } else {
+            const size_t lang_end = url.find('/', host_end + 1);
+            if (lang_end == std::string::npos) {
+                base = url.substr(0, host_end + 1);
+            } else {
+                base = url.substr(0, lang_end + 1);
+            }
+        }
+    }
+
+    // Print history is per-user and has no public-web equivalent. Falling back
+    // to the localized homepage is the least-surprising outcome.
+    if (url.find("/studio/print-history") != std::string::npos) {
+        return wxString::FromUTF8(base.c_str());
+    }
+
+    // Search results: /studio/webview/search?...keyword=K... -> /search?keyword=K
+    if (url.find("/studio/webview/search") != std::string::npos) {
+        const size_t kw_pos = url.find("keyword=");
+        if (kw_pos != std::string::npos) {
+            const size_t kw_start = kw_pos + std::strlen("keyword=");
+            const size_t kw_end   = url.find('&', kw_start);
+            const std::string keyword =
+                url.substr(kw_start, kw_end == std::string::npos
+                                         ? std::string::npos
+                                         : kw_end - kw_start);
+            // keyword stays URL-encoded -- it was percent-encoded going in.
+            return wxString::FromUTF8((base + "search?keyword=" + keyword).c_str());
+        }
+        // Search URL with no keyword param: drop user at the search landing.
+        return wxString::FromUTF8((base + "search").c_str());
+    }
+
+    // Single-model detail: /studio/webview?modelid=N -> /models/N
+    {
+        const size_t mid_pos = url.find("modelid=");
+        if (mid_pos != std::string::npos) {
+            const size_t mid_start = mid_pos + std::strlen("modelid=");
+            const size_t mid_end   = url.find('&', mid_start);
+            const std::string mid =
+                url.substr(mid_start, mid_end == std::string::npos
+                                          ? std::string::npos
+                                          : mid_end - mid_start);
+            if (!mid.empty())
+                return wxString::FromUTF8((base + "models/" + mid).c_str());
+        }
+    }
+
+    // Default landing: /studio/webview -> homepage.
+    return wxString::FromUTF8(base.c_str());
 }
 
 bool WebViewPanel::GetJumpUrl(bool login, wxString ticket, wxString targeturl, wxString &finalurl)

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -1378,22 +1378,25 @@ wxString WebViewPanel::TranslateMakerWorldEmbeddedUrl(const wxString &embedded_u
                                            : value_end - value_start);
     };
 
-    // Search results: /studio/webview/search?...keyword=K... -> /search?keyword=K
-    if (url.find("/studio/webview/search") != std::string::npos) {
-        const std::string keyword = find_param("keyword");
-        if (!keyword.empty()) {
-            // keyword stays URL-encoded -- it was percent-encoded going in.
-            return wxString::FromUTF8((base + "search?keyword=" + keyword).c_str());
-        }
-        // Search URL with no keyword param: drop user at the search landing.
-        return wxString::FromUTF8((base + "search").c_str());
-    }
-
-    // Single-model detail: /studio/webview?modelid=N -> /models/N
+    // Single-model detail comes first: a model viewed THROUGH the search
+    // context still has a modelid in the URL, and what the user wants to
+    // share is the model itself, not the search query that found it.
+    //
+    //   /studio/webview?modelid=N             -> /models/N
+    //   /studio/webview/search?...&modelid=N  -> /models/N
     {
         const std::string mid = find_param("modelid");
         if (!mid.empty())
             return wxString::FromUTF8((base + "models/" + mid).c_str());
+    }
+
+    // Search results with no modelid: there is no public-web search-results
+    // URL we can hand back. /<lang>/search?keyword=K returns 404 on
+    // makerworld.com (verified 2026-05-20). Fall back to the localized
+    // homepage, same shape as the print-history branch above. The user
+    // gets a working link, not a broken one.
+    if (url.find("/studio/webview/search") != std::string::npos) {
+        return wxString::FromUTF8(base.c_str());
     }
 
     // Default landing: /studio/webview -> homepage.

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -1,5 +1,6 @@
 #include "WebViewDialog.hpp"
 
+#include "SystemShare.hpp"
 #include "I18N.hpp"
 #include "slic3r/GUI/wxExtensions.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
@@ -159,8 +160,29 @@ WebViewPanel::WebViewPanel(wxWindow *parent)
     left_group->Add(m_online_back_btn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(12));
     left_group->Add(m_online_refresh_btn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(12));
 
-    m_online_open_browser_btn = make_online_toolbar_button("open_in_browser", _L("Open in browser"));
-    right_group->Add(m_online_open_browser_btn, 0, wxALIGN_CENTER_VERTICAL);
+    // Share toolbar button. Replaces the previous Open-in-browser button --
+    // the menu Share opens has Open Link as its first item, so the
+    // Open-in-browser flow is preserved as a strict subset of Share. Tinted
+    // Bambu green to read as the primary action on this surface; uses the
+    // same toolbar chrome (no border, same min-size) as the other toolbar
+    // buttons so it slots in cleanly.
+    {
+        const std::string accent = "#00AE42";
+        wxBitmap bitmap = create_scaled_bitmap("share", this, m_online_toolbar_icon_px, false, accent);
+        m_online_share_btn = new wxBitmapButton(m_online_toolbar_panel, wxID_ANY, bitmap,
+                                                wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
+        m_online_share_btn->SetToolTip(_L("Share"));
+        m_online_share_btn->SetBackgroundColour(toolbar_bg);
+        m_online_share_btn->SetBitmapDisabled(
+            create_scaled_bitmap("share", this, m_online_toolbar_icon_px, false,
+                                 StateColor::darkModeColorFor(wxColour("#c0babaff"))
+                                     .GetAsString(wxC2S_HTML_SYNTAX).ToStdString()));
+        m_online_share_btn->SetMinSize(wxSize(FromDIP(28), FromDIP(28)));
+        // Right-margin keeps the icon off the window edge -- without this
+        // the Share button sits flush against the right edge of the
+        // toolbar panel, which reads as crowded next to the iframe edge.
+        right_group->Add(m_online_share_btn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(12));
+    }
 
     m_online_toolbar_sizer->Add(left_group, 0, wxALIGN_CENTER_VERTICAL);
     m_online_toolbar_sizer->AddStretchSpacer(1);
@@ -168,7 +190,7 @@ WebViewPanel::WebViewPanel(wxWindow *parent)
 
     m_online_back_btn->Enable(false);
     m_online_refresh_btn->Enable(false);
-    m_online_open_browser_btn->Enable(false);
+    m_online_share_btn->Enable(false);
 
     m_online_toolbar_panel->Hide();
     int toolbar_top_padding = FromDIP(8);
@@ -319,7 +341,7 @@ WebViewPanel::WebViewPanel(wxWindow *parent)
 #endif //BBL_RELEASE_TO_PUBLIC
     Bind(wxEVT_BUTTON, &WebViewPanel::OnOnlineBack, this, m_online_back_btn->GetId());
     Bind(wxEVT_BUTTON, &WebViewPanel::OnOnlineReload, this, m_online_refresh_btn->GetId());
-    Bind(wxEVT_BUTTON, &WebViewPanel::OnOpenInBrowser, this, m_online_open_browser_btn->GetId());
+    Bind(wxEVT_BUTTON, &WebViewPanel::OnShareCurrent, this, m_online_share_btn->GetId());
 
     // Connect the menu events
     Bind(wxEVT_MENU, &WebViewPanel::OnViewSourceRequest, this, viewSource->GetId());
@@ -571,33 +593,24 @@ void WebViewPanel::OnOnlineReload(wxCommandEvent& WXUNUSED(evt))
     UpdateOnlineToolbarState();
 }
 
-void WebViewPanel::OnOpenInBrowser(wxCommandEvent& WXUNUSED(evt))
+void WebViewPanel::OnShareCurrent(wxCommandEvent &evt)
 {
-    wxWebView *target = nullptr;
-    if (m_contentname == "online")
-        target = m_browserMW;
-    else if (m_contentname == "makerlab")
-        target = m_browserML;
+    // Only "online" (MakerWorld) shares for now; makerlab URLs don't have a
+    // public-web equivalent that makes sense to share. The Share menu's
+    // "Open Link" item replaces the previous toolbar Open-in-browser
+    // button; "Copy Link" and "Share..." (macOS / Windows) are the new
+    // affordances.
+    if (m_contentname != "online" || !m_browserMW) return;
 
-    if (!target) return;
+    wxString current_url = m_browserMW->GetCurrentURL();
+    if (IsBlankWebUrl(current_url)) return;
 
-    wxString current_url = target->GetCurrentURL();
-    if (IsBlankWebUrl(current_url))
-        return;
+    const wxString public_url = TranslateMakerWorldEmbeddedUrl(current_url);
 
-    // For the "Online Models" tab the embedded URL is the slicer-only
-    // /studio/webview view, which hides comments, designer profile,
-    // version-specific print profiles, and link rendering in descriptions.
-    // Translate to the public-web equivalent (e.g. /models/{id}) so the user
-    // lands on the actual MakerWorld page.
-    //
-    // For "makerlab" we don't translate yet; embedded MakerLab URLs don't
-    // have an obvious 1:1 public mapping.
-    if (m_contentname == "online")
-        current_url = TranslateMakerWorldEmbeddedUrl(current_url);
+    wxWindow *anchor = wxDynamicCast(evt.GetEventObject(), wxWindow);
+    if (!anchor) anchor = m_online_share_btn ? (wxWindow *) m_online_share_btn : (wxWindow *) this;
 
-    wxLaunchDefaultBrowser(current_url);
-    UpdateOnlineToolbarState();
+    SystemShare::ShareUrl(anchor, public_url, m_online_last_title);
 }
 
 void WebViewPanel::OnCut(wxCommandEvent& WXUNUSED(evt))
@@ -1349,16 +1362,26 @@ wxString WebViewPanel::TranslateMakerWorldEmbeddedUrl(const wxString &embedded_u
         return wxString::FromUTF8(base.c_str());
     }
 
+    // Find a query parameter value. Matches `?key=` or `&key=` (delimited)
+    // so we don't false-positive on substrings like `?fromodelid=` finding
+    // `modelid=` at offset 4. Returns "" if absent.
+    auto find_param = [&url](const char *key) -> std::string {
+        const std::string needle_q = std::string("?") + key + "=";
+        const std::string needle_a = std::string("&") + key + "=";
+        size_t pos = url.find(needle_q);
+        if (pos == std::string::npos) pos = url.find(needle_a);
+        if (pos == std::string::npos) return std::string();
+        const size_t value_start = pos + needle_q.size(); // same len as needle_a
+        const size_t value_end   = url.find('&', value_start);
+        return url.substr(value_start, value_end == std::string::npos
+                                           ? std::string::npos
+                                           : value_end - value_start);
+    };
+
     // Search results: /studio/webview/search?...keyword=K... -> /search?keyword=K
     if (url.find("/studio/webview/search") != std::string::npos) {
-        const size_t kw_pos = url.find("keyword=");
-        if (kw_pos != std::string::npos) {
-            const size_t kw_start = kw_pos + std::strlen("keyword=");
-            const size_t kw_end   = url.find('&', kw_start);
-            const std::string keyword =
-                url.substr(kw_start, kw_end == std::string::npos
-                                         ? std::string::npos
-                                         : kw_end - kw_start);
+        const std::string keyword = find_param("keyword");
+        if (!keyword.empty()) {
             // keyword stays URL-encoded -- it was percent-encoded going in.
             return wxString::FromUTF8((base + "search?keyword=" + keyword).c_str());
         }
@@ -1368,17 +1391,9 @@ wxString WebViewPanel::TranslateMakerWorldEmbeddedUrl(const wxString &embedded_u
 
     // Single-model detail: /studio/webview?modelid=N -> /models/N
     {
-        const size_t mid_pos = url.find("modelid=");
-        if (mid_pos != std::string::npos) {
-            const size_t mid_start = mid_pos + std::strlen("modelid=");
-            const size_t mid_end   = url.find('&', mid_start);
-            const std::string mid =
-                url.substr(mid_start, mid_end == std::string::npos
-                                          ? std::string::npos
-                                          : mid_end - mid_start);
-            if (!mid.empty())
-                return wxString::FromUTF8((base + "models/" + mid).c_str());
-        }
+        const std::string mid = find_param("modelid");
+        if (!mid.empty())
+            return wxString::FromUTF8((base + "models/" + mid).c_str());
     }
 
     // Default landing: /studio/webview -> homepage.
@@ -1726,6 +1741,11 @@ void WebViewPanel::OnDocumentLoaded(wxWebViewEvent& evt)
 void WebViewPanel::OnTitleChanged(wxWebViewEvent &evt)
 {
     BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << ": " << evt.GetString().ToUTF8().data();
+    // Cache the MakerWorld page title so the system share menu can use it
+    // (Mail subject lines, Messages link previews, etc.).
+    if (m_browserMW != nullptr && evt.GetId() == m_browserMW->GetId()) {
+        m_online_last_title = evt.GetString();
+    }
     // wxGetApp().CallAfter([this] { SendRecentList(); });
 }
 
@@ -2407,7 +2427,7 @@ void WebViewPanel::SetOnlineToolbarVisible(bool visible)
     if (!visible) {
         if (m_online_back_btn) m_online_back_btn->Enable(false);
         if (m_online_refresh_btn) m_online_refresh_btn->Enable(false);
-        if (m_online_open_browser_btn) m_online_open_browser_btn->Enable(false);
+        if (m_online_share_btn) m_online_share_btn->Enable(false);
     } else {
         UpdateOnlineToolbarState();
     }
@@ -2448,13 +2468,18 @@ void WebViewPanel::UpdateOnlineToolbarState()
 
     update_btn_state(m_online_back_btn, can_go_back, "mall_control_back");
     update_btn_state(m_online_refresh_btn, can_show_open_button, "mall_control_refresh");
-    if (m_online_open_browser_btn) {
-        bool has_url = false;
-        if (can_show_open_button) {
-            wxString url = active_webview->GetCurrentURL();
-            has_url      = !IsBlankWebUrl(url);
-        }
-        m_online_open_browser_btn->Enable(has_url);
+    bool has_url = false;
+    if (can_show_open_button) {
+        wxString url = active_webview->GetCurrentURL();
+        has_url      = !IsBlankWebUrl(url);
+    }
+    if (m_online_share_btn) {
+        // The Share button is the only enabled action for "makerlab" too --
+        // wait, actually it's not, because OnShareCurrent early-returns
+        // when m_contentname != "online". So only enable the button on the
+        // online tab. On makerlab/no-content, leave it disabled so clicking
+        // doesn't dead-end.
+        m_online_share_btn->Enable(on_online_tab && has_url);
     }
 }
 

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -1445,22 +1445,25 @@ wxString WebViewPanel::TranslateMakerWorldEmbeddedUrl(const wxString &embedded_u
                                            : value_end - value_start);
     };
 
-    // Search results: /studio/webview/search?...keyword=K... -> /search?keyword=K
-    if (url.find("/studio/webview/search") != std::string::npos) {
-        const std::string keyword = find_param("keyword");
-        if (!keyword.empty()) {
-            // keyword stays URL-encoded -- it was percent-encoded going in.
-            return wxString::FromUTF8((base + "search?keyword=" + keyword).c_str());
-        }
-        // Search URL with no keyword param: drop user at the search landing.
-        return wxString::FromUTF8((base + "search").c_str());
-    }
-
-    // Single-model detail: /studio/webview?modelid=N -> /models/N
+    // Single-model detail comes first: a model viewed THROUGH the search
+    // context still has a modelid in the URL, and what the user wants to
+    // share is the model itself, not the search query that found it.
+    //
+    //   /studio/webview?modelid=N             -> /models/N
+    //   /studio/webview/search?...&modelid=N  -> /models/N
     {
         const std::string mid = find_param("modelid");
         if (!mid.empty())
             return wxString::FromUTF8((base + "models/" + mid).c_str());
+    }
+
+    // Search results with no modelid: there is no public-web search-results
+    // URL we can hand back. /<lang>/search?keyword=K returns 404 on
+    // makerworld.com (verified 2026-05-20). Fall back to the localized
+    // homepage, same shape as the print-history branch above. The user
+    // gets a working link, not a broken one.
+    if (url.find("/studio/webview/search") != std::string::npos) {
+        return wxString::FromUTF8(base.c_str());
     }
 
     // Default landing: /studio/webview -> homepage.

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -639,6 +639,17 @@ void WebViewPanel::OnOpenInBrowser(wxCommandEvent& WXUNUSED(evt))
     if (IsBlankWebUrl(current_url))
         return;
 
+    // For the "Online Models" tab the embedded URL is the slicer-only
+    // /studio/webview view, which hides comments, designer profile,
+    // version-specific print profiles, and link rendering in descriptions.
+    // Translate to the public-web equivalent (e.g. /models/{id}) so the user
+    // lands on the actual MakerWorld page.
+    //
+    // For "makerlab" we don't translate yet; embedded MakerLab URLs don't
+    // have an obvious 1:1 public mapping.
+    if (m_contentname == "online")
+        current_url = TranslateMakerWorldEmbeddedUrl(current_url);
+
     wxLaunchDefaultBrowser(current_url);
     UpdateOnlineToolbarState();
 }
@@ -1309,6 +1320,136 @@ std::string UrlDecode(const std::string &str)
             strTemp += str[i];
     }
     return strTemp;
+}
+
+// Translate the slicer-embedded MakerWorld view URL to the equivalent public-web
+// URL. The embedded view (loaded as e.g. https://makerworld.com/en/studio/webview
+// ?modelid=12345&from=bambustudio) is a Studio-only iframe shape that hides
+// comments, designer profile, hyperlinks in descriptions, version selection and
+// per-version print profiles. The public-web shape (e.g.
+// https://makerworld.com/en/models/12345) shows all of that. This translation
+// powers the "Open in browser" toolbar button so users see the full model page
+// instead of a duplicate of what's already in the slicer.
+//
+// Returns the input unchanged when no public-web equivalent is known (e.g.
+// agree-terms / sign-in / sign-out auth redirects, makerlab sub-tools); the
+// caller can decide whether to launch as-is or skip.
+wxString WebViewPanel::TranslateMakerWorldEmbeddedUrl(const wxString &embedded_url)
+{
+    if (embedded_url.IsEmpty()) return embedded_url;
+
+    std::string url = embedded_url.ToStdString();
+
+    // Drop #fragment and utm_* tracking params before pattern matching. Both
+    // are noise in any context this function returns into (Open in browser,
+    // Share to system picker, copy link), and we want pass-through URLs (the
+    // ones the recognizer below doesn't match) to be cleaned too.
+    {
+        const size_t hash_pos = url.find('#');
+        if (hash_pos != std::string::npos) url.erase(hash_pos);
+
+        const size_t q_pos = url.find('?');
+        if (q_pos != std::string::npos) {
+            const std::string params = url.substr(q_pos + 1);
+            std::string filtered;
+            size_t start = 0;
+            while (start <= params.size()) {
+                const size_t end = params.find('&', start);
+                const size_t len = (end == std::string::npos)
+                                       ? params.size() - start
+                                       : end - start;
+                const std::string param = params.substr(start, len);
+                const bool is_utm = param.size() > 4
+                                    && param.compare(0, 4, "utm_") == 0;
+                if (!param.empty() && !is_utm) {
+                    if (!filtered.empty()) filtered += '&';
+                    filtered += param;
+                }
+                if (end == std::string::npos) break;
+                start = end + 1;
+            }
+            url = filtered.empty()
+                      ? url.substr(0, q_pos)
+                      : url.substr(0, q_pos + 1) + filtered;
+        }
+    }
+
+    // Find the host root: everything up to and including the first '/' after
+    // the host. We keep the original scheme+host+lang prefix (e.g.
+    // "https://makerworld.com/en/" or "https://makerworld.com.cn/zh-CN/") so
+    // that region- and language-localized embedded URLs translate to the same
+    // region/language on the public web.
+    const size_t scheme_end = url.find("://");
+    if (scheme_end == std::string::npos) return wxString::FromUTF8(url.c_str());
+    const size_t host_start = scheme_end + 3;
+    const size_t host_end = url.find('/', host_start);
+    if (host_end == std::string::npos) return wxString::FromUTF8(url.c_str());
+
+    // Bail out early if this isn't a MakerWorld URL we recognize. We don't
+    // attempt to translate makerlab/, store/, sign-in/, sign-out/, etc.
+    if (url.find("/studio/webview") == std::string::npos &&
+        url.find("/studio/print-history") == std::string::npos)
+        return wxString::FromUTF8(url.c_str());
+
+    // Lang prefix: "/en/", "/zh-CN/", or empty if no lang segment. The first
+    // path segment after the host is the language unless it's "studio" itself
+    // (in which case the URL has no lang prefix and we land at scheme+host+/).
+    std::string base; // scheme+host(+lang)+slash
+    {
+        const bool first_seg_is_studio =
+            url.compare(host_end + 1, 7, "studio/") == 0;
+        if (first_seg_is_studio) {
+            base = url.substr(0, host_end + 1);
+        } else {
+            const size_t lang_end = url.find('/', host_end + 1);
+            if (lang_end == std::string::npos) {
+                base = url.substr(0, host_end + 1);
+            } else {
+                base = url.substr(0, lang_end + 1);
+            }
+        }
+    }
+
+    // Print history is per-user and has no public-web equivalent. Falling back
+    // to the localized homepage is the least-surprising outcome.
+    if (url.find("/studio/print-history") != std::string::npos) {
+        return wxString::FromUTF8(base.c_str());
+    }
+
+    // Search results: /studio/webview/search?...keyword=K... -> /search?keyword=K
+    if (url.find("/studio/webview/search") != std::string::npos) {
+        const size_t kw_pos = url.find("keyword=");
+        if (kw_pos != std::string::npos) {
+            const size_t kw_start = kw_pos + std::strlen("keyword=");
+            const size_t kw_end   = url.find('&', kw_start);
+            const std::string keyword =
+                url.substr(kw_start, kw_end == std::string::npos
+                                         ? std::string::npos
+                                         : kw_end - kw_start);
+            // keyword stays URL-encoded -- it was percent-encoded going in.
+            return wxString::FromUTF8((base + "search?keyword=" + keyword).c_str());
+        }
+        // Search URL with no keyword param: drop user at the search landing.
+        return wxString::FromUTF8((base + "search").c_str());
+    }
+
+    // Single-model detail: /studio/webview?modelid=N -> /models/N
+    {
+        const size_t mid_pos = url.find("modelid=");
+        if (mid_pos != std::string::npos) {
+            const size_t mid_start = mid_pos + std::strlen("modelid=");
+            const size_t mid_end   = url.find('&', mid_start);
+            const std::string mid =
+                url.substr(mid_start, mid_end == std::string::npos
+                                          ? std::string::npos
+                                          : mid_end - mid_start);
+            if (!mid.empty())
+                return wxString::FromUTF8((base + "models/" + mid).c_str());
+        }
+    }
+
+    // Default landing: /studio/webview -> homepage.
+    return wxString::FromUTF8(base.c_str());
 }
 
 bool WebViewPanel::GetJumpUrl(bool login, wxString ticket, wxString targeturl, wxString &finalurl)

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -1,5 +1,6 @@
 #include "WebViewDialog.hpp"
 
+#include "SystemShare.hpp"
 #include "I18N.hpp"
 #include "slic3r/GUI/wxExtensions.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
@@ -213,8 +214,29 @@ WebViewPanel::WebViewPanel(wxWindow *parent)
     left_group->Add(m_online_back_btn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(12));
     left_group->Add(m_online_refresh_btn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(12));
 
-    m_online_open_browser_btn = make_online_toolbar_button("open_in_browser", _L("Open in browser"));
-    right_group->Add(m_online_open_browser_btn, 0, wxALIGN_CENTER_VERTICAL);
+    // Share toolbar button. Replaces the previous Open-in-browser button --
+    // the menu Share opens has Open Link as its first item, so the
+    // Open-in-browser flow is preserved as a strict subset of Share. Tinted
+    // Bambu green to read as the primary action on this surface; uses the
+    // same toolbar chrome (no border, same min-size) as the other toolbar
+    // buttons so it slots in cleanly.
+    {
+        const std::string accent = "#00AE42";
+        wxBitmap bitmap = create_scaled_bitmap("share", this, m_online_toolbar_icon_px, false, accent);
+        m_online_share_btn = new wxBitmapButton(m_online_toolbar_panel, wxID_ANY, bitmap,
+                                                wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
+        m_online_share_btn->SetToolTip(_L("Share"));
+        m_online_share_btn->SetBackgroundColour(toolbar_bg);
+        m_online_share_btn->SetBitmapDisabled(
+            create_scaled_bitmap("share", this, m_online_toolbar_icon_px, false,
+                                 StateColor::darkModeColorFor(wxColour("#c0babaff"))
+                                     .GetAsString(wxC2S_HTML_SYNTAX).ToStdString()));
+        m_online_share_btn->SetMinSize(wxSize(FromDIP(28), FromDIP(28)));
+        // Right-margin keeps the icon off the window edge -- without this
+        // the Share button sits flush against the right edge of the
+        // toolbar panel, which reads as crowded next to the iframe edge.
+        right_group->Add(m_online_share_btn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(12));
+    }
 
     m_online_toolbar_sizer->Add(left_group, 0, wxALIGN_CENTER_VERTICAL);
     m_online_toolbar_sizer->AddStretchSpacer(1);
@@ -222,7 +244,7 @@ WebViewPanel::WebViewPanel(wxWindow *parent)
 
     m_online_back_btn->Enable(false);
     m_online_refresh_btn->Enable(false);
-    m_online_open_browser_btn->Enable(false);
+    m_online_share_btn->Enable(false);
 
     m_online_toolbar_panel->Hide();
     int toolbar_top_padding = FromDIP(8);
@@ -373,7 +395,7 @@ WebViewPanel::WebViewPanel(wxWindow *parent)
 #endif //BBL_RELEASE_TO_PUBLIC
     Bind(wxEVT_BUTTON, &WebViewPanel::OnOnlineBack, this, m_online_back_btn->GetId());
     Bind(wxEVT_BUTTON, &WebViewPanel::OnOnlineReload, this, m_online_refresh_btn->GetId());
-    Bind(wxEVT_BUTTON, &WebViewPanel::OnOpenInBrowser, this, m_online_open_browser_btn->GetId());
+    Bind(wxEVT_BUTTON, &WebViewPanel::OnShareCurrent, this, m_online_share_btn->GetId());
 
     // Connect the menu events
     Bind(wxEVT_MENU, &WebViewPanel::OnViewSourceRequest, this, viewSource->GetId());
@@ -625,33 +647,24 @@ void WebViewPanel::OnOnlineReload(wxCommandEvent& WXUNUSED(evt))
     UpdateOnlineToolbarState();
 }
 
-void WebViewPanel::OnOpenInBrowser(wxCommandEvent& WXUNUSED(evt))
+void WebViewPanel::OnShareCurrent(wxCommandEvent &evt)
 {
-    wxWebView *target = nullptr;
-    if (m_contentname == "online")
-        target = m_browserMW;
-    else if (m_contentname == "makerlab")
-        target = m_browserML;
+    // Only "online" (MakerWorld) shares for now; makerlab URLs don't have a
+    // public-web equivalent that makes sense to share. The Share menu's
+    // "Open Link" item replaces the previous toolbar Open-in-browser
+    // button; "Copy Link" and "Share..." (macOS / Windows) are the new
+    // affordances.
+    if (m_contentname != "online" || !m_browserMW) return;
 
-    if (!target) return;
+    wxString current_url = m_browserMW->GetCurrentURL();
+    if (IsBlankWebUrl(current_url)) return;
 
-    wxString current_url = target->GetCurrentURL();
-    if (IsBlankWebUrl(current_url))
-        return;
+    const wxString public_url = TranslateMakerWorldEmbeddedUrl(current_url);
 
-    // For the "Online Models" tab the embedded URL is the slicer-only
-    // /studio/webview view, which hides comments, designer profile,
-    // version-specific print profiles, and link rendering in descriptions.
-    // Translate to the public-web equivalent (e.g. /models/{id}) so the user
-    // lands on the actual MakerWorld page.
-    //
-    // For "makerlab" we don't translate yet; embedded MakerLab URLs don't
-    // have an obvious 1:1 public mapping.
-    if (m_contentname == "online")
-        current_url = TranslateMakerWorldEmbeddedUrl(current_url);
+    wxWindow *anchor = wxDynamicCast(evt.GetEventObject(), wxWindow);
+    if (!anchor) anchor = m_online_share_btn ? (wxWindow *) m_online_share_btn : (wxWindow *) this;
 
-    wxLaunchDefaultBrowser(current_url);
-    UpdateOnlineToolbarState();
+    SystemShare::ShareUrl(anchor, public_url, m_online_last_title);
 }
 
 void WebViewPanel::OnCut(wxCommandEvent& WXUNUSED(evt))
@@ -1416,16 +1429,26 @@ wxString WebViewPanel::TranslateMakerWorldEmbeddedUrl(const wxString &embedded_u
         return wxString::FromUTF8(base.c_str());
     }
 
+    // Find a query parameter value. Matches `?key=` or `&key=` (delimited)
+    // so we don't false-positive on substrings like `?fromodelid=` finding
+    // `modelid=` at offset 4. Returns "" if absent.
+    auto find_param = [&url](const char *key) -> std::string {
+        const std::string needle_q = std::string("?") + key + "=";
+        const std::string needle_a = std::string("&") + key + "=";
+        size_t pos = url.find(needle_q);
+        if (pos == std::string::npos) pos = url.find(needle_a);
+        if (pos == std::string::npos) return std::string();
+        const size_t value_start = pos + needle_q.size(); // same len as needle_a
+        const size_t value_end   = url.find('&', value_start);
+        return url.substr(value_start, value_end == std::string::npos
+                                           ? std::string::npos
+                                           : value_end - value_start);
+    };
+
     // Search results: /studio/webview/search?...keyword=K... -> /search?keyword=K
     if (url.find("/studio/webview/search") != std::string::npos) {
-        const size_t kw_pos = url.find("keyword=");
-        if (kw_pos != std::string::npos) {
-            const size_t kw_start = kw_pos + std::strlen("keyword=");
-            const size_t kw_end   = url.find('&', kw_start);
-            const std::string keyword =
-                url.substr(kw_start, kw_end == std::string::npos
-                                         ? std::string::npos
-                                         : kw_end - kw_start);
+        const std::string keyword = find_param("keyword");
+        if (!keyword.empty()) {
             // keyword stays URL-encoded -- it was percent-encoded going in.
             return wxString::FromUTF8((base + "search?keyword=" + keyword).c_str());
         }
@@ -1435,17 +1458,9 @@ wxString WebViewPanel::TranslateMakerWorldEmbeddedUrl(const wxString &embedded_u
 
     // Single-model detail: /studio/webview?modelid=N -> /models/N
     {
-        const size_t mid_pos = url.find("modelid=");
-        if (mid_pos != std::string::npos) {
-            const size_t mid_start = mid_pos + std::strlen("modelid=");
-            const size_t mid_end   = url.find('&', mid_start);
-            const std::string mid =
-                url.substr(mid_start, mid_end == std::string::npos
-                                          ? std::string::npos
-                                          : mid_end - mid_start);
-            if (!mid.empty())
-                return wxString::FromUTF8((base + "models/" + mid).c_str());
-        }
+        const std::string mid = find_param("modelid");
+        if (!mid.empty())
+            return wxString::FromUTF8((base + "models/" + mid).c_str());
     }
 
     // Default landing: /studio/webview -> homepage.
@@ -1924,6 +1939,11 @@ void WebViewPanel::OnDocumentLoaded(wxWebViewEvent& evt)
 void WebViewPanel::OnTitleChanged(wxWebViewEvent &evt)
 {
     BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << ": " << evt.GetString().ToUTF8().data();
+    // Cache the MakerWorld page title so the system share menu can use it
+    // (Mail subject lines, Messages link previews, etc.).
+    if (m_browserMW != nullptr && evt.GetId() == m_browserMW->GetId()) {
+        m_online_last_title = evt.GetString();
+    }
     // wxGetApp().CallAfter([this] { SendRecentList(); });
 }
 
@@ -2671,7 +2691,7 @@ void WebViewPanel::SetOnlineToolbarVisible(bool visible)
     if (!visible) {
         if (m_online_back_btn) m_online_back_btn->Enable(false);
         if (m_online_refresh_btn) m_online_refresh_btn->Enable(false);
-        if (m_online_open_browser_btn) m_online_open_browser_btn->Enable(false);
+        if (m_online_share_btn) m_online_share_btn->Enable(false);
     } else {
         UpdateOnlineToolbarState();
     }
@@ -2712,13 +2732,18 @@ void WebViewPanel::UpdateOnlineToolbarState()
 
     update_btn_state(m_online_back_btn, can_go_back, "mall_control_back");
     update_btn_state(m_online_refresh_btn, can_show_open_button, "mall_control_refresh");
-    if (m_online_open_browser_btn) {
-        bool has_url = false;
-        if (can_show_open_button) {
-            wxString url = active_webview->GetCurrentURL();
-            has_url      = !IsBlankWebUrl(url);
-        }
-        m_online_open_browser_btn->Enable(has_url);
+    bool has_url = false;
+    if (can_show_open_button) {
+        wxString url = active_webview->GetCurrentURL();
+        has_url      = !IsBlankWebUrl(url);
+    }
+    if (m_online_share_btn) {
+        // The Share button is the only enabled action for "makerlab" too --
+        // wait, actually it's not, because OnShareCurrent early-returns
+        // when m_contentname != "online". So only enable the button on the
+        // online tab. On makerlab/no-content, leave it disabled so clicking
+        // doesn't dead-end.
+        m_online_share_btn->Enable(on_online_tab && has_url);
     }
 }
 

--- a/src/slic3r/GUI/WebViewDialog.hpp
+++ b/src/slic3r/GUI/WebViewDialog.hpp
@@ -51,7 +51,7 @@ public:
     void OnReload(wxCommandEvent& evt);
     void OnOnlineBack(wxCommandEvent& evt);
     void OnOnlineReload(wxCommandEvent& evt);
-    void OnOpenInBrowser(wxCommandEvent& evt);
+    void OnShareCurrent(wxCommandEvent& evt);
     void OnNavigationRequest(wxWebViewEvent& evt);
     void OnNavigationComplete(wxWebViewEvent& evt);
     void OnDocumentLoaded(wxWebViewEvent& evt);
@@ -211,10 +211,21 @@ private:
     wxBoxSizer *    m_online_toolbar_sizer { nullptr };
     wxBitmapButton *m_online_back_btn { nullptr };
     wxBitmapButton *m_online_refresh_btn { nullptr };
-    wxBitmapButton *m_online_open_browser_btn { nullptr };
+    // Share toolbar button. Replaces the previous Open-in-browser button:
+    // clicking pops a 3-item menu (Open Link / Copy Link / Share...) so the
+    // open-in-browser flow is preserved as the menu's first item, plus
+    // copy/share are now reachable from the same surface. Tinted Bambu
+    // green to read as the primary action on the Online Models toolbar.
+    wxBitmapButton *m_online_share_btn { nullptr };
     wxPanel *       m_online_container { nullptr };
     wxBoxSizer *    m_online_container_sizer { nullptr };
     int             m_online_toolbar_icon_px { 16 };
+
+    // Most recent document title from m_browserMW, captured via
+    // wxEVT_WEBVIEW_TITLE_CHANGED. Used as the title item passed to the
+    // system share menu so targets like Mail/Messages can prefill subject
+    // lines or link previews.
+    wxString m_online_last_title;
 
     wxMenu* m_tools_menu;
     wxMenuItem* m_tools_handle_navigation;

--- a/src/slic3r/GUI/WebViewDialog.hpp
+++ b/src/slic3r/GUI/WebViewDialog.hpp
@@ -112,6 +112,13 @@ public:
     //DisconnectPage
     wxString MakeDisconnectUrl(std::string MenuName);
 
+    // Translate the slicer-embedded MakerWorld view URL
+    // (https://makerworld.com/<lang>/studio/webview?modelid=N&from=bambustudio
+    // and friends) to the equivalent public-web URL the user can open in their
+    // default browser to see comments, designer profile, hyperlinks etc.
+    // Returns the input unchanged if no translation applies.
+    wxString TranslateMakerWorldEmbeddedUrl(const wxString &embedded_url);
+
     //LeftMenu
     std::string m_contentname; // CurrentMenu
     bool        m_leftfirst;   // Left First Loaded

--- a/src/slic3r/GUI/WebViewDialog.hpp
+++ b/src/slic3r/GUI/WebViewDialog.hpp
@@ -53,7 +53,7 @@ public:
     void OnReload(wxCommandEvent& evt);
     void OnOnlineBack(wxCommandEvent& evt);
     void OnOnlineReload(wxCommandEvent& evt);
-    void OnOpenInBrowser(wxCommandEvent& evt);
+    void OnShareCurrent(wxCommandEvent& evt);
     void OnNavigationRequest(wxWebViewEvent& evt);
     void OnNavigationComplete(wxWebViewEvent& evt);
     void OnDocumentLoaded(wxWebViewEvent& evt);
@@ -220,10 +220,21 @@ private:
     wxBoxSizer *    m_online_toolbar_sizer { nullptr };
     wxBitmapButton *m_online_back_btn { nullptr };
     wxBitmapButton *m_online_refresh_btn { nullptr };
-    wxBitmapButton *m_online_open_browser_btn { nullptr };
+    // Share toolbar button. Replaces the previous Open-in-browser button:
+    // clicking pops a 3-item menu (Open Link / Copy Link / Share...) so the
+    // open-in-browser flow is preserved as the menu's first item, plus
+    // copy/share are now reachable from the same surface. Tinted Bambu
+    // green to read as the primary action on the Online Models toolbar.
+    wxBitmapButton *m_online_share_btn { nullptr };
     wxPanel *       m_online_container { nullptr };
     wxBoxSizer *    m_online_container_sizer { nullptr };
     int             m_online_toolbar_icon_px { 16 };
+
+    // Most recent document title from m_browserMW, captured via
+    // wxEVT_WEBVIEW_TITLE_CHANGED. Used as the title item passed to the
+    // system share menu so targets like Mail/Messages can prefill subject
+    // lines or link previews.
+    wxString m_online_last_title;
 
     wxMenu* m_tools_menu;
     wxMenuItem* m_tools_handle_navigation;

--- a/src/slic3r/GUI/WebViewDialog.hpp
+++ b/src/slic3r/GUI/WebViewDialog.hpp
@@ -115,6 +115,13 @@ public:
     //DisconnectPage
     wxString MakeDisconnectUrl(std::string MenuName);
 
+    // Translate the slicer-embedded MakerWorld view URL
+    // (https://makerworld.com/<lang>/studio/webview?modelid=N&from=bambustudio
+    // and friends) to the equivalent public-web URL the user can open in their
+    // default browser to see comments, designer profile, hyperlinks etc.
+    // Returns the input unchanged if no translation applies.
+    wxString TranslateMakerWorldEmbeddedUrl(const wxString &embedded_url);
+
     //LeftMenu
     std::string m_contentname; // CurrentMenu
     bool        m_leftfirst;   // Left First Loaded


### PR DESCRIPTION
## Summary

Two related improvements to the Online Models tab, bundled because they share the same code surface (`WebViewPanel` toolbar + URL handling) and cooperate at runtime:

1. **URL translation:** the existing toolbar "Open in browser" button used to launch the slicer-embedded URL (`/studio/webview?modelid=N`), which serves a stripped-down view designed for the in-app iframe — comments hidden, designer profile hidden, hyperlinks in descriptions not rendered, version selector abbreviated. Translate that to the public-web URL (`/<lang>/models/N`) so the user lands on the actual MakerWorld page they expect.

2. **Share menu:** replace the single-action "Open in browser" toolbar button with a Share button (Bambu green) that pops a 3-item menu — `Open Link`, `Copy Link`, `Share...`. The previous open-in-browser flow is preserved as the menu's first item; copy and system-share are now reachable from the same surface. `Share...` opens the OS-native share UI (`NSSharingServicePicker` on macOS, `DataTransferManager` on Windows) so the user can send the link via Messages, Mail, AirDrop, Notes, or any installed share extension (Slack, Telegram, etc.). On Linux (and on Windows builds without the Win10 SDK) the menu falls back to Open Link / Copy Link only.

Addresses #5755 (comments hidden, can't copy links) and helps #10165 (read makerworld comments), #9321 (render hyperlinks), #5076 (related discoverability gaps).

## Architecture

The cross-platform interface lives in `src/slic3r/GUI/SystemShare.{hpp,cpp}` plus three platform implementations selected by CMake:

- `SystemShare_mac.mm` — `NSSharingServicePicker` anchored to the wxWindow's NSView via `wxWindow::GetHandle()`.
- `SystemShare_win.cpp` — `Windows.ApplicationModel.DataTransfer.DataTransferManager` driven via `IDataTransferManagerInterop` so a Win32 HWND can talk to what's normally a UWP-only API. Activation pattern follows the existing `Utils/FixModelByWin10.cpp`: dynamic-load `ComBase.dll` and look up `RoInitialize` / `RoGetActivationFactory` / `WindowsCreateString` at runtime via `GetProcAddress`. Gated on `HAS_WIN10SDK`, same gate `FixModelByWin10.cpp` uses.
- `SystemShare_fallback.cpp` — Linux, plus Windows builds without `HAS_WIN10SDK`. `HasNativePicker()` returns false; the menu omits the `Share...` item.

`HasNativePicker()` on Windows additionally consults the lazy WinRT loader so older Windows installs lacking ComBase.dll (or the specific symbols we depend on) hide the menu item entirely instead of advertising a feature that would silently no-op when invoked.

`add_DataRequested` is additive on the per-HWND `DataTransferManager` singleton, so the handler must be unregistered explicitly. We capture the cookie returned by `add_DataRequested` via `shared_ptr<EventRegistrationToken>` into the handler's closure and the handler removes itself on first fire; explicit cleanup at the call site if `ShowShareUIForWindow` returns an error before invoking the data callback. macOS picker is autoreleased (project default is MRR, no `-fobjc-arc`) so each Share... invocation doesn't permanently retain a picker.

## Test plan

**URL translation:**
1. Open Online Models tab.
2. Click any model card.
3. Click the new toolbar Share button → choose Open Link.
4. **Without patch:** browser opens `/studio/webview?modelid=N` (slicer-embedded view, comments hidden). **With patch:** browser opens `/<lang>/models/N` (real MakerWorld page).

**Share menu:**
1. Open Online Models tab; click any model card.
2. Click the toolbar Share button.
3. Verify menu items: `Open Link`, `Copy Link`, separator, `Share...` (macOS / Windows only).
4. Choose `Copy Link` → paste anywhere; verify the URL is the public `/<lang>/models/N` form.
5. (macOS / Windows) Choose `Share...` → verify the system share picker appears anchored at the toolbar button, listing Messages, Mail, AirDrop, etc.

## Tested

- macOS 26.4.1, Apple Silicon (M5 Max), Xcode 26.5 SDK. Open Link, Copy Link, and Share... (NSSharingServicePicker) all verified end-to-end.
- Windows: implementation written against the WinRT docs and the existing `Utils/FixModelByWin10.cpp` activation pattern in this codebase. Compiles per Bambu Windows CI; runtime-untested by author (no Windows test machine). Happy to iterate on feedback from a maintainer or Windows-using contributor.
- Linux: fallback path (Open Link / Copy Link only) compiles; the macOS-tested URL translation logic is platform-independent so the Linux user-visible behavior is the same as macOS minus the `Share...` item.
