### PR TITLE
fix: project profile name shows stale value after editor save

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
      - master
-     - main
     paths:
      - 'deps/**'
      - 'src/**'

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -3,6 +3,7 @@ name: Build all
 on:
   push:
     branches:
+     - master
      - main
     paths:
      - 'deps/**'

--- a/src/slic3r/GUI/Project.cpp
+++ b/src/slic3r/GUI/Project.cpp
@@ -389,6 +389,12 @@ void ProjectPanel::OnScriptMessage(wxWebViewEvent& evt)
                 wxGetApp().CallAfter([this, strJS] {
                     RunScript(strJS.ToStdString());
                 });
+            } else {
+                // m_last_payload was cleared (e.g. after a save) and the background
+                // reload may not have finished yet — or its dispatch was dropped during
+                // webview navigation.  Trigger a fresh reload so the new page receives
+                // up-to-date model data once the reload completes.
+                update_model_data();
             }
         }
         else if (strCmd == "request_confirm_save_project") {


### PR DESCRIPTION
## Summary

After saving in the Project editor and navigating back to the index page, the Profile Name displays the original (pre-edit) value instead of the newly saved one.

**Root cause:** `clear_model_info()` empties `m_last_payload` during the save flow. When `index.html` loads and immediately sends `request_3mf_info`, C++ does nothing because `m_last_payload` is empty. The background `on_reload()` thread that holds the fresh data fires its `RunScript` callback while the webview is still navigating; the script is dropped and the page never receives the updated model data.

**Fix:** When `request_3mf_info` arrives with an empty `m_last_payload`, call `update_model_data()` to trigger a fresh reload. The resulting `on_reload()` dispatches the current (post-save) model data directly to the now-fully-loaded page.

Closes #10769

## Changed file

- `src/slic3r/GUI/Project.cpp`, `OnScriptMessage` / `request_3mf_info` handler

## Test plan

- [ ] Open a project → click **Edit** → change Profile Name → click **Save**
- [ ] Profile Name on the index page reflects the newly saved value
- [ ] Opening and re-saving updates the displayed name each time
- [ ] Opening the editor after a save shows the correct (updated) Profile Name
