### PR TITLE
fix: Fill with copies assigns sequential names in grid path

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
      - master
-     - main
     paths:
      - 'deps/**'
      - 'src/**'

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -3,6 +3,7 @@ name: Build all
 on:
   push:
     branches:
+     - master
      - main
     paths:
      - 'deps/**'

--- a/src/slic3r/GUI/Jobs/FillBedJob.cpp
+++ b/src/slic3r/GUI/Jobs/FillBedJob.cpp
@@ -350,6 +350,7 @@ void FillBedJob::process()
                 m_selected[i].translation = scaled<coord_t>(empty_cells[cell_idx]);
                 m_selected[i].translation -= offset_on_origin;
                 m_selected[i].bed_idx = 0;
+                m_selected[i].itemid = static_cast<int>(placed);
                 ++cell_idx;
                 ++placed;
             } else {


### PR DESCRIPTION
## Problem

When using *Fill with copies* on small objects (where the grid placement path is used instead of the arrange path), all copies receive the name `<object> -1` instead of sequential names like `<object> 0`, `<object> 1`, etc.

**Root cause:** In `FillBedJob::process()`, the grid path (used when `grid_cap > FILL_BED_GRID_PATH_MIN_CAPACITY`, i.e. > 50) never updated `itemid` after placing each copy. The field stays at its initial value of `-1` (set in `FillBedJob::prepare()`), so the setter at line 172:
```cpp
newObj->name = mo->name + " " + std::to_string(p.itemid);
```
produces `"Cube -1"` for every single copy.

The arrange path (used for large objects) correctly assigns sequential IDs via `firstfit.hpp` → `it->get().itemId(item_id++)`.

## Fix

Assign `itemid` sequentially in the grid path loop, matching the 0-based sequential IDs produced by the arrange path:

```cpp
m_selected[i].itemid = static_cast<int>(placed);
```

Added inside the `if (cell_idx < empty_cells.size())` block, before `++placed`.

## Related

Closes #10492