### PR TITLE
fix(devicemanager): percision -> precision in motion calibration

### DIFF
--- a/bbl/i18n/cs/BambuStudio_cs.po
+++ b/bbl/i18n/cs/BambuStudio_cs.po
@@ -4412,10 +4412,10 @@ msgstr "Pozastavení (chyba první vrstvy)"
 msgid "Pause (nozzle clog)"
 msgstr "Pozastavení (ucpání trysky)"
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr "Měření přesnosti pohybu"
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr "Zvyšování přesnosti pohybu"
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/de/BambuStudio_de.po
+++ b/bbl/i18n/de/BambuStudio_de.po
@@ -4354,10 +4354,10 @@ msgstr ""
 msgid "Pause (nozzle clog)"
 msgstr ""
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr ""
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr ""
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/en/BambuStudio_en.po
+++ b/bbl/i18n/en/BambuStudio_en.po
@@ -4310,10 +4310,10 @@ msgstr ""
 msgid "Pause (nozzle clog)"
 msgstr ""
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr ""
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr ""
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/es/BambuStudio_es.po
+++ b/bbl/i18n/es/BambuStudio_es.po
@@ -4352,10 +4352,10 @@ msgstr ""
 msgid "Pause (nozzle clog)"
 msgstr ""
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr ""
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr ""
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/fr/BambuStudio_fr.po
+++ b/bbl/i18n/fr/BambuStudio_fr.po
@@ -4341,10 +4341,10 @@ msgstr "Pause (erreur première couche)"
 msgid "Pause (nozzle clog)"
 msgstr "Pause (buse bouchée)"
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr "Mesurer la précision des mouvements"
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr "Améliorer la précision des mouvements"
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/hu/BambuStudio_hu.po
+++ b/bbl/i18n/hu/BambuStudio_hu.po
@@ -4350,10 +4350,10 @@ msgstr "Szünet (első réteg hibája)"
 msgid "Pause (nozzle clog)"
 msgstr "Szünet (fúvóka eltömődése)"
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr "Mozgás pontosságának mérése"
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr "Mozgás pontosságának javítása"
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/it/BambuStudio_it.po
+++ b/bbl/i18n/it/BambuStudio_it.po
@@ -4355,10 +4355,10 @@ msgstr ""
 msgid "Pause (nozzle clog)"
 msgstr ""
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr ""
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr ""
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/ja/BambuStudio_ja.po
+++ b/bbl/i18n/ja/BambuStudio_ja.po
@@ -4330,10 +4330,10 @@ msgstr "一時停止（1層目のエラー）"
 msgid "Pause (nozzle clog)"
 msgstr "一時停止 (ノズル詰まり)"
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr "動作精度の測定"
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr "動作精度の向上"
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/ko/BambuStudio_ko.po
+++ b/bbl/i18n/ko/BambuStudio_ko.po
@@ -4344,10 +4344,10 @@ msgstr "일시 중지 (첫 레이어 오류)"
 msgid "Pause (nozzle clog)"
 msgstr "일시 중지 (노즐 막힘)"
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr "모션 정확도 측정중"
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr "모션 정확도 향상"
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/nl/BambuStudio_nl.po
+++ b/bbl/i18n/nl/BambuStudio_nl.po
@@ -4350,10 +4350,10 @@ msgstr ""
 msgid "Pause (nozzle clog)"
 msgstr ""
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr ""
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr ""
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/pl/BambuStudio_pl.po
+++ b/bbl/i18n/pl/BambuStudio_pl.po
@@ -4355,10 +4355,10 @@ msgstr "Wstrzymano (błąd pierwszej warstwy)"
 msgid "Pause (nozzle clog)"
 msgstr "Wstrzymano (zatkanie dyszy)"
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr "Pomiar precyzji ruchu"
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr "Poprawa percyzji ruchu"
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/pt_BR/BambuStudio_pt_BR.po
+++ b/bbl/i18n/pt_BR/BambuStudio_pt_BR.po
@@ -4353,10 +4353,10 @@ msgstr "Pausa (erro na primeira camada)"
 msgid "Pause (nozzle clog)"
 msgstr "Pausa (bico entupido)"
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr "Medindo a precisão do movimento"
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr "Melhorando a precisão do movimento"
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/ru/BambuStudio_ru.po
+++ b/bbl/i18n/ru/BambuStudio_ru.po
@@ -4407,10 +4407,10 @@ msgstr ""
 msgid "Pause (nozzle clog)"
 msgstr ""
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr ""
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr ""
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/sv/BambuStudio_sv.po
+++ b/bbl/i18n/sv/BambuStudio_sv.po
@@ -4347,10 +4347,10 @@ msgstr "Paus (fel på första lagret)"
 msgid "Pause (nozzle clog)"
 msgstr "Paus (igensatt nozzle)"
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr "Mäter rörelse precision"
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr "Förbättra rörelseprecisionen"
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/tr/BambuStudio_tr.po
+++ b/bbl/i18n/tr/BambuStudio_tr.po
@@ -4339,10 +4339,10 @@ msgstr "Duraklat (ilk katman hatası)"
 msgid "Pause (nozzle clog)"
 msgstr "Duraklatma (nozul tıkanıklığı)"
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr "Hareket hassasiyetinin ölçülmesi"
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr "Hareket hassasiyetini artırma"
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/uk/BambuStudio_uk.po
+++ b/bbl/i18n/uk/BambuStudio_uk.po
@@ -4331,10 +4331,10 @@ msgstr ""
 msgid "Pause (nozzle clog)"
 msgstr ""
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr ""
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr ""
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/zh_CN/BambuStudio_zh_CN.po
+++ b/bbl/i18n/zh_CN/BambuStudio_zh_CN.po
@@ -4319,10 +4319,10 @@ msgstr "暂停（首层扫描异常）"
 msgid "Pause (nozzle clog)"
 msgstr "暂停（堵头）"
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr "检查运动精度"
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr "运动精度增强"
 
 msgid "Measure motion accuracy"

