### PR TITLE
Show filament name and left/right nozzle in filament selectors

### DIFF
--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -2560,6 +2560,11 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
     std::vector<std::string> ams_filament_colors;
     std::vector<std::string> ams_filament_color_types;
     std::vector<AMSMapInfo>  ams_array_maps;
+    // BBS: nozzle assignment per built filament (1 = left, 2 = right), kept in lockstep with
+    // ams_filament_presets. The nozzle is encoded in the filament_ams_list key (bit 0x10000
+    // => right/main nozzle, else left/deputy), so we capture it here instead of defaulting all
+    // filaments to the left nozzle.
+    std::vector<int>         ams_filament_nozzles;
     ams_multi_color_filment.clear();
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": filament_ams_list size: %1%") % filament_ams_list.size();
     struct AmsInfo
@@ -2570,6 +2575,7 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
         std::string filament_color_type = "";
         std::string filament_preset = "";
         std::vector<std::string> mutli_filament_color;
+        int nozzle{1}; // BBS: 1 = left, 2 = right
     };
     auto is_double_extruder = get_printer_extruder_count() == 2;
     std::vector<AmsInfo> ams_infos;
@@ -2577,6 +2583,7 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
     std::set<std::pair<std::string, std::string>> added_filaments;
     for (auto &entry : filament_ams_list) {
         auto & ams = entry.second;
+        const int this_nozzle = (entry.first & 0x10000) ? 2 : 1; // BBS: 1 = left, 2 = right
         auto filament_id = ams.opt_string("filament_id", 0u);
         auto tray_name = ams.opt_string("tray_name", 0u);
         if (tray_name == "Ext" && skip_ext) {
@@ -2596,6 +2603,7 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
         auto ams_id     = ams.opt_string("ams_id", 0u);
         auto slot_id    = ams.opt_string("slot_id", 0u);
         ams_infos.push_back({filament_id.empty() ? false : true,false, filament_color});
+        ams_infos.back().nozzle = this_nozzle;
         AMSMapInfo temp = {ams_id, slot_id};
         ams_array_maps.push_back(temp);
         index++;
@@ -2607,6 +2615,7 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
                     }
                 }
                 ams_filament_presets.push_back("Generic PLA");//for unknow matieral
+                ams_filament_nozzles.push_back(this_nozzle);
                 auto default_unknown_color = "#CECECE";
                 ams_filament_colors.push_back(default_unknown_color);
                 ams_filament_color_types.push_back("1");
@@ -2619,6 +2628,7 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
         }
         if (!filament_changed && this->filament_presets.size() > ams_filament_presets.size()) {
             ams_filament_presets.push_back(this->filament_presets[ams_filament_presets.size()]);
+            ams_filament_nozzles.push_back(this_nozzle);
             ams_filament_colors.push_back(filament_color);
             ams_filament_color_types.push_back(filament_color_type);
             ams_multi_color_filment.push_back(filament_multi_color);
@@ -2642,6 +2652,7 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
                 // Prefer old selection
                 if (ams_filament_presets.size() < this->filament_presets.size()) {
                     ams_filament_presets.push_back(this->filament_presets[ams_filament_presets.size()]);
+                    ams_filament_nozzles.push_back(this_nozzle);
                     ams_filament_colors.push_back(filament_color);
                     ams_filament_color_types.push_back(filament_color_type);
                     ams_multi_color_filment.push_back(filament_multi_color);
@@ -2663,6 +2674,7 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
             filament_id = iter->filament_id;
         }
         ams_filament_presets.push_back(iter->name);
+        ams_filament_nozzles.push_back(this_nozzle);
         ams_filament_colors.push_back(filament_color);
         ams_filament_color_types.push_back(filament_color_type);
         ams_multi_color_filment.push_back(filament_multi_color);
@@ -2765,6 +2777,9 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
         auto exist_colors = filament_color->values;
         auto exist_color_types = filament_color_type->values;
         auto exist_filament_presets = this->filament_presets;
+        // BBS: nozzle assignment kept in lockstep with exist_filament_presets (1 = left, 2 = right).
+        std::vector<int> exist_nozzles = filament_map->values;
+        exist_nozzles.resize(exist_filament_presets.size(), 1);
         std::vector<std::vector<std::string>> exist_multi_color_filment;
         exist_multi_color_filment.resize(exist_colors.size());
         for (int i = 0; i < exist_colors.size(); i++) {
@@ -2778,6 +2793,8 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
                     exist_color_types[i]      = ams_filament_color_types[valid_index];
                     exist_filament_presets[i] = ams_filament_presets[valid_index];
                     exist_multi_color_filment[i] = ams_multi_color_filment[valid_index];
+                    if (valid_index < (int) ams_filament_nozzles.size() && i < exist_nozzles.size())
+                        exist_nozzles[i] = ams_filament_nozzles[valid_index]; // BBS: real nozzle
                 } else {
                     BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << "check error: array bound (mapping exist)";
                 }
@@ -2838,18 +2855,23 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
                 exist_colors.push_back(need_append_colors[i].filament_color);
                 exist_color_types.push_back(need_append_colors[i].filament_color_type);
                 exist_multi_color_filment.push_back(need_append_colors[i].mutli_filament_color);
+                exist_nozzles.push_back(need_append_colors[i].nozzle); // BBS: real nozzle
             }
         }
         filament_color->values = exist_colors;
         filament_color_type->values = exist_color_types;
         ams_multi_color_filment = exist_multi_color_filment;
         this->filament_presets = exist_filament_presets;
