### PR TITLE
Fix stale LAN printer info before local print

### DIFF
--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -2380,15 +2380,15 @@ bool MachineObject::is_info_ready(bool check_version) const
     }
 
     std::chrono::system_clock::time_point curr_time = std::chrono::system_clock::now();
-    auto diff = std::chrono::duration_cast<std::chrono::microseconds>(last_push_time - curr_time);
-    if (m_full_msg_count > 0 && m_push_count > 0 && diff.count() < PUSHINFO_TIMEOUT) {
+    auto push_age = std::chrono::duration_cast<std::chrono::milliseconds>(curr_time - last_push_time);
+    if (m_full_msg_count > 0 && m_push_count > 0 && push_age.count() >= 0 && push_age.count() < PUSHINFO_TIMEOUT) {
         return true;
     }
 
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__
         << ": not ready, m_full_msg_count=" << m_full_msg_count
         << ", m_push_count=" << m_push_count
-        << ", diff.count()=" << diff.count()
+        << ", push_age_ms=" << push_age.count()
         << ", dev_id=" << BBLCrossTalk::Crosstalk_DevId(get_dev_id());
     return false;
 }

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -3663,6 +3663,8 @@ void SelectMachineDialog::on_selection_changed(wxCommandEvent &event)
     /* reset timeout and reading printer info */
     m_status_bar->reset();
     m_timeout_count      = 0;
+    m_lan_info_reconnect_dev_id.clear();
+    m_lan_info_refresh_tick = 0;
     s_nozzle_mapping_last_request_time = 0;
     m_ams_mapping_result.clear();
     m_pre_print_checker.clear();
@@ -3702,14 +3704,24 @@ void SelectMachineDialog::on_selection_changed(wxCommandEvent &event)
     }
 
     if (obj) {
-        obj->command_get_version();
-        obj->command_request_push_all();
-        obj->get_nozzle_mapping_result()->SetPlater(m_plater);
+        bool reconnected_lan_printer = false;
         if (!dev->get_selected_machine()) {
-            dev->set_selected_machine(m_printer_last_select);
+            reconnected_lan_printer = dev->set_selected_machine(m_printer_last_select) && obj->is_lan_mode_printer();
         }else if (dev->get_selected_machine()->get_dev_id() != m_printer_last_select) {
-            dev->set_selected_machine(m_printer_last_select);
+            reconnected_lan_printer = dev->set_selected_machine(m_printer_last_select) && obj->is_lan_mode_printer();
+        } else if (obj->is_lan_mode_printer() && !obj->is_info_ready(false)) {
+            reconnected_lan_printer = dev->set_selected_machine(m_printer_last_select);
         }
+
+        if (reconnected_lan_printer) {
+            m_lan_info_reconnect_dev_id = obj->get_dev_id();
+            m_lan_info_refresh_tick = 0;
+            reset_timeout();
+        } else {
+            obj->command_get_version();
+            obj->command_request_push_all();
+        }
+        obj->get_nozzle_mapping_result()->SetPlater(m_plater);
 
         // Has changed machine unrecoverably
         m_check_flag = false;
@@ -3726,6 +3738,45 @@ void SelectMachineDialog::on_selection_changed(wxCommandEvent &event)
     show_status(PrintDialogStatus::PrintStatusInit);
     update_show_status();
     update_print_status_msg();
+}
+
+bool SelectMachineDialog::refresh_lan_info_if_needed(MachineObject* obj_)
+{
+    if (!obj_ || !obj_->is_lan_mode_printer())
+        return false;
+
+    DeviceManager* dev = Slic3r::GUI::wxGetApp().getDeviceManager();
+    if (!dev)
+        return false;
+
+    const std::string dev_id = obj_->get_dev_id();
+    if (m_lan_info_reconnect_dev_id != dev_id) {
+        BOOST_LOG_TRIVIAL(info) << __FUNCTION__
+            << ": lan printer info is not ready, reconnect selected machine, dev_id="
+            << BBLCrossTalk::Crosstalk_DevId(dev_id);
+        m_lan_info_reconnect_dev_id = dev_id;
+        m_lan_info_refresh_tick = 0;
+        reset_timeout();
+        dev->set_selected_machine(dev_id);
+        return true;
+    }
+
+    ++m_lan_info_refresh_tick;
+    const int request_interval_ticks = 1000 / LIST_REFRESH_INTERVAL;
+    if (m_lan_info_refresh_tick < request_interval_ticks)
+        return true;
+
+    if ((m_lan_info_refresh_tick - request_interval_ticks) % request_interval_ticks == 0) {
+        int version_ret = obj_->command_get_version(true);
+        int push_ret = obj_->command_request_push_all(true);
+        BOOST_LOG_TRIVIAL(info) << __FUNCTION__
+            << ": lan printer info is not ready, request info after reconnect, dev_id="
+            << BBLCrossTalk::Crosstalk_DevId(dev_id)
+            << ", get_version_ret=" << version_ret
+            << ", pushall_ret=" << push_ret;
+    }
+
+    return false;
 }
 
 void SelectMachineDialog::update_ams_check(MachineObject *obj)
