### PR TITLE
fix(slicer): invalidate slice result when instance printability toggles

### DIFF
--- a/src/libslic3r/PrintApply.cpp
+++ b/src/libslic3r/PrintApply.cpp
@@ -1757,6 +1757,10 @@ Print::ApplyStatus Print::apply(const Model &model, DynamicPrintConfig new_full_
 	        	// Synchronize the content of instances.
 	        	auto new_instance = model_object_new.instances.begin();
 				for (auto old_instance = model_object.instances.begin(); old_instance != model_object.instances.end(); ++ old_instance, ++ new_instance) {
+                    // BBS: printable toggle changes which instances generate G-code; invalidate skirt/brim, wipe tower, and G-code.
+                    if ((*old_instance)->printable != (*new_instance)->printable) {
+                        update_apply_status(this->invalidate_steps({psSkirtBrim, psWipeTower, psGCodeExport}));
+                    }
                     if (is_printable_filament_changed(new_full_config, (*old_instance)->convex_hull_2d(), (*new_instance)->convex_hull_2d())) {
                         update_apply_status(this->invalidate_steps({psWipeTower, psGCodeExport}));
                     }


### PR DESCRIPTION
## Summary

Fix a regression where toggling an object instance's "Printable" flag leaves the slice button grayed out, requiring an unrelated change to the project before the user can re-slice.

Closes #10891

## Root cause

`Print::apply()`'s instance synchronization branch (`src/libslic3r/PrintApply.cpp` ~line 1757) updates each instance's `printable` flag but only invalidates Print steps when `is_printable_filament_changed()` detects a filament-set change. A pure printability toggle leaves the filament assignment unchanged, so this loop produces no invalidation.

Section 4 of `Print::apply` does fire `invalidate_all_steps()` for the toggled object, but in the affected workflow the print steps are already in INVALID state from earlier background-process activity, so `invalidate_all_steps()` returns false and the overall `apply_status` caps at `APPLY_STATUS_CHANGED` (1) instead of `APPLY_STATUS_INVALIDATED` (2).

`Plater::priv::update_background_process` only calls `update_slice_result_valid_state(false)` on `APPLY_STATUS_INVALIDATED` ([Plater.cpp:10210](https://github.com/bambulab/BambuStudio/blob/master/src/slic3r/GUI/Plater.cpp#L10210)). With `APPLY_STATUS_CHANGED`, the cached slice result stays valid, so `MainFrame::get_enable_slice_status()` returns false (button disabled) because `PartPlate::is_slice_result_valid()` is still true.

## Regression

Introduced by [`e22d328f`](https://github.com/bambulab/BambuStudio/commit/e22d328fa9d1682c00617a4cad0498c67a7512f4) ("ENH: Optimizing the shape invalid condition for wipe tower of multi-extruder", May 2025), which replaced an unconditional invalidation in the `set_instances` path with a narrower convex-hull-based check. The optimization was correct for translation/rotation cases, but printability toggles do not change geometry, so they fall through both the new and old checks in this loop.

## Fix

Invalidate `{psSkirtBrim, psWipeTower, psGCodeExport}` whenever `old_instance->printable != new_instance->printable`. The triplet matches the one used elsewhere in `PrintApply.cpp` (line 1852) and in `PrintObject::set_instances` ([PrintObject.cpp:116](https://github.com/bambulab/BambuStudio/blob/master/src/libslic3r/PrintObject.cpp#L116)).

Skirt/brim is included because the set of `PrintInstance`s feeding `Print::_make_skirt` is filtered upstream by `ModelInstance::is_printable()` at [`PrintApply.cpp:147`](https://github.com/bambulab/BambuStudio/blob/master/src/libslic3r/PrintApply.cpp#L147) — when printability toggles, the cached skirt geometry is stale.

The diff is 4 lines.

## Test plan

- [x] Verified with `BBL_INTERNAL_TESTING=1` build that pre-patch toggle produces `apply_status=1` (CHANGED) and `enable_slice=0`, while post-patch the same toggle produces `apply_status=2` (INVALIDATED) and `enable_slice=1`.
- [x] Toggle off, slice button enables, slice; toggle on, slice button enables, slice. Confirmed across 7 toggle events on a multi-object plate.
- [x] No regression in the non-toggling case: translation/rotation/transform changes still take the `is_printable_filament_changed` path and behave as `e22d328f` intended.
- [ ] Verified on multi-extruder H2C profile (the configuration where the bug was originally reported).
