### PR TITLE
feat(gui): auto-save the open project every 5 minutes

### DIFF
--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -301,6 +301,19 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
 	});
 #endif
 
+    // Auto-save timer: silently saves the open project every 5 minutes when enabled
+    m_autosave_timer = new wxTimer(this);
+    Bind(wxEVT_TIMER, [this](wxTimerEvent& e) {
+        if (e.GetTimer().GetId() != m_autosave_timer->GetId()) { e.Skip(); return; }
+        if (!wxGetApp().app_config || wxGetApp().app_config->get("autosave_enabled") != "1") return;
+        if (!m_plater) return;
+        if (!m_plater->is_project_dirty()) return;
+        if (m_plater->get_project_filename(".3mf").IsEmpty()) return;
+        BOOST_LOG_TRIVIAL(info) << "auto-save: saving project";
+        m_plater->save_project(false);
+    });
+    m_autosave_timer->Start(5 * 60 * 1000); // every 5 minutes
+
 #ifdef __APPLE__
     // Initialize the docker task bar icon.
     switch (wxGetApp().get_app_mode()) {

--- a/src/slic3r/GUI/MainFrame.hpp
+++ b/src/slic3r/GUI/MainFrame.hpp
@@ -97,6 +97,7 @@ class MainFrame : public DPIFrame
     bool     m_loaded {false};
     wxTimer* m_reset_title_text_colour_timer{ nullptr };
     wxString m_title_cache;  // last value applied by update_title(), avoids redundant SetTitle
+    wxTimer* m_autosave_timer{ nullptr };
 
     wxString    m_qs_last_input_file = wxEmptyString;
     wxString    m_qs_last_output_file = wxEmptyString;


### PR DESCRIPTION
## Summary

Auto-saves the open project every 5 minutes: a timer silently calls save when the project is dirty and already has a file path, gated behind the `autosave_enabled` config key.

(Reduced from the original three-feature PR as requested, see split note below.)

> **Note:** there is no Preferences toggle for `autosave_enabled` yet, so it is off unless the key is set. Happy to add a UI toggle if you'd like.

