### PR TITLE
fix: show 'Sup.' prefix for support filaments in filament grouping dialog

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -23146,6 +23146,17 @@ void Plater::open_filament_map_setting_dialog(wxCommandEvent &evt)
     const auto& project_config = wxGetApp().preset_bundle->project_config;
     auto filament_colors = config()->option<ConfigOptionStrings>("filament_colour")->values;
     auto filament_types = config()->option<ConfigOptionStrings>("filament_type")->values;
+    // Distinguish support filaments from their base material type so the grouping
+    // panel does not show identical labels (e.g. two "ABS" entries instead of
+    // "ABS" and "Sup.ABS" when one slot holds Support for ABS).
+    const auto& fila_preset_names = preset_bundle->filament_presets;
+    for (size_t i = 0; i < filament_types.size() && i < fila_preset_names.size(); ++i) {
+        const Preset *fila_preset = preset_bundle->filaments.find_preset(fila_preset_names[i]);
+        if (!fila_preset) continue;
+        const auto *is_support = dynamic_cast<const ConfigOptionBools *>(fila_preset->config.option("filament_is_support"));
+        if (is_support && !is_support->values.empty() && is_support->values[0])
+            filament_types[i] = "Sup." + filament_types[i];
+    }
 
     auto plate_filament_maps = curr_plate->get_real_filament_maps(project_config);
     auto plate_filament_map_mode = curr_plate->get_filament_map_mode();


### PR DESCRIPTION
## Problem

When a project loads both a regular filament (e.g. ABS) and its support variant (e.g. Support for ABS), the filament grouping dialog (`FilamentMapDialog`) shows two identical **ABS** labels. This makes it impossible to tell which slot is the regular material and which is the support material.

## Root cause

Both preset types store `filament_type = "ABS"` in their config. The code in `Plater::open_filament_map_setting_dialog()` reads the raw `filament_type` option values without checking the `filament_is_support` flag, so both entries look the same.

## Fix

Before passing the type list to the dialog, iterate over the active filament presets and prepend `"Sup."` to any slot whose preset has `filament_is_support = true`. This is the same naming convention already used by `Preset::get_filament_type()` for display purposes elsewhere in the UI (yielding `"Sup.ABS"` for Support for ABS).

## Test plan

- [ ] Load a project with at least one ABS slot and one Support for ABS slot
- [ ] Open the filament grouping dialog
- [ ] Verify the two slots are labeled **ABS** and **Sup.ABS** respectively (not both **ABS**)
- [ ] Verify projects with only regular filaments are unaffected

Fixes #10773