### PR TITLE
fix: don't skip user presets when parent preset is not found

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1453,8 +1453,13 @@ void PresetCollection::load_presets(
                     else {
                         auto inherits_config2 = dynamic_cast<ConfigOptionString *>(inherits_config);
                         if ((inherits_config2 && !inherits_config2->value.empty())) {
-                            BOOST_LOG_TRIVIAL(error) << boost::format("can not find parent %1% for config %2%!") % inherits_config2->value % PathSanitizer::sanitize(preset.file);
-                            continue;
+                            // Parent preset not found (e.g. renamed or removed by a system update).
+                            // Do NOT skip the preset — that would silently delete the user's work.
+                            // Fall back to the built-in default config so the user at least sees
+                            // their preset and can correct any settings that differ from the old parent.
+                            BOOST_LOG_TRIVIAL(warning) << boost::format(
+                                "Parent preset '%1%' not found for '%2%'; loading with default config as fallback.")
+                                % inherits_config2->value % PathSanitizer::sanitize(preset.file);
                         }
                         // We support custom root preset now
                         // Find a default preset for the config. The PrintPresetCollection provides different default preset based on the "printer_technology" field.


### PR DESCRIPTION
## Summary

Fixes #10869

### Root Cause

In `PresetCollection::load_presets()` (`src/libslic3r/Preset.cpp`), when a user preset has an `inherits` field that points to a system preset that no longer exists (e.g. because it was renamed or removed in a system update), the preset is silently skipped:

```cpp
// BEFORE – buggy
if ((inherits_config2 && !inherits_config2->value.empty())) {
    BOOST_LOG_TRIVIAL(error) << "can not find parent ...";
    continue;  // ← preset disappears from the UI entirely
}
```

From the user's perspective the preset appears to be gone after restarting the application, even though the file is still on disk. This explains why the workaround of recreating the `User` directory helps — it forces the user to re-create presets under the current system-preset names, so the parent is always found.

The bug can be triggered whenever:
- A system-preset name changes between releases (version bump, printer variant rename, etc.)
- The user's `inherits` reference still points to the old name

### Fix

Instead of `continue`-ing (dropping the preset), fall back to the built-in **default config** and emit a `warning` log entry. The user's saved values are applied on top of the default, so their settings are preserved as well as possible. The preset is now visible in the UI and the user can correct any values that used to derive from the missing parent.

```cpp
// AFTER – fixed
if ((inherits_config2 && !inherits_config2->value.empty())) {
    BOOST_LOG_TRIVIAL(warning) << "Parent preset not found; loading with default config as fallback.";
    // fall through to default config path — do NOT skip
}
preset.config = default_preset.config;
preset.config.apply(std::move(config));
extend_default_config_length(preset.config, {}, true, default_preset.config);
```

### Behaviour change

| Scenario | Before | After |
|----------|--------|-------|
| Parent preset found | ✅ loaded correctly | ✅ unchanged |
| Parent preset **not** found | ❌ preset silently dropped | ✅ preset loaded with default base + user diffs, warning in log |

### Notes

The fallback may produce subtly different values for settings that were inherited (not explicitly saved) from the missing parent. This is a known trade-off: a preset with potentially imperfect settings is always preferable to a silently deleted preset.