### PR TITLE
feat: add preference to disable daily tips after slicing

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
      - master
-     - main
     paths:
      - 'deps/**'
      - 'src/**'

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -3,6 +3,7 @@ name: Build all
 on:
   push:
     branches:
+     - master
      - main
     paths:
      - 'deps/**'

--- a/src/slic3r/GUI/DailyTips.cpp
+++ b/src/slic3r/GUI/DailyTips.cpp
@@ -614,6 +614,8 @@ DailyTipsWindow::DailyTipsWindow()
 
 void DailyTipsWindow::open()
 {
+    if (wxGetApp().app_config && wxGetApp().app_config->get("show_daily_tips") == "false")
+        return;
     m_show = true;
     m_panel->retrieve_data_from_hint_database(HintDataNavigation::Curr);
 }

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1592,11 +1592,11 @@ void PreferencesDialog::create_gui_page()
 
     auto title_index_and_tip = create_item_title(_L("Home page and daily tips"), page, _L("Home page and daily tips"));
     auto item_home_page      = create_item_checkbox(_L("Show home page on startup"), page, _L("Show home page on startup"), 50, "show_home_page");
-    //auto item_daily_tip      = create_item_checkbox(_L("Show daily tip on startup"), page, _L("Show daily tip on startup"), 50, "show_daily_tips");
+    auto item_daily_tip      = create_item_checkbox(_L("Show daily tips after slicing"), page, _L("If enabled, daily tips are shown in the slicing notification panel after slicing completes."), 50, "show_daily_tips");
 
     sizer_page->Add(title_index_and_tip, 0, wxTOP, 26);
     sizer_page->Add(item_home_page, 0, wxTOP, 6);
-    //sizer_page->Add(item_daily_tip, 0, wxTOP, 6);
+    sizer_page->Add(item_daily_tip, 0, wxTOP, 6);
 
     page->SetSizer(sizer_page);
     page->Layout();

