### PR TITLE
fix: guard load_object_volume against objects with no instances (crash opening some MakerWorld 3MFs)

### DIFF
--- a/src/slic3r/GUI/3DScene.cpp
+++ b/src/slic3r/GUI/3DScene.cpp
@@ -1322,6 +1322,15 @@ int GLVolumeCollection::load_object_volume(
     bool                 use_loaded_id,
     bool                 lod_enabled)
 {
+    // Guard against malformed or partially-loaded objects: the code below
+    // dereferences volumes[volume_idx] and, in particular, instances[instance_idx]
+    // (e.g. instance->get_transformation()). An object with no instances - or an
+    // out-of-range index - would dereference a null/garbage pointer and crash.
+    // Seen when opening some MakerWorld 3MFs via the object-color dialog. See #11016.
+    if (model_object == nullptr
+        || volume_idx < 0 || volume_idx >= (int) model_object->volumes.size()
+        || instance_idx < 0 || instance_idx >= (int) model_object->instances.size())
+        return -1;
     const ModelVolume   *model_volume = model_object->volumes[volume_idx];
     const int            extruder_id  = model_volume->extruder_id();
     const ModelInstance *instance 	  = model_object->instances[instance_idx];


### PR DESCRIPTION
## Problem

Opening certain MakerWorld 3MFs crashes BambuStudio while loading. From the crash report in #11016 (macOS, Apple Silicon):

    Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
    Exception Codes: KERN_INVALID_ADDRESS at 0x0000000000000000

    0   ???                 0x0  ???
    1   GLVolumeCollection::load_object_volume(...)
    2   Plater::update_obj_preview_origin_thumbnail(...)
    3   ObjColorPanel::generate_origin_thumbnail()
    4   ObjColorPanel::ObjColorPanel(...)
    ...
    9   GUI_App::handle_web_request(...)   // opened from MakerWorld

## Root cause

`GLVolumeCollection::load_object_volume` dereferences `model_object->instances[instance_idx]` and later calls `instance->get_transformation()` without validating the index:

```cpp
const ModelInstance *instance = model_object->instances[instance_idx];
...
v.set_instance_transformation(instance->get_transformation());   // crash if instance is garbage
```

`Plater::update_obj_preview_origin_thumbnail` (and `update_obj_preview_thumbnail`) call this with a **hard-coded `instance_idx = 0`** for every object. An object that has no instance yet during loading makes `instances[0]` undefined behaviour → a null/garbage `ModelInstance*` → the jump-to-`0x0` crash above.

## Fix

A defensive guard at the top of `load_object_volume`: return early (`-1`, "no volume added") when `model_object` is null or `volume_idx` / `instance_idx` are out of range. The three call sites either pass valid indices or ignore the return value, so the healthy path is unchanged.

Fixes #11016

It may also be the cause of the intermittent MakerWorld-3MF import crash in #11025, though I have not confirmed that from a stack trace.
