### PR TITLE
Add FilAr filament vendor (PLA, PLA-mate, PETG)

### DIFF
--- a/resources/profiles/BBL.json
+++ b/resources/profiles/BBL.json
@@ -3156,6 +3156,174 @@
             "sub_path": "filament/fdm_filament_pla.json"
         },
         {
+            "name": "FilAr PLA @base",
+            "sub_path": "filament/FilAr/FilAr PLA @base.json"
+        },
+        {
+            "name": "FilAr PLA @BBL A1",
+            "sub_path": "filament/FilAr/FilAr PLA @BBL A1.json"
+        },
+        {
+            "name": "FilAr PLA @BBL A1 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PLA @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PLA @BBL A1M",
+            "sub_path": "filament/FilAr/FilAr PLA @BBL A1M.json"
+        },
+        {
+            "name": "FilAr PLA @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PLA @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PLA @BBL X1",
+            "sub_path": "filament/FilAr/FilAr PLA @BBL X1.json"
+        },
+        {
+            "name": "FilAr PLA @BBL X1C",
+            "sub_path": "filament/FilAr/FilAr PLA @BBL X1C.json"
+        },
+        {
+            "name": "FilAr PLA @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PLA @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PLA @BBL H2D",
+            "sub_path": "filament/FilAr/FilAr PLA @BBL H2D.json"
+        },
+        {
+            "name": "FilAr PLA @BBL H2D 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PLA @BBL H2D 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PLA @BBL H2DP",
+            "sub_path": "filament/FilAr/FilAr PLA @BBL H2DP.json"
+        },
+        {
+            "name": "FilAr PLA @BBL H2DP 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PLA @BBL H2DP 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PLA @BBL H2S",
+            "sub_path": "filament/FilAr/FilAr PLA @BBL H2S.json"
+        },
+        {
+            "name": "FilAr PLA @BBL H2S 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PLA @BBL H2S 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PLA-mate @base",
+            "sub_path": "filament/FilAr/FilAr PLA-mate @base.json"
+        },
+        {
+            "name": "FilAr PLA-mate @BBL A1",
+            "sub_path": "filament/FilAr/FilAr PLA-mate @BBL A1.json"
+        },
+        {
+            "name": "FilAr PLA-mate @BBL A1 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PLA-mate @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PLA-mate @BBL A1M",
+            "sub_path": "filament/FilAr/FilAr PLA-mate @BBL A1M.json"
+        },
+        {
+            "name": "FilAr PLA-mate @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PLA-mate @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PLA-mate @BBL X1",
+            "sub_path": "filament/FilAr/FilAr PLA-mate @BBL X1.json"
+        },
+        {
+            "name": "FilAr PLA-mate @BBL X1C",
+            "sub_path": "filament/FilAr/FilAr PLA-mate @BBL X1C.json"
+        },
+        {
+            "name": "FilAr PLA-mate @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PLA-mate @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PLA-mate @BBL H2D",
+            "sub_path": "filament/FilAr/FilAr PLA-mate @BBL H2D.json"
+        },
+        {
+            "name": "FilAr PLA-mate @BBL H2D 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PLA-mate @BBL H2D 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PLA-mate @BBL H2DP",
+            "sub_path": "filament/FilAr/FilAr PLA-mate @BBL H2DP.json"
+        },
+        {
+            "name": "FilAr PLA-mate @BBL H2DP 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PLA-mate @BBL H2DP 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PLA-mate @BBL H2S",
+            "sub_path": "filament/FilAr/FilAr PLA-mate @BBL H2S.json"
+        },
+        {
+            "name": "FilAr PLA-mate @BBL H2S 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PLA-mate @BBL H2S 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PETG @base",
+            "sub_path": "filament/FilAr/FilAr PETG @base.json"
+        },
+        {
+            "name": "FilAr PETG @BBL A1",
+            "sub_path": "filament/FilAr/FilAr PETG @BBL A1.json"
+        },
+        {
+            "name": "FilAr PETG @BBL A1 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PETG @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PETG @BBL A1M",
+            "sub_path": "filament/FilAr/FilAr PETG @BBL A1M.json"
+        },
+        {
+            "name": "FilAr PETG @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PETG @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PETG @BBL X1",
+            "sub_path": "filament/FilAr/FilAr PETG @BBL X1.json"
+        },
+        {
+            "name": "FilAr PETG @BBL X1C",
+            "sub_path": "filament/FilAr/FilAr PETG @BBL X1C.json"
+        },
+        {
+            "name": "FilAr PETG @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PETG @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PETG @BBL H2D",
+            "sub_path": "filament/FilAr/FilAr PETG @BBL H2D.json"
+        },
+        {
+            "name": "FilAr PETG @BBL H2D 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PETG @BBL H2D 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PETG @BBL H2DP",
+            "sub_path": "filament/FilAr/FilAr PETG @BBL H2DP.json"
+        },
+        {
+            "name": "FilAr PETG @BBL H2DP 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PETG @BBL H2DP 0.2 nozzle.json"
+        },
+        {
+            "name": "FilAr PETG @BBL H2S",
+            "sub_path": "filament/FilAr/FilAr PETG @BBL H2S.json"
+        },
+        {
+            "name": "FilAr PETG @BBL H2S 0.2 nozzle",
+            "sub_path": "filament/FilAr/FilAr PETG @BBL H2S 0.2 nozzle.json"
+        },
+        {
             "name": "Bambu PLA Aero @base",
             "sub_path": "filament/Bambu PLA Aero @base.json"
         },

