### PR TITLE
fix(deps): use system zlib for Assimp on macOS/Linux

### DIFF
--- a/deps/Assimp/Assimp.cmake
+++ b/deps/Assimp/Assimp.cmake
@@ -6,6 +6,17 @@ else()
     set(_assimp_hash "SHA256=66dfbaee288f2bc43172440a55d0235dfc7bf885dda6435c038e8000e79582cb")
 endif()
 
+# Assimp bundles an old zlib (contrib/zlib) whose K&R-style function declarations
+# (e.g. `int ZEXPORT compress2(dest, destLen, ...)`) and fdopen() macro no longer
+# parse against the macOS 15+ / 26 SDK, breaking the dependency build on Mac.
+# The system zlib is always available on macOS and Linux, so link against it there
+# and only keep Assimp's bundled copy on Windows.
+if (WIN32)
+    set(_assimp_build_zlib ON)
+else ()
+    set(_assimp_build_zlib OFF)
+endif ()
+
 bambustudio_add_cmake_project(Assimp
     URL ${_assimp_url}
     URL_HASH ${_assimp_hash}
@@ -19,7 +30,7 @@ bambustudio_add_cmake_project(Assimp
         -DASSIMP_BUILD_GLTF_IMPORTER=ON
         -DASSIMP_BUILD_OBJ_IMPORTER=ON
         -DASSIMP_BUILD_FBX_IMPORTER=ON
-        -DASSIMP_BUILD_ZLIB=ON
+        -DASSIMP_BUILD_ZLIB=${_assimp_build_zlib}
         -DASSIMP_WARNINGS_AS_ERRORS=OFF
         -DBUILD_WITH_STATIC_CRT=OFF
 )


### PR DESCRIPTION
## Problem
The dependency build fails on macOS while building Assimp — see the failing run [`Build All (macos-15, arm64) / Build Deps`](https://github.com/bambulab/BambuStudio/actions/runs/26564990881/job/78257304925):

    [1/119] Building C object contrib/zlib/CMakeFiles/zlibstatic.dir/zutil.c.o
       22 | int ZEXPORT compress2(dest, destLen, source, sourceLen, level)
    error: expected ')'
    ninja: build stopped: subcommand failed.

Assimp bundles an old copy of zlib (`contrib/zlib`) that still uses K&R-style function declarations and an `fdopen()` macro. These no longer parse against the macOS 15+/26 SDK headers, so `ASSIMP_BUILD_ZLIB=ON` breaks the macOS dependency build.

## Fix
Build Assimp against the **system zlib** on macOS and Linux (always available there), keeping the bundled copy only on Windows. One-file change, no behavior change on Windows.