### PR TITLE
feat: add 'Don't show this warning again' to cloud connection failure dialog

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2088,10 +2088,14 @@ void GUI_App::init_networking_callbacks()
 
                     static bool s_mqtt_connect_failed_dialog_shown = false;
                     if (s_mqtt_connect_failed_dialog_shown) return;
+                    if (app_config && app_config->get("suppress_cloud_device_server_warning") == "1") return;
                     s_mqtt_connect_failed_dialog_shown = true;
                     BOOST_LOG_TRIVIAL(trace) << "static: server connection failed";
-                    MessageDialog msg_dlg(nullptr, _L("Failed to connect to the cloud device server. Please check your network and firewall."), "", wxOK);
+                    RichMessageDialog msg_dlg(nullptr, _L("Failed to connect to the cloud device server. Please check your network and firewall."), "", wxOK);
+                    msg_dlg.ShowCheckBox(_L("Don't show this warning again"));
                     msg_dlg.ShowModal();
+                    if (msg_dlg.IsCheckBoxChecked() && app_config)
+                        app_config->set("suppress_cloud_device_server_warning", "1");
                 });
                 return;
             }

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2090,10 +2090,17 @@ void GUI_App::init_networking_callbacks()
 
                     static bool s_mqtt_connect_failed_dialog_shown = false;
                     if (s_mqtt_connect_failed_dialog_shown) return;
+                    if (app_config && app_config->get("suppress_cloud_device_server_warning") == "1") return;
                     s_mqtt_connect_failed_dialog_shown = true;
                     BOOST_LOG_TRIVIAL(trace) << "static: server connection failed";
-                    MessageDialog msg_dlg(nullptr, _L("Failed to connect to the cloud device server. Please check your network and firewall."), "", wxOK);
+                    RichMessageDialog msg_dlg(nullptr, _L("Failed to connect to the cloud device server. Please check your network and firewall."), "", wxOK);
+                    msg_dlg.ShowCheckBox(_L("Don't show this warning again"));
                     msg_dlg.ShowModal();
+                    if (msg_dlg.IsCheckBoxChecked() && app_config) {
+                        app_config->set("suppress_cloud_device_server_warning", "1");
+                        app_config->save();
+                    }
+                    s_mqtt_connect_failed_dialog_shown = false;
                 });
                 return;
             }

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1454,6 +1454,7 @@ wxWindow* PreferencesDialog::create_general_page()
     });
     // auto item_backup = create_item_switch(_L("Backup switch"), page, _L("Backup switch"), "units");
     auto item_gcodes_warning = create_item_checkbox(_L("No warnings when loading 3MF with modified G-codes"), page,_L("No warnings when loading 3MF with modified G-codes"), 50, "no_warn_when_modified_gcodes");
+    auto item_cloud_server_warning = create_item_checkbox(_L("Don't show cloud device server connection warnings"), page, _L("When enabled, the \"Failed to connect to the cloud device server\" dialog will not appear. Uncheck to restore the warning."), 50, "suppress_cloud_device_server_warning");
     auto item_backup  = create_item_checkbox(_L("Auto-Backup"), page,_L("Backup your project periodically for restoring from the occasional crash."), 50, "backup_switch");
     auto item_backup_interval = create_item_backup_input(_L("every"), page, _L("The peroid of backup in seconds."), "backup_interval");
 
@@ -1567,6 +1568,7 @@ wxWindow* PreferencesDialog::create_general_page()
     sizer_page->Add(item_max_recent_count, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_save_choise, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_gcodes_warning, 0, wxTOP, FromDIP(3));
+    sizer_page->Add(item_cloud_server_warning, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_backup, 0, wxTOP,FromDIP(3));
     item_backup->Add(item_backup_interval, 0, wxLEFT, 0);
 

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1614,6 +1614,7 @@ wxWindow *PreferencesDialog::create_other_tab()
     });
     auto item_gcodes_warning = create_item_checkbox(_L("No warnings when loading 3MF with modified G-codes"), scrolled, _L("No warnings when loading 3MF with modified G-codes"),
                                                     50, "no_warn_when_modified_gcodes");
+    auto item_cloud_server_warning = create_item_checkbox(_L("Don't show cloud device server connection warnings"), scrolled, _L("When enabled, the \"Failed to connect to the cloud device server\" dialog will not appear. Uncheck to restore the warning."), 50, "suppress_cloud_device_server_warning");
     std::vector<wxString>    backup_labels = {_L("10 seconds"), _L("20 seconds"), _L("30 seconds"), _L("1 minute"), _L("2 minutes"),
                                               _L("5 minutes"),  _L("10 minutes"), _L("30 minutes"), _L("never")};
     std::vector<std::string> backup_values = {"10", "20", "30", "60", "120", "300", "600", "1800", "0"};
@@ -1632,6 +1633,7 @@ wxWindow *PreferencesDialog::create_other_tab()
     sizer->Add(item_max_recent_count, flags);
     sizer->Add(item_auto_backup, flags);
     sizer->Add(item_gcodes_warning, flags);
+    sizer->Add(item_cloud_server_warning, flags);
 
     // ---- Online Models (visible only when has_model_mall()) ----
     auto title_modelmall   = create_item_title(_L("Online Models"), scrolled, _L("Online Models"));


### PR DESCRIPTION
## Summary

The "Failed to connect to the cloud device server" dialog previously reappeared on every MQTT connection failure, which interrupted LAN-only and offline users repeatedly.

**Fix:** replace `MessageDialog` with `RichMessageDialog` and add a **"Don't show this warning again"** checkbox. When the user checks it, the config key `suppress_cloud_warnings` is set to `"1"` and the dialog is permanently suppressed for future sessions.

The existing `is_showing` re-entrancy guard is preserved, and an early-return reads the config key before showing the dialog.

## Test plan

- [ ] With cloud connection failing, the dialog appears and shows the checkbox.
- [ ] Check the box and click OK: dialog no longer appears on subsequent connection failures.
- [ ] Manually remove `suppress_cloud_warnings=1` from app config: dialog reappears.

Closes #10589