### PR TITLE
fix: 'z' key triggers zoom shortcut instead of typing in text fields

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
      - master
-     - main
     paths:
      - 'deps/**'
      - 'src/**'

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -3,6 +3,7 @@ name: Build all
 on:
   push:
     branches:
+     - master
      - main
     paths:
      - 'deps/**'

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -100,10 +100,20 @@ wxDEFINE_EVENT(EVT_LOAD_PRINTER_URL, wxCommandEvent);
 
 static bool is_text_entry_focused()
 {
-    for (wxWindow *window = wxWindow::FindFocus(); window != nullptr; window = window->GetParent())
-        if (dynamic_cast<wxTextEntry *>(window) != nullptr)
+    wxWindow *focused = wxWindow::FindFocus();
+    // Walk up the parent chain — covers the common case where a native text
+    // control (wxTextCtrl) or a composite widget's inner text ctrl has focus.
+    for (wxWindow *w = focused; w != nullptr; w = w->GetParent())
+        if (dynamic_cast<wxTextEntry *>(w) != nullptr)
             return true;
-
+    // Also check direct children of the focused window: on some platforms
+    // (e.g. Windows with custom TextInput panels) focus lands on the outer
+    // container while the inner wxTextCtrl is a direct child.
+    if (focused) {
+        for (wxWindowList::Node *node = focused->GetChildren().GetFirst(); node; node = node->GetNext())
+            if (dynamic_cast<wxTextEntry *>(node->GetData()) != nullptr)
+                return true;
+    }
     return false;
 }
 


### PR DESCRIPTION
## Summary

On Windows, pressing 'z' while typing in a custom `TextInput` widget (e.g., filament name in the Calibration tab) triggered the canvas "zoom to fit" shortcut instead of inserting the character.

**Root cause:** `is_text_entry_focused()` walked up the parent chain looking for a `wxTextEntry`. On Windows, focus sometimes lands on the outer `StaticBox` container (the `TextInput` widget itself) rather than on the inner `wxTextCtrl`. The parent walk never finds a `wxTextEntry` in that case.

**Fix:** Also scan the direct children of the focused window. If any direct child is a `wxTextEntry`, treat focus as being in a text field.

## Test plan

- [x] Open the Calibration tab
- [x] Click on a filament name input field
- [x] Type a name containing 'z' → the letter should appear, no zoom triggered

Closes #10684