### PR TITLE
fix: persist GCode view type (color scheme) across sessions

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
      - master
-     - main
     paths:
      - 'deps/**'
      - 'src/**'

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -3,6 +3,7 @@ name: Build all
 on:
   push:
     branches:
+     - master
      - main
     paths:
      - 'deps/**'

--- a/src/slic3r/GUI/GCodeRenderer/BaseRenderer.cpp
+++ b/src/slic3r/GUI/GCodeRenderer/BaseRenderer.cpp
@@ -192,7 +192,7 @@ namespace Slic3r
                 m_layers_slider = new IMSlider(0, 0, 0, 100, wxSL_VERTICAL);
                 m_p_extrusions = std::make_shared<Extrusions>();
                 m_p_extrusions->reset_role_visibility_flags();
-                if (GUI::wxGetApp().app_config->get_bool("enable_record_gcodeviewer_option_item")) {
+                {
                     auto back_gcodeviewer_option_item = wxGetApp().app_config->get("gcodeviewer_option_item");
                     if (!back_gcodeviewer_option_item.empty()) {
                         m_last_non_helio_option_item = std::atoi(back_gcodeviewer_option_item.c_str());
@@ -3009,10 +3009,8 @@ namespace Slic3r
             }
 
             void BaseRenderer::record_gcodeviewer_option_item() {
-                if (GUI::wxGetApp().app_config->get_bool("enable_record_gcodeviewer_option_item")) {
-                    wxGetApp().app_config->set("gcodeviewer_option_item", std::to_string(m_last_non_helio_option_item));
-                    wxGetApp().app_config->save();
-                }
+                wxGetApp().app_config->set("gcodeviewer_option_item", std::to_string(m_last_non_helio_option_item));
+                wxGetApp().app_config->save();
             }
 
             bool BaseRenderer::get_min_max_value_of_option(int index, float& _min, float& _max) const


### PR DESCRIPTION
## Summary

The selected GCode color scheme (Line Type, Filament, Feedrate, etc.) was not remembered across sessions. The save/restore code existed but was gated behind an `enable_record_gcodeviewer_option_item` config flag that defaults to `false`.

Removed the guard so the last selection is always saved to `gcodeviewer_option_item` in app config and restored on next startup.

## Test plan

- [ ] Slice a model
- [ ] Switch the GCode view color scheme to "Filament" (or any non-default)
- [ ] Restart BambuStudio
- [ ] Open the same or any other sliced model → "Filament" color scheme should still be selected

Closes #7131