@@ -3934,6 +3985,7 @@ void SelectMachineDialog::update_show_status(MachineObject* obj_)
     }
 
     if (!obj_->is_info_ready()) {
+        refresh_lan_info_if_needed(obj_);
         if (is_timeout()) {
             m_ams_mapping_result.clear();
             sync_ams_mapping_result(m_ams_mapping_result);
@@ -3946,6 +3998,8 @@ void SelectMachineDialog::update_show_status(MachineObject* obj_)
     }
 
     reset_timeout();
+    m_lan_info_reconnect_dev_id.clear();
+    m_lan_info_refresh_tick = 0;
 
     /*check print all*/
     if (!obj_->GetConfig()->SupportPrintAllPlates() && m_print_plate_idx == PLATE_ALL_IDX)

--- a/src/slic3r/GUI/SelectMachine.hpp
+++ b/src/slic3r/GUI/SelectMachine.hpp
@@ -321,6 +321,8 @@ private:
     std::string                         m_print_error_msg;
     std::string                         m_print_error_extra;
     std::string                         m_printer_last_select;
+    std::string                         m_lan_info_reconnect_dev_id;
+    int                                 m_lan_info_refresh_tick{0};
     std::string                         m_print_info;
     wxString                            m_current_project_name;
     PrintDialogStatus                   m_print_status { PrintStatusInit };
@@ -485,6 +487,7 @@ public:
     void update_user_printer();
     void reset_ams_material();
     void update_show_status(MachineObject* obj_ = nullptr);
+    bool refresh_lan_info_if_needed(MachineObject* obj_);
 
     bool CheckErrorRackStatus(MachineObject* obj_);//return true if no errors
     bool CheckErrorExtruderNozzleWithSlicing(MachineObject* obj_);//return true if no errors

--- a/src/slic3r/GUI/SendToPrinter.cpp
+++ b/src/slic3r/GUI/SendToPrinter.cpp
@@ -1204,6 +1204,8 @@ void SendToPrinterDialog::on_selection_changed(wxCommandEvent &event)
     /* reset timeout and reading printer info */
     //m_status_bar->reset();
     timeout_count      = 0;
+    m_lan_info_reconnect_dev_id.clear();
+    m_lan_info_refresh_tick = 0;
 
     auto selection = m_comboBox_printer->GetSelection();
     DeviceManager* dev = Slic3r::GUI::wxGetApp().getDeviceManager();
@@ -1222,14 +1224,24 @@ void SendToPrinterDialog::on_selection_changed(wxCommandEvent &event)
     }
 
     if (obj) {
-        obj->command_get_version();
-        obj->command_request_push_all();
+        bool reconnected_lan_printer = false;
         if (!dev->get_selected_machine()) {
-            dev->set_selected_machine(m_printer_last_select);
+            reconnected_lan_printer = dev->set_selected_machine(m_printer_last_select) && obj->is_lan_mode_printer();
 
         }else if (dev->get_selected_machine()->get_dev_id() != m_printer_last_select) {
             update_storage_list(std::vector<std::string>());
-            dev->set_selected_machine(m_printer_last_select);
+            reconnected_lan_printer = dev->set_selected_machine(m_printer_last_select) && obj->is_lan_mode_printer();
+        } else if (obj->is_lan_mode_printer() && !obj->is_info_ready(false)) {
+            reconnected_lan_printer = dev->set_selected_machine(m_printer_last_select);
+        }
+
+        if (reconnected_lan_printer) {
+            m_lan_info_reconnect_dev_id = obj->get_dev_id();
+            m_lan_info_refresh_tick = 0;
+            reset_timeout();
+        } else {
+            obj->command_get_version();
+            obj->command_request_push_all();
         }
     }
     else {
@@ -1238,6 +1250,45 @@ void SendToPrinterDialog::on_selection_changed(wxCommandEvent &event)
     }
 
     update_show_status();
