### PR TITLE
Preserve per-triangle painting through merge, split, merge-to-multipart, and repair

### DIFF
--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -10,6 +10,8 @@
 #include "MTUtils.hpp"
 #include "TriangleMeshSlicer.hpp"
 #include "TriangleSelector.hpp"
+#include "AABBTreeIndirect.hpp"
+#include <queue>
 
 #include "Format/AMF.hpp"
 #include "Format/svg.hpp"
@@ -2744,9 +2746,21 @@ ModelObjectPtrs ModelObject::merge_volumes(std::vector<int>& vol_indeces)
 
 #if 1
     TriangleMesh mesh;
+    // BBS: preserve painting across the merge. its_merge() appends faces in
+    // order (only vertex indices are offset), so face f of the merged mesh maps
+    // exactly to the captured per-part triangles below. Capture before
+    // reset_mesh() empties the source volumes.
+    std::vector<std::string> merged_supported, merged_seam, merged_mmu, merged_fuzzy;
     for (int i : vol_indeces) {
         auto volume = volumes[i];
         if (!volume->mesh().empty()) {
+            const size_t nf = volume->mesh().its.indices.size();
+            for (size_t f = 0; f < nf; ++f) {
+                merged_supported.emplace_back(volume->supported_facets.get_triangle_as_string((int)f));
+                merged_seam.emplace_back(volume->seam_facets.get_triangle_as_string((int)f));
+                merged_mmu.emplace_back(volume->mmu_segmentation_facets.get_triangle_as_string((int)f));
+                merged_fuzzy.emplace_back(volume->fuzzy_skin_facets.get_triangle_as_string((int)f));
+            }
             const auto volume_matrix = volume->get_matrix();
             TriangleMesh mesh_(volume->mesh());
             mesh_.transform(volume_matrix, true);
@@ -2766,6 +2780,13 @@ ModelObjectPtrs ModelObject::merge_volumes(std::vector<int>& vol_indeces)
 #endif
 
     ModelVolume* vol = upper->add_volume(mesh);
+    // BBS: re-apply the painting captured above onto the merged volume.
+    for (size_t f = 0; f < merged_mmu.size() && f < mesh.its.indices.size(); ++f) {
+        if (!merged_supported[f].empty()) vol->supported_facets.set_triangle_from_string((int)f, merged_supported[f]);
+        if (!merged_seam[f].empty())      vol->seam_facets.set_triangle_from_string((int)f, merged_seam[f]);
+        if (!merged_mmu[f].empty())       vol->mmu_segmentation_facets.set_triangle_from_string((int)f, merged_mmu[f]);
+        if (!merged_fuzzy[f].empty())     vol->fuzzy_skin_facets.set_triangle_from_string((int)f, merged_fuzzy[f]);
+    }
     for (int i = 0; i < volumes.size();i++) {
         if (std::find(vol_indeces.begin(), vol_indeces.end(), i) != vol_indeces.end()) {
             vol->name = "Merged Parts";
@@ -3105,6 +3126,106 @@ void ModelVolume::reset_extra_facets() {
     this->seam_facets.reset();
     this->mmu_segmentation_facets.reset();
 }
+
+// ---- BBS: best-effort paint re-projection across mesh-rebuilding ops ----------
+// Walk a TriangleSelector's split tree for source face s; return the first
+// non-NONE leaf state (collapses sub-triangle painting to the dominant intent).
+static EnforcerBlockerType reproj_first_leaf(TriangleSelector &sel, int root_idx)
+{
+    const auto &tris = sel.get_triangles();
+    if (root_idx < 0 || root_idx >= (int)tris.size()) return EnforcerBlockerType::NONE;
+    std::queue<int> q;
+    q.push(root_idx);
+    while (!q.empty()) {
+        int i = q.front(); q.pop();
+        const auto &t = tris[i];
+        if (!t.valid()) continue;
+        if (!t.is_split()) {
+            if (t.get_state() != EnforcerBlockerType::NONE)
+                return t.get_state();
+        } else {
+            for (int c : t.children) if (c >= 0) q.push(c);
+        }
+    }
+    return EnforcerBlockerType::NONE;
+}
+
+// Per-face dominant state of one annotation layer over `mesh`.
+static void reproj_per_face_states(const TriangleMesh &mesh, const FacetsAnnotation &ann,
+                                   std::vector<EnforcerBlockerType> &out)
+{
+    out.assign(mesh.its.indices.size(), EnforcerBlockerType::NONE);
+    if (ann.empty() || mesh.its.indices.empty()) return;
+    TriangleSelector sel(mesh);
+    sel.deserialize(ann.get_data(), true);
+    for (int f = 0; f < (int)mesh.its.indices.size(); ++f)
+        out[f] = reproj_first_leaf(sel, f);
+}
+
+// Write per-face states onto `mesh`'s annotation layer (NONE entries skipped).
+static void reproj_apply_states(const TriangleMesh &mesh,
+                                const std::vector<EnforcerBlockerType> &states,
+                                FacetsAnnotation &out)
+{
+    out.reset();
+    bool any = false;
+    TriangleSelector sel(mesh);
+    const int n = std::min<int>((int)states.size(), (int)mesh.its.indices.size());
+    for (int f = 0; f < n; ++f) {
+        if (states[f] != EnforcerBlockerType::NONE) { sel.set_facet(f, states[f]); any = true; }
+    }
+    if (any) out.set(sel);
+}
+
+// Map each face of new_mesh to the nearest face of old_mesh (by centroid), then
+// transfer the four precomputed old per-face state vectors onto new annotations.
+static void reproj_transfer(const TriangleMesh &old_mesh, const TriangleMesh &new_mesh,
+                            const std::vector<EnforcerBlockerType> &o_sup,
+                            const std::vector<EnforcerBlockerType> &o_seam,
+                            const std::vector<EnforcerBlockerType> &o_mmu,
+                            const std::vector<EnforcerBlockerType> &o_fuzzy,
+                            FacetsAnnotation &d_sup, FacetsAnnotation &d_seam,
+                            FacetsAnnotation &d_mmu, FacetsAnnotation &d_fuzzy)
+{
+    d_sup.reset(); d_seam.reset(); d_mmu.reset(); d_fuzzy.reset();
+    if (old_mesh.its.indices.empty() || new_mesh.its.indices.empty()) return;
+    auto tree = AABBTreeIndirect::build_aabb_tree_over_indexed_triangle_set(
+        old_mesh.its.vertices, old_mesh.its.indices);
+    const int nf = (int)new_mesh.its.indices.size();
+    std::vector<EnforcerBlockerType> n_sup(nf, EnforcerBlockerType::NONE), n_seam = n_sup, n_mmu = n_sup, n_fuzzy = n_sup;
+    for (int f = 0; f < nf; ++f) {
+        const Vec3i &idx = new_mesh.its.indices[f];
+        Vec3f c = (new_mesh.its.vertices[idx[0]] + new_mesh.its.vertices[idx[1]] + new_mesh.its.vertices[idx[2]]) / 3.f;
+        size_t hit = size_t(-1);
+        Vec3f hp;
+        double d2 = AABBTreeIndirect::squared_distance_to_indexed_triangle_set(
+            old_mesh.its.vertices, old_mesh.its.indices, tree, c, hit, hp);
+        if (d2 < 0. || hit == size_t(-1) || hit >= o_sup.size()) continue;
+        n_sup[f]   = o_sup[hit];
+        n_seam[f]  = o_seam[hit];
+        n_mmu[f]   = o_mmu[hit];
+        n_fuzzy[f] = o_fuzzy[hit];
+    }
+    reproj_apply_states(new_mesh, n_sup,   d_sup);
+    reproj_apply_states(new_mesh, n_seam,  d_seam);
+    reproj_apply_states(new_mesh, n_mmu,   d_mmu);
+    reproj_apply_states(new_mesh, n_fuzzy, d_fuzzy);
+}
+
+void ModelVolume::set_mesh_keep_paint(TriangleMesh &&mesh_in)
+{
+    const TriangleMesh old_mesh = this->mesh(); // copy before replacing
+    std::vector<EnforcerBlockerType> o_sup, o_seam, o_mmu, o_fuzzy;
+    reproj_per_face_states(old_mesh, this->supported_facets,        o_sup);
+    reproj_per_face_states(old_mesh, this->seam_facets,             o_seam);
+    reproj_per_face_states(old_mesh, this->mmu_segmentation_facets, o_mmu);
+    reproj_per_face_states(old_mesh, this->fuzzy_skin_facets,       o_fuzzy);
+    this->set_mesh(std::move(mesh_in));
+    reproj_transfer(old_mesh, this->mesh(), o_sup, o_seam, o_mmu, o_fuzzy,
+                    this->supported_facets, this->seam_facets,
+                    this->mmu_segmentation_facets, this->fuzzy_skin_facets);
+}
+// ------------------------------------------------------------------------------
 
 ModelMaterial* ModelVolume::material() const
 {
@@ -3449,10 +3570,19 @@ size_t ModelVolume::split(unsigned int max_extruders, float scale_det)
     unsigned int extruder_counter = 0;
     const Vec3d offset = this->get_offset();
     std::vector<std::string> tris_split_strs;
+    // BBS: also carry support/seam/fuzzy-skin painting across the split (the
+    // ships[] relationship maps each split face back to its source face).
+    std::vector<std::string> tris_sup_strs, tris_seam_strs, tris_fuzzy_strs;
     auto face_count = m_mesh->its.indices.size();
     tris_split_strs.reserve(face_count);
+    tris_sup_strs.reserve(face_count);
+    tris_seam_strs.reserve(face_count);
+    tris_fuzzy_strs.reserve(face_count);
     for (size_t i = 0; i < face_count; i++) {
         tris_split_strs.emplace_back(mmu_segmentation_facets.get_triangle_as_string(i));
+        tris_sup_strs.emplace_back(supported_facets.get_triangle_as_string(i));
+        tris_seam_strs.emplace_back(seam_facets.get_triangle_as_string(i));
+        tris_fuzzy_strs.emplace_back(fuzzy_skin_facets.get_triangle_as_string(i));
     }
     int last_all_mesh_face_count = 0;
     for (TriangleMesh &mesh : meshes) {
@@ -3478,9 +3608,14 @@ size_t ModelVolume::split(unsigned int max_extruders, float scale_det)
             for (size_t i = 0; i < cur_face_count; i++) {
                 if (ships[idx].find(i) != ships[idx].end()) {
                     auto index = ships[idx][i];
-                    if (tris_split_strs[index].size() > 0) {
+                    if (tris_split_strs[index].size() > 0)
                         mmu_segmentation_facets.set_triangle_from_string(i, tris_split_strs[index]);
-                    }
+                    if (tris_sup_strs[index].size() > 0)
+                        supported_facets.set_triangle_from_string(i, tris_sup_strs[index]);
+                    if (tris_seam_strs[index].size() > 0)
+                        seam_facets.set_triangle_from_string(i, tris_seam_strs[index]);
+                    if (tris_fuzzy_strs[index].size() > 0)
+                        fuzzy_skin_facets.set_triangle_from_string(i, tris_fuzzy_strs[index]);
                 }
             }
         } else {
@@ -3489,9 +3624,14 @@ size_t ModelVolume::split(unsigned int max_extruders, float scale_det)
             for (size_t i = 0; i < new_mv->mesh_ptr()->its.indices.size(); i++) {
                 if (ships[idx].find(i) != ships[idx].end()) {
                     auto index = ships[idx][i];
-                    if (tris_split_strs[index].size() > 0) {
+                    if (tris_split_strs[index].size() > 0)
                         new_mv->mmu_segmentation_facets.set_triangle_from_string(i, tris_split_strs[index]);
-                    }
+                    if (tris_sup_strs[index].size() > 0)
+                        new_mv->supported_facets.set_triangle_from_string(i, tris_sup_strs[index]);
+                    if (tris_seam_strs[index].size() > 0)
+                        new_mv->seam_facets.set_triangle_from_string(i, tris_seam_strs[index]);
+                    if (tris_fuzzy_strs[index].size() > 0)
+                        new_mv->fuzzy_skin_facets.set_triangle_from_string(i, tris_fuzzy_strs[index]);
                 }
             }
         }

--- a/src/libslic3r/Model.hpp
+++ b/src/libslic3r/Model.hpp
@@ -989,6 +989,11 @@ public:
     t_model_material_id material_id() const { return m_material_id; }
     void                set_material_id(t_model_material_id material_id);
     void                reset_extra_facets();
+    // BBS: best-effort paint preservation across mesh-rebuilding operations
+    // (repair/simplify/smooth). Replaces the mesh, then re-projects all four
+    // paint layers from the OLD mesh onto the new one by nearest-surface lookup.
+    // Approximate: a remeshed surface has no exact face correspondence.
+    void                set_mesh_keep_paint(TriangleMesh &&mesh);
     ModelMaterial*      material() const;
     void                set_material(t_model_material_id material_id, const ModelMaterial &material);
     // Extract the current extruder ID based on this ModelVolume's config and the parent ModelObject's config.

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2470,6 +2470,18 @@ static LogEncOptions s_get_log_enc_opts()
     return enc_options;
 };
 
+bool GUI_App::confirm_mesh_paint_warning()
+{
+    MessageDialog dlg(nullptr,
+        _L("This operation rebuilds the model's mesh. Painted color, supports, seam and "
+           "fuzzy-skin will be transferred to the new mesh by a best-effort approximation, "
+           "so the result may be slightly off and, in rare cases, some painting may be lost.\n\n"
+           "Do you want to continue?"),
+        _L("Painting may change"),
+        wxICON_WARNING | wxYES_NO | wxNO_DEFAULT);
+    return dlg.ShowModal() == wxID_YES;
+}
+
 void GUI_App::init_app_config()
 {
 	// Profiles for the alpha are stored into the PrusaSlicer-alpha directory to not mix with the current release.

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -380,6 +380,10 @@ public:
 
     bool get_app_conf_exists() { return m_app_conf_exists; }
     void show_message_box(std::string msg) { wxMessageBox(msg); }
+    // BBS: warn before a mesh-rebuilding op (repair/simplify/smooth/boolean) that
+    // painting is transferred by best-effort approximation and may be imperfect.
+    // Returns true if the user chooses to continue.
+    bool confirm_mesh_paint_warning();
     EAppMode get_app_mode() const { return m_app_mode; }
     Slic3r::DeviceManager* getDeviceManager() { return m_device_manager; }
     bool                   is_blocking_printing(MachineObject *obj_ = nullptr);

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -3215,6 +3215,11 @@ void ObjectList::merge(bool to_multipart_object)
                     }
                 }
                 new_volume->mmu_segmentation_facets.assign(std::move(volume->mmu_segmentation_facets));
+                // BBS: also carry support/seam/fuzzy-skin painting across the merge
+                // (each part keeps its own mesh, so the per-triangle data maps 1:1).
+                new_volume->supported_facets.assign(std::move(volume->supported_facets));
+                new_volume->seam_facets.assign(std::move(volume->seam_facets));
+                new_volume->fuzzy_skin_facets.assign(std::move(volume->fuzzy_skin_facets));
             }
             new_object->sort_volumes(true);
 
@@ -6211,6 +6216,10 @@ void ObjectList::fix_through_netfabb()
     if (!wxGetApp().plater()->get_view3D_canvas3D()->get_gizmos_manager().check_gizmos_closed_except(GLGizmosManager::Undefined))
         return;
 
+    // BBS: repair rebuilds the mesh; warn that painting is transferred approximately.
+    if (!wxGetApp().confirm_mesh_paint_warning())
+        return;
+
     //          model_name
     std::vector<std::string>                           succes_models;
     //                   model_name     failing reason
@@ -6268,7 +6277,9 @@ void ObjectList::fix_through_netfabb()
             msg += "\n";
         }
 
-        plater->clear_before_change_mesh(obj_idx);
+        // BBS: do NOT wipe painting here; the repair below re-projects it
+        // (best-effort) via set_mesh_keep_paint instead.
+        // plater->clear_before_change_mesh(obj_idx);
         std::string res;
         if (!fix_model_by_win10_sdk_gui(*(object(obj_idx)), vol_idx, progress_dlg, msg, res))
             return false;

--- a/src/slic3r/Utils/FixModelByWin10.cpp
+++ b/src/slic3r/Utils/FixModelByWin10.cpp
@@ -462,7 +462,7 @@ bool fix_model_by_win10_sdk_gui(ModelObject &model_object, int volume_idx, GUI::
 				meshes_repaired.emplace_back(std::move(repaired_its));
 			}
 			for (size_t i = 0; i < volumes.size(); ++ i) {
-				volumes[i]->set_mesh(std::move(meshes_repaired[i]));
+				volumes[i]->set_mesh_keep_paint(std::move(meshes_repaired[i])); // BBS: best-effort paint transfer
 				volumes[i]->calculate_convex_hull();
 				volumes[i]->invalidate_convex_hull_2d();
 				volumes[i]->set_new_unique_id();


### PR DESCRIPTION
## What
Bambu Studio drops per-triangle painting (color/MMU, support, seam, fuzzy-skin) on several mesh-editing operations. Upstream already fixed **cut** in #10613 (@solidblu). This PR continues that work, extending the **same source-face-index / annotation-propagation idea** from plane cuts to the remaining operations:
- **merge** (to a single object), **split**, and **merge-to-multipart** — exact carry-through of the facet annotations.
- **repair** — best-effort transfer across the re-projected mesh, with a cancelable **warning dialog** before a repair that may alter painted data.

## Why
Losing paint on these routine edits forces users to re-paint after every operation. Cut already preserves it (#10613); these operations should behave consistently.

## Relationship to #10613
This is the natural next step after @solidblu's merged cut-preservation PR (#10613), which was itself based on the corresponding PrusaSlicer fix. Same approach, applied to merge/split/multipart/repair.

## Changes (6 files, +178/-4)
- `libslic3r/Model.{cpp,hpp}` — carry annotations through merge/split/multipart and repair
- `slic3r/GUI/GUI_ObjectList.cpp`, `GUI_App.{cpp,hpp}` — warning dialog and operation hooks
- `slic3r/Utils/FixModelByWin10.cpp` — preserve through the Win10 repair path

## Testing
Built locally on Windows (VS2022 / MSVC v143) from current master; validated interactively:
- Merge -> single part, Split, Merge-to-multipart — paint retained (including painted supports)
- Repair keeps paint; warning dialog appears and cancels correctly

## Scope
Cut is already upstream (#10613, untouched here). Exact preservation for merge/split/multipart; best-effort for repair. Simplify/smooth/boolean preservation are intentionally not in this PR (separate work, still WIP).

Edit::::
Related to #750 — the report of paint being lost on Cut. That case is fixed upstream in 2.7.1 (#10613); this PR extends the same preservation to the operations that still drop paint.