### PR TITLE
feat: add preference to open full MakerWorld site in Online Models tab

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
      - master
-     - main
     paths:
      - 'deps/**'
      - 'src/**'

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -3,6 +3,7 @@ name: Build all
 on:
   push:
     branches:
+     - master
      - main
     paths:
      - 'deps/**'

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1425,6 +1425,9 @@ wxWindow* PreferencesDialog::create_general_page()
 
     auto item_show_history = create_item_checkbox(_L("Show history on the home page"), page, _L("Show history on the home page"), 50, "show_print_history");
 
+    auto item_makerworld_fullsite = create_item_checkbox(_L("Open full MakerWorld site instead of the simplified Studio view"), page,
+        _L("Load the full MakerWorld website in the Online Models tab instead of the restricted Studio webview."), 50, "makerworld_use_full_site");
+
     std::vector<wxString>  air_temp_timing_list = {_L("Reminder During Slicing"), _L("Automatic mode")};
     std::vector<std::string> air_temp_timing_value_list = {"slicing", "auto"};
 
@@ -1527,15 +1530,17 @@ wxWindow* PreferencesDialog::create_general_page()
     sizer_page->Add(item_associate_stl, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_associate_step, 0, wxTOP, FromDIP(3));
 #endif // _WIN32
-    auto item_title_modelmall   = sizer_page->Add(title_modelmall, 0, wxTOP | wxEXPAND, FromDIP(20));
-    auto item_item_modelmall    = sizer_page->Add(item_modelmall, 0, wxTOP, FromDIP(3));
-    auto item_item_show_history = sizer_page->Add(item_show_history, 0, wxTOP, FromDIP(3));
+    auto item_title_modelmall        = sizer_page->Add(title_modelmall, 0, wxTOP | wxEXPAND, FromDIP(20));
+    auto item_item_modelmall         = sizer_page->Add(item_modelmall, 0, wxTOP, FromDIP(3));
+    auto item_item_show_history      = sizer_page->Add(item_show_history, 0, wxTOP, FromDIP(3));
+    auto item_item_mw_fullsite       = sizer_page->Add(item_makerworld_fullsite, 0, wxTOP, FromDIP(3));
 
-    auto update_modelmall = [this, item_title_modelmall, item_item_modelmall, item_item_show_history](wxEvent &e) {
+    auto update_modelmall = [this, item_title_modelmall, item_item_modelmall, item_item_show_history, item_item_mw_fullsite](wxEvent &e) {
         bool has_model_mall = wxGetApp().has_model_mall();
         item_title_modelmall->Show(has_model_mall);
         item_item_modelmall->Show(has_model_mall);
         item_item_show_history->Show(has_model_mall);
+        item_item_mw_fullsite->Show(has_model_mall);
         Layout();
         Fit();
     };

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -1303,7 +1303,11 @@ void WebViewPanel::SetMakerworldPageLoginStatus(bool login ,wxString ticket)
 
             wxString language_code = wxString::FromUTF8(GetStudioLanguage()).BeforeFirst('_');
 
-            mw_currenturl = (boost::format("%1%%2%/studio/webview?from=bambustudio") % host % language_code.mb_str()).str();
+            bool full_site = wxGetApp().app_config->get("makerworld_use_full_site") == "1";
+            if (full_site)
+                mw_currenturl = (boost::format("%1%%2%/?from=bambustudio") % host % language_code.mb_str()).str();
+            else
+                mw_currenturl = (boost::format("%1%%2%/studio/webview?from=bambustudio") % host % language_code.mb_str()).str();
         }
     } else {
         //std::cout << "The string does not match the pattern." << std::endl;
@@ -1946,7 +1950,11 @@ void WebViewPanel::OpenMakerworldSearchPage(std::string KeyWord)
 
     wxString language_code = wxString::FromUTF8(GetStudioLanguage()).BeforeFirst('_');
 
-    m_online_LastUrl = (boost::format("%1%%2%/studio/webview/search?from=bambustudio&keyword=%3%&from_studio_home=true") % host % language_code.mb_str() % UrlEncode(KeyWord)).str();
+    bool full_site_search = wxGetApp().app_config->get("makerworld_use_full_site") == "1";
+    if (full_site_search)
+        m_online_LastUrl = (boost::format("%1%%2%/search?from=bambustudio&keyword=%3%&from_studio_home=true") % host % language_code.mb_str() % UrlEncode(KeyWord)).str();
+    else
+        m_online_LastUrl = (boost::format("%1%%2%/studio/webview/search?from=bambustudio&keyword=%3%&from_studio_home=true") % host % language_code.mb_str() % UrlEncode(KeyWord)).str();
     SwitchWebContent("online");
     //SwitchLeftMenu("online");
 }
@@ -1957,10 +1965,18 @@ void WebViewPanel::SetMakerworldModelID(std::string ModelID)
 
     wxString language_code = wxString::FromUTF8(GetStudioLanguage()).BeforeFirst('_');
 
-    if (ModelID != "")
-        m_online_LastUrl = (boost::format("%1%%2%/studio/webview?modelid=%3%&from=bambustudio") % host % language_code.mb_str() % ModelID).str();
-    else
-        m_online_LastUrl = (boost::format("%1%%2%/studio/webview?from=bambustudio") % host % language_code.mb_str()).str();
+    bool full_site_model = wxGetApp().app_config->get("makerworld_use_full_site") == "1";
+    if (ModelID != "") {
+        if (full_site_model)
+            m_online_LastUrl = (boost::format("%1%%2%/models/%3%?from=bambustudio") % host % language_code.mb_str() % ModelID).str();
+        else
+            m_online_LastUrl = (boost::format("%1%%2%/studio/webview?modelid=%3%&from=bambustudio") % host % language_code.mb_str() % ModelID).str();
+    } else {
+        if (full_site_model)
+            m_online_LastUrl = (boost::format("%1%%2%/?from=bambustudio") % host % language_code.mb_str()).str();
+        else
+            m_online_LastUrl = (boost::format("%1%%2%/studio/webview?from=bambustudio") % host % language_code.mb_str()).str();
+    }
 }
 
 void WebViewPanel::SetPrintHistoryTaskID(int TaskID)


### PR DESCRIPTION
## Summary

Preferences → Online Models gains a **"Open full MakerWorld site instead of the simplified Studio view"** checkbox (config key `makerworld_use_full_site`).

When enabled, the three URL construction paths in `WebViewDialog.cpp` omit the `/studio/webview` path segment and map model-detail links to `/models/<id>`, restoring access to comments, account management, and other full-site features that the restricted webview does not expose.

## Test plan

- [ ] Preferences → uncheck the new option (default): Online Models loads the restricted `/studio/webview` as before.
- [ ] Check the option: Online Models loads the full MakerWorld site.
- [ ] Restart Studio: setting is persisted.

Closes #10801