### PR TITLE
fix: filament weight resets to 1000g after 'push local to cloud'

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
      - master
-     - main
     paths:
      - 'deps/**'
      - 'src/**'

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -3,6 +3,7 @@ name: Build all
 on:
   push:
     branches:
+     - master
      - main
     paths:
      - 'deps/**'

--- a/src/slic3r/GUI/DeviceWeb/FilaManagerVM.cpp
+++ b/src/slic3r/GUI/DeviceWeb/FilaManagerVM.cpp
@@ -77,24 +77,33 @@ FilaManagerVM::FilaManagerVM()
                                         const std::string& msg) {
             publish_push_failed(id, op, code, msg);
         });
-        // Cloud is the source of truth: whenever a local push succeeds we
-        // immediately enqueue a pull so the next spool list the web sees is
-        // whatever the cloud just acknowledged. The dispatcher is single-slot
-        // so the pull runs right after this push op returns to idle.
+        // After a successful push we refresh the spool list so the UI reflects
+        // the latest local state immediately.  A follow-up cloud pull is only
+        // necessary for CREATE operations — we need the server-assigned spool
+        // id before advertising the new row to the web UI.  For UPDATE and
+        // DELETE we already know the outcome and triggering a pull introduces
+        // a read-after-write race: the cloud PUT may not yet be visible to the
+        // subsequent GET, so the pull can return stale data (e.g., the old
+        // netWeight before the user's manual-weight edit was pushed) and
+        // overwrite the local store back to the pre-edit value.  Skipping the
+        // pull for non-create ops avoids that race without losing any
+        // information — the local store is already consistent.
         disp->set_on_push_done([this](const std::string& id,
                                       const std::string& op) {
             if (m_bridge) {
                 m_bridge->ReportMsg(MakeResp("spool", "list", 0, "", build_spool_list()));
             }
             publish_push_done(id, op);
-            // If create returned an id, the dispatcher has already inserted
-            // the accepted cloud row locally. The follow-up pull will see no
-            // size delta, so carry the create count into publish_pull_done.
-            if (op == "create" && !id.empty()) {
-                m_pending_pull_added_hint += 1;
-            }
-            if (auto* d = wxGetApp().fila_manager_cloud_disp()) {
-                d->enqueue_pull();
+            if (op == "create") {
+                // If create returned an id, the dispatcher has already inserted
+                // the accepted cloud row locally. The follow-up pull will see no
+                // size delta, so carry the create count into publish_pull_done.
+                if (!id.empty()) {
+                    m_pending_pull_added_hint += 1;
+                }
+                if (auto* d = wxGetApp().fila_manager_cloud_disp()) {
+                    d->enqueue_pull();
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary

- After manually editing a filament's **current net weight** in the Filament Manager and pressing **Push local to cloud**, the weight was immediately reset back to 1000 g (the AMS default for a full spool).
- Root cause: the `on_push_done` callback triggered an unconditional `enqueue_pull()` after every successful push. Due to read-after-write lag in the cloud backend, the subsequent `GET /filaments` could return the **stale** `netWeight` (before the push was committed) and overwrite the user's edited value in the local store.

## Fix

`enqueue_pull()` is now only called after **CREATE** operations, where we genuinely need the server-assigned spool id. For **UPDATE** and **DELETE** pushes the local store is already consistent with what was sent, so triggering a pull introduces a race without any benefit.

## How to reproduce

1. Filament Manager → Add Filament → Read from AMS → select a spool → Add.
2. Click the spool detail icon → Edit Filament Info.
3. Change **Current Net Weight** to any value other than 1000 g and save.
4. Press **Push local to cloud** (printer must be on, or turn it on after saving).
5. Observe: weight is reset to 1000 g.

## Test plan

- [ ] Reproduce steps 1-4 above, weight should now stay at the edited value after pushing.
- [ ] Create a new spool manually and push, the pull should still happen (to get the server-assigned id).
- [ ] Delete a spool and push, no spurious pull should be triggered.

Fixes #10766