+        // BBS: write the real nozzle assignment captured during the build (1 = left, 2 = right).
+        filament_map->values = exist_nozzles;
         filament_map->values.resize(exist_filament_presets.size(), 1);
     }
     else {//overwrite;
         filament_color->values = ams_filament_colors;
         filament_color_type->values = ams_filament_color_types;
         this->filament_presets = ams_filament_presets;
+        // BBS: write the real nozzle assignment captured during the build (1 = left, 2 = right).
+        filament_map->values = ams_filament_nozzles;
         filament_map->values.resize(ams_filament_colors.size(), 1);
 
         auto& print_config = this->prints.get_edited_preset().config;

--- a/src/slic3r/GUI/ExtraRenderers.cpp
+++ b/src/slic3r/GUI/ExtraRenderers.cpp
@@ -1,9 +1,14 @@
 #include "ExtraRenderers.hpp"
 #include "wxExtensions.hpp"
 #include "GUI.hpp"
+#include "GUI_App.hpp"
 #include "BitmapComboBox.hpp"
 #include "Plater.hpp"
+#include "PartPlate.hpp"
+#include "GUI_ObjectList.hpp"
 #include "Widgets/ComboBox.hpp"
+#include "libslic3r/PresetBundle.hpp"
+#include "libslic3r/Print.hpp"
 
 #include <wx/dc.h>
 #ifdef wxHAS_GENERIC_DATAVIEWCTRL
@@ -263,37 +268,310 @@ bool BitmapChoiceRenderer::GetValue(wxVariant& value) const
     return true;
 }
 
