### PR TITLE
fix: PA profiles not shown in AMS dialog for main extruder (extruder 0)

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
      - master
-     - main
     paths:
      - 'deps/**'
      - 'src/**'

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -3,6 +3,7 @@ name: Build all
 on:
   push:
     branches:
+     - master
      - main
     paths:
      - 'deps/**'

--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -1166,7 +1166,7 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
     if (obj->GetCalib()->IsVersionInited() && !obj->GetCalib()->IsPAHistoryReady()) {
         PACalibExtruderInfo cali_info;
         int ext_id = obj->GetFilaSystem()->GetExtruderIdByAmsId(std::to_string(ams_id));
-        if (ext_id > 0) {
+        if (ext_id >= 0) {
             cali_info.nozzle_diameter = obj->GetExtderSystem()->GetNozzleDiameter(ext_id);
             cali_info.use_extruder_id = false;
             cali_info.use_nozzle_volume_type = false;


### PR DESCRIPTION
## Root cause

`AMSMaterialsSetting::Popup` requests the PA calibration history with this guard (introduced in the post-fix of commit 33b62edc1 / re-applied in 2263815):

```cpp
int ext_id = obj->GetFilaSystem()->GetExtruderIdByAmsId(std::to_string(ams_id));
if (ext_id > 0) {          // ← BUG
    CalibUtils::emit_get_PA_calib_infos(cali_info);
```

`MAIN_EXTRUDER_ID` is `0` (defined in `DevDefs.h:94`). Any AMS unit bound to the first extruder returns `ext_id = 0`, which fails `> 0`, so the `extrusion_cali_get` MQTT command is never sent. The profile dropdown then contains only the hard-coded "Default" entry, even though the printer has saved profiles.

`GetExtruderIdByAmsId` returns `-1` as its "not found" sentinel, so the correct guard is `>= 0`.

## Fix

```cpp
-        if (ext_id > 0) {
+        if (ext_id >= 0) {
```

One character. Extruder 0 now triggers the request; the `-1` sentinel still suppresses it when the AMS ID is unknown.

## Affected printers

Any printer where an AMS unit is bound to extruder 0 (virtually all single-extruder printers, and at least one AMS unit on dual-extruder printers like X2D). Reported as #10845.

## Test plan

- [ ] Open AMS Materials Setting dialog for a filament slot on an AMS unit bound to extruder 0
- [ ] Confirm PA profile dropdown shows profiles saved on the printer, not just "Default"
- [ ] Open dialog for an AMS on extruder 1 (X2D), profiles still shown
- [ ] AMS ID not found in fila system → `ext_id = -1` → no request sent (no regression)

Closes #10845.
