### PR TITLE
fix: AMS Materials Setting dialog clips to wrong monitor on multi-monitor setups

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
      - master
-     - main
     paths:
      - 'deps/**'
      - 'src/**'

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -3,6 +3,7 @@ name: Build all
 on:
   push:
     branches:
+     - master
      - main
     paths:
      - 'deps/**'

--- a/src/slic3r/GUI/StatusPanel.cpp
+++ b/src/slic3r/GUI/StatusPanel.cpp
@@ -4909,7 +4909,7 @@ void StatusPanel::on_filament_edit(wxCommandEvent &event)
 
     int  current_position_x = m_ams_control->GetScreenPosition().x;
     int  current_position_y = m_ams_control->GetScreenPosition().y - FromDIP(40);
-    auto drect              = wxDisplay(GetParent()).GetGeometry().GetHeight() - FromDIP(50);
+    int  drect              = wxDisplay(GetParent()).GetGeometry().GetBottom() - FromDIP(50);
     current_position_y = current_position_y + m_filament_setting_dlg->GetSize().GetHeight() > drect ? drect - m_filament_setting_dlg->GetSize().GetHeight() : current_position_y;
 
     if (obj) {
@@ -4972,7 +4972,7 @@ void StatusPanel::on_ext_spool_edit(wxCommandEvent &event)
 
     int  current_position_x = m_ams_control->GetScreenPosition().x;
     int  current_position_y = m_ams_control->GetScreenPosition().y - FromDIP(40);
-    auto drect              = wxDisplay(GetParent()).GetGeometry().GetHeight() - FromDIP(50);
+    int  drect              = wxDisplay(GetParent()).GetGeometry().GetBottom() - FromDIP(50);
     current_position_y = current_position_y + m_filament_setting_dlg->GetSize().GetHeight() > drect ? drect - m_filament_setting_dlg->GetSize().GetHeight() : current_position_y;
 
     if (obj) {


### PR DESCRIPTION
## Problem

On multi-monitor setups where the secondary monitor is not vertically aligned with the primary (e.g. a monitor positioned below, or a monitor with a non-zero Y offset), the AMS Materials Setting dialog (opened by clicking a slot in the Device tab) would appear on the primary monitor instead of the monitor containing Bambu Studio.

**Root cause:** `StatusPanel::on_filament_edit()` and `StatusPanel::on_ext_spool_edit()` clamp the dialog's Y position to keep it on screen. The clamp used:

```cpp
auto drect = wxDisplay(GetParent()).GetGeometry().GetHeight() - FromDIP(50);
```

`GetGeometry().GetHeight()` returns the pixel height of the display (e.g. `1080`) — a relative value, not an absolute screen coordinate. When the secondary monitor starts at Y > 0, the dialog's absolute Y coordinate (e.g. `1400`) exceeds `drect` (`1080 - 50 = 1030`), so the clamp computes a new Y of `1030 - dialog_height ≈ 430`, which lands on the primary monitor.

## Fix

Replace `GetHeight()` with `GetBottom()`, which returns the absolute screen Y coordinate of the bottom edge of the display:

```cpp
int drect = wxDisplay(GetParent()).GetGeometry().GetBottom() - FromDIP(50);
```

Applied in both `on_filament_edit()` and `on_ext_spool_edit()`.

## Related

Closes #10166