+// BBS: return the human-readable filament name (e.g. "PLA Matte") for the
+// extruder index stored as text in the filament column ("1", "2", ... or "default").
+// Returns an empty string when no meaningful name is available.
+static wxString get_filament_label_for_extruder_text(const wxString& extruder_text)
+{
+    using namespace Slic3r;
+    using namespace Slic3r::GUI;
+
+    const int extruder_idx = atoi(extruder_text.c_str()); // 1-based, 0 means "default"/none
+    if (extruder_idx <= 0)
+        return wxEmptyString;
+
+    PresetBundle* preset_bundle = wxGetApp().preset_bundle;
+    if (preset_bundle == nullptr)
+        return wxEmptyString;
+
+    const std::vector<std::string>& filament_presets = preset_bundle->filament_presets;
+    const size_t pos = (size_t)(extruder_idx - 1);
+    if (pos >= filament_presets.size())
+        return wxEmptyString;
+
+    const Preset* preset = preset_bundle->filaments.find_preset(filament_presets[pos]);
+    if (preset == nullptr)
+        return wxEmptyString;
+
+    return from_u8(preset->display_name());
+}
+
+// BBS: for dual-nozzle printers, return the nozzle-side suffix for a 1-based filament index:
+// " (L)" if the filament is mapped to the left nozzle, " (R)" for the right nozzle.
+// Returns an empty string for single-nozzle printers or when the mapping is unknown.
+wxString get_filament_nozzle_suffix(int extruder_idx_1based)
+{
+    using namespace Slic3r;
+    using namespace Slic3r::GUI;
+
+    if (extruder_idx_1based <= 0)
+        return wxEmptyString;
+
+    PresetBundle* preset_bundle = wxGetApp().preset_bundle;
+    if (preset_bundle == nullptr)
+        return wxEmptyString;
+
+    // Single-nozzle printers have no left/right distinction.
+    const auto* nozzle_opt = preset_bundle->printers.get_edited_preset().config
+                                 .option<ConfigOptionFloatsNullable>("nozzle_diameter");
+    if (nozzle_opt == nullptr || nozzle_opt->values.size() < 2)
+        return wxEmptyString;
+
+    Plater* plater = wxGetApp().plater();
+    if (plater == nullptr)
+        return wxEmptyString;
+
+    // The left/right split is written into "filament_map" when filaments are synced
+    // (1 = left, 2 = right). Only meaningful once the printer info has been synced.
+    if (!plater->get_machine_sync_status())
+        return wxEmptyString;
+
+    // Read the global "filament_map" written by the AMS sync (1 = left, 2 = right). Use the
+    // global project config directly — the per-plate map can shadow it with a stale value.
+    const auto* map_opt = preset_bundle->project_config.option<ConfigOptionInts>("filament_map");
+    if (map_opt == nullptr)
+        return wxEmptyString;
+    const size_t pos = (size_t)(extruder_idx_1based - 1);
+    if (pos >= map_opt->values.size())
+        return wxEmptyString;
+
+    switch (map_opt->values[pos]) {
+    case 1:  return " (L)";
+    case 2:  return " (R)";
+    default: return wxEmptyString;
+    }
+}
+
+// BBS: full filament cell label for a given extruder text ("1", "2", ... or "default"):
+// the filament name plus the nozzle-side suffix, e.g. "PLA Matte (L)".
+static wxString get_filament_cell_label(const wxString& extruder_text)
+{
+    const wxString name = get_filament_label_for_extruder_text(extruder_text);
+    if (name.IsEmpty())
+        return wxEmptyString;
+    return name + get_filament_nozzle_suffix(atoi(extruder_text.c_str()));
+}
+
+// BBS: return a human-readable color name for a hex string (e.g. "#1A1A1A" -> "Black"),
+// picking the nearest entry from a small table of common colors. Falls back to the input.
+static wxString get_color_display_name(const wxString& hex_in)
+{
+    wxString hex = hex_in;
+    if (hex.StartsWith("#") && hex.length() > 7)
+        hex = hex.substr(0, 7); // drop any alpha component (#RRGGBBAA -> #RRGGBB)
+
+    wxColour c(hex);
+    if (!c.IsOk())
+        return hex_in;
+
+    struct NamedColor { const char* name; int r, g, b; };
+    static const NamedColor table[] = {
+        {"Black", 0, 0, 0},        {"White", 255, 255, 255},   {"Gray", 128, 128, 128},
+        {"Silver", 192, 192, 192}, {"Red", 220, 20, 20},       {"Dark Red", 139, 0, 0},
+        {"Orange", 255, 140, 0},   {"Yellow", 240, 225, 40},   {"Gold", 212, 175, 55},
+        {"Green", 30, 160, 60},    {"Dark Green", 0, 100, 0},  {"Lime", 160, 210, 60},
+        {"Cyan", 0, 200, 200},     {"Blue", 30, 80, 200},      {"Navy", 20, 30, 90},
+        {"Sky Blue", 110, 170, 220}, {"Purple", 128, 0, 128},  {"Magenta", 200, 40, 160},
+        {"Pink", 240, 150, 180},   {"Brown", 120, 70, 40},     {"Beige", 225, 210, 170},
+    };
+
+    long best_dist = 2000000000L;
+    const char* best_name = "";
+    for (const NamedColor& nc : table) {
+        const long dr = (long)c.Red() - nc.r;
+        const long dg = (long)c.Green() - nc.g;
+        const long db = (long)c.Blue() - nc.b;
+        const long dist = dr * dr + dg * dg + db * db;
+        if (dist < best_dist) {
+            best_dist = dist;
+            best_name = nc.name;
+        }
+    }
+    return wxString::FromUTF8(best_name);
+}
+
+// BBS: for each project filament (0-based), the AMS tray it is loaded in (e.g. "A1", "HT-B",
+// "Ext"), derived from the synced AMS list by matching color + filament id. Empty when unknown.
+static std::vector<wxString> build_filament_ams_locations()
+{
+    using namespace Slic3r;
+    using namespace Slic3r::GUI;
+
+    std::vector<wxString> result;
+
+    PresetBundle* preset_bundle = wxGetApp().preset_bundle;
+    if (preset_bundle == nullptr)
+        return result;
+
+    const std::map<int, DynamicPrintConfig>& ams_list = preset_bundle->filament_ams_list;
+    if (ams_list.empty())
+        return result;
+
+    const auto* color_opt = preset_bundle->project_config.option<ConfigOptionStrings>("filament_colour");
+    if (color_opt == nullptr)
+        return result;
+    const std::vector<std::string>& proj_colors = color_opt->values;
+    result.assign(proj_colors.size(), wxString());
+
+    auto norm_color = [](std::string s) -> std::string {
+        if (!s.empty() && s[0] == '#') s.erase(0, 1);
+        for (char& c : s) c = (char) ::toupper((unsigned char) c);
+        if (s.size() > 6) s = s.substr(0, 6);
+        return s;
+    };
+    auto get_str = [](const DynamicPrintConfig& cfg, const char* key) -> std::string {
+        const ConfigOption* opt = cfg.option(key);
+        if (opt == nullptr) return std::string();
+        if (const auto* s = dynamic_cast<const ConfigOptionStrings*>(opt))
+            return s->values.empty() ? std::string() : s->values.front();
+        if (const auto* s = dynamic_cast<const ConfigOptionString*>(opt))
+            return s->value;
+        return std::string();
+    };
+
+    struct AmsEntry { std::string color; std::string id; wxString name; bool used; };
+    std::vector<AmsEntry> entries;
+    entries.reserve(ams_list.size());
+    for (const auto& kv : ams_list) {
+        AmsEntry e;
+        e.color = norm_color(get_str(kv.second, "filament_colour"));
+        e.id    = get_str(kv.second, "filament_id");
+        e.name  = from_u8(get_str(kv.second, "tray_name"));
+        e.used  = false;
+        entries.push_back(std::move(e));
+    }
+
+    for (size_t i = 0; i < proj_colors.size(); ++i) {
+        const std::string pcolor = norm_color(proj_colors[i]);
+        std::string pid;
+        if (i < preset_bundle->filament_presets.size()) {
+            if (const Preset* preset = preset_bundle->filaments.find_preset(preset_bundle->filament_presets[i]))
+                pid = get_str(preset->config, "filament_id");
+        }
+
+        int found = -1;
+        for (size_t j = 0; j < entries.size(); ++j)
+            if (!entries[j].used && entries[j].color == pcolor && !pid.empty() && entries[j].id == pid) { found = (int) j; break; }
+        if (found < 0)
+            for (size_t j = 0; j < entries.size(); ++j)
+                if (!entries[j].used && entries[j].color == pcolor) { found = (int) j; break; }
+        if (found < 0 && !pid.empty())
+            for (size_t j = 0; j < entries.size(); ++j)
+                if (!entries[j].used && entries[j].id == pid) { found = (int) j; break; }
+
+        if (found >= 0) {
+            entries[found].used = true;
+            result[i] = entries[found].name;
+        }
+    }
+
+    return result;
+}
+
+// BBS: human-readable AMS location for a tray name ("A1" -> "AMS A1", "HT-B" -> "AMS HT-B",
+// "Ext" -> "External spool"). Empty input yields an empty string.
+static wxString format_ams_location(const wxString& tray_name)
+{
+    if (tray_name.IsEmpty())
+        return wxEmptyString;
+    if (tray_name == "Ext")
+        return _L("External spool");
+    return _L("AMS") + " " + tray_name;
+}
+
+wxString get_filament_column_tooltip(const wxString& extruder_text)
+{
+    using namespace Slic3r;
+    using namespace Slic3r::GUI;
+
+    const int idx = atoi(extruder_text.c_str());
+
+    wxString label = get_filament_label_for_extruder_text(extruder_text);
+    if (!label.IsEmpty())
+        label += get_filament_nozzle_suffix(idx);
+
+    wxString color_name;
+    wxString location;
+    if (idx > 0) {
+        if (PresetBundle* pb = wxGetApp().preset_bundle) {
+            if (const auto* opt = pb->project_config.option<ConfigOptionStrings>("filament_colour")) {
+                const size_t pos = (size_t)(idx - 1);
+                if (pos < opt->values.size())
+                    color_name = get_color_display_name(from_u8(opt->values[pos]));
+            }
+        }
+        const std::vector<wxString> locations = build_filament_ams_locations();
+        if ((size_t)(idx - 1) < locations.size())
+            location = format_ams_location(locations[idx - 1]);
+    }
+
+    // Compose: "<name> — <color> — <AMS location>" (omitting any empty parts).
+    wxString out = label;
+    auto append = [&out](const wxString& part) {
+        if (part.IsEmpty()) return;
+        if (!out.IsEmpty()) out += " — ";
+        out += part;
+    };
+    if (label.IsEmpty()) out = color_name; else append(color_name);
+    append(location);
+    return out;
+}
+
 bool BitmapChoiceRenderer::Render(wxRect rect, wxDC* dc, int state)
 {
-//    int xoffset = 0;
+    int xoffset = 0;
 
     const wxBitmap& icon = m_value.GetBitmap();
     if (icon.IsOk())
     {
         dc->DrawBitmap(icon, rect.x, rect.y + (rect.height - icon.GetHeight()) / 2);
-//        xoffset = icon.GetWidth() + 4;
+        xoffset = icon.GetWidth() + 4;
 
         if (rect.height == 0)
           rect.height = icon.GetHeight();
     }
 
+    // BBS: filament name (left, after the swatch) and the nozzle side (right-aligned at the cell edge).
 #ifdef _WIN32
     // workaround for Windows DarkMode : Don't respect to the state & wxDATAVIEW_CELL_SELECTED to avoid update of the text color
-//    RenderText(m_value.GetText(), xoffset, rect, dc, state & wxDATAVIEW_CELL_SELECTED ? 0 : state);
+    const int text_state = state & wxDATAVIEW_CELL_SELECTED ? 0 : state;
 #else
-//    RenderText(m_value.GetText(), xoffset, rect, dc, state);
+    const int text_state = state;
 #endif
+
+    const wxString name   = get_filament_label_for_extruder_text(m_value.GetText());
+    wxString       suffix = name.IsEmpty() ? wxString() : get_filament_nozzle_suffix(atoi(m_value.GetText().c_str()));
+    suffix.Trim(false); // drop the leading space used when appended inline
+
+    int suffix_w = 0;
+    if (!suffix.IsEmpty())
+        suffix_w = dc->GetTextExtent(suffix).x;
+
+    if (!name.IsEmpty()) {
+        // Reserve room on the right for the side label so the name doesn't run under it.
+        wxRect name_rect = rect;
+        if (suffix_w > 0)
+            name_rect.width = std::max(0, name_rect.width - (suffix_w + 8));
+        RenderText(name, xoffset, name_rect, dc, text_state);
+    }
+
+    if (suffix_w > 0) {
+        // Right-align the side label at the cell's right edge.
+        const int xo = std::max(xoffset, rect.width - suffix_w - 2);
+        RenderText(suffix, xo, rect, dc, text_state);
+    }
 
     return true;
 }
 
 wxSize BitmapChoiceRenderer::GetSize() const
 {
-    wxSize sz;// = GetTextExtent(m_value.GetText());
+    const wxString label = get_filament_cell_label(m_value.GetText());
+    wxSize sz = label.IsEmpty() ? wxSize(0, 0) : GetTextExtent(label);
 
     if (m_value.GetBitmap().IsOk()) {
         sz.x += m_value.GetBitmap().GetWidth() + 4;
-        sz.y = m_value.GetBitmap().GetHeight() + 4;
+        sz.y = std::max(sz.y, m_value.GetBitmap().GetHeight() + 4);
     }
 
     return sz;
@@ -305,6 +583,12 @@ wxWindow* BitmapChoiceRenderer::CreateEditorCtrl(wxWindow* parent, wxRect labelR
     if (can_create_editor_ctrl && !can_create_editor_ctrl())
         return nullptr;
 
+    // BBS: filaments (and their nozzle map) may have been synced since the rows were last
+    // painted. Repaint the filament column now so the cells behind reflect the latest
+    // sync state, matching the up-to-date labels shown in the dropdown we are about to open.
+    if (Slic3r::GUI::ObjectList* obj_list = Slic3r::GUI::wxGetApp().obj_list())
+        obj_list->Refresh();
+
     std::vector<wxBitmap*> icons = get_extruder_color_icons();
     if (icons.empty())
         return nullptr;
@@ -312,16 +596,49 @@ wxWindow* BitmapChoiceRenderer::CreateEditorCtrl(wxWindow* parent, wxRect labelR
     DataViewBitmapText data;
     data << value;
 
+    // BBS: keep item text visible (no CB_NO_TEXT) so the filament name shows next to each color swatch
     ::ComboBox *c_editor = new ::ComboBox(parent, wxID_ANY, wxEmptyString,
         labelRect.GetTopLeft(), wxSize(labelRect.GetWidth(), -1),
-        0, nullptr, wxCB_READONLY | CB_NO_DROP_ICON | CB_NO_TEXT);
+        0, nullptr, wxCB_READONLY | CB_NO_DROP_ICON);
     c_editor->GetDropDown().SetUseContentWidth(true);
 
     if (has_default_extruder && has_default_extruder())
         c_editor->Append(_L("default"), *get_default_extruder_color_icon());
 
-    for (size_t i = 0; i < icons.size(); i++)
-        c_editor->Append(wxString::Format("%d", i+1), *icons[i]);
+    // BBS: filament colors and AMS locations for the hover tooltip.
+    std::vector<std::string> fila_colors;
+    if (Slic3r::PresetBundle* pb = Slic3r::GUI::wxGetApp().preset_bundle) {
+        if (const auto* opt = pb->project_config.option<Slic3r::ConfigOptionStrings>("filament_colour"))
+            fila_colors = opt->values;
+    }
+    const std::vector<wxString> ams_locations = build_filament_ams_locations();
+
+    for (size_t i = 0; i < icons.size(); i++) {
+        // BBS: label each choice with the filament name (left) and the nozzle side (right-aligned),
+        // falling back to the index only when no filament name is available.
+        const int      idx   = (int)i + 1;
+        const wxString name  = get_filament_label_for_extruder_text(wxString::Format("%d", idx));
+        const wxString label = name.IsEmpty() ? wxString::Format("%d", idx) : name;
+        const int item_index = c_editor->Append(label, *icons[i]);
+
+        // BBS: nozzle side (e.g. "(L)"/"(R)") drawn right-aligned so the sides line up vertically.
+        wxString suffix = get_filament_nozzle_suffix(idx);
+        suffix.Trim(false); // drop the leading space used for inline rendering
+        if (!suffix.IsEmpty())
+            c_editor->SetItemRightText(item_index, suffix);
+
+        // BBS: tooltip shows the readable color name and the AMS location (e.g. "Black — AMS HT-B").
+        wxString tip;
+        if (i < fila_colors.size())
+            tip = get_color_display_name(from_u8(fila_colors[i]));
+        if (i < ams_locations.size()) {
+            const wxString loc = format_ams_location(ams_locations[i]);
+            if (!loc.IsEmpty())
+                tip = tip.IsEmpty() ? loc : (tip + " — " + loc);
+        }
+        if (!tip.IsEmpty())
+            c_editor->SetItemTooltip(item_index, tip);
+    }
 
     if (has_default_extruder && has_default_extruder())
         c_editor->SetSelection(atoi(data.GetText().c_str()));
@@ -350,10 +667,18 @@ bool BitmapChoiceRenderer::GetValueFromEditorCtrl(wxWindow* ctrl, wxVariant& val
     int selection = c->GetSelection();
     if (selection < 0)
         return false;
-   
+
     DataViewBitmapText bmpText;
 
-    bmpText.SetText(c->GetString(selection));
+    // BBS: the visible item label is now the filament name, but the stored value must remain
+    // the numeric extruder index. Derive it from the selection position, not the label text.
+    int extruder_number;
+    if (has_default_extruder && has_default_extruder())
+        extruder_number = selection;      // index 0 == "default" (stored as "0")
+    else
+        extruder_number = selection + 1;  // no "default" item, first entry is extruder 1
+
+    bmpText.SetText(wxString::Format("%d", extruder_number));
     bmpText.SetBitmap(c->GetItemBitmap(selection));
 
     value << bmpText;

--- a/src/slic3r/GUI/ExtraRenderers.hpp
+++ b/src/slic3r/GUI/ExtraRenderers.hpp
@@ -188,4 +188,13 @@ private:
 };
 
 
+// BBS: human-readable tooltip for the filament column, given the extruder text
+// ("1", "2", ... or "default"): "<filament name> (L/R) — <color name>".
+wxString get_filament_column_tooltip(const wxString& extruder_text);
+
+// BBS: nozzle-side suffix for a 1-based filament index on a synced dual-nozzle printer:
+// " (L)" (left), " (R)" (right), or empty for single-nozzle / unknown.
+wxString get_filament_nozzle_suffix(int extruder_idx_1based);
+
+
 #endif // slic3r_GUI_ExtraRenderers_hpp_

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -5,6 +5,7 @@
 #include "GUI_Factories.hpp"
 #include "GUI_ObjectList.hpp"
 #include "GUI_App.hpp"
+#include "ExtraRenderers.hpp"
 #include "I18N.hpp"
 #include "Plater.hpp"
 #include "ObjectDataViewModel.hpp"
@@ -942,6 +943,8 @@ void MenuFactory::append_menu_item_change_extruder(wxMenu* menu)
             } else {
                 item_name = from_u8(preset->label(false));
             }
+            // BBS: on a synced dual-nozzle printer, show which nozzle this filament is on.
+            item_name += get_filament_nozzle_suffix(i);
         }
 
         if (is_active_extruder) {
@@ -2358,6 +2361,8 @@ void MenuFactory::append_menu_item_change_filament(wxMenu* menu)
             } else {
                 item_name = from_u8(preset->label(false));
             }