--- a/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL A1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL A1 0.2 nozzle.json
@@ -1,0 +1,17 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG @BBL A1 0.2 nozzle",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "setting_id": "FILARPETG_01",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "1"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 0.2 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL A1.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL A1.json
@@ -1,0 +1,19 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG @BBL A1",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "setting_id": "FILARPETG_00",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 0.4 nozzle",
+        "Bambu Lab A1 0.6 nozzle",
+        "Bambu Lab A1 0.8 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL A1M 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL A1M 0.2 nozzle.json
@@ -1,0 +1,17 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG @BBL A1M 0.2 nozzle",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "setting_id": "FILARPETG_03",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "1"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.2 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL A1M.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL A1M.json
@@ -1,0 +1,19 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG @BBL A1M",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "setting_id": "FILARPETG_02",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.4 nozzle",
+        "Bambu Lab A1 mini 0.6 nozzle",
+        "Bambu Lab A1 mini 0.8 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL H2D 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL H2D 0.2 nozzle.json
@@ -1,0 +1,47 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG @BBL H2D 0.2 nozzle",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "setting_id": "FILARPETG_08",
+    "instantiation": "true",
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "1",
+        "1"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "240",
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "245",
+        "245"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.2 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL H2D.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL H2D.json
@@ -1,0 +1,49 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG @BBL H2D",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "setting_id": "FILARPETG_07",
+    "instantiation": "true",
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "12",
+        "12"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "240",
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "245",
+        "245"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle",
+        "Bambu Lab H2D 0.6 nozzle",
+        "Bambu Lab H2D 0.8 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL H2DP 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL H2DP 0.2 nozzle.json
@@ -1,0 +1,47 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG @BBL H2DP 0.2 nozzle",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "setting_id": "FILARPETG_10",
+    "instantiation": "true",
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "1",
+        "1"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "240",
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "245",
+        "245"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D Pro 0.2 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL H2DP.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL H2DP.json
@@ -1,0 +1,49 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG @BBL H2DP",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "setting_id": "FILARPETG_09",
+    "instantiation": "true",
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "12",
+        "12"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "240",
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "245",
+        "245"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D Pro 0.4 nozzle",
+        "Bambu Lab H2D Pro 0.6 nozzle",
+        "Bambu Lab H2D Pro 0.8 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL H2S 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL H2S 0.2 nozzle.json
@@ -1,0 +1,59 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG @BBL H2S 0.2 nozzle",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "setting_id": "FILARPETG_12",
+    "instantiation": "true",
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_flush_volumetric_speed": [
+        "3",
+        "3"
+    ],
+    "filament_max_volumetric_speed": [
+        "1",
+        "1"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "nozzle_temperature": [
+        "240",
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "245",
+        "245"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2S 0.2 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL H2S.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL H2S.json
@@ -1,0 +1,73 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG @BBL H2S",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "setting_id": "FILARPETG_11",
+    "instantiation": "true",
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "12",
+        "12"
+    ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "nozzle_temperature": [
+        "240",
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "245",
+        "245"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2S 0.4 nozzle",
+        "Bambu Lab H2S 0.6 nozzle",
+        "Bambu Lab H2S 0.8 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL X1.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL X1.json
@@ -1,0 +1,16 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG @BBL X1",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "setting_id": "FILARPETG_04",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab X1 0.6 nozzle",
+        "Bambu Lab X1 0.8 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL X1C 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL X1C 0.2 nozzle.json
@@ -1,0 +1,20 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG @BBL X1C 0.2 nozzle",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "setting_id": "FILARPETG_06",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "1"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.2 nozzle",
+        "Bambu Lab X1 0.2 nozzle",
+        "Bambu Lab P1S 0.2 nozzle",
+        "Bambu Lab X1E 0.2 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL X1C.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PETG @BBL X1C.json
@@ -1,0 +1,22 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG @BBL X1C",
+    "inherits": "FilAr PETG @base",
+    "from": "system",
+    "setting_id": "FILARPETG_05",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1E 0.4 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PETG @base.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PETG @base.json
@@ -1,0 +1,80 @@
+{
+    "type": "filament",
+    "name": "FilAr PETG @base",
+    "inherits": "fdm_filament_pet",
+    "from": "system",
+    "filament_id": "FILARPETG",
+    "instantiation": "false",
+    "cool_plate_temp": [
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "70"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "70"
+    ],
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "fan_max_speed": [
+        "60"
+    ],
+    "fan_min_speed": [
+        "40"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "hot_plate_temp": [
+        "78"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "78"
+    ],
+    "nozzle_temperature_range_high": [
+        "250"
+    ],
+    "overhang_fan_speed": [
+        "90"
+    ],
+    "overhang_fan_threshold": [
+        "10%"
+    ],
+    "slow_down_layer_time": [
+        "12"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
+    "textured_plate_temp": [
+        "78"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "78"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "filament_density": [
+        "1.27"
+    ],
+    "nozzle_temperature": [
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "245"
+    ],
+    "nozzle_temperature_range_low": [
+        "230"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL A1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL A1 0.2 nozzle.json
@@ -1,0 +1,29 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA @BBL A1 0.2 nozzle",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "setting_id": "FILARPLA_01",
+    "instantiation": "true",
+    "fan_cooling_layer_time": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.8"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 0.2 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL A1.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL A1.json
@@ -1,0 +1,28 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA @BBL A1",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "setting_id": "FILARPLA_00",
+    "instantiation": "true",
+    "fan_cooling_layer_time": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "60"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 0.4 nozzle",
+        "Bambu Lab A1 0.6 nozzle",
+        "Bambu Lab A1 0.8 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL A1M 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL A1M 0.2 nozzle.json
@@ -1,0 +1,29 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA @BBL A1M 0.2 nozzle",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "setting_id": "FILARPLA_03",
+    "instantiation": "true",
+    "fan_cooling_layer_time": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.8"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.2 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL A1M.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL A1M.json
@@ -1,0 +1,28 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA @BBL A1M",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "setting_id": "FILARPLA_02",
+    "instantiation": "true",
+    "fan_cooling_layer_time": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "60"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.4 nozzle",
+        "Bambu Lab A1 mini 0.6 nozzle",
+        "Bambu Lab A1 mini 0.8 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL H2D 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL H2D 0.2 nozzle.json
@@ -1,0 +1,51 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA @BBL H2D 0.2 nozzle",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "setting_id": "FILARPLA_08",
+    "instantiation": "true",
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.8",
+        "1.8"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "210",
+        "210"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "215",
+        "215"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.2 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL H2D.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL H2D.json
@@ -1,0 +1,53 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA @BBL H2D",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "setting_id": "FILARPLA_07",
+    "instantiation": "true",
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16",
+        "16"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "210",
+        "210"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "215",
+        "215"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle",
+        "Bambu Lab H2D 0.6 nozzle",
+        "Bambu Lab H2D 0.8 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL H2DP 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL H2DP 0.2 nozzle.json
@@ -1,0 +1,51 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA @BBL H2DP 0.2 nozzle",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "setting_id": "FILARPLA_10",
+    "instantiation": "true",
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.8",
+        "1.8"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "210",
+        "210"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "215",
+        "215"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D Pro 0.2 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL H2DP.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL H2DP.json
@@ -1,0 +1,53 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA @BBL H2DP",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "setting_id": "FILARPLA_09",
+    "instantiation": "true",
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16",
+        "16"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "210",
+        "210"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "215",
+        "215"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D Pro 0.4 nozzle",
+        "Bambu Lab H2D Pro 0.6 nozzle",
+        "Bambu Lab H2D Pro 0.8 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL H2S 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL H2S 0.2 nozzle.json
@@ -1,0 +1,70 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA @BBL H2S 0.2 nozzle",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "setting_id": "FILARPLA_12",
+    "instantiation": "true",
+    "additional_cooling_fan_speed": [
+        "75"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_flush_volumetric_speed": [
+        "3",
+        "3"
+    ],
+    "filament_long_retractions_when_cut": [
+        "0",
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.8",
+        "1.8"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "nozzle_temperature": [
+        "210",
+        "210"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "215",
+        "215"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2S 0.2 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL H2S.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL H2S.json
@@ -1,0 +1,68 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA @BBL H2S",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "setting_id": "FILARPLA_11",
+    "instantiation": "true",
+    "additional_cooling_fan_speed": [
+        "75"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_long_retractions_when_cut": [
+        "0",
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "16",
+        "16"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "nozzle_temperature": [
+        "210",
+        "210"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "215",
+        "215"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2S 0.4 nozzle",
+        "Bambu Lab H2S 0.6 nozzle",
+        "Bambu Lab H2S 0.8 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL X1.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL X1.json
@@ -1,0 +1,54 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA @BBL X1",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "setting_id": "FILARPLA_04",
+    "instantiation": "true",
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16",
+        "16"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "nozzle_temperature": [
+        "210",
+        "210"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "215",
+        "215"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_layer_time": [
+        "10"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab X1 0.6 nozzle",
+        "Bambu Lab X1 0.8 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL X1C 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL X1C 0.2 nozzle.json
@@ -1,0 +1,52 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA @BBL X1C 0.2 nozzle",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "setting_id": "FILARPLA_06",
+    "instantiation": "true",
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.8",
+        "1.8"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "nozzle_temperature": [
+        "210",
+        "210"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "215",
+        "215"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.2 nozzle",
+        "Bambu Lab X1 0.2 nozzle",
+        "Bambu Lab P1S 0.2 nozzle",
+        "Bambu Lab X1E 0.2 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL X1C.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA @BBL X1C.json
@@ -1,0 +1,57 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA @BBL X1C",
+    "inherits": "FilAr PLA @base",
+    "from": "system",
+    "setting_id": "FILARPLA_05",
+    "instantiation": "true",
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16",
+        "16"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "nozzle_temperature": [
+        "210",
+        "210"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "215",
+        "215"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1E 0.4 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA @base.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA @base.json
@@ -1,0 +1,50 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "FILARPLA",
+    "instantiation": "false",
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "nozzle_temperature": [
+        "210"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "215"
+    ],
+    "nozzle_temperature_range_low": [
+        "200"
+    ],
+    "nozzle_temperature_range_high": [
+        "220"
+    ],
+    "hot_plate_temp": [
+        "60"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "60"
+    ],
+    "textured_plate_temp": [
+        "60"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "60"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL A1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL A1 0.2 nozzle.json
@@ -1,0 +1,29 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate @BBL A1 0.2 nozzle",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "setting_id": "FILARPLAM_01",
+    "instantiation": "true",
+    "fan_cooling_layer_time": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.8"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 0.2 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL A1.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL A1.json
@@ -1,0 +1,28 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate @BBL A1",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "setting_id": "FILARPLAM_00",
+    "instantiation": "true",
+    "fan_cooling_layer_time": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "60"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 0.4 nozzle",
+        "Bambu Lab A1 0.6 nozzle",
+        "Bambu Lab A1 0.8 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL A1M 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL A1M 0.2 nozzle.json
@@ -1,0 +1,29 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate @BBL A1M 0.2 nozzle",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "setting_id": "FILARPLAM_03",
+    "instantiation": "true",
+    "fan_cooling_layer_time": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.8"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.2 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL A1M.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL A1M.json
@@ -1,0 +1,28 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate @BBL A1M",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "setting_id": "FILARPLAM_02",
+    "instantiation": "true",
+    "fan_cooling_layer_time": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "60"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.4 nozzle",
+        "Bambu Lab A1 mini 0.6 nozzle",
+        "Bambu Lab A1 mini 0.8 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL H2D 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL H2D 0.2 nozzle.json
@@ -1,0 +1,51 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate @BBL H2D 0.2 nozzle",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "setting_id": "FILARPLAM_08",
+    "instantiation": "true",
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.8",
+        "1.8"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "200",
+        "200"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "205",
+        "205"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.2 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL H2D.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL H2D.json
@@ -1,0 +1,53 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate @BBL H2D",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "setting_id": "FILARPLAM_07",
+    "instantiation": "true",
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16",
+        "16"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "200",
+        "200"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "205",
+        "205"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle",
+        "Bambu Lab H2D 0.6 nozzle",
+        "Bambu Lab H2D 0.8 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL H2DP 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL H2DP 0.2 nozzle.json
@@ -1,0 +1,51 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate @BBL H2DP 0.2 nozzle",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "setting_id": "FILARPLAM_10",
+    "instantiation": "true",
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.8",
+        "1.8"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "200",
+        "200"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "205",
+        "205"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D Pro 0.2 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL H2DP.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL H2DP.json
@@ -1,0 +1,53 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate @BBL H2DP",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "setting_id": "FILARPLAM_09",
+    "instantiation": "true",
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16",
+        "16"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "200",
+        "200"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "205",
+        "205"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D Pro 0.4 nozzle",
+        "Bambu Lab H2D Pro 0.6 nozzle",
+        "Bambu Lab H2D Pro 0.8 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL H2S 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL H2S 0.2 nozzle.json
@@ -1,0 +1,70 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate @BBL H2S 0.2 nozzle",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "setting_id": "FILARPLAM_12",
+    "instantiation": "true",
+    "additional_cooling_fan_speed": [
+        "75"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_flush_volumetric_speed": [
+        "3",
+        "3"
+    ],
+    "filament_long_retractions_when_cut": [
+        "0",
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.8",
+        "1.8"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "nozzle_temperature": [
+        "200",
+        "200"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "205",
+        "205"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2S 0.2 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL H2S.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL H2S.json
@@ -1,0 +1,68 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate @BBL H2S",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "setting_id": "FILARPLAM_11",
+    "instantiation": "true",
+    "additional_cooling_fan_speed": [
+        "75"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_long_retractions_when_cut": [
+        "0",
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "16",
+        "16"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "nozzle_temperature": [
+        "200",
+        "200"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "205",
+        "205"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2S 0.4 nozzle",
+        "Bambu Lab H2S 0.6 nozzle",
+        "Bambu Lab H2S 0.8 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL X1.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL X1.json
@@ -1,0 +1,54 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate @BBL X1",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "setting_id": "FILARPLAM_04",
+    "instantiation": "true",
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16",
+        "16"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "nozzle_temperature": [
+        "200",
+        "200"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "205",
+        "205"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_layer_time": [
+        "10"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab X1 0.6 nozzle",
+        "Bambu Lab X1 0.8 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL X1C 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL X1C 0.2 nozzle.json
@@ -1,0 +1,52 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate @BBL X1C 0.2 nozzle",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "setting_id": "FILARPLAM_06",
+    "instantiation": "true",
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.8",
+        "1.8"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "nozzle_temperature": [
+        "200",
+        "200"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "205",
+        "205"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.2 nozzle",
+        "Bambu Lab X1 0.2 nozzle",
+        "Bambu Lab P1S 0.2 nozzle",
+        "Bambu Lab X1E 0.2 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL X1C.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @BBL X1C.json
@@ -1,0 +1,57 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate @BBL X1C",
+    "inherits": "FilAr PLA-mate @base",
+    "from": "system",
+    "setting_id": "FILARPLAM_05",
+    "instantiation": "true",
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16",
+        "16"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "nozzle_temperature": [
+        "200",
+        "200"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "205",
+        "205"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1E 0.4 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @base.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @base.json
@@ -1,0 +1,50 @@
+{
+    "type": "filament",
+    "name": "FilAr PLA-mate @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "FILARPLAM",
+    "instantiation": "false",
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_vendor": [
+        "FilAr"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "nozzle_temperature": [
+        "200"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "205"
+    ],
+    "nozzle_temperature_range_low": [
+        "195"
+    ],
+    "nozzle_temperature_range_high": [
+        "210"
+    ],
+    "hot_plate_temp": [
+        "60"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "60"
+    ],
+    "textured_plate_temp": [
+        "60"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "60"
+    ]
+}

--- a/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @base.json
+++ b/resources/profiles/BBL/filament/FilAr/FilAr PLA-mate @base.json
@@ -36,15 +36,15 @@
         "210"
     ],
     "hot_plate_temp": [
-        "60"
+        "50"
     ],
     "hot_plate_temp_initial_layer": [
-        "60"
+        "50"
     ],
     "textured_plate_temp": [
-        "60"
+        "50"
     ],
     "textured_plate_temp_initial_layer": [
-        "60"
+        "50"
     ]
 }


### PR DESCRIPTION
## Add FilAr filament vendor (PLA, PLA-mate, PETG)

This PR adds **FilAr**, an Argentine filament manufacturer (https://www.filar.com.ar), as a system filament vendor for Bambu Lab printers.

### What's included
For each of the three materials (**PLA**, **PLA-mate**, **PETG**):
- 1 non-instantiated `@base` profile inheriting from `fdm_filament_pla` / `fdm_filament_pet`.
- 13 printer-specific presets covering the same machine set as the existing third-party `eSUN PLA+` line: **A1**, **A1 mini**, **X1**, **X1 Carbon / P1S / X1E**, **H2D**, **H2D Pro**, **H2S** (with 0.2 nozzle variants).
- All 42 presets registered in `resources/profiles/BBL.json` → `filament_list`.

Files live under `resources/profiles/BBL/filament/FilAr/` (following the `SUNLU/` sub-folder convention).

### Profile parameters (per manufacturer datasheet)
| Material | Nozzle | Range | Bed |
|---|---|---|---|
| PLA | 210 °C (init 215) | 200–220 | 60 °C |
| PLA-mate | 200 °C (init 205) | 195–210 | 60 °C |
| PETG | 240 °C (init 245) | 230–250 | 78 °C, reduced part cooling (40–60%) |

Density: PLA 1.24, PETG 1.27 g/cm³. The per-printer mechanical tuning (fan curves, max volumetric speed, plate handling, dual-extruder includes) is inherited from Bambu's own `eSUN PLA+` (PLA/PLA-mate) and `Generic PETG` (PETG) presets, so behavior matches established profiles; only the material identity and temperatures reflect FilAr's datasheet.

### ⚠️ Notes for maintainers (please read)
- **`filament_id` / `setting_id` are placeholders** (`FILARPLA`, `FILARPLA_00`, …). I don't have officially assigned Bambu IDs. They are unique and pass `check_duplicated_setting_id.py`, but please **reassign them to the proper registry values** before merging if required — happy to update.
- Temperatures are the manufacturer's **published baseline ranges, not per-printer calibrated**. I'm glad to refine any value or add calibration evidence on request.
- Scope mirrors the existing `eSUN PLA+` coverage. P1P / H2C / P2S / X2D are not included yet (same as eSUN) but can be added if desired.
- Colors are not enumerated as separate presets (Bambu convention for third-party brands); color is selected by the user.

Submitted on behalf of the FilAr team.
