### PR TITLE
Work-around old CGAL not supporting newer Boost

### DIFF
--- a/src/libslic3r/TextureToColor/ColorUtils.cpp
+++ b/src/libslic3r/TextureToColor/ColorUtils.cpp
@@ -9,6 +9,8 @@
 #include <iostream>
 #include <numeric>
 
+#include <boost/next_prior.hpp>
+
 #include <CGAL/AABB_face_graph_triangle_primitive.h>
 #include <CGAL/AABB_traits.h>
 #include <CGAL/AABB_tree.h>

--- a/src/libslic3r/TextureToColor/TextureToColor.cpp
+++ b/src/libslic3r/TextureToColor/TextureToColor.cpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <set>
 
+#include <boost/next_prior.hpp>
 #include "CgalUtils.hpp"
 #include "ColorUtils.hpp"
 #include "libslic3r/TriangleMesh.hpp"


### PR DESCRIPTION
The errors during the build should be fixed with a newer CGAL, but those changes work-around the problem.