### PR TITLE
fix(threads): bump worker thread stack to 16MB to survive CGAL emboss

### DIFF
--- a/src/libslic3r/Thread.hpp
+++ b/src/libslic3r/Thread.hpp
@@ -46,11 +46,23 @@ void name_tbb_thread_pool_threads_set_locale();
 template<class Fn>
 inline boost::thread create_thread(boost::thread::attributes &attrs, Fn &&fn)
 {
-    // Duplicating the stack allocation size of Thread Building Block worker
-    // threads of the thread pool: allocate 4MB on a 64bit system, allocate 2MB
-    // on a 32bit system by default.
-    
-    attrs.set_stack_size((sizeof(void*) == 4) ? (2048 * 1024) : (4096 * 1024));
+    // Stack size for our worker threads. Originally duplicated TBB's pool
+    // default (4 MB), but the Emboss text-cut path calls into CGAL's
+    // Polygon_mesh_processing::corefine, which falls back from filtered
+    // interval arithmetic to exact rational arithmetic (mpq_class) on
+    // near-degenerate input, and the constrained 2D triangulation walker
+    // (Triangulation_2::march_locate_2D) can recurse deeply enough to
+    // exceed 4 MB on real models -- producing a SIGBUS at the next thread's
+    // stack guard page on macOS / Linux.
+    //
+    // 16 MB chosen as 4x defensive headroom over the observed crash
+    // threshold (n=1 reproducer at exactly 4 MB on macOS arm64). All three
+    // platforms defer-commit reserved stack pages: macOS / Linux mmap the
+    // stack and only fault in pages on touch; Boost.Thread on Win32 passes
+    // STACK_SIZE_PARAM_IS_A_RESERVATION to _beginthreadex, so the value is
+    // a reserve, not the initial commit. Resident memory therefore stays
+    // proportional to actual stack depth on every target.
+    attrs.set_stack_size(16 * 1024 * 1024);
     return boost::thread{attrs, std::forward<Fn>(fn)};
 }
 


### PR DESCRIPTION
## Summary

Fixes a `SIGBUS` crash in the Emboss text-cut workflow when the worker thread overflows its 4 MB default stack. CGAL's `Polygon_mesh_processing::corefine` falls back from filtered interval arithmetic to exact rational arithmetic (mpq_class) on near-degenerate input, and the constrained 2D triangulation walker `Triangulation_2::march_locate_2D` recurses deeply enough to exceed 4 MB on real models. The fault address sits exactly inside the next thread's stack guard page — the textbook macOS stack-overflow signature.

This appears to be the same crash class as several already-open issues:

- #7782 — "Cannot Add SVG to Surface of Object" — SVG → "Use Surface" crashes on macOS. Same `Slic3r::cut_surface` → `Polygon_mesh_processing::corefine` path.
- #5995 — "Bambu studio crashes when adding negative part modifier SVG to model" — Negative-part SVG modifier with "Use Surface". Same code path.
- #9418 — "Leading Spaces Crash" — Text emboss at 0.2 mm embed depth on macOS M4. Same code path. macOS-specific symptoms match the stack-overflow fingerprint exactly.

Reporters of those issues and a maintainer with the original repro models can verify the fix end-to-end.

Bump `Slic3r::create_thread`'s default stack size from 4 MB to 16 MB on 64-bit. Resident memory remains proportional to actual stack depth on every target (defer-commit on macOS / Linux mmap'd stacks; `STACK_SIZE_PARAM_IS_A_RESERVATION` on Boost.Thread for Win32 means the reserve does not pre-commit).

## Reproducer

- BambuStudio Dev v02.07.00.55 on macOS 26.4.1 / Apple Silicon
- Emboss → text → embed depth ~0.6 mm into a real model with non-trivial topology under the text region (curved seam, sharp edge, or thin font stems all suffice to trigger the exact-arithmetic fallback)
- Crash report excerpt:

```
Exception Type:  EXC_BAD_ACCESS (SIGBUS)
Exception Subtype: KERN_PROTECTION_FAILURE at 0x00000001712ac000
Bad access in stack guard region for thread 45 but crash was associated
with thread 44 - possible stray access?

VM Region Info: 0x1712ac000 is in 0x1712ac000-0x1712b0000;
  Stack            170ea4000-1712ac000  [ 4128K] rw-/rwx  thread 44
--->STACK GUARD    1712ac000-1712b0000  [   16K] ---/rwx  stack guard for thread 45

Thread 44 Crashed:
  __gmpn_mul_1 / __gmpz_mul / __gmpq_mul
  CGAL::determinant<mpq_class>
  Projected_orientation_with_normal_3
  Filtered_predicate_with_state::operator()
  Triangulation_2<Projection_traits_3<Epeck>>::march_locate_2D
  Surface_intersection_visitor::triangulate_intersected_faces
  Polygon_mesh_processing::corefine
  Slic3r::cut_surface
  Emboss::cut_surface_to_its
  Emboss::GenerateTextJob::get_text_mesh
  PlaterWorker::PlaterJob::process
```

The thread's stack region is exactly 4128K — the default 4 MB plus a small TLS overhead.

## Why 16 MB and not a tighter number

We have one observed reproducer; the 16 MB value is chosen as 4× defensive headroom over that, not as a measured upper bound. CGAL's `march_locate_2D` recursion depth is data-dependent on input geometry, and we have no a-priori bound. Picking 16 MB rather than 8 MB trades a small amount of bounded virtual address space for a wider safety margin against future heavier emboss workloads.

## Why this scope and not a per-callsite override

Considered narrowing the bump to just the Emboss `GenerateTextJob` path by plumbing a stack-size override through `PlaterWorker` → `BoostThreadWorker(attribs, name)`. Rejected because:

1. The cost is bounded virtual address space on 64-bit (resident memory tracks actual depth on every supported OS).
2. The same exact-arithmetic recursion shape appears in OrcaSlicer issue trackers for STEP loading and other CGAL-heavy paths in this codebase, so a uniform bump preempts the same crash in adjacent code.
3. Per-callsite plumbing adds maintenance burden disproportionate to the saved address space.

## Cumulative cost

`Slic3r::create_thread` has 22 callsites across the codebase. Realistic peak concurrent live count is on the order of 10–15 workers (Plater UI worker, slicing process, FDM-support gizmo, STEP loader, network sync helpers, per-task sender threads in `TaskManager` up to `MaxSendingAtSameTime`, per-machine info threads in device-list dialogs). At 16 MB reserve × ~15 = ~240 MB of address-space commitment in the worst case, which is bounded on any 64-bit target.

## Test plan

- [x] Apple Silicon / macOS 26.4.1 / Apple Clang 21 / CMake 4.x — compiles clean. The original reproducer on the author's working model no longer crashes.
- [ ] Same build on a smaller-RAM Mac would also be useful to confirm there's no resident-memory regression. Author's expectation is "no" because pages are deferred-allocated on macOS, but a maintainer with diverse hardware could verify with the same emboss reproducer.
- [ ] Linux / Windows build verification by maintainers.
