### PR TITLE
feat: fall back to user-data volume when the temp dir is low on free space

### DIFF
--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -1050,6 +1050,30 @@ std::string Model::get_backup_path()
     {
         auto pid = get_current_pid();
         boost::filesystem::path parent_path(temporary_dir());
+        // Guard against a system temp dir that is low on free space — most often a
+        // small RAM-backed tmpfs /tmp on Linux, which a multi-GB multi-colour
+        // G-code export can overflow (surfaced to the user as "Is the disk full?").
+        // When the temp volume is nearly full, fall back to a folder on the
+        // user-data volume (always on real disk) if it offers materially more room.
+        // Best-effort only: any filesystem error leaves the default temp dir in place.
+        try {
+            namespace fs = boost::filesystem;
+            const boost::uintmax_t min_free  = boost::uintmax_t(2) << 30; // 2 GiB headroom
+            const boost::uintmax_t temp_free = fs::space(parent_path).available;
+            if (temp_free < min_free && !data_dir().empty()) {
+                fs::path fallback = fs::path(data_dir()) / "tmp";
+                fs::create_directories(fallback);
+                if (fs::space(fallback).available > temp_free) {
+                    BOOST_LOG_TRIVIAL(warning) << boost::format(
+                        "backup temp dir %1% low on space (%2% MiB free); falling back to %3%")
+                        % PathSanitizer::sanitize(parent_path) % (temp_free >> 20)
+                        % PathSanitizer::sanitize(fallback);
+                    parent_path = fallback;
+                }
+            }
+        } catch (const std::exception &ex) {
+            BOOST_LOG_TRIVIAL(warning) << "backup temp dir space check failed, using default: " << ex.what();
+        }
         std::time_t t = std::time(0);
         std::tm* now_time = std::localtime(&t);
         std::stringstream buf;


### PR DESCRIPTION
## Problem

The project backup/scratch directory — which holds the per-plate G-code temp file written during slicing — is created under `temporary_dir()` (the system temp dir). On Linux `/tmp` is frequently a **RAM-backed tmpfs** (commonly sized at half of RAM, e.g. ~8 GB). A large multi-colour model produces multi-GB G-code (prime tower + flushing), which **overflows the tmpfs** and makes export fail with:

> G-code export to … failed. Is the disk full?

…even though the real disk has hundreds of GB free. Reported from a real 4-colour print on a Debian host where `/tmp` is a 7.8 GB tmpfs.

## Fix

`Model::get_backup_path()` now checks the free space on the temp volume and, when it has **less than 2 GiB** free, falls back to `<data_dir>/tmp` — which lives on the user-data volume (real disk) — **if** that offers more room.

- Best-effort and fully guarded: any filesystem error leaves the default temp dir in place (slicing behaviour unchanged on error).
- The fast tmpfs is still used whenever it has enough space; the fallback only triggers under genuine pressure.
- Platform-neutral: on systems where the system temp already lives on a large disk (typical on Windows/macOS), the check simply never triggers.

Small and self-contained: `src/libslic3r/Model.cpp` (+24). Complements a separate change that makes the export error report the real errno instead of always guessing 'disk full'.