### PR TITLE
fix: pin Windows CI jobs to windows-2022 until VS 2026 support lands

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -46,7 +46,7 @@ jobs:
           - os: ubuntu-22.04
           - os: ubuntu-24.04
           - os: ubuntu-26.04
-          - os: windows-latest
+          - os: windows-2022
           - os: macos-15-intel
             arch: x86_64
           - os: macos-15

--- a/.github/workflows/build_bambu.yml
+++ b/.github/workflows/build_bambu.yml
@@ -37,7 +37,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Get the version and date on Ubuntu and macOS
-        if: inputs.os != 'windows-latest'
+        if: inputs.os != 'windows-2022'
         run: |
           ver_pure=$(grep 'set(SLIC3R_VERSION' version.inc | cut -d '"' -f2)
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
@@ -51,7 +51,7 @@ jobs:
         shell: bash
 
       - name: Get the version and date on Windows
-        if: inputs.os == 'windows-latest'
+        if: inputs.os == 'windows-2022'
         run: |
           $date = Get-Date -Format 'yyyyMMdd'
           $ref = "${{ github.ref }}"
@@ -114,18 +114,18 @@ jobs:
 
   # Windows
       - name: setup MSVC
-        if: inputs.os == 'windows-latest'
+        if: inputs.os == 'windows-2022'
         uses: microsoft/setup-msbuild@v2
 
       - name: Install nsis and pkgconfig
-        if: inputs.os == 'windows-latest'
+        if: inputs.os == 'windows-2022'
         run: |
           dir "C:/Program Files (x86)/Windows Kits/10/Include"
           choco install nsis
           choco install pkgconfiglite
 
       - name: Build slicer Win
-        if: inputs.os == 'windows-latest'
+        if: inputs.os == 'windows-2022'
         working-directory: ${{ github.workspace }}
         run: |
           mkdir build
@@ -134,25 +134,25 @@ jobs:
           cmake --build . --target install --config Release -- -m
 
       # - name: Create installer Win
-      #   if: inputs.os == 'windows-latest'
+      #   if: inputs.os == 'windows-2022'
       #   working-directory: ${{ github.workspace }}/build
       #   run: |
       #     cpack -G NSIS
 
       - name: Pack app
-        if: inputs.os == 'windows-latest'
+        if: inputs.os == 'windows-2022'
         working-directory: ${{ github.workspace }}
         shell: cmd
         run: '"C:/Program Files/7-Zip/7z.exe" a -tzip BambuStudio_Windows_${{ env.ver }}_portable.zip ${{ github.workspace }}/install-dir'
 
       # - name: Pack PDB
-      #   if: inputs.os == 'windows-latest'
+      #   if: inputs.os == 'windows-2022'
       #   working-directory: ${{ github.workspace }}/build/src/Release
       #   shell: cmd
       #   run: '"C:/Program Files/7-Zip/7z.exe" a -m0=lzma2 -mx9 Debug_PDB_${{ env.ver }}_for_developers_only.7z  *.pdb'
 
       - name: Upload artifacts Win zip
-        if: inputs.os == 'windows-latest'
+        if: inputs.os == 'windows-2022'
         uses: actions/upload-artifact@v6
         with:
           name: BambuStudio_Windows_${{ env.ver }}_portable

--- a/.github/workflows/build_check_cache.yml
+++ b/.github/workflows/build_check_cache.yml
@@ -30,8 +30,8 @@ jobs:
       - name: set outputs
         id: set_outputs
         env:
-          dep-folder-name: ${{ inputs.os == 'windows-latest' && '/BambuStudio_dep' || ((inputs.os == 'macos-15-intel' || inputs.os == 'macos-15' || inputs.os == 'macos-26') && '') || (inputs.os != 'macos-15-intel' && inputs.os != 'macos-15' && inputs.os != 'macos-26') && '/destdir' || '' }}
-          output-cmd: ${{ inputs.os == 'windows-latest' && '$env:GITHUB_OUTPUT' || '"$GITHUB_OUTPUT"'}}
+          dep-folder-name: ${{ inputs.os == 'windows-2022' && '/BambuStudio_dep' || ((inputs.os == 'macos-15-intel' || inputs.os == 'macos-15' || inputs.os == 'macos-26') && '') || (inputs.os != 'macos-15-intel' && inputs.os != 'macos-15' && inputs.os != 'macos-26') && '/destdir' || '' }}
+          output-cmd: ${{ inputs.os == 'windows-2022' && '$env:GITHUB_OUTPUT' || '"$GITHUB_OUTPUT"'}}
         run: |
           echo cache-key=${{ inputs.os }}-cache-bambustudio_deps-build-${{ hashFiles('deps/**') }} >> ${{ env.output-cmd }}
           echo cache-path=${{ github.workspace }}/deps/build${{ env.dep-folder-name }} >> ${{ env.output-cmd }}

