### PR TITLE
fix: warn user when filament serial input sanitizes to empty string

### DIFF
--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -1038,6 +1038,12 @@ wxBoxSizer *CreateFilamentPresetDialog::create_button_item()
         }
         boost::algorithm::trim(vendor_name);
         boost::algorithm::trim(serial_name);
+        if (!serial_str.IsEmpty() && serial_name.empty()) {
+            MessageDialog dlg(this, _L("The filament serial contains only invalid characters or spaces. Please correct it or leave it blank."),
+                              wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Info"), wxYES | wxYES_DEFAULT | wxCENTRE);
+            dlg.ShowModal();
+            return;
+        }
         if (vendor_name.empty() || serial_name.empty()) {
             MessageDialog dlg(this, _L("All inputs in the custom vendor or serial are spaces. Please re-enter."),
                               wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Info"), wxYES | wxYES_DEFAULT | wxCENTRE);

--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -1038,8 +1038,8 @@ wxBoxSizer *CreateFilamentPresetDialog::create_button_item()
         }
         boost::algorithm::trim(vendor_name);
         boost::algorithm::trim(serial_name);
-        if (!serial_str.IsEmpty() && serial_name.empty()) {
-            MessageDialog dlg(this, _L("The filament serial contains only invalid characters or spaces. Please correct it or leave it blank."),
+        if (serial_name.empty()) {
+            MessageDialog dlg(this, _L("The filament serial contains only invalid characters or spaces. Please correct it."),
                               wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Info"), wxYES | wxYES_DEFAULT | wxCENTRE);
             dlg.ShowModal();
             return;

--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -1030,7 +1030,7 @@ wxBoxSizer *CreateFilamentPresetDialog::create_button_item()
         vendor_name = remove_special_key(vendor_name);
         serial_name = remove_special_key(serial_name);
 
-        if (vendor_name.empty()) {
+        if (vendor_name.empty() || serial_name.empty()) {
             MessageDialog dlg(this, _L("There may be escape characters in the vendor or serial input of filament. Please delete and re-enter."), wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Info"),
                               wxYES | wxYES_DEFAULT | wxCENTRE);
             dlg.ShowModal();
@@ -1044,7 +1044,7 @@ wxBoxSizer *CreateFilamentPresetDialog::create_button_item()
             dlg.ShowModal();
             return;
         }
-        if (vendor_name.empty() || serial_name.empty()) {
+        if (vendor_name.empty()) {
             MessageDialog dlg(this, _L("All inputs in the custom vendor or serial are spaces. Please re-enter."),
                               wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Info"), wxYES | wxYES_DEFAULT | wxCENTRE);
             dlg.ShowModal();

--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -1030,7 +1030,7 @@ wxBoxSizer *CreateFilamentPresetDialog::create_button_item()
         vendor_name = remove_special_key(vendor_name);
         serial_name = remove_special_key(serial_name);
 
-        if (vendor_name.empty() || serial_name.empty()) {
+        if (vendor_name.empty()) {
             MessageDialog dlg(this, _L("There may be escape characters in the vendor or serial input of filament. Please delete and re-enter."), wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Info"),
                               wxYES | wxYES_DEFAULT | wxCENTRE);
             dlg.ShowModal();


### PR DESCRIPTION
## Summary

- Show a warning message when the user enters a filament serial number that gets sanitized (trimmed/filtered) to an empty string, preventing silent data loss

## Changes

- `src/slic3r/GUI/CreatePresetsDialog.cpp`: Add validation that warns the user when serial input becomes empty after sanitization

## Test plan

- [ ] Enter a filament serial number consisting only of whitespace or invalid characters
- [ ] Verify a warning is shown instead of silently saving an empty serial
- [ ] Verify normal serial numbers still save correctly