--- a/src/slic3r/GUI/SlicingProgressNotification.cpp
+++ b/src/slic3r/GUI/SlicingProgressNotification.cpp
@@ -219,19 +219,20 @@ void NotificationManager::SlicingProgressNotification::render(GLCanvas3D& canvas
 	//if (m_sp_state == SlicingProgressNotification::SlicingProgressState::SP_COMPLETED || m_sp_state == SlicingProgressNotification::SlicingProgressState::SP_CANCELLED)
 	//	m_window_width = m_line_height * 25;
 	const ImVec2 progress_child_window_padding = ImVec2(15.f, 0.f) * scale;
-	const ImVec2 dailytips_child_window_padding = m_dailytips_panel->is_expanded() ? ImVec2(15.f, 10.f) * scale : ImVec2(15.f, 0.f) * scale;
+	const bool   show_daily_tips = !wxGetApp().app_config || wxGetApp().app_config->get("show_daily_tips") != "false";
+	const ImVec2 dailytips_child_window_padding = (show_daily_tips && m_dailytips_panel->is_expanded()) ? ImVec2(15.f, 10.f) * scale : ImVec2(15.f, 0.f) * scale;
 	const ImVec2 bottom_padding = ImVec2(0.f, 0.f) * scale;
 	const float  progress_panel_width = (m_window_width - 2 * progress_child_window_padding.x);
 	const float  progress_panel_height = (58.0f * scale);
 	const float  dailytips_panel_width = (m_window_width - 2 * dailytips_child_window_padding.x);
 	const float  gcodeviewer_height = wxGetApp().plater()->get_preview_canvas3D()->get_gcode_viewer().get_legend_height();
 	//const float  dailytips_panel_height = std::min(380.0f * scale, std::max(90.0f, (cnv_size.get_height() - gcodeviewer_height - progress_panel_height - dailytips_child_window_padding.y - initial_y - m_line_height * 4)));
-	const float  dailytips_panel_height = 380.0f * scale;
+	const float  dailytips_panel_height = show_daily_tips ? 380.0f * scale : 0.f;
 
 	float right_gap = right_margin + (move_from_overlay ? overlay_width + m_line_height * 5 : 0);
 	m_window_pos = ImVec2((float)cnv_size.get_width() - right_gap - m_window_width, (float)cnv_size.get_height() - m_top_y);
 	imgui.set_next_window_pos(m_window_pos.x, m_window_pos.y, ImGuiCond_Always, 0.0f, 0.0f);
-	m_window_height = progress_panel_height + m_dailytips_panel->get_size().y + progress_child_window_padding.y + dailytips_child_window_padding.y + bottom_padding.y;
+	m_window_height = progress_panel_height + (show_daily_tips ? m_dailytips_panel->get_size().y : 0.f) + progress_child_window_padding.y + dailytips_child_window_padding.y + bottom_padding.y;
 	m_top_y = initial_y + m_window_height;
 	ImGui::SetNextWindowSizeConstraints(ImVec2(m_window_width, m_window_height), ImVec2(m_window_width, m_window_height));
 
@@ -287,22 +288,24 @@ void NotificationManager::SlicingProgressNotification::render(GLCanvas3D& canvas
 			}
 			ImGui::EndChild();
 
-			// Separator Line
-			ImVec2 separator_min = ImVec2(ImGui::GetCursorScreenPos().x + progress_child_window_padding.x, ImGui::GetCursorScreenPos().y);
-			ImVec2 separator_max = ImVec2(ImGui::GetCursorScreenPos().x + progress_child_window_padding.x + progress_panel_width, ImGui::GetCursorScreenPos().y);
-			ImGui::GetCurrentWindow()->DrawList->AddLine(separator_min, separator_max, ImColor(238, 238, 238, (int)(255 * m_current_fade_opacity)));
+			if (show_daily_tips) {
+				// Separator Line
+				ImVec2 separator_min = ImVec2(ImGui::GetCursorScreenPos().x + progress_child_window_padding.x, ImGui::GetCursorScreenPos().y);
+				ImVec2 separator_max = ImVec2(ImGui::GetCursorScreenPos().x + progress_child_window_padding.x + progress_panel_width, ImGui::GetCursorScreenPos().y);
+				ImGui::GetCurrentWindow()->DrawList->AddLine(separator_min, separator_max, ImColor(238, 238, 238, (int)(255 * m_current_fade_opacity)));
 
-			child_name = "##DailyTipsPanel" + std::to_string(parent_window->ID);
-			ImVec2 dailytips_pos = ImGui::GetCursorScreenPos() + dailytips_child_window_padding;
-			ImVec2 dailytips_size = ImVec2(dailytips_panel_width, dailytips_panel_height);
-			m_dailytips_panel->set_position(dailytips_pos);
-			m_dailytips_panel->set_size(dailytips_size);
-			m_dailytips_panel->set_fade_opacity(m_current_fade_opacity);
-			ImGui::SetNextWindowPos(dailytips_pos);
-			if (ImGui::BeginChild(child_name.c_str(), ImVec2(dailytips_panel_width, dailytips_panel_height), false, child_window_flags)) {
-				render_dailytips_panel(dailytips_pos, dailytips_size);
+				child_name = "##DailyTipsPanel" + std::to_string(parent_window->ID);
+				ImVec2 dailytips_pos = ImGui::GetCursorScreenPos() + dailytips_child_window_padding;
+				ImVec2 dailytips_size = ImVec2(dailytips_panel_width, dailytips_panel_height);
+				m_dailytips_panel->set_position(dailytips_pos);
+				m_dailytips_panel->set_size(dailytips_size);
+				m_dailytips_panel->set_fade_opacity(m_current_fade_opacity);
+				ImGui::SetNextWindowPos(dailytips_pos);
+				if (ImGui::BeginChild(child_name.c_str(), ImVec2(dailytips_panel_width, dailytips_panel_height), false, child_window_flags)) {
+					render_dailytips_panel(dailytips_pos, dailytips_size);
+				}
+				ImGui::EndChild();
 			}
-			ImGui::EndChild();
 		}
 
 		if (ImGui::IsMouseHoveringRect(ImGui::GetWindowPos(), ImGui::GetWindowPos() + ImGui::GetWindowSize(), true)) {


### PR DESCRIPTION
## Summary

Users had no way to permanently turn off the daily tips panel that appears in the slicing notification. Added a **"Show daily tips after slicing"** checkbox to **Preferences → Home page and daily tips** (config key: `show_daily_tips`).

When unchecked:
- `DailyTipsWindow::open()` returns early without showing tips
- `SlicingProgressNotification` skips the separator and tips child window entirely, collapsing the notification to its compact progress-only height

The existing commented-out preference code already used this config key — it just needed to be uncommented and the guard added in the rendering path.

## Test plan

- [ ] Open Preferences → uncheck "Show daily tips after slicing"
- [ ] Slice any model → no daily tips panel, notification is compact
- [ ] Re-enable the option → tips panel reappears after next slice

Closes #3142