### PR TITLE
fix(macos): skip JS on hidden WebViews; re-layout main frame on wake

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2705,6 +2705,21 @@ void GUI_App::MacPowerCallBack(void* refcon, io_service_t service, natural_t mes
             dev_manager->set_selected_machine(last_selected_machine);
             BOOST_LOG_TRIVIAL(info) << "MacPowerCallBack restore selected machine:" << BBLCrossTalk::Crosstalk_DevId(last_selected_machine);
         }
+
+        // After wake, force a re-layout of the main frame on the UI thread.
+        // macOS can leave the selected tab's wxWebView with a stale hidden
+        // NSView (setHidden:YES) after sleep/wake; events still route to the
+        // window but the hit-test view is hidden so keyboard/mouse input is
+        // silently dropped. Re-running Layout()+Refresh() reconciles wx's
+        // notion of visibility with AppKit's and unsticks the content view.
+        wxGetApp().CallAfter([] {
+            MainFrame *mf = wxGetApp().mainframe;
+            if (mf == nullptr) return;
+            BOOST_LOG_TRIVIAL(info) << "MacPowerCallBack: re-laying out main frame after wake";
+            mf->Layout();
+            mf->Refresh();
+            mf->Update();
+        });
     };
 }
 

--- a/src/slic3r/GUI/Widgets/WebView.cpp
+++ b/src/slic3r/GUI/Widgets/WebView.cpp
@@ -385,6 +385,39 @@ bool WebView::RunScript(wxWebView *webView, wxString const &javascript)
             && javascript.find("studio_userlogin") == wxString::npos)
         wxLogMessage("Running JavaScript:\n%s\n", javascript);
 
