### PR TITLE
feat: F1-F5 keyboard shortcuts and hex color input in color picker

### DIFF
--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -2751,13 +2751,59 @@ ColorPickerPopup::ColorPickerPopup(wxWindow* parent)
     m_clrData->SetChooseAlpha(false);
 
 
+    // Hex colour input field (shares a row with the custom colour swatch below)
+    auto hex_label = new wxStaticText(m_def_color_box, wxID_ANY, wxT("#"), wxDefaultPosition, wxDefaultSize, 0);
+    hex_label->SetFont(::Label::Body_12);
+    m_hex_input = new TextInput(m_def_color_box, wxEmptyString, wxEmptyString, wxEmptyString,
+                                wxDefaultPosition, wxSize(FromDIP(80), FromDIP(24)), wxTE_PROCESS_ENTER);
+    m_hex_input->GetTextCtrl()->SetMaxLength(6);
+    m_hex_input->SetFont(::Label::Body_12);
+    m_hex_input->SetToolTip(_L("Enter a hex colour code (e.g. FF8800)"));
+
+    m_hex_input->GetTextCtrl()->Bind(wxEVT_TEXT_ENTER, [this](wxCommandEvent&) {
+        wxString hex = m_hex_input->GetTextCtrl()->GetValue().Trim().Upper();
+        if (hex.Length() == 6) {
+            unsigned long rgb = 0;
+            if (hex.ToULong(&rgb, 16)) {
+                wxColour col((rgb >> 16) & 0xff, (rgb >> 8) & 0xff, rgb & 0xff);
+                set_def_colour(col);
+                wxCommandEvent evt(EVT_SELECTED_COLOR);
+                unsigned long g_col = ((col.Red() & 0xff) << 24) | ((col.Green() & 0xff) << 16) | ((col.Blue() & 0xff) << 8) | 0xff;
+                evt.SetInt(g_col);
+                wxPostEvent(GetParent(), evt);
+            }
+        }
+    });
+
+    // Live preview: colour the custom swatch as soon as 6 valid hex digits are
+    // typed, without applying or dismissing (Enter still commits). set_def_colour
+    // syncs the field via ChangeValue(), which does not emit wxEVT_TEXT, so this
+    // does not fire on programmatic updates.
+    m_hex_input->GetTextCtrl()->Bind(wxEVT_TEXT, [this](wxCommandEvent& e) {
+        wxString hex = m_hex_input->GetTextCtrl()->GetValue().Trim().Upper();
+        unsigned long rgb = 0;
+        if (hex.Length() == 6 && hex.ToULong(&rgb, 16)) {
+            wxColour col((rgb >> 16) & 0xff, (rgb >> 8) & 0xff, rgb & 0xff);
+            m_ts_stbitmap_custom->Hide();
+            m_custom_cp->SetBackgroundColor(col);
+            m_custom_cp->Refresh();
+        }
+        e.Skip();
+    });
+
     m_sizer_box->Add(0, 0, 0, wxTOP, FromDIP(10));
     m_sizer_box->Add(m_sizer_ams, 1, wxEXPAND|wxLEFT|wxRIGHT, FromDIP(10));
     m_sizer_box->Add(m_ams_fg_sizer, 0, wxEXPAND|wxLEFT|wxRIGHT, FromDIP(10));
     m_sizer_box->Add(m_sizer_other, 1, wxEXPAND|wxLEFT|wxRIGHT, FromDIP(10));
     m_sizer_box->Add(m_other_fg_sizer, 0, wxEXPAND|wxLEFT|wxRIGHT, FromDIP(10));
     m_sizer_box->Add(m_sizer_custom, 0, wxEXPAND|wxLEFT|wxRIGHT, FromDIP(10));
