### PR TITLE
fix: Prepare 3D view shows old model after opening a second .3mf

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
      - master
-     - main
     paths:
      - 'deps/**'
      - 'src/**'

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -3,6 +3,7 @@ name: Build all
 on:
   push:
     branches:
+     - master
      - main
     paths:
      - 'deps/**'

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -17070,6 +17070,12 @@ int Plater::load_project(wxString const &filename2,
         p->select_view("topfront");
         p->get_current_camera().requires_zoom_to_plate = REQUIRES_ZOOM_TO_ALL_PLATE;
         wxGetApp().mainframe->select_tab(MainFrame::tp3DEditor);
+        // Ensure the Prepare view shows the newly loaded scene.  If the canvas
+        // was dirty or the tab was switching, the reload inside load_files() may
+        // not have produced a visible repaint.  Force one here so that the old
+        // model is never left on screen after a second file is opened.
+        p->view3D->get_canvas3d()->set_as_dirty();
+        p->view3D->get_canvas3d()->request_extra_frame();
     }
     else {
         p->partplate_list.select_plate_view();


### PR DESCRIPTION
## Summary

After opening a second `.3mf` file while BambuStudio is already running, the Prepare 3D view continued to show the old model. The new file appeared to load correctly (sync prompts, save dialog appeared) but the 3D canvas was stale.

**Root cause:** `load_project()` calls `load_files()` which internally calls `update()` → `reload_scene()`. However, if the canvas was not currently visible or was in a dirty/deferred paint state, the reload may not produce a visible repaint. After `select_tab(tp3DEditor)` there was no explicit paint trigger.

**Fix:** After `select_tab()` in `load_project()`, call `set_as_dirty()` + `request_extra_frame()` on the view3D canvas to guarantee a fresh render regardless of prior canvas state.

## Test plan

- [ ] Open a `.3mf` file and wait for it to load
- [ ] Open a second, different `.3mf` file (File → Open or double-click)
- [ ] The Prepare 3D view should immediately show the new model

Closes #10787