+    if (webView == nullptr)
+        return false;
+
+#ifdef __WXMAC__
+    // Skip JS evaluation on hidden webviews on macOS. Several panels keep a
+    // pool of wxWebView instances that are Hide()'d and swapped in on demand
+    // (see WebViewPanel::SetWebviewShow). Pushing JS into a hidden view
+    // still wakes the WebContent process via WKWebView evaluateJavaScript
+    // (runJavaScriptInFrameInScriptWorld cancels ProcessThrottler
+    // suspension) while the events delivered to its NSView are silently
+    // dropped because it is setHidden:YES. After sleep/wake this has been
+    // observed to produce a minutes-long "frozen input" state for the user
+    // -- the window has focus but the hit-test view is hidden.
+    //
+    // Return true (not false) because "view is hidden, skipped" is not an
+    // error from the caller's perspective: the wxWebView's wxEVT_SHOW
+    // handler in WebViewDialog re-pushes the relevant state when a hidden
+    // panel becomes visible. Returning false would conflate this benign
+    // skip with a real wkWebView/ICoreWebView2 failure and trigger the
+    // error-log paths in callers like wgtFilaManagerPanel::SendMsg. Same
+    // truthy contract as the macOS evaluateJavaScript path further down.
+    //
+    // Known follow-up: the timer-driven JS pushes that fire on a hidden
+    // home tab (e.g. m_LoginUpdateTimer's user-print-task refresh in
+    // WebViewPanel::OnFreshLoginStatus) drop on the floor without an
+    // explicit replay-on-show hook. The home page already lazy-initializes
+    // most state on tab activation, so this is mostly cosmetic, but a
+    // future commit could add the same m_has_pending_* defer/replay
+    // pattern used by SendDesignStaffpick at WebViewDialog.cpp:763.
+    if (!webView->IsShownOnScreen())
+        return true;
+#endif // __WXMAC__
+
     try {
 #ifdef __WIN32__
         ICoreWebView2 *   webView2 = (ICoreWebView2 *) webView->GetNativeBackend();


### PR DESCRIPTION
## Summary

After macOS sleep/wake, BambuStudio's window can enter a state where it has focus but keyboard/mouse input is silently dropped — the user sees a "frozen" window for minutes, with force-reboot the only reliable recovery. Two related defects combine to produce this:

1. **`WebView::RunScript` evaluates JS into hidden webviews.** The home panel keeps a pool of ~6 wxWebView instances (left nav, right/home, makerworld, makerlab, print history, wiki) that get `Hide()`'d and swapped in via `SetWebviewShow`. The 2s `m_LoginUpdateTimer` (`WebViewPanel::OnFreshLoginStatus`) keeps pushing JS into them. On macOS, each call becomes `WKWebView evaluateJavaScript`, which wakes the WebContent child process via `runJavaScriptInFrameInScriptWorld`, cancels `ProcessThrottler` suspension, and fails `markAllLayersVolatile`. After sleep/wake the layer-suspension churn compounds until the window's hit-test view ends up `setHidden:YES` while the window still has focus. Input events route to a hidden NSView and get silently dropped.

   **Fix:** gate `RunScript` on `webView->IsShownOnScreen()`, scoped via `#ifdef __WXMAC__` so non-macOS builds (where `ICoreWebView2::ExecuteScript` and `webkit_web_view_run_javascript` don't have an out-of-process content renderer with the same throttler-vs-hidden-host-view interaction) keep their existing behavior. Returns `true` for the skip case (matching the macOS path's existing semantics) so callers that branch on the return value don't conflate a benign hidden-view skip with a real script failure. Same `IsShownOnScreen()` precedent already at `WebViewDialog.cpp:763` (`SendDesignStaffpick`).

2. **`MacPowerCallBack` doesn't re-layout on wake.** `kIOMessageSystemHasPoweredOn` only restores the previously-selected printer; nothing nudges the wxWidgets <-> AppKit visibility reconciliation. Any view left with a stale `setHidden:YES` from defect 1 stays hidden indefinitely.

   **Fix:** schedule `Layout()/Refresh()/Update()` on the main frame via `wxGetApp().CallAfter` so wxWidgets reconciles with AppKit after the IOKit notification handler unwinds. The `CallAfter` is structurally unnecessary (the IOKit notification is dispatched on the main run loop via `IONotificationPortGetRunLoopSource(CFRunLoopGetCurrent(), ...)`), but it's defensive: lets the system-power notification finish its own cleanup before we touch wx state.

## Reproduction

1. Launch the BambuStudio Dev build on macOS.
2. Use the app normally for a few minutes (any tab; doesn't have to be Home).
3. Close the laptop lid (or `pmset sleepnow`).
4. Wait several minutes (long enough for `markAllLayersVolatile` failures to accumulate).
5. Wake the machine, focus the BambuStudio window.

**Without patch:** keyboard/mouse input dropped silently. Console shows `WKWebView_evaluateJavaScript` wakeups every 2 s during sleep, plus repeated `PageClientImpl: window visible 1, view hidden 1, window occluded 0` traces during the stuck-focus window. Eventually requires force-reboot.

**With patch:** input continues to work after wake; no frozen state observed across multiple sleep/wake cycles over several days.

## Test plan

- [x] Smoke-test sleep/wake in the patched Dev build over multiple cycles. Author has run this for several days without recurrence.
- [ ] Smoke-test home-panel state staleness: switch to Prepare for ~30s with a login-status change happening (sign out via web), switch back to Home, confirm UI reflects current state. (Known follow-up: `IsShownOnScreen()` gate causes some timer-driven JS pushes to drop on the floor while the user is on a non-Home tab. The home page already lazy-initializes most state on tab activation, so this is mostly cosmetic, but a future commit could add the `m_has_pending_*` defer/replay pattern used by `SendDesignStaffpick` at `WebViewDialog.cpp:763`. Out of scope for this PR.)

## Tested

- macOS 26.4.1 / Apple Silicon (M5 Max) / Xcode 26.5 SDK / BambuStudio v02.06.01.55-Dev. Multiple sleep/wake cycles over several days, no recurrence.
- Windows / Linux: not exercised, but the `__WXMAC__` scoping leaves their behavior unchanged. The unconditional null-check is added defensive code only.