--- a/bbl/i18n/zh_TW/BambuStudio_zh_TW.po
+++ b/bbl/i18n/zh_TW/BambuStudio_zh_TW.po
@@ -4320,10 +4320,10 @@ msgstr "暫停（首層掃描異常）"
 msgid "Pause (nozzle clog)"
 msgstr "暫停（堵頭）"
 
-msgid "Measuring motion percision"
+msgid "Measuring motion precision"
 msgstr "檢查運動精度"
 
-msgid "Enhancing motion percision"
+msgid "Enhancing motion precision"
 msgstr "運動精度增強"
 
 msgid "Measure motion accuracy"

--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -159,9 +159,9 @@ wxString Slic3r::get_stage_string(int stage)
     case 35:
         return _L("Pause (nozzle clog)");
     case 36:
-        return _L("Measuring motion percision");
+        return _L("Measuring motion precision");
     case 37:
-        return _L("Enhancing motion percision");
+        return _L("Enhancing motion precision");
     case 38:
         return _L("Measure motion accuracy");
     case 39:


### PR DESCRIPTION
## Summary

Closes #10856. The device status panel rendered "Measuring motion percision" and "Enhancing motion percision" during motion calibration (cases 36/37 in `src/slic3r/GUI/DeviceManager.cpp:162,164`). The intended word is `precision`. This PR fixes the source strings and updates the `msgid` keys in all 18 `bbl/i18n/*.po` files to match, so existing `msgstr` translations still resolve via gettext lookup.

## Why this matters

These two strings are visible to every user who triggers motion calibration, so the typo is high-visibility in the device status panel. Updating only `DeviceManager.cpp` would silently break the gettext lookup for every translated locale (the existing `msgid "Measuring motion percision"` entries no longer match the corrected source, so gettext falls back to English and translators' work is dropped on the floor until the next extraction cycle).

Updating the `msgid` key on each `.po` file at the same time as the source keeps the existing `msgstr` translations attached to the corrected source string. Translators don't have to redo their work, and non-English users keep seeing translated text instead of falling back to the corrected English.

## Changes

- `src/slic3r/GUI/DeviceManager.cpp:162,164` - `percision` -> `precision` in both `_L(...)` calls.
- `bbl/i18n/{cs,de,en,es,fr,hu,it,ja,ko,nl,pl,pt_BR,ru,sv,tr,uk,zh_CN,zh_TW}/BambuStudio_*.po` - `msgid` keys updated to match. 18 files, 2 lines each.

Total: 19 files, 38 added + 38 deleted lines. Mechanical search-and-replace of two exact strings.

## How to test

```
$ grep -rln "percision" --include="*.cpp" --include="*.po" --include="*.json" --include="*.h" .
(empty)
$ grep -n "Measuring motion precision\|Enhancing motion precision" src/slic3r/GUI/DeviceManager.cpp
162:        return _L("Measuring motion precision");
164:        return _L("Enhancing motion precision");
```

The 18 `.po` files each have two updated `msgid` lines; the matching `msgstr` translations are untouched.

Fixes #10856

AI-assisted.
