### PR TITLE
fix(macos): guard WebView async callback against use-after-free (macOS 26.5 crash/hang)

### DIFF
--- a/src/slic3r/GUI/Widgets/WebView.cpp
+++ b/src/slic3r/GUI/Widgets/WebView.cpp
@@ -233,6 +233,12 @@ public:
         assert(iter != g_webviews.end());
         if (iter != g_webviews.end())
             g_webviews.erase(iter);
+        // Also drop it from the delayed list so a pending flush of g_delay_webviews
+        // never calls AddScriptMessageHandler() on an already-destroyed view.
+        // See bambulab/BambuStudio #11004 and #10968.
+        auto diter = std::find(g_delay_webviews.begin(), g_delay_webviews.end(), m_webView);
+        if (diter != g_delay_webviews.end())
+            g_delay_webviews.erase(diter);
     }
     wxWebView *m_webView;
 };
@@ -344,6 +350,14 @@ wxWebView* WebView::CreateWebView(wxWindow * parent, wxString const & url)
         };
 #ifndef __WIN32__
         webView->CallAfter([webView, addScriptMessageHandler] {
+            // This async callback may fire after webView has already been destroyed,
+            // which would call AddScriptMessageHandler() on a dangling pointer
+            // (use-after-free -> pointer-authentication crash on Apple Silicon, or a
+            // long hang during startup on macOS 26.5+). g_webviews lists every live
+            // view, so bail out if this one is already gone.
+            // See bambulab/BambuStudio #11004 and #10968.
+            if (std::find(g_webviews.begin(), g_webviews.end(), webView) == g_webviews.end())
+                return;
 #endif
             if (Slic3r::GUI::wxGetApp().is_adding_script_handler()) {
                 g_delay_webviews.push_back(webView);


### PR DESCRIPTION
## Problem

On macOS 26.5 / 26.5.1, BambuStudio either **hangs for a long time on startup** (#10968) or **crashes within ~20 s of launch** (#11004), with steadily growing memory use in both cases. The crash is an Apple-Silicon pointer-authentication failure:

    Exception: EXC_BAD_ACCESS (SIGSEGV)
    Subtype:   KERN_INVALID_ADDRESS ... possible pointer authentication failure

    0  BambuStudio  WebView::CreateWebView(...)::$_0::operator()(wxWebView*) const + 240
    1  BambuStudio  wxAsyncMethodCallEventFunctor<...>::Execute() + 156

## Likely cause

`WebView::CreateWebView` registers the `"wx"` script message handler from a `CallAfter()` callback. The callback captures the **raw `webView` pointer** and calls `AddScriptMessageHandler()` on it.

The stack (a `CreateWebView` lambda invoked from `wxAsyncMethodCallEventFunctor::Execute`, failing with a PAC error on a corrupted pointer) is consistent with the WebKit view being torn down before this async callback runs, so the callback would dereference a freed `wxWebView*` (use-after-free). I am **inferring** the use-after-free from the stack and the PAC failure — I have not confirmed it with a heap / ASan trace — but the captured raw pointer makes it possible and it is the most likely explanation. On Apple Silicon a corrupted pointer trips pointer authentication → hard crash; elsewhere the same path surfaces as the long startup hang.

The same hazard applies to `g_delay_webviews`, which holds raw pointers that are never cleared when a view is destroyed.

## Fix

- In the `CallAfter` lambda, check `g_webviews` (the list of live views) and bail out if `webView` has already been destroyed.
- In `~WebViewRef`, also remove the view from `g_delay_webviews`, so a later flush of the delayed list can never touch a freed view.

Small, self-contained change: no effect on Windows (the block runs synchronously there) and no functional change on the healthy path. The guards are defensive and correct regardless of whether the use-after-free is the exact mechanism.

Fixes #11004
Fixes #10968