+            // BBS: on a synced dual-nozzle printer, show which nozzle this filament is on.
+            item_name += get_filament_nozzle_suffix(i);
         }
 
         if (is_active_extruder) {

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -14,6 +14,7 @@
 #include "OptionsGroup.hpp"
 #include "Tab.hpp"
 #include "wxExtensions.hpp"
+#include "ExtraRenderers.hpp"
 #include "libslic3r/Model.hpp"
 #include "GLCanvas3D.hpp"
 #include "Selection.hpp"
@@ -389,7 +390,7 @@ void ObjectList::create_objects_ctrl()
     m_columns_width[colName] = 22;
     m_columns_width[colHeight] = 3;
     m_columns_width[colPrint] = 3;
-    m_columns_width[colFilament] = 5;
+    m_columns_width[colFilament] = 14;
     m_columns_width[colSupportPaint] = 3;
     m_columns_width[colFuzzySkin]    = 3;
     m_columns_width[colSinking] = 3;
@@ -431,7 +432,7 @@ void ObjectList::create_objects_ctrl()
                m_objects_model->GetItemType(GetSelection()) == itLayer;
     });
     AppendColumn(new wxDataViewColumn(_L("Fila."), bmp_choice_renderer,
-        colFilament, m_columns_width[colFilament] * em, wxALIGN_CENTER_HORIZONTAL, 0));
+        colFilament, m_columns_width[colFilament] * em, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE));
 
     // BBS
     AppendBitmapColumn(" ", colSupportPaint, wxOSX ? wxDATAVIEW_CELL_EDITABLE : wxDATAVIEW_CELL_INERT, m_columns_width[colSupportPaint] * em,
@@ -655,6 +656,11 @@ void ObjectList::set_tooltip_for_item(const wxPoint& pt)
     else if (col->GetModelColumn() == (unsigned int)colSinking) {
         if (node->HasSinking())
             tooltip = _(L("Click the icon to shift this object to the bed"));
+    }
+    // BBS: show the filament name + nozzle side + readable color name instead of the
+    // raw internal cell value (which otherwise leaks as "<wxCustomRendererObject ...>").
+    else if (col->GetModelColumn() == (unsigned int)colFilament) {
+        tooltip = get_filament_column_tooltip(node->GetExtruder());
     }
     else if (col->GetModelColumn() == (unsigned int)colName && (pt.x >= 2 * wxGetApp().em_unit() && pt.x <= 4 * wxGetApp().em_unit()))
     {

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -151,6 +151,7 @@
 #include "Widgets/Button.hpp"
 #include "Widgets/StaticBox.hpp"
 #include "Widgets/ComboBox.hpp"
+#include "ExtraRenderers.hpp"
 #include "Widgets/StaticGroup.hpp"
 #include "Widgets/MultiNozzleSync.hpp"
 
@@ -1375,8 +1376,14 @@ static struct DynamicFilamentList : DynamicList
         int old_slot  = (old_index >= 0 && old_index < (int)slot_map.size()) ? slot_map[old_index] : -1;
         cb->Clear();
         cb->Append(_L("Default"));
-        for (auto i : items) {
-            cb->Append(i.first, i.second ? *i.second : wxNullBitmap);
+        for (size_t k = 0; k < items.size(); ++k) {
+            const int combo_idx = cb->Append(items[k].first, items[k].second ? *items[k].second : wxNullBitmap);
+            // BBS: match the object-list filament menu: right-aligned nozzle side on dual-nozzle printers.
+            const int slot = (k + 1 < slot_map.size()) ? slot_map[k + 1] : 0;
+            wxString suffix = get_filament_nozzle_suffix(slot);
+            suffix.Trim(false);
+            if (!suffix.IsEmpty())
+                cb->SetItemRightText(combo_idx, suffix);
         }
 
         int restored = index_of(wxString::Format("%d", old_slot));
@@ -1416,10 +1423,17 @@ static struct DynamicFilamentList : DynamicList
         for (int i = 0; i < (int)presets.size(); ++i) {
             if (wxGetApp().preset_bundle->is_mixed_filament(i))
                 continue;
+            // BBS: show the filament display name (e.g. "PLA Matte"), matching the object-list menu,
+            // falling back to the filament type when no name is available.
+            auto preset = wxGetApp().preset_bundle->filaments.find_preset(presets[i]);
             wxString str;
-            std::string type;
-            wxGetApp().preset_bundle->filaments.find_preset(presets[i])->get_filament_type(type);
-            str << type;
+            if (preset != nullptr)
+                str = from_u8(preset->display_name());
+            if (str.IsEmpty() && preset != nullptr) {
+                std::string type;
+                preset->get_filament_type(type);
+                str = from_u8(type);
+            }
             items.push_back({str, icons[i]});
             slot_map.push_back(i + 1); // 1-based filament slot
         }
@@ -4311,7 +4325,11 @@ std::map<int, DynamicPrintConfig> Sidebar::build_filament_ams_list(MachineObject
     if (obj->ams_support_virtual_tray) {
         int extruder = 0x10000; // Main (first) extruder at right
         for (auto & vt_tray : obj->vt_slot) {
-            filament_ams_list.emplace(extruder + stoi(vt_tray.id), build_tray_config(vt_tray, "Ext",vt_tray.id, "0"));//254 or 255
+            // BBS: only include an external spool slot when a spool is actually present.
+            // Empty slots would otherwise add phantom "Ext" filaments (and a spurious left
+            // assignment) even when the user has no external spools.
+            if (vt_tray.is_exists && !vt_tray.setting_id.empty())
+                filament_ams_list.emplace(extruder + stoi(vt_tray.id), build_tray_config(vt_tray, "Ext",vt_tray.id, "0"));//254 or 255
             extruder = 0;
         }
     }
@@ -4328,23 +4346,40 @@ std::map<int, DynamicPrintConfig> Sidebar::build_filament_ams_list(MachineObject
         return std::string();
     };
 
+    // Determine each AMS's physical nozzle exactly like the Left/Right Nozzle view does:
+    // for switch machines use the current switcher position, otherwise the uniquely bound
+    // extruder (NOT the static binded-extruder set, which can point at the wrong nozzle for
+    // a switchable AMS such as the AMS-HT). Extruder id 0 (main) is on the right, 1 on the left.
+    const bool fila_switch_flag = is_fila_switch_ready();
     auto list = obj->GetFilaSystem()->GetAmsList();
     for (const auto& ams : list) {
-        for (auto extruder_id : ams.second->GetBindedExtruderSet()) {
-            int extruder = extruder_id ? 0 : 0x10000; // Main (first) extruder at right
-            for (auto tray : ams.second->GetTrays()) {
-                int ams_id = -1;
-                int slot_id = -1;
-                try {
-                    ams_id  = std::stoi(ams.first);
-                    slot_id = std::stoi(tray.first);
-                    filament_ams_list.emplace(extruder + (ams_id * 4 + slot_id), build_tray_config(*tray.second, get_ams_name(ams_id, slot_id), std::to_string(ams_id), std::to_string(slot_id)));
-                } catch(...) {
-                    BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << "invalid ams_id:"<< ams.first << " or slot_id:" << tray.first;
-                }
+        int extruder_id;
+        if (fila_switch_flag) {
+            auto switcher_pos = ams.second->GetSwitcherPos();
+            if (!switcher_pos)
+                continue;
+            extruder_id = obj->is_main_extruder_on_left() ? (1 - static_cast<int>(switcher_pos.value()))
+                                                          : static_cast<int>(switcher_pos.value());
+        } else {
+            const auto& uniq_extruder_id = ams.second->GetUniqueBindedExtruderId();
+            if (!uniq_extruder_id)
+                continue;
+            extruder_id = uniq_extruder_id.value();
+        }
+        int extruder = extruder_id ? 0 : 0x10000; // Main (first) extruder at right
+        for (auto tray : ams.second->GetTrays()) {
+            int ams_id = -1;
+            int slot_id = -1;
+            try {
+                ams_id  = std::stoi(ams.first);
+                slot_id = std::stoi(tray.first);
+                filament_ams_list.emplace(extruder + (ams_id * 4 + slot_id), build_tray_config(*tray.second, get_ams_name(ams_id, slot_id), std::to_string(ams_id), std::to_string(slot_id)));
+            } catch(...) {
+                BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << "invalid ams_id:"<< ams.first << " or slot_id:" << tray.first;
             }
         }
     }
+
     return filament_ams_list;
 }
 

--- a/src/slic3r/GUI/Widgets/ComboBox.cpp
+++ b/src/slic3r/GUI/Widgets/ComboBox.cpp
@@ -287,6 +287,12 @@ void ComboBox::SetItemTooltip(unsigned int n, wxString const &value) {
     if (n == drop.GetSelection()) drop.SetToolTip(value);
 }
 
+void ComboBox::SetItemRightText(unsigned int n, wxString const &value) {
+    if (n >= items.size()) return;
+    items[n].text_right = value;
+    drop.Invalidate();
+}
+
 wxBitmap ComboBox::GetItemBitmap(unsigned int n) { return items[n].icon; }
 
 void ComboBox::SetItemBitmap(unsigned int n, wxBitmap const &bitmap)

--- a/src/slic3r/GUI/Widgets/ComboBox.hpp
+++ b/src/slic3r/GUI/Widgets/ComboBox.hpp
@@ -75,6 +75,8 @@ public:
     wxString GetItemTooltip(unsigned int n) const;
     void     SetItemTooltip(unsigned int n, wxString const &value);
 
+    void     SetItemRightText(unsigned int n, wxString const &value);
+
     wxString GetItemAlias(unsigned int n) const;
     void     SetItemAlias(unsigned int n, wxString const &value);
 

--- a/src/slic3r/GUI/Widgets/DropDown.cpp
+++ b/src/slic3r/GUI/Widgets/DropDown.cpp
@@ -394,13 +394,20 @@ void DropDown::render(wxDC &dc)
         auto text = group.IsEmpty()
                         ? (item.group.IsEmpty() ? item.text : item.group)
                         : (item.text.StartsWith(group) && !group.EndsWith(' ') ? item.text.substr(group.size()).Trim(false) : item.text);
+        // optional right-aligned text (e.g. a nozzle side label) reserved at the row's right edge
+        int right_text_w = 0;
+        if (!text_off && !item.text_right.IsEmpty()) {
+            dc.SetFont(GetFont());
+            right_text_w = dc.GetTextExtent(item.text_right).x;
+        }
         if (!text_off && !text.IsEmpty()) {
             wxSize tSize = dc.GetMultiLineTextExtent(text);
-            if (pt.x + tSize.x > rcContent.GetRight()) {
+            const int avail_right = rcContent.GetRight() - (right_text_w > 0 ? right_text_w + 8 : 0);
+            if (pt.x + tSize.x > avail_right) {
                 if (is_hover && item.tip.IsEmpty())
                     SetToolTip(text);
                 text = wxControl::Ellipsize(text, dc, wxELLIPSIZE_END,
-                                            rcContent.GetRight() - pt.x);
+                                            avail_right - pt.x);
             }
             pt.y += (rcContent.height - textSize.y) / 2;
             dc.SetFont(GetFont());
@@ -412,6 +419,14 @@ void DropDown::render(wxDC &dc)
                 pt.y = rcContent.y + (rcContent.height - szBmp.y) / 2;
                 dc.DrawBitmap(arrow_bitmap.bmp(), pt);
             }
+        }
+        if (right_text_w > 0) {
+            wxPoint rpt;
+            rpt.x = rcContent.GetRight() - right_text_w - 5;
+            rpt.y = rcContent.y + (rcContent.height - textSize.y) / 2;
+            dc.SetFont(GetFont());
+            dc.SetTextForeground(is_dimmed ? wxColour(0xCE, 0xCE, 0xCE) : text_color.colorForStates(states2));
+            dc.DrawText(item.text_right, rpt);
         }
         rcContent.y += rowSize.y;
     }
@@ -509,6 +524,8 @@ void DropDown::messureSize()
             size1 = dc.GetMultiLineTextExtent(text);
             if (group.IsEmpty() && !item.group.IsEmpty())
                 size1.x += 5 + arrow_bitmap.GetBmpWidth();
+            if (!item.text_right.IsEmpty())
+                size1.x += dc.GetTextExtent(item.text_right).x + 8;
         }
         if (item.icon.IsOk()) {
             wxSize size2 = GetBmpSize(item.icon);

--- a/src/slic3r/GUI/Widgets/DropDown.hpp
+++ b/src/slic3r/GUI/Widgets/DropDown.hpp
@@ -30,6 +30,7 @@ public:
         wxString group{};
         wxString alias{};
         wxString tip{};
+        wxString text_right{};// optional text drawn right-aligned at the row's right edge
         int      flag{0};
         int      style{ 0 };// the style of item
     };


### PR DESCRIPTION
Addresses #10354 (Material info not displayed at Material selection on objects view).

## What
Across the filament-selection UIs, show the filament **display name** and, on dual-nozzle printers (H2D/H2C), a right-aligned **(L)/(R)** indicating which nozzle the filament is loaded on:
- Object list **"Fila."** column and its dropdown editor
- **"Change Filament"** context menus
- **Support/raft base** and **Support/raft interface** selectors

## Why
On dual-nozzle machines it isn't obvious from these menus which nozzle a filament is on, and the object-view material selection showed little material info. This surfaces the filament name and nozzle side consistently, matching the sidebar Left/Right Nozzle view.

## How
- During AMS sync, write the real per-filament nozzle into `filament_map` (both the overwrite and merge paths) instead of defaulting everything to the left nozzle. The nozzle is derived from each AMS's bound extruder / current filament-switcher position, the same way the Left/Right Nozzle view computes it.
- Skip empty external-spool slots in `build_filament_ams_list` so they no longer add phantom filaments (which previously shifted the assignment).
- Add an opt-in right-aligned text column to the `DropDown` widget so the (L)/(R) labels line up vertically; other dropdowns are unaffected.
- Object-tree filament cell tooltip shows the readable color name + AMS location.

## Notes
- The (L)/(R) only shows on dual-nozzle printers once filaments are synced; single-nozzle printers are unchanged.
- Tested on macOS with a connected H2C (3× AMS + 3× AMS-HT, 2 left / 13 right).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