+}
+
+bool SendToPrinterDialog::refresh_lan_info_if_needed(MachineObject* obj_)
+{
+    if (!obj_ || !obj_->is_lan_mode_printer())
+        return false;
+
+    DeviceManager* dev = Slic3r::GUI::wxGetApp().getDeviceManager();
+    if (!dev)
+        return false;
+
+    const std::string dev_id = obj_->get_dev_id();
+    if (m_lan_info_reconnect_dev_id != dev_id) {
+        BOOST_LOG_TRIVIAL(info) << __FUNCTION__
+            << ": lan printer info is not ready, reconnect selected machine, dev_id="
+            << BBLCrossTalk::Crosstalk_DevId(dev_id);
+        m_lan_info_reconnect_dev_id = dev_id;
+        m_lan_info_refresh_tick = 0;
+        reset_timeout();
+        dev->set_selected_machine(dev_id);
+        return true;
+    }
+
+    ++m_lan_info_refresh_tick;
+    const int request_interval_ticks = 1000 / LIST_REFRESH_INTERVAL;
+    if (m_lan_info_refresh_tick < request_interval_ticks)
+        return true;
+
+    if ((m_lan_info_refresh_tick - request_interval_ticks) % request_interval_ticks == 0) {
+        int version_ret = obj_->command_get_version(true);
+        int push_ret = obj_->command_request_push_all(true);
+        BOOST_LOG_TRIVIAL(info) << __FUNCTION__
+            << ": lan printer info is not ready, request info after reconnect, dev_id="
+            << BBLCrossTalk::Crosstalk_DevId(dev_id)
+            << ", get_version_ret=" << version_ret
+            << ", pushall_ret=" << push_ret;
+    }
+
+    return false;
 }
 
 void SendToPrinterDialog::update_show_status()
@@ -1267,6 +1318,7 @@ void SendToPrinterDialog::update_show_status()
     }
 
     if (!obj_->is_info_ready()) {
+        refresh_lan_info_if_needed(obj_);
         if (is_timeout()) {
             show_status(PrintDialogStatus::PrintStatusReadingTimeout);
             return;
@@ -1280,6 +1332,8 @@ void SendToPrinterDialog::update_show_status()
     }
 
     reset_timeout();
+    m_lan_info_reconnect_dev_id.clear();
+    m_lan_info_refresh_tick = 0;
 
     // reading done
     if (is_blocking_printing(obj_)) {

--- a/src/slic3r/GUI/SendToPrinter.hpp
+++ b/src/slic3r/GUI/SendToPrinter.hpp
@@ -72,6 +72,8 @@ private:
     std::string                         m_print_info;
     std::string                         m_printer_last_select;
     std::string                         m_device_select;
+    std::string                         m_lan_info_reconnect_dev_id;
+    int                                 m_lan_info_refresh_tick{0};
     wxString                            m_current_project_name;
 
     TextInput*                          m_rename_input{ nullptr };
@@ -189,6 +191,7 @@ public:
     void reset_timeout();
     void update_user_printer();
     void update_show_status();
+    bool refresh_lan_info_if_needed(MachineObject* obj_);
     bool is_blocking_printing(MachineObject* obj_);
     void prepare(int print_plate_idx);
     void check_focus(wxWindow* window);


### PR DESCRIPTION
## Summary
- Fix LAN printer readiness check to reject stale push info.
- Automatically reconnect the selected LAN printer when printer info is stale.
- Retry get_version and pushall while waiting for refreshed LAN printer info before local printing.

## Root Cause
In LAN/developer mode, stale printer push data could be treated as ready, so the print dialog showed cached device information while the local MQTT publish path was no longer valid. Printing then failed with local print publish error (-4030). After correcting the readiness check, the dialog exposed the real issue: it waited until timeout without re-triggering the same LAN reconnect flow users performed manually by reselecting the printer.

## Verification
- Built Release target `BambuStudio_app_gui` successfully with VS 2022:
  `cmake --build build-verify --config Release --target BambuStudio_app_gui -- /m /nr:false /v:minimal`
- Verified with a local LAN A1 printer:
  - Before fix: device info changed from syncing to timeout, or local print failed with -4030.
  - After fix: device info refreshes and LAN print can start successfully.