### PR TITLE
fix: suppress LOG_EMERG syslog on Linux to stop journald wall broadcasts

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
      - master
-     - main
     paths:
      - 'deps/**'
      - 'src/**'

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -3,6 +3,7 @@ name: Build all
 on:
   push:
     branches:
+     - master
      - main
     paths:
      - 'deps/**'

--- a/src/BambuStudio.cpp
+++ b/src/BambuStudio.cpp
@@ -31,6 +31,7 @@ using namespace nlohmann;
 #if defined(__linux__) || defined(__LINUX__)
 #include <condition_variable>
 #include <mutex>
+#include <syslog.h>
 #include <boost/thread.hpp>
 #endif
 
@@ -1462,6 +1463,17 @@ int CLI::run(int argc, char **argv)
     set_current_thread_name("bambustu_main");
     // Save the thread ID of the main thread.
     save_main_thread_id();
+
+#if defined(__linux__) || defined(__LINUX__)
+    // The closed-source bambu_networking plugin calls syslog() with LOG_EMERG
+    // for certain non-critical errors (e.g. "SO register failed").  On Linux,
+    // systemd-journald broadcasts every PRIORITY=0 message to all logged-in
+    // terminals as a wall message, which is disruptive.  Suppress LOG_EMERG
+    // and LOG_ALERT in this process's syslog mask so those messages are simply
+    // not forwarded to the system journal.  All other priorities (CRIT and
+    // below) are unaffected.
+    setlogmask(LOG_UPTO(LOG_DEBUG) & ~LOG_MASK(LOG_EMERG) & ~LOG_MASK(LOG_ALERT));
+#endif
 
 #ifdef __WXGTK__
     // On Linux, wxGTK has no support for Wayland, and the app crashes on


### PR DESCRIPTION
## Summary

On Linux, the closed-source `bambu_networking` plugin calls `syslog()` with `LOG_EMERG` (priority 0) for non-critical errors such as:

```
SO register failed, so could not monitor it.
```

`systemd-journald` broadcasts every `PRIORITY=0` message as a `wall` message to all logged-in terminals, causing disruptive pop-ups during normal use.

Since the message origin is in a closed-source binary that cannot be modified, the fix is applied at process level: call `setlogmask()` at the start of `CLI::run()` to remove `LOG_EMERG` and `LOG_ALERT` from the process-wide syslog priority mask. This takes effect before the networking plugin is loaded via `dlopen()`. All other syslog priorities (`LOG_CRIT` and below) remain unaffected.

## Test plan

- [ ] Build on Linux, start BambuStudio, open Device tab with a printer connected
- [ ] Verify no wall messages appear in other terminals
- [ ] `journalctl -f` should show no `PRIORITY=0` entries from `bambu-studio`

Closes #10820