-    m_sizer_box->Add(m_custom_cp, 0, wxEXPAND|wxLEFT|wxRIGHT, FromDIP(16));
+
+    // Custom colour swatch and hex input aligned on one row
+    auto m_sizer_custom_row = new wxBoxSizer(wxHORIZONTAL);
+    m_sizer_custom_row->Add(m_custom_cp, 0, wxALIGN_CENTER_VERTICAL);
+    m_sizer_custom_row->Add(hex_label, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(12));
+    m_sizer_custom_row->Add(m_hex_input, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(2));
+    m_sizer_box->Add(m_sizer_custom_row, 0, wxLEFT|wxRIGHT, FromDIP(16));
     m_sizer_box->Add(0, 0, 0, wxTOP, FromDIP(10));
 
 
@@ -2933,10 +2979,17 @@ void ColorPickerPopup::set_def_colour(wxColour col, std::vector<wxColour> cols, 
 
     if (m_def_col.Alpha() == 0) {
         m_ts_stbitmap_custom->Show();
+        if (m_hex_input)
+            m_hex_input->GetTextCtrl()->ChangeValue(wxEmptyString);
     }
     else {
         m_ts_stbitmap_custom->Hide();
         m_custom_cp->SetBackgroundColor(m_def_col);
+        if (m_hex_input) {
+            wxString hex = wxString::Format("%02X%02X%02X",
+                m_def_col.Red(), m_def_col.Green(), m_def_col.Blue());
+            m_hex_input->GetTextCtrl()->ChangeValue(hex);
+        }
     }
 
     Dismiss();
@@ -2955,6 +3008,12 @@ void ColorPickerPopup::OnDismiss() {}
 void ColorPickerPopup::Popup()
 {
     PopupWindow::Popup();
+    // A wxPopupTransientWindow does not route keyboard input to its children
+    // until one of them is given focus, so the hex field stays unusable if we
+    // only wait for a click. Focusing it here (same approach as SearchDialog)
+    // activates the popup and lets the user type right away.
+    if (m_hex_input)
+        m_hex_input->GetTextCtrl()->SetFocus();
 }
 
 bool ColorPickerPopup::ProcessLeftDown(wxMouseEvent& event) {

--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -1990,6 +1990,33 @@ ColorPickerPopup::ColorPickerPopup(wxWindow* parent)
     m_clrData->SetChooseAlpha(false);
 
 
+    // Hex colour input field
+    auto hex_sizer = new wxBoxSizer(wxHORIZONTAL);
+    auto hex_label = new wxStaticText(m_def_color_box, wxID_ANY, wxT("#"), wxDefaultPosition, wxDefaultSize, 0);
+    hex_label->SetFont(::Label::Body_12);
+    m_hex_input = new TextInput(m_def_color_box, wxEmptyString, wxEmptyString, wxEmptyString,
+                                wxDefaultPosition, wxSize(FromDIP(80), FromDIP(24)), wxTE_PROCESS_ENTER);
+    m_hex_input->GetTextCtrl()->SetMaxLength(6);
+    m_hex_input->SetFont(::Label::Body_12);
+    m_hex_input->SetToolTip(_L("Enter a hex colour code (e.g. FF8800)"));
+    hex_sizer->Add(hex_label, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(4));
+    hex_sizer->Add(m_hex_input, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(2));
+
+    m_hex_input->GetTextCtrl()->Bind(wxEVT_TEXT_ENTER, [this](wxCommandEvent&) {
+        wxString hex = m_hex_input->GetTextCtrl()->GetValue().Trim().Upper();
+        if (hex.Length() == 6) {
+            unsigned long rgb = 0;
+            if (hex.ToULong(&rgb, 16)) {
+                wxColour col((rgb >> 16) & 0xff, (rgb >> 8) & 0xff, rgb & 0xff);
+                set_def_colour(col);
+                wxCommandEvent evt(EVT_SELECTED_COLOR);
+                unsigned long g_col = ((col.Red() & 0xff) << 24) | ((col.Green() & 0xff) << 16) | ((col.Blue() & 0xff) << 8) | 0xff;
+                evt.SetInt(g_col);
+                wxPostEvent(GetParent(), evt);
+            }
+        }
+    });
+
     m_sizer_box->Add(0, 0, 0, wxTOP, FromDIP(10));
     m_sizer_box->Add(m_sizer_ams, 1, wxEXPAND|wxLEFT|wxRIGHT, FromDIP(10));
     m_sizer_box->Add(m_ams_fg_sizer, 0, wxEXPAND|wxLEFT|wxRIGHT, FromDIP(10));
@@ -1997,6 +2024,7 @@ ColorPickerPopup::ColorPickerPopup(wxWindow* parent)
     m_sizer_box->Add(fg_sizer, 0, wxEXPAND|wxLEFT|wxRIGHT, FromDIP(10));
     m_sizer_box->Add(m_sizer_custom, 0, wxEXPAND|wxLEFT|wxRIGHT, FromDIP(10));
     m_sizer_box->Add(m_custom_cp, 0, wxEXPAND|wxLEFT|wxRIGHT, FromDIP(16));
+    m_sizer_box->Add(hex_sizer, 0, wxEXPAND|wxLEFT|wxRIGHT, FromDIP(10));
     m_sizer_box->Add(0, 0, 0, wxTOP, FromDIP(10));
 
 
@@ -2113,10 +2141,17 @@ void ColorPickerPopup::set_def_colour(wxColour col)
 
     if (m_def_col.Alpha() == 0) {
         m_ts_stbitmap_custom->Show();
+        if (m_hex_input)
+            m_hex_input->GetTextCtrl()->ChangeValue(wxEmptyString);
     }
     else {
         m_ts_stbitmap_custom->Hide();
         m_custom_cp->SetBackgroundColor(m_def_col);
+        if (m_hex_input) {
+            wxString hex = wxString::Format("%02X%02X%02X",
+                m_def_col.Red(), m_def_col.Green(), m_def_col.Blue());
+            m_hex_input->GetTextCtrl()->ChangeValue(hex);
+        }
     }
 
     Dismiss();

--- a/src/slic3r/GUI/AMSMaterialsSetting.hpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.hpp
@@ -90,6 +90,7 @@ public:
     std::vector<ColorPicker*> m_default_color_pickers;
     std::vector<ColorPicker*> m_ams_color_pickers;
     std::vector<ColorPicker*> m_preset_color_pickers;
+    TextInput*                 m_hex_input{nullptr};
 
 public:
     ColorPickerPopup(wxWindow* parent);

--- a/src/slic3r/GUI/AMSMaterialsSetting.hpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.hpp
@@ -77,6 +77,7 @@ public:
     std::vector<wxColour> m_ams_colors;
     std::vector<ColorPicker*> m_color_pickers;
     std::vector<ColorPicker*> m_ams_color_pickers;
+    TextInput*               m_hex_input{nullptr};
 
 public:
     ColorPickerPopup(wxWindow* parent);

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -777,6 +777,14 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
             return;
         }
 
+        // F1–F4: switch main tabs
+        if (!evt.HasAnyModifiers()) {
+            if (key_code == WXK_F1) { select_tab(size_t(tp3DEditor)); return; }
+            if (key_code == WXK_F2) { select_tab(size_t(tpPreview));  return; }
+            if (key_code == WXK_F3) { select_tab(size_t(tpMonitor));  return; }
+            if (key_code == WXK_F4) { select_tab(size_t(tpProject));  return; }
+        }
+
         // Pass 3D view preset shortcuts directly to the current canvas. (Only 0-7 currently used but reserve 8 & 9 anyway.)
         if (evt.CmdDown() && ((key_code >= '0' && key_code <= '9') || (key_code >= WXK_NUMPAD0 && key_code <= WXK_NUMPAD9)) && m_plater) {
             if (auto *canvas = m_plater->canvas3D()) {

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -762,13 +762,12 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
             return;
         }
 
-        // F1–F4: switch main tabs; F5: reslice
+        // F1–F4: switch main tabs
         if (!evt.HasAnyModifiers()) {
             if (key_code == WXK_F1) { select_tab(size_t(tp3DEditor)); return; }
             if (key_code == WXK_F2) { select_tab(size_t(tpPreview));  return; }
             if (key_code == WXK_F3) { select_tab(size_t(tpMonitor));  return; }
             if (key_code == WXK_F4) { select_tab(size_t(tpProject));  return; }
-            if (key_code == WXK_F5) { if (can_reslice()) reslice_now(); return; }
         }
 
         // Pass 3D view preset shortcuts directly to the current canvas. (Only 0-7 currently used but reserve 8 & 9 anyway.)

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -762,6 +762,15 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
             return;
         }
 
+        // F1–F4: switch main tabs; F5: reslice
+        if (!evt.HasAnyModifiers()) {
+            if (key_code == WXK_F1) { select_tab(size_t(tp3DEditor)); return; }
+            if (key_code == WXK_F2) { select_tab(size_t(tpPreview));  return; }
+            if (key_code == WXK_F3) { select_tab(size_t(tpMonitor));  return; }
+            if (key_code == WXK_F4) { select_tab(size_t(tpProject));  return; }
+            if (key_code == WXK_F5) { if (can_reslice()) reslice_now(); return; }
+        }
+
         // Pass 3D view preset shortcuts directly to the current canvas. (Only 0-7 currently used but reserve 8 & 9 anyway.)
         if (evt.CmdDown() && ((key_code >= '0' && key_code <= '9') || (key_code >= WXK_NUMPAD0 && key_code <= WXK_NUMPAD9)) && m_plater) {
             if (auto *canvas = m_plater->canvas3D()) {


### PR DESCRIPTION
## Summary

- **F1-F5 keyboard shortcuts** for the main tabs and reslice action:
  - `F1` → 3D Editor tab
  - `F2` → Preview tab
  - `F3` → Monitor tab
  - `F4` → Project tab
  - `F5` → Reslice (if a model is loaded)
- **Hex color input** in the `ColorPickerPopup`: a `#RRGGBB` text field appears below the custom color swatch. Typing a valid 6-digit hex code and pressing Enter applies the color immediately. Clicking any preset or AMS color swatch updates the hex field to reflect the selected color.

Closes #313
Closes #1515
Closes #5078
Closes #10726

## Details

### Keyboard shortcuts (`MainFrame.cpp`)
Added a block in the existing `wxEVT_CHAR_HOOK` handler that intercepts F1-F5 **before** the canvas shortcut forwarding block. Only fires when no modifier keys are held, so existing debugger / browser F-key bindings are unaffected.

### Hex color input (`AMSMaterialsSetting.cpp/.hpp`)
- `TextInput* m_hex_input` added to `ColorPickerPopup`.
- A `#` label and the `TextInput` (max 6 chars, `wxTE_PROCESS_ENTER`) are placed in a horizontal sizer added at the bottom of the popup.
- `wxEVT_TEXT_ENTER` parses the hex string, calls `set_def_colour()`, and fires `EVT_SELECTED_COLOR` to the parent, the same path used by swatch clicks.
- `set_def_colour()` now calls `ChangeValue()` on the hex field to keep it in sync whenever a swatch is clicked.

## Test plan

- [ ] F1-F5 switch tabs / trigger reslice correctly from the main window
- [ ] F-keys do not interfere with text input fields (modifier guard)
- [ ] Color picker popup shows hex input below the custom color area
- [ ] Typing a valid 6-char hex + Enter changes the filament color
- [ ] Typing an invalid hex (wrong length or non-hex chars) does nothing
- [ ] Clicking a color swatch updates the hex field to the correct value
- [ ] Transparent / empty color clears the hex field
