### PR TITLE
fix: correct 'percision' typo to 'precision' in motion calibration UI strings

### DIFF
--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -197,9 +197,9 @@ wxString Slic3r::get_stage_string(int stage)
     case 35:
         return _L("Pause (nozzle clog)");
     case 36:
-        return _L("Measuring motion percision");
+        return _L("Measuring motion precision");
     case 37:
-        return _L("Enhancing motion percision");
+        return _L("Enhancing motion precision");
     case 38:
         return _L("Measure motion accuracy");
     case 39:


### PR DESCRIPTION
## Problem

Two printer status strings in `DeviceManager.cpp` (cases 36 and 37) used the misspelling **"percision"** instead of **"precision"**:

- `"Measuring motion percision"`
- `"Enhancing motion percision"`

These strings are shown to users in the device status panel during motion calibration.

## Fix

Correct both strings in `src/slic3r/GUI/DeviceManager.cpp`.

Source-string change only, the translation catalogs (`bbl/i18n/*.po`, `BambuStudio.pot`) are intentionally left untouched and regenerated by the upstream gettext pipeline, per maintainer guidance on #10871.

Closes #10856.

