### PR TITLE
fix: correct grammar and punctuation in English UI strings

### DIFF
--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -197,9 +197,9 @@ wxString Slic3r::get_stage_string(int stage)
     case 35:
         return _L("Pause (nozzle clog)");
     case 36:
-        return _L("Measuring motion percision");
+        return _L("Measuring motion precision");
     case 37:
-        return _L("Enhancing motion percision");
+        return _L("Enhancing motion precision");
     case 38:
         return _L("Measure motion accuracy");
     case 39:

--- a/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp
@@ -2795,7 +2795,7 @@ void GLGizmoAdvancedCut::render_input_window_warning() const
                    (m_info_stats.outside_cut_contour == 1 ? _L("connector is out of cut contour") : _L("connectors are out of cut contour"));
         if (m_info_stats.outside_bb > size_t(0))
             out += "\n - " + std::to_string(m_info_stats.outside_bb) +
-                   (m_info_stats.outside_bb == 1 ? _L("connector is out of object") : _L("connectors is out of object"));
+                   (m_info_stats.outside_bb == 1 ? _L("connector is out of object") : _L("connectors are out of object"));
         if (m_info_stats.is_overlap)
             out += "\n - " + _L("Some connectors are overlapped");
         m_imgui->warning_text(out);

--- a/src/slic3r/GUI/Gizmos/GLGizmoText.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoText.cpp
@@ -2433,7 +2433,7 @@ void GLGizmoText::on_render_input_window(float x, float y, float bottom_limit)
     }
     if (m_show_warning_error_mesh) {
         m_imgui->warning_text_wrapped(
-            _L("Error:Detecting an incorrect mesh id or an unknown error, regenerating text may result in incorrect outcomes.Please drag text,save it then reedit it again."),
+            _L("Error: Detecting an incorrect mesh id or an unknown error, regenerating text may result in incorrect outcomes. Please drag text, save it then reedit it again."),
             full_width);
         m_parent.request_extra_frame();
     }

--- a/src/slic3r/GUI/MediaPlayCtrl.cpp
+++ b/src/slic3r/GUI/MediaPlayCtrl.cpp
@@ -373,7 +373,7 @@ void MediaPlayCtrl::Play()
 
     if (m_lan_proto <= MachineObject::LVL_Disable && (m_lan_mode || !m_remote_proto)) {
         Stop(m_lan_proto == MachineObject::LVL_None
-            ? _L("Problem occured. Please update the printer firmware and try again.")
+            ? _L("Problem occurred. Please update the printer firmware and try again.")
             : _L("LAN Only Liveview is off. Please turn on the liveview on printer screen."));
         return;
     }

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -1847,7 +1847,7 @@ void SelectMachineDialog::show_status(PrintDialogStatus status, std::vector<wxSt
         for (auto warning : plate->get_slice_result()->warnings) {
             if (warning.msg == NOT_GENERATE_TIMELAPSE) {
                 if (warning.error_code == "10014001") {
-                    msg_text = _L("When enable spiral vase mode, machines with I3 structure will not generate timelapse videos.");
+                    msg_text = _L("When enabling spiral vase mode, machines with I3 structure will not generate timelapse videos.");
                 }
                 else if (warning.error_code == "10014002") {
                     msg_text = _L("The current printer does not support timelapse in Traditional Mode when printing By-Object.");
@@ -4203,7 +4203,7 @@ bool SelectMachineDialog::has_timelapse_warning(wxString &msg_text)
     for (auto warning : plate->get_slice_result()->warnings) {
         if (warning.msg == NOT_GENERATE_TIMELAPSE) {
             if (warning.error_code == "10014001") {
-                msg_text = _L("When enable spiral vase mode, machines with I3 structure will not generate timelapse videos.");
+                msg_text = _L("When enabling spiral vase mode, machines with I3 structure will not generate timelapse videos.");
             } else if (warning.error_code == "10014002") {
                 msg_text = _L("The current printer does not support timelapse in Traditional Mode when printing By-Object.");
             }

--- a/src/slic3r/GUI/SyncAmsInfoDialog.cpp
+++ b/src/slic3r/GUI/SyncAmsInfoDialog.cpp
@@ -1807,7 +1807,7 @@ void SyncAmsInfoDialog::show_status(PrintDialogStatus status, std::vector<wxStri
         for (auto warning : plate->get_slice_result()->warnings) {
             if (warning.msg == NOT_GENERATE_TIMELAPSE) {
                 if (warning.error_code == "10014001") {
-                    msg_text = _L("When enable spiral vase mode, machines with I3 structure will not generate timelapse videos.");
+                    msg_text = _L("When enabling spiral vase mode, machines with I3 structure will not generate timelapse videos.");
                 } else if (warning.error_code == "10014002") {
                     msg_text = _L("Timelapse is not supported because Print sequence is set to \"By object\".");
                 }


### PR DESCRIPTION
## Summary

Four English grammar/spelling/punctuation errors corrected in UI strings displayed to users:

| File | Before | After |
|------|--------|-------|
| `src/slic3r/GUI/MediaPlayCtrl.cpp` | `"Problem occured."` | `"Problem occurred."` |
| `src/slic3r/GUI/SelectMachine.cpp` | `"When enable spiral vase mode…"` | `"When enabling spiral vase mode…"` |
| `src/slic3r/GUI/SyncAmsInfoDialog.cpp` | `"When enable spiral vase mode…"` | `"When enabling spiral vase mode…"` |
| `src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp` | `"connectors is out of object"` | `"connectors are out of object"` |
| `src/slic3r/GUI/Gizmos/GLGizmoText.cpp` | `"Error:Detecting …outcomes.Please drag…"` | `"Error: Detecting …outcomes. Please drag…"` |

Source-string changes only, the translation catalogs (`bbl/i18n/*.po`, `BambuStudio.pot`) are left to the upstream gettext pipeline, per maintainer guidance on #10871.

Closes #10854.

