### PR TITLE
feat: make filament Serial field optional in CreatePresetsDialog

### DIFF
--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -840,7 +840,7 @@ wxBoxSizer *CreateFilamentPresetDialog::create_serial_item()
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer        = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_serial_text = new wxStaticText(this, wxID_ANY, _L("Serial (optional)"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_serial_text = new wxStaticText(this, wxID_ANY, _L("Serial / Variant"), wxDefaultPosition, wxDefaultSize);
     optionSizer->Add(static_serial_text, 0, wxEXPAND | wxALL, 0);
     optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(5));
@@ -1030,6 +1030,12 @@ wxBoxSizer *CreateFilamentPresetDialog::create_button_item()
         }
         boost::algorithm::trim(vendor_name);
         boost::algorithm::trim(serial_name);
+        if (!serial_str.IsEmpty() && serial_name.empty()) {
+            MessageDialog dlg(this, _L("The filament serial contains only invalid characters or spaces. Please correct it or leave it blank."),
+                              wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Info"), wxYES | wxYES_DEFAULT | wxCENTRE);
+            dlg.ShowModal();
+            return;
+        }
         if (vendor_name.empty()) {
             MessageDialog dlg(this, _L("The filament vendor name cannot be blank. Please enter a vendor name."),
                               wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Info"), wxYES | wxYES_DEFAULT | wxCENTRE);
@@ -4839,7 +4845,7 @@ wxBoxSizer *EditFilamentPresetDialog::create_filament_basic_info()
 
     //serial
     wxBoxSizer *  serial_key_sizer   = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_serial_text = new wxStaticText(this, wxID_ANY, _L("Serial"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_serial_text = new wxStaticText(this, wxID_ANY, _L("Serial / Variant"), wxDefaultPosition, wxDefaultSize);
     serial_key_sizer->Add(static_serial_text, 0, wxEXPAND | wxALL, 0);
     serial_key_sizer->SetMinSize(OPTION_SIZE);
     serial_sizer->Add(serial_key_sizer, 0, wxEXPAND | wxLEFT | wxBOTTOM | wxALIGN_CENTER_VERTICAL, FromDIP(10));

--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -840,7 +840,7 @@ wxBoxSizer *CreateFilamentPresetDialog::create_serial_item()
     wxBoxSizer *horizontal_sizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxBoxSizer *  optionSizer        = new wxBoxSizer(wxVERTICAL);
-    wxStaticText *static_serial_text = new wxStaticText(this, wxID_ANY, _L("Serial"), wxDefaultPosition, wxDefaultSize);
+    wxStaticText *static_serial_text = new wxStaticText(this, wxID_ANY, _L("Serial (optional)"), wxDefaultPosition, wxDefaultSize);
     optionSizer->Add(static_serial_text, 0, wxEXPAND | wxALL, 0);
     optionSizer->SetMinSize(OPTION_SIZE);
     horizontal_sizer->Add(optionSizer, 0, wxEXPAND | wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(5));
@@ -1018,28 +1018,20 @@ wxBoxSizer *CreateFilamentPresetDialog::create_button_item()
         }
         //get filament serial
         wxString    serial_str = m_filament_serial_input->GetTextCtrl()->GetValue();
-        std::string serial_name;
-        if (serial_str.empty()) {
-            MessageDialog dlg(this, _L("Filament serial is not inputed, please input serial."), wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Info"),
-                              wxYES | wxYES_DEFAULT | wxCENTRE);
-            dlg.ShowModal();
-            return;
-        } else {
-            serial_name = into_u8(serial_str);
-        }
+        std::string serial_name = into_u8(serial_str);
         vendor_name = remove_special_key(vendor_name);
         serial_name = remove_special_key(serial_name);
 
-        if (vendor_name.empty() || serial_name.empty()) {
-            MessageDialog dlg(this, _L("There may be escape characters in the vendor or serial input of filament. Please delete and re-enter."), wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Info"),
+        if (vendor_name.empty()) {
+            MessageDialog dlg(this, _L("The filament vendor name contains invalid characters. Please remove them and try again."), wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Info"),
                               wxYES | wxYES_DEFAULT | wxCENTRE);
             dlg.ShowModal();
             return;
         }
         boost::algorithm::trim(vendor_name);
         boost::algorithm::trim(serial_name);
-        if (vendor_name.empty() || serial_name.empty()) {
-            MessageDialog dlg(this, _L("All inputs in the custom vendor or serial are spaces. Please re-enter."),
+        if (vendor_name.empty()) {
+            MessageDialog dlg(this, _L("The filament vendor name cannot be blank. Please enter a vendor name."),
                               wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Info"), wxYES | wxYES_DEFAULT | wxCENTRE);
             dlg.ShowModal();
             return;
@@ -1058,7 +1050,8 @@ wxBoxSizer *CreateFilamentPresetDialog::create_button_item()
             return;
         }
 
-        std::string filament_preset_name = vendor_name + " " + (type_name == "PLA-AERO" ? "PLA Aero" : type_name) + " " + serial_name;
+        std::string display_type         = type_name == "PLA-AERO" ? "PLA Aero" : type_name;
+        std::string filament_preset_name = vendor_name + " " + display_type + (serial_name.empty() ? "" : " " + serial_name);
         PresetBundle *preset_bundle        = wxGetApp().preset_bundle;
         if (preset_bundle->filaments.is_alias_exist(filament_preset_name)) {
             MessageDialog dlg(this,


### PR DESCRIPTION
## Summary

Closes #10866

The filament **Serial** field in the *Create/Edit Filament Presets* dialog is currently mandatory, the dialog silently requires a non-empty value to build the preset name. This is confusing for users who want to create a generic filament preset without a specific serial/variant number.

### Changes

- The **Serial** field is now optional (label updated to *"Serial (optional)"*)
- When Serial is left blank the preset name is built as `<Vendor> <Type>` instead of `<Vendor> <Type> <Serial>`
- When Serial is filled in but contains only invalid/special characters (i.e. `remove_special_key()` strips everything), the dialog shows a clear validation error instead of silently dropping the value:
  > *"The filament serial contains only invalid characters or spaces. Please correct it or leave it blank."*
- Existing validation for the vendor name field is unchanged

### Before / After

| Before | After |
|--------|-------|
| Serial field required | Serial field optional |
| Blank serial → preset creation blocked | Blank serial → preset named `Vendor Type` |
| Invalid serial silently dropped | Invalid serial → validation error with message |

### Testing

Tested the following scenarios:
- Create preset with Serial filled in → preset name includes serial ✓
- Create preset with Serial left blank → preset name is `Vendor Type` ✓
- Enter `!!!` as serial (all special chars) → validation error shown, dialog stays open ✓
- Vendor field left blank → existing error shown as before ✓
