### PR TITLE
fix(deps): disable Assimp bundled zlib on macOS to fix SDK 15+ build failure

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
      - master
-     - main
     paths:
      - 'deps/**'
      - 'src/**'

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -3,6 +3,7 @@ name: Build all
 on:
   push:
     branches:
+     - master
      - main
     paths:
      - 'deps/**'

--- a/deps/Assimp/Assimp.cmake
+++ b/deps/Assimp/Assimp.cmake
@@ -1,3 +1,12 @@
+if (WIN32)
+    set(_assimp_build_zlib ON)
+else ()
+    # On macOS the bundled zlib's fdopen() macro conflicts with the macOS 15+ SDK
+    # __DARWIN_ALIAS(fdopen) expansion, causing a parse error during dep builds.
+    # System zlib is always available on macOS/Linux, so disable the bundled copy.
+    set(_assimp_build_zlib OFF)
+endif ()
+
 bambustudio_add_cmake_project(Assimp
     URL "https://github.com/assimp/assimp/archive/refs/tags/v5.4.3.tar.gz"
     URL_HASH SHA256=66dfbaee288f2bc43172440a55d0235dfc7bf885dda6435c038e8000e79582cb
@@ -11,7 +20,7 @@ bambustudio_add_cmake_project(Assimp
         -DASSIMP_BUILD_GLTF_IMPORTER=ON
         -DASSIMP_BUILD_OBJ_IMPORTER=ON
         -DASSIMP_BUILD_FBX_IMPORTER=ON
-        -DASSIMP_BUILD_ZLIB=ON
+        -DASSIMP_BUILD_ZLIB=${_assimp_build_zlib}
         -DASSIMP_WARNINGS_AS_ERRORS=OFF
         -DBUILD_WITH_STATIC_CRT=OFF
 )


### PR DESCRIPTION
## Problem

Assimp 5.4.3 ships a bundled zlib that defines \`#define fdopen(fd,mode) NULL\` in \`contrib/zlib/zutil.h:147\`. On macOS 15+ the SDK's \`_stdio.h\` declares \`fdopen\` through \`__DARWIN_ALIAS(fdopen)\`, which expands through the \`NULL\` definition and produces a C preprocessor parse error:

\`\`\`
dep_Assimp/contrib/zlib/zutil.h:147:18: error: expected unqualified-id
#define fdopen(fd,mode) NULL
                        ^
/Applications/Xcode.app/.../MacOSX15.5.sdk/usr/include/_stdio.h:318:47: note: expanded from macro '__DARWIN_ALIAS'
FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(..., __DARWIN_ALIAS(fdopen));
\`\`\`

This breaks the **Build Deps** step on both \`macos-15 arm64\` and \`macos-15 x86_64\` for any PR that triggers macOS CI.

## Fix

Only build the bundled zlib on Windows (where a system zlib is not guaranteed). On macOS and Linux the system zlib is always available, so \`-DASSIMP_BUILD_ZLIB=OFF\` is safe.

## Test plan

- [ ] macOS arm64 CI passes \"Build Deps\"
- [ ] macOS x86_64 CI passes \"Build Deps\"
- [ ] Windows build still uses bundled zlib (\`WIN32\` guard keeps \`ON\`)

Closes #10851.