--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -42,23 +42,23 @@ jobs:
           key: ${{ inputs.cache-key }}
 
       - name: setup dev on Windows
-        if: inputs.os == 'windows-latest'
+        if: inputs.os == 'windows-2022'
         uses: microsoft/setup-msbuild@v2
 
       - name: Get the date on Ubuntu and macOS
-        if: inputs.os != 'windows-latest'
+        if: inputs.os != 'windows-2022'
         run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_ENV
         shell: bash
 
       - name: Get the date on Windows
-        if: inputs.os == 'windows-latest'
+        if: inputs.os == 'windows-2022'
         run: echo "date=$(Get-Date -Format 'yyyyMMdd')" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
         shell: pwsh
 
 
       # Build Dependencies
       - name: Build on Windows
-        if: inputs.os == 'windows-latest'
+        if: inputs.os == 'windows-2022'
         working-directory: ${{ github.workspace }}
         run: |
             choco install strawberryperl
@@ -70,7 +70,7 @@ jobs:
             msbuild /m ALL_BUILD.vcxproj
 
       - name: pack deps on Windows
-        if: inputs.os == 'windows-latest'
+        if: inputs.os == 'windows-2022'
         working-directory: ${{ github.workspace }}
         run: Compress-Archive -Path "${{ github.workspace }}\deps\build\BambuStudio_dep\*" -DestinationPath "${{ github.workspace }}\deps\build\BambuStudio_dep_win64_${{ env.date }}_vs2022.zip"
         shell: pwsh
@@ -161,7 +161,7 @@ jobs:
         run: rm -rf ${{ github.workspace }}/deps/build/BambuStudio_dep_mac_${{ inputs.arch }}*.tar.gz
 
       - name: Upload Windows artifacts
-        if: inputs.os == 'windows-latest'
+        if: inputs.os == 'windows-2022'
         uses: actions/upload-artifact@v6
         with:
           name: BambuStudio_dep_win64_${{ env.date }}

--- a/.github/workflows/winget_updater.yml
+++ b/.github/workflows/winget_updater.yml
@@ -4,7 +4,7 @@ on:
     types: [ released ]
 jobs:
   publish:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: vedantmgoyal9/winget-releaser@main
         with:


### PR DESCRIPTION
## Summary

Pin the Windows CI jobs to `windows-2022` so the build stops failing on every PR.

`windows-latest` now resolves to the `windows-2025-vs2026` image, which ships **Visual Studio 2026 (v18) only** - no VS 2022. So the hardcoded `cmake -G "Visual Studio 17 2022"` fails at configure time:

```
Image: windows-2025-vs2026
CMake Error: Generator Visual Studio 17 2022 could not find any instance of Visual Studio.
```

`windows-2022` still provides **Visual Studio Enterprise 2022 (17.14)**, matching the `Visual Studio 17 2022` generator and the `..._vs2022.zip` deps cache built by `build_deps.yml`. This unblocks the Windows deps + slicer build for all current PRs.

This is a stop-gap: @MackBambu is adding proper Visual Studio 2026 support upstream, which will supersede this pin (the `..._vs2022.zip` deps cache will need a matching VS 2026 rebuild at that point).

## Scope

Narrowed to the Windows-runner pin only. The unrelated CI fixes that were originally bundled here (ubuntu-20.04 removal, `podman buildx`, `main`→`master` branch refs, `setup-msbuild` v3, `winget-releaser` pin, brew dedup) are split out to #11277 so they can land independently of the VS work.

## Test plan

- Like-for-like runner pin, no build logic changed.
- My fork already builds the Windows target green on `windows-2022` (VS 2022 17.14).
