### PR TITLE
fix: correct punctuation and grammar in UI warning/tip strings

### DIFF
--- a/src/slic3r/GUI/AMSSetting.cpp
+++ b/src/slic3r/GUI/AMSSetting.cpp
@@ -128,7 +128,7 @@ void AMSSetting::create()
     m_sizer_starting_tip_inline = new wxBoxSizer(wxVERTICAL);
 
     m_tip_starting_line1 = new Label(m_panel_body,
-        _L("The AMS will automatically read the information of inserted filament on start-up. It will take about 1 minute.The reading process will roll filament spools.")
+        _L("The AMS will automatically read the information of inserted filament on start-up. It will take about 1 minute. The reading process will roll filament spools.")
     );
     m_tip_starting_line1->SetFont(::Label::Body_13);
     m_tip_starting_line1->SetForegroundColour(AMS_SETTING_GREY700);

--- a/src/slic3r/GUI/BindDialog.cpp
+++ b/src/slic3r/GUI/BindDialog.cpp
@@ -485,7 +485,7 @@ PingCodeBindDialog::~PingCodeBindDialog() {
      m_link_Terms_title->Wrap(FromDIP(450));
      m_link_Terms_title->SetForegroundColour(wxColour("#00AE42"));
      m_link_Terms_title->Bind(wxEVT_LEFT_DOWN, [this](auto& e) {
-         wxString txt = _L("Thank you for purchasing a Bambu Lab device.Before using your Bambu Lab device, please read the termsand conditions.By clicking to agree to use your Bambu Lab device, you agree to abide by the Privacy Policy and Terms of Use(collectively, the \"Terms\"). If you do not comply with or agree to the Bambu Lab Privacy Policy, please do not use Bambu Lab equipment and services.");
+         wxString txt = _L("Thank you for purchasing a Bambu Lab device. Before using your Bambu Lab device, please read the terms and conditions. By clicking to agree to use your Bambu Lab device, you agree to abide by the Privacy Policy and Terms of Use (collectively, the \"Terms\"). If you do not comply with or agree to the Bambu Lab Privacy Policy, please do not use Bambu Lab equipment and services.");
          ConfirmBeforeSendDialog confirm_dlg(this, wxID_ANY, _L("Terms and Conditions"), ConfirmBeforeSendDialog::ButtonStyle::ONLY_CONFIRM);
          confirm_dlg.update_text(txt);
          confirm_dlg.CenterOnParent();

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -189,7 +189,7 @@ void ConfigManipulation::check_chamber_temperature(DynamicPrintConfig* config)
         auto iter = recommend_temp_map.find(filament_type);
         if (iter!=recommend_temp_map.end()) {
             if (iter->second < config->option<ConfigOptionInts>("chamber_temperatures")->get_at(0)) {
-                wxString msg_text = wxString::Format(_L("Current chamber temperature is higher than the material's safe temperature,it may result in material softening and clogging.The maximum safe temperature for the material is %d"), iter->second);
+                wxString msg_text = wxString::Format(_L("Current chamber temperature is higher than the material's safe temperature, it may result in material softening and clogging. The maximum safe temperature for the material is %d"), iter->second);
                 MessageDialog dialog(m_msg_dlg_parent, msg_text, "", wxICON_WARNING | wxOK);
                 is_msg_dlg_already_exist = true;
                 dialog.ShowModal();

--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -197,9 +197,9 @@ wxString Slic3r::get_stage_string(int stage)
     case 35:
         return _L("Pause (nozzle clog)");
     case 36:
-        return _L("Measuring motion percision");
+        return _L("Measuring motion precision");
     case 37:
-        return _L("Enhancing motion percision");
+        return _L("Enhancing motion precision");
     case 38:
         return _L("Measure motion accuracy");
     case 39:
@@ -2955,7 +2955,7 @@ int MachineObject::parse_json(std::string tunnel, std::string payload, bool key_
                         if (jj["errno"].is_number()) {
                             wxString text;
                             if (jj["errno"].get<int>() == -2) {
-                                 text = _L("Low temperature filament(PLA/PETG/TPU) is loaded in the extruder.In order to avoid extruder clogging,it is not allowed to set the chamber temperature.");
+                                 text = _L("Low temperature filament (PLA/PETG/TPU) is loaded in the extruder. In order to avoid extruder clogging, it is not allowed to set the chamber temperature.");
                             }
                             else if (jj["errno"].get<int>() == -4) {
                                  text = _L("When you set the chamber temperature below 40\u2103, the chamber temperature control will not be activated. And the target chamber temperature will automatically be set to 0\u2103.");

--- a/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp
@@ -2795,7 +2795,7 @@ void GLGizmoAdvancedCut::render_input_window_warning() const
                    (m_info_stats.outside_cut_contour == 1 ? _L("connector is out of cut contour") : _L("connectors are out of cut contour"));
         if (m_info_stats.outside_bb > size_t(0))
             out += "\n - " + std::to_string(m_info_stats.outside_bb) +
-                   (m_info_stats.outside_bb == 1 ? _L("connector is out of object") : _L("connectors is out of object"));
+                   (m_info_stats.outside_bb == 1 ? _L("connector is out of object") : _L("connectors are out of object"));
         if (m_info_stats.is_overlap)
             out += "\n - " + _L("Some connectors are overlapped");
         m_imgui->warning_text(out);

--- a/src/slic3r/GUI/Gizmos/GLGizmoMeasure.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMeasure.cpp
@@ -1886,14 +1886,14 @@ void GLGizmoMeasure::show_selection_ui()
     if (m_selected_wrong_feature_waring_tip) {
         if (m_measure_mode == EMeasureMode::ONLY_ASSEMBLY) {
             if (m_assembly_mode == AssemblyMode::FACE_FACE) {
-                m_imgui->warning_text(_L("Warning:please select Plane's feature."));
+                m_imgui->warning_text(_L("Warning: Please select a Plane feature."));
             } else if (m_assembly_mode == AssemblyMode::POINT_POINT) {
-                m_imgui->warning_text(_L("Warning:please select Point's or Circle's feature."));
+                m_imgui->warning_text(_L("Warning: Please select a Point or Circle feature."));
             }
         }
     }
     if (m_measure_mode == EMeasureMode::ONLY_ASSEMBLY && m_hit_different_volumes.size() == 1) {
-        m_imgui->warning_text(_L("Warning:please select two different mesh."));
+        m_imgui->warning_text(_L("Warning: Please select two different meshes."));
     }
 }
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoSVG.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSVG.cpp
@@ -1355,7 +1355,7 @@ void GLGizmoSVG::draw_window()
         draw_model_type();
     }
     if (!m_can_use_surface) {
-        m_imgui->text_wrapped(_L("Tip:If you want to place svg file on another part surface,you should select part first, and then drag svg file to the part surface."),
+        m_imgui->text_wrapped(_L("Tip: If you want to place an SVG file on another part surface, select the part first, then drag the SVG file to the part surface."),
                               m_gui_cfg->input_offset + m_gui_cfg->input_width + m_gui_cfg->icon_width);
     }
 }

--- a/src/slic3r/GUI/Gizmos/GLGizmoText.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoText.cpp
@@ -2400,24 +2400,24 @@ void GLGizmoText::on_render_input_window(float x, float y, float bottom_limit)
     std::string text = m_text;
     auto    cur_world = m_model_object_in_world_tran.get_matrix() * m_text_tran_in_object.get_matrix();
     if (!is_only_text_case() && has_reflection(cur_world)) {
-        m_imgui->warning_text_wrapped(_L("Warning:There is a mirror in the text matrix, and dragging it will completely regenerate it."), full_width);
+        m_imgui->warning_text_wrapped(_L("Warning: There is a mirror in the text matrix, and dragging it will completely regenerate it."), full_width);
         m_parent.request_extra_frame();
     }
     if (m_warning_font) {
-        m_imgui->warning_text_wrapped(_L("Warning:Due to font upgrades,previous font may not necessarily be replaced successfully, and recommend you to modify the font."), full_width);
+        m_imgui->warning_text_wrapped(_L("Warning: Due to font upgrades, previous font may not necessarily be replaced successfully. Please modify the font."), full_width);
         m_parent.request_extra_frame();
     }
     if (m_show_warning_text_create_fail) {
-        m_imgui->warning_text(_L("Warning:create text fail."));
+        m_imgui->warning_text(_L("Warning: Text creation failed."));
     }
     if (m_show_text_normal_error) {
-        m_imgui->warning_text(_L("Warning:text normal is error."));
+        m_imgui->warning_text(_L("Warning: Text normal has an error."));
     }
     if (m_show_text_normal_reset_tip) {
-        m_imgui->warning_text(_L("Warning:text normal has been reset."));
+        m_imgui->warning_text(_L("Warning: Text normal has been reset."));
     }
     if (m_font_version == NEW_FONT_BEGIN_VERSION) {
-        m_imgui->warning_text_wrapped(_L("Warning:current text spacing is not very reasonable. If you continue editing, a more reasonable text spacing will be generated.")
+        m_imgui->warning_text_wrapped(_L("Warning: Current text spacing is not optimal. If you continue editing, a more reasonable text spacing will be generated.")
                                           ,full_width);
     }
    /* if (m_show_warning_regenerated && m_font_version != CUR_FONT_VERSION) {
@@ -2426,25 +2426,25 @@ void GLGizmoText::on_render_input_window(float x, float y, float bottom_limit)
         m_parent.request_extra_frame();
     }*/
     if (m_show_warning_old_tran) {
-        m_imgui->warning_text_wrapped(_L("Warning:old matrix has at least two parameters: mirroring, scaling, and rotation. If you continue editing, it may not be correct. Please "
-                                 "dragging text or cancel using current pose, save and reedit again."),
+        m_imgui->warning_text_wrapped(_L("Warning: Old matrix has at least two parameters: mirroring, scaling, and rotation. If you continue editing, it may not be correct. Please "
+                                 "drag the text or cancel the current pose, save and reedit again."),
                               full_width);
         m_parent.request_extra_frame();
     }
     if (m_show_warning_error_mesh) {
         m_imgui->warning_text_wrapped(
-            _L("Error:Detecting an incorrect mesh id or an unknown error, regenerating text may result in incorrect outcomes.Please drag text,save it then reedit it again."),
+            _L("Error: Detecting an incorrect mesh id or an unknown error, regenerating text may result in incorrect outcomes. Please drag text, save it then reedit it again."),
             full_width);
         m_parent.request_extra_frame();
     }
     if (m_show_warning_lost_rotate) {
         m_imgui->warning_text_wrapped(
-            _L("Warning:Due to functional upgrade, rotation information cannot be restored. Please drag or modify text,save it and reedit it will ok."),
+            _L("Warning: Due to functional upgrade, rotation information cannot be restored. Please drag or modify text, save it and reedit it to fix the issue."),
                               full_width);
         m_parent.request_extra_frame();
     }
     if (m_last_text_mv && m_rr.mesh_id < 0 && !is_only_text_case()) {
-        m_imgui->warning_text_wrapped(_L("Warning") + ":"+ _L("Detected that text did not adhere to mesh surface. Please manually drag yellow square to mesh surface that needs to be adhered."),
+        m_imgui->warning_text_wrapped(_L("Warning") + ": " + _L("Detected that text did not adhere to mesh surface. Please manually drag yellow square to mesh surface that needs to be adhered."),
                                       full_width);
         m_parent.request_extra_frame();
     }

--- a/src/slic3r/GUI/Jobs/PlaterWorker.hpp
+++ b/src/slic3r/GUI/Jobs/PlaterWorker.hpp
@@ -90,7 +90,7 @@ class PlaterWorker: public Worker {
             if (eptr) try {
                 std::rethrow_exception(eptr);
             }  catch (std::exception &e) {
-                show_error(m_plater, _L("An unexpected error occured") + ": " + e.what());
+                show_error(m_plater, _L("An unexpected error occurred") + ": " + e.what());
                 eptr = nullptr;
             }
         }

--- a/src/slic3r/GUI/MediaPlayCtrl.cpp
+++ b/src/slic3r/GUI/MediaPlayCtrl.cpp
@@ -373,7 +373,7 @@ void MediaPlayCtrl::Play()
 
     if (m_lan_proto <= MachineObject::LVL_Disable && (m_lan_mode || !m_remote_proto)) {
         Stop(m_lan_proto == MachineObject::LVL_None
-            ? _L("Problem occured. Please update the printer firmware and try again.")
+            ? _L("Problem occurred. Please update the printer firmware and try again.")
             : _L("LAN Only Liveview is off. Please turn on the liveview on printer screen."));
         return;
     }

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1350,7 +1350,7 @@ wxWindow* PreferencesDialog::create_general_page()
                                                          _L("Zoom in towards the mouse pointer's position in the 3D view, rather than the 2D window center."), 50,
                                                          "zoom_to_mouse");
     auto  item_show_shells_in_preview_settings = create_item_checkbox(_L("Always show shells in preview"), page,
-                                                         _L("Always show shells or not in preview view tab.If change value,you should reslice."), 50,
+                                                         _L("Always show shells or not in preview view tab. If you change this value, you should reslice."), 50,
                                                          "show_shells_in_preview");
     auto  item_import_single_svg_and_split         = create_item_checkbox(_L("Import a single SVG and split it"), page,
                                                                      _L("Import a single SVG and then split it to several parts."), 50,

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -1847,7 +1847,7 @@ void SelectMachineDialog::show_status(PrintDialogStatus status, std::vector<wxSt
         for (auto warning : plate->get_slice_result()->warnings) {
             if (warning.msg == NOT_GENERATE_TIMELAPSE) {
                 if (warning.error_code == "10014001") {
-                    msg_text = _L("When enable spiral vase mode, machines with I3 structure will not generate timelapse videos.");
+                    msg_text = _L("When enabling spiral vase mode, machines with I3 structure will not generate timelapse videos.");
                 }
                 else if (warning.error_code == "10014002") {
                     msg_text = _L("The current printer does not support timelapse in Traditional Mode when printing By-Object.");
@@ -4203,7 +4203,7 @@ bool SelectMachineDialog::has_timelapse_warning(wxString &msg_text)
     for (auto warning : plate->get_slice_result()->warnings) {
         if (warning.msg == NOT_GENERATE_TIMELAPSE) {
             if (warning.error_code == "10014001") {
-                msg_text = _L("When enable spiral vase mode, machines with I3 structure will not generate timelapse videos.");
+                msg_text = _L("When enabling spiral vase mode, machines with I3 structure will not generate timelapse videos.");
             } else if (warning.error_code == "10014002") {
                 msg_text = _L("The current printer does not support timelapse in Traditional Mode when printing By-Object.");
             }

--- a/src/slic3r/GUI/SyncAmsInfoDialog.cpp
+++ b/src/slic3r/GUI/SyncAmsInfoDialog.cpp
@@ -1807,7 +1807,7 @@ void SyncAmsInfoDialog::show_status(PrintDialogStatus status, std::vector<wxStri
         for (auto warning : plate->get_slice_result()->warnings) {
             if (warning.msg == NOT_GENERATE_TIMELAPSE) {
                 if (warning.error_code == "10014001") {
-                    msg_text = _L("When enable spiral vase mode, machines with I3 structure will not generate timelapse videos.");
+                    msg_text = _L("When enabling spiral vase mode, machines with I3 structure will not generate timelapse videos.");
                 } else if (warning.error_code == "10014002") {
                     msg_text = _L("Timelapse is not supported because Print sequence is set to \"By object\".");
                 }


### PR DESCRIPTION
## Summary

Fixes missing spaces after `Warning:`, `Error:`, and `Tip:` prefixes, missing spaces after sentence-ending periods and commas, and several grammar errors in UI strings.

### Files changed

| File | Issues fixed |
|---|---|
| `GLGizmoText.cpp` | 9× `Warning:X` → `Warning: X`; `create text fail` → `Text creation failed`; `text normal is error` → `Text normal has an error`; `reedit it will ok` → `reedit it to fix the issue`; `dragging text` → `drag the text`; missing comma spaces |
| `GLGizmoMeasure.cpp` | 3× `Warning:X` → `Warning: X`; `two different mesh` → `two different meshes` |
| `GLGizmoSVG.cpp` | `Tip:If...` → `Tip: If...`; missing comma; `svg file` → `SVG file` |
| `PlaterWorker.hpp` | `error occured` → `error occurred` |
| `DeviceManager.cpp` | `filament(PLA...)` → `filament (PLA...)`; missing spaces after `.` and `,` |
| `BindDialog.cpp` | `device.Before` → `device. Before`; `termsand` → `terms and`; `Use(collectively)` → `Use (collectively)` |
| `ConfigManipulation.cpp` | Missing spaces after `,` and `.` in chamber temperature warning |
| `AMSSetting.cpp` | `1 minute.The` → `1 minute. The` |
| `Preferences.cpp` | `tab.If change value` → `tab. If you change this value` |

Source-string changes only — the translation catalogs (`bbl/i18n/*.po`, `BambuStudio.pot`) are left to the upstream gettext pipeline, per maintainer guidance on #10871.

Closes #10853.
