### PR TITLE
fix(macos): Cmd+H hide-app shortcut blocked by missing evt.Skip()

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
      - master
-     - main
     paths:
      - 'deps/**'
      - 'src/**'

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -3,6 +3,7 @@ name: Build all
 on:
   push:
     branches:
+     - master
      - main
     paths:
      - 'deps/**'

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -681,8 +681,12 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
         const int key_code = evt.GetKeyCode();
 #ifdef __APPLE__
         if (evt.CmdDown() && (evt.GetKeyCode() == 'H')) {
-            //call parent_menu hide behavior
-            return;}
+            // Pass Cmd+H through to the macOS application menu so the
+            // standard "Hide BambuStudio" action fires.  Without evt.Skip()
+            // wxEVT_CHAR_HOOK consumes the event and macOS never sees it.
+            evt.Skip();
+            return;
+        }
         if (evt.CmdDown() && !evt.ShiftDown() && (evt.GetKeyCode() == 'M')) {
             this->Iconize();
             return;


### PR DESCRIPTION
## Problem

On macOS, pressing **Cmd+H** to hide BambuStudio has no effect — users have to go to the menu bar and click "Hide BambuStudio" manually (#10740).

## Root cause

`MainFrame.cpp` has a `wxEVT_CHAR_HOOK` handler that special-cases Cmd+H on macOS with a comment "call parent_menu hide behavior". But the implementation just calls `return` without first calling `evt.Skip()`. In wxWidgets, returning from a `wxEVT_CHAR_HOOK` handler without `Skip()` **consumes** the event — macOS never sees it, so the native "Hide Application" behaviour never fires.

```cpp
// Before (broken):
if (evt.CmdDown() && (evt.GetKeyCode() == 'H')) {
    //call parent_menu hide behavior
    return;}   // ← consumes the event, macOS never sees Cmd+H
```

## Fix

Call `evt.Skip()` before returning, so the event propagates through wxWidgets to the macOS application menu where the standard hide action lives.

```cpp
// After:
if (evt.CmdDown() && (evt.GetKeyCode() == 'H')) {
    evt.Skip();  // pass to macOS "Hide BambuStudio"
    return;
}
```

## Test plan

- [ ] macOS: press Cmd+H → BambuStudio window is hidden
- [ ] macOS: click "BambuStudio" in menu bar → "Hide BambuStudio" entry works the same way
- [ ] No regression on Windows/Linux (change is inside `#ifdef __APPLE__`)

Closes #10740