### PR TITLE
fix: AMS slot edit icon click detection misses Y-bound check

### DIFF
--- a/src/slic3r/GUI/Widgets/AMSItem.cpp
+++ b/src/slic3r/GUI/Widgets/AMSItem.cpp
@@ -1038,7 +1038,7 @@ void AMSLib::on_left_down(wxMouseEvent &evt)
                 bottom = size.y - FromDIP(20);
             }
 
-            if (pos.x >= left && pos.x <= right && pos.y >= top && top <= bottom) {
+            if (pos.x >= left && pos.x <= right && pos.y >= top && pos.y <= bottom) {
                 if (m_selected) {
                     if (m_info.material_state == AMSCanType::AMS_CAN_TYPE_VIRTUAL) {
                         post_event(wxCommandEvent(EVT_VAMS_ON_FILAMENT_EDIT));


### PR DESCRIPTION
## Summary

`AMSLib::on_left_down()` checks `top <= bottom` as the upper Y bound for the edit-icon hit-test, but `top` is always less than or equal to `bottom` by construction, so this condition is always `true`. Any click with the correct X range triggers the edit dialog regardless of how far below the icon the click lands.

**One-character fix:** replace `top <= bottom` with `pos.y <= bottom`.

Applies to all AMS model variants (AMS, N3F, N3S, EXT_SPOOL, AMS_LITE).

Closes #10858

## Changed file

- `src/slic3r/GUI/Widgets/AMSItem.cpp` — line 1039

## Test plan

- [ ] Click on the edit icon of an AMS slot → edit dialog opens
- [ ] Click just below the edit icon → dialog does NOT open
- [ ] Click above the edit icon (but still in X range) → dialog does NOT open