### PR TITLE
fix: center Edit Filament dialog on parent window

### DIFF
--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -4627,6 +4627,7 @@ EditFilamentPresetDialog::EditFilamentPresetDialog(wxWindow *parent, FilamentInf
     this->SetSizer(m_main_sizer);
     this->Layout();
     this->Fit();
+    this->CenterOnParent();
     wxGetApp().UpdateDlgDarkUI(this);
 }
 EditFilamentPresetDialog::~EditFilamentPresetDialog() {}


### PR DESCRIPTION
## Summary

- `EditFilamentPresetDialog` was created with `wxDefaultPosition`, causing the OS to place it on the primary monitor even when Bambu Studio was running on a secondary display.
- Adding `CenterOnParent()` in the constructor mirrors the positioning pattern already used by every other dialog in the codebase (e.g. `ReleaseNote`, `KBShortcutsDialog`, `CaliHistoryDialog`).

## How to reproduce

1. Move Bambu Studio to a secondary monitor.
2. Go to Prepare tab → click a filament's settings icon → Custom Filament → Edit.
3. The "Edit Filament" dialog opens on the **primary** monitor instead of the one where Studio is running.

## Fix

One line: call `this->CenterOnParent()` after `Fit()` in the `EditFilamentPresetDialog` constructor so the dialog is always centred over its parent window, regardless of which monitor it is on.

## Test plan

- [ ] Move Studio to a secondary monitor and open Edit Filament — dialog should appear on the same monitor as Studio.
- [ ] Verify dialog still opens normally when Studio is on the primary monitor.

Fixes #10720