### PR TITLE
fix: AMS slot labels always show 'A' when selecting a non-first AMS unit

### DIFF
--- a/src/slic3r/GUI/DeviceWeb/device_page/src/features/filament-manager/AddEditDialog.tsx
+++ b/src/slic3r/GUI/DeviceWeb/device_page/src/features/filament-manager/AddEditDialog.tsx
@@ -1846,7 +1846,8 @@ export function AddEditDialog({
   if (!open) return null;
 
   const currentUnit = amsData?.ams_units.find((u) => u.ams_id === selectedUnit);
-  const slotLabels = ['A1', 'A2', 'A3', 'A4'];
+  const unitLetter = currentUnit ? String.fromCharCode('A'.charCodeAt(0) + parseInt(currentUnit.ams_id, 10)) : 'A';
+  const slotLabels = [1, 2, 3, 4].map((n) => `${unitLetter}${n}`);
   // STUDIO-18344: form lock + form visibility derive from the new selection
   // model. Multi-select (>=2) hides the form entirely, so the lock flags
   // only matter in single-select mode.
@@ -2045,7 +2046,7 @@ export function AddEditDialog({
                   </div>
                   <div className="flex gap-[8px] py-[8px]">
                     {currentUnit.trays.map((tray, i) => {
-                      const label = slotLabels[i] || `A${i + 1}`;
+                      const label = slotLabels[i] || `${unitLetter}${i + 1}`;
                       const slotKey = `${currentUnit.ams_id}:${tray.slot_id}`;
                       const isSelected = selectedSlotKeys.has(slotKey);
                       if (!tray.is_exists) {


### PR DESCRIPTION
## Summary

- In the **Add Filament → Read from AMS** dialog, the slot labels (A1-A4) were hardcoded and never updated when the user switched to a second or third AMS unit.
- With multi-AMS setups, selecting AMS B would still display slot labels A1, A2, A3, A4, matching none of the identifiers shown everywhere else in the UI (filament grouping, bound_ams_id field, etc.).
- Fix: derive the unit letter from `currentUnit.ams_id` (`'0'` = A, `'1'` = B, …) and construct `slotLabels` dynamically so they always reflect the currently selected AMS unit.

## Change

One-line change in `AddEditDialog.tsx`:

```tsx
// Before
const slotLabels = ['A1', 'A2', 'A3', 'A4'];

// After
const unitLetter = currentUnit ? String.fromCharCode('A'.charCodeAt(0) + parseInt(currentUnit.ams_id, 10)) : 'A';
const slotLabels = [1, 2, 3, 4].map((n) => `${unitLetter}${n}`);
```

## Test plan

- [ ] Single AMS: slot labels still show A1-A4
- [ ] Two AMS units connected: switching to unit 2 shows B1-B4; switching back shows A1-A4
- [ ] Three+ AMS units: C1-C4 for unit 3, etc.

Fixes #10512
