### PR TITLE
AMS preview: equal frames, width-aware paging, tooltips and click-to-highlight

### DIFF
--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -2560,6 +2560,11 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
     std::vector<std::string> ams_filament_colors;
     std::vector<std::string> ams_filament_color_types;
     std::vector<AMSMapInfo>  ams_array_maps;
+    // BBS: nozzle assignment per built filament (1 = left, 2 = right), kept in lockstep with
+    // ams_filament_presets. The nozzle is encoded in the filament_ams_list key (bit 0x10000
+    // => right/main nozzle, else left/deputy), so we capture it here instead of defaulting all
+    // filaments to the left nozzle.
+    std::vector<int>         ams_filament_nozzles;
     ams_multi_color_filment.clear();
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": filament_ams_list size: %1%") % filament_ams_list.size();
     struct AmsInfo
@@ -2570,6 +2575,7 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
         std::string filament_color_type = "";
         std::string filament_preset = "";
         std::vector<std::string> mutli_filament_color;
+        int nozzle{1}; // BBS: 1 = left, 2 = right
     };
     auto is_double_extruder = get_printer_extruder_count() == 2;
     std::vector<AmsInfo> ams_infos;
@@ -2577,6 +2583,7 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
     std::set<std::pair<std::string, std::string>> added_filaments;
     for (auto &entry : filament_ams_list) {
         auto & ams = entry.second;
+        const int this_nozzle = (entry.first & 0x10000) ? 2 : 1; // BBS: 1 = left, 2 = right
         auto filament_id = ams.opt_string("filament_id", 0u);
         auto tray_name = ams.opt_string("tray_name", 0u);
         if (tray_name == "Ext" && skip_ext) {
@@ -2596,6 +2603,7 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
         auto ams_id     = ams.opt_string("ams_id", 0u);
         auto slot_id    = ams.opt_string("slot_id", 0u);
         ams_infos.push_back({filament_id.empty() ? false : true,false, filament_color});
+        ams_infos.back().nozzle = this_nozzle;
         AMSMapInfo temp = {ams_id, slot_id};
         ams_array_maps.push_back(temp);
         index++;
@@ -2607,6 +2615,7 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
                     }
                 }
                 ams_filament_presets.push_back("Generic PLA");//for unknow matieral
+                ams_filament_nozzles.push_back(this_nozzle);
                 auto default_unknown_color = "#CECECE";
                 ams_filament_colors.push_back(default_unknown_color);
                 ams_filament_color_types.push_back("1");
@@ -2619,6 +2628,7 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
         }
         if (!filament_changed && this->filament_presets.size() > ams_filament_presets.size()) {
             ams_filament_presets.push_back(this->filament_presets[ams_filament_presets.size()]);
+            ams_filament_nozzles.push_back(this_nozzle);
             ams_filament_colors.push_back(filament_color);
             ams_filament_color_types.push_back(filament_color_type);
             ams_multi_color_filment.push_back(filament_multi_color);
@@ -2642,6 +2652,7 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
                 // Prefer old selection
                 if (ams_filament_presets.size() < this->filament_presets.size()) {
                     ams_filament_presets.push_back(this->filament_presets[ams_filament_presets.size()]);
+                    ams_filament_nozzles.push_back(this_nozzle);
                     ams_filament_colors.push_back(filament_color);
                     ams_filament_color_types.push_back(filament_color_type);
                     ams_multi_color_filment.push_back(filament_multi_color);
@@ -2663,6 +2674,7 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
             filament_id = iter->filament_id;
         }
         ams_filament_presets.push_back(iter->name);
+        ams_filament_nozzles.push_back(this_nozzle);
         ams_filament_colors.push_back(filament_color);
         ams_filament_color_types.push_back(filament_color_type);
         ams_multi_color_filment.push_back(filament_multi_color);
@@ -2765,6 +2777,9 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
         auto exist_colors = filament_color->values;
         auto exist_color_types = filament_color_type->values;
         auto exist_filament_presets = this->filament_presets;
+        // BBS: nozzle assignment kept in lockstep with exist_filament_presets (1 = left, 2 = right).
+        std::vector<int> exist_nozzles = filament_map->values;
+        exist_nozzles.resize(exist_filament_presets.size(), 1);
         std::vector<std::vector<std::string>> exist_multi_color_filment;
         exist_multi_color_filment.resize(exist_colors.size());
         for (int i = 0; i < exist_colors.size(); i++) {
@@ -2778,6 +2793,8 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
                     exist_color_types[i]      = ams_filament_color_types[valid_index];
                     exist_filament_presets[i] = ams_filament_presets[valid_index];
                     exist_multi_color_filment[i] = ams_multi_color_filment[valid_index];
+                    if (valid_index < (int) ams_filament_nozzles.size() && i < exist_nozzles.size())
+                        exist_nozzles[i] = ams_filament_nozzles[valid_index]; // BBS: real nozzle
                 } else {
                     BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << "check error: array bound (mapping exist)";
                 }
@@ -2838,18 +2855,23 @@ unsigned int PresetBundle::sync_ams_list(std::vector<std::pair<DynamicPrintConfi
                 exist_colors.push_back(need_append_colors[i].filament_color);
                 exist_color_types.push_back(need_append_colors[i].filament_color_type);
                 exist_multi_color_filment.push_back(need_append_colors[i].mutli_filament_color);
+                exist_nozzles.push_back(need_append_colors[i].nozzle); // BBS: real nozzle
             }
         }
         filament_color->values = exist_colors;
         filament_color_type->values = exist_color_types;
         ams_multi_color_filment = exist_multi_color_filment;
         this->filament_presets = exist_filament_presets;
+        // BBS: write the real nozzle assignment captured during the build (1 = left, 2 = right).
+        filament_map->values = exist_nozzles;
         filament_map->values.resize(exist_filament_presets.size(), 1);
     }
     else {//overwrite;
         filament_color->values = ams_filament_colors;
         filament_color_type->values = ams_filament_color_types;
         this->filament_presets = ams_filament_presets;
+        // BBS: write the real nozzle assignment captured during the build (1 = left, 2 = right).
+        filament_map->values = ams_filament_nozzles;
         filament_map->values.resize(ams_filament_colors.size(), 1);
 
         auto& print_config = this->prints.get_edited_preset().config;

--- a/src/slic3r/GUI/ExtraRenderers.cpp
+++ b/src/slic3r/GUI/ExtraRenderers.cpp
@@ -354,7 +354,7 @@ static wxString get_filament_cell_label(const wxString& extruder_text)
 
 // BBS: return a human-readable color name for a hex string (e.g. "#1A1A1A" -> "Black"),
 // picking the nearest entry from a small table of common colors. Falls back to the input.
-static wxString get_color_display_name(const wxString& hex_in)
+wxString get_color_display_name(const wxString& hex_in)
 {
     wxString hex = hex_in;
     if (hex.StartsWith("#") && hex.length() > 7)
@@ -392,7 +392,7 @@ static wxString get_color_display_name(const wxString& hex_in)
 
 // BBS: for each project filament (0-based), the AMS tray it is loaded in (e.g. "A1", "HT-B",
 // "Ext"), derived from the synced AMS list by matching color + filament id. Empty when unknown.
-static std::vector<wxString> build_filament_ams_locations()
+std::vector<wxString> build_filament_ams_locations()
 {
     using namespace Slic3r;
     using namespace Slic3r::GUI;

--- a/src/slic3r/GUI/ExtraRenderers.cpp
+++ b/src/slic3r/GUI/ExtraRenderers.cpp
@@ -1,9 +1,14 @@
 #include "ExtraRenderers.hpp"
 #include "wxExtensions.hpp"
 #include "GUI.hpp"
+#include "GUI_App.hpp"
 #include "BitmapComboBox.hpp"
 #include "Plater.hpp"
+#include "PartPlate.hpp"
+#include "GUI_ObjectList.hpp"
 #include "Widgets/ComboBox.hpp"
+#include "libslic3r/PresetBundle.hpp"
+#include "libslic3r/Print.hpp"
 
 #include <wx/dc.h>
 #ifdef wxHAS_GENERIC_DATAVIEWCTRL
@@ -263,37 +268,310 @@ bool BitmapChoiceRenderer::GetValue(wxVariant& value) const
     return true;
 }
 
+// BBS: return the human-readable filament name (e.g. "PLA Matte") for the
+// extruder index stored as text in the filament column ("1", "2", ... or "default").
+// Returns an empty string when no meaningful name is available.
+static wxString get_filament_label_for_extruder_text(const wxString& extruder_text)
+{
+    using namespace Slic3r;
+    using namespace Slic3r::GUI;
+
+    const int extruder_idx = atoi(extruder_text.c_str()); // 1-based, 0 means "default"/none
+    if (extruder_idx <= 0)
+        return wxEmptyString;
+
+    PresetBundle* preset_bundle = wxGetApp().preset_bundle;
+    if (preset_bundle == nullptr)
+        return wxEmptyString;
+
+    const std::vector<std::string>& filament_presets = preset_bundle->filament_presets;
+    const size_t pos = (size_t)(extruder_idx - 1);
+    if (pos >= filament_presets.size())
+        return wxEmptyString;
+
+    const Preset* preset = preset_bundle->filaments.find_preset(filament_presets[pos]);
+    if (preset == nullptr)
+        return wxEmptyString;
+
+    return from_u8(preset->display_name());
+}
+
+// BBS: for dual-nozzle printers, return the nozzle-side suffix for a 1-based filament index:
+// " (L)" if the filament is mapped to the left nozzle, " (R)" for the right nozzle.
+// Returns an empty string for single-nozzle printers or when the mapping is unknown.
+wxString get_filament_nozzle_suffix(int extruder_idx_1based)
+{
+    using namespace Slic3r;
+    using namespace Slic3r::GUI;
+
+    if (extruder_idx_1based <= 0)
+        return wxEmptyString;
+
+    PresetBundle* preset_bundle = wxGetApp().preset_bundle;
+    if (preset_bundle == nullptr)
+        return wxEmptyString;
+
+    // Single-nozzle printers have no left/right distinction.
+    const auto* nozzle_opt = preset_bundle->printers.get_edited_preset().config
+                                 .option<ConfigOptionFloatsNullable>("nozzle_diameter");
+    if (nozzle_opt == nullptr || nozzle_opt->values.size() < 2)
+        return wxEmptyString;
+
+    Plater* plater = wxGetApp().plater();
+    if (plater == nullptr)
+        return wxEmptyString;
+
+    // The left/right split is written into "filament_map" when filaments are synced
+    // (1 = left, 2 = right). Only meaningful once the printer info has been synced.
+    if (!plater->get_machine_sync_status())
+        return wxEmptyString;
+
+    // Read the global "filament_map" written by the AMS sync (1 = left, 2 = right). Use the
+    // global project config directly — the per-plate map can shadow it with a stale value.
+    const auto* map_opt = preset_bundle->project_config.option<ConfigOptionInts>("filament_map");
+    if (map_opt == nullptr)
+        return wxEmptyString;
+    const size_t pos = (size_t)(extruder_idx_1based - 1);
+    if (pos >= map_opt->values.size())
+        return wxEmptyString;
+
+    switch (map_opt->values[pos]) {
+    case 1:  return " (L)";
+    case 2:  return " (R)";
+    default: return wxEmptyString;
+    }
+}
+
+// BBS: full filament cell label for a given extruder text ("1", "2", ... or "default"):
+// the filament name plus the nozzle-side suffix, e.g. "PLA Matte (L)".
+static wxString get_filament_cell_label(const wxString& extruder_text)
+{
+    const wxString name = get_filament_label_for_extruder_text(extruder_text);
+    if (name.IsEmpty())
+        return wxEmptyString;
+    return name + get_filament_nozzle_suffix(atoi(extruder_text.c_str()));
+}
+
+// BBS: return a human-readable color name for a hex string (e.g. "#1A1A1A" -> "Black"),
+// picking the nearest entry from a small table of common colors. Falls back to the input.
+static wxString get_color_display_name(const wxString& hex_in)
+{
+    wxString hex = hex_in;
+    if (hex.StartsWith("#") && hex.length() > 7)
+        hex = hex.substr(0, 7); // drop any alpha component (#RRGGBBAA -> #RRGGBB)
+
+    wxColour c(hex);
+    if (!c.IsOk())
+        return hex_in;
+
+    struct NamedColor { const char* name; int r, g, b; };
+    static const NamedColor table[] = {
+        {"Black", 0, 0, 0},        {"White", 255, 255, 255},   {"Gray", 128, 128, 128},
+        {"Silver", 192, 192, 192}, {"Red", 220, 20, 20},       {"Dark Red", 139, 0, 0},
+        {"Orange", 255, 140, 0},   {"Yellow", 240, 225, 40},   {"Gold", 212, 175, 55},
+        {"Green", 30, 160, 60},    {"Dark Green", 0, 100, 0},  {"Lime", 160, 210, 60},
+        {"Cyan", 0, 200, 200},     {"Blue", 30, 80, 200},      {"Navy", 20, 30, 90},
+        {"Sky Blue", 110, 170, 220}, {"Purple", 128, 0, 128},  {"Magenta", 200, 40, 160},
+        {"Pink", 240, 150, 180},   {"Brown", 120, 70, 40},     {"Beige", 225, 210, 170},
+    };
+
+    long best_dist = 2000000000L;
+    const char* best_name = "";
+    for (const NamedColor& nc : table) {
+        const long dr = (long)c.Red() - nc.r;
+        const long dg = (long)c.Green() - nc.g;
+        const long db = (long)c.Blue() - nc.b;
+        const long dist = dr * dr + dg * dg + db * db;
+        if (dist < best_dist) {
+            best_dist = dist;
+            best_name = nc.name;
+        }
+    }
+    return wxString::FromUTF8(best_name);
+}
+
+// BBS: for each project filament (0-based), the AMS tray it is loaded in (e.g. "A1", "HT-B",
+// "Ext"), derived from the synced AMS list by matching color + filament id. Empty when unknown.
+static std::vector<wxString> build_filament_ams_locations()
+{
+    using namespace Slic3r;
+    using namespace Slic3r::GUI;
+
+    std::vector<wxString> result;
+
+    PresetBundle* preset_bundle = wxGetApp().preset_bundle;
+    if (preset_bundle == nullptr)
+        return result;
+
+    const std::map<int, DynamicPrintConfig>& ams_list = preset_bundle->filament_ams_list;
+    if (ams_list.empty())
+        return result;
+
+    const auto* color_opt = preset_bundle->project_config.option<ConfigOptionStrings>("filament_colour");
+    if (color_opt == nullptr)
+        return result;
+    const std::vector<std::string>& proj_colors = color_opt->values;
+    result.assign(proj_colors.size(), wxString());
+
+    auto norm_color = [](std::string s) -> std::string {
+        if (!s.empty() && s[0] == '#') s.erase(0, 1);
+        for (char& c : s) c = (char) ::toupper((unsigned char) c);
+        if (s.size() > 6) s = s.substr(0, 6);
+        return s;
+    };
+    auto get_str = [](const DynamicPrintConfig& cfg, const char* key) -> std::string {
+        const ConfigOption* opt = cfg.option(key);
+        if (opt == nullptr) return std::string();
+        if (const auto* s = dynamic_cast<const ConfigOptionStrings*>(opt))
+            return s->values.empty() ? std::string() : s->values.front();
+        if (const auto* s = dynamic_cast<const ConfigOptionString*>(opt))
+            return s->value;
+        return std::string();
+    };
+
+    struct AmsEntry { std::string color; std::string id; wxString name; bool used; };
+    std::vector<AmsEntry> entries;
+    entries.reserve(ams_list.size());
+    for (const auto& kv : ams_list) {
+        AmsEntry e;
+        e.color = norm_color(get_str(kv.second, "filament_colour"));
+        e.id    = get_str(kv.second, "filament_id");
+        e.name  = from_u8(get_str(kv.second, "tray_name"));
+        e.used  = false;
+        entries.push_back(std::move(e));
+    }
+
+    for (size_t i = 0; i < proj_colors.size(); ++i) {
+        const std::string pcolor = norm_color(proj_colors[i]);
+        std::string pid;
+        if (i < preset_bundle->filament_presets.size()) {
+            if (const Preset* preset = preset_bundle->filaments.find_preset(preset_bundle->filament_presets[i]))
+                pid = get_str(preset->config, "filament_id");
+        }
+
+        int found = -1;
+        for (size_t j = 0; j < entries.size(); ++j)
+            if (!entries[j].used && entries[j].color == pcolor && !pid.empty() && entries[j].id == pid) { found = (int) j; break; }
+        if (found < 0)
+            for (size_t j = 0; j < entries.size(); ++j)
+                if (!entries[j].used && entries[j].color == pcolor) { found = (int) j; break; }
+        if (found < 0 && !pid.empty())
+            for (size_t j = 0; j < entries.size(); ++j)
+                if (!entries[j].used && entries[j].id == pid) { found = (int) j; break; }
+
+        if (found >= 0) {
+            entries[found].used = true;
+            result[i] = entries[found].name;
+        }
+    }
+
+    return result;
+}
+
+// BBS: human-readable AMS location for a tray name ("A1" -> "AMS A1", "HT-B" -> "AMS HT-B",
+// "Ext" -> "External spool"). Empty input yields an empty string.
+static wxString format_ams_location(const wxString& tray_name)
+{
+    if (tray_name.IsEmpty())
+        return wxEmptyString;
+    if (tray_name == "Ext")
+        return _L("External spool");
+    return _L("AMS") + " " + tray_name;
+}
+
+wxString get_filament_column_tooltip(const wxString& extruder_text)
+{
+    using namespace Slic3r;
+    using namespace Slic3r::GUI;
+
+    const int idx = atoi(extruder_text.c_str());
+
+    wxString label = get_filament_label_for_extruder_text(extruder_text);
+    if (!label.IsEmpty())
+        label += get_filament_nozzle_suffix(idx);
+
+    wxString color_name;
+    wxString location;
+    if (idx > 0) {
+        if (PresetBundle* pb = wxGetApp().preset_bundle) {
+            if (const auto* opt = pb->project_config.option<ConfigOptionStrings>("filament_colour")) {
+                const size_t pos = (size_t)(idx - 1);
+                if (pos < opt->values.size())
+                    color_name = get_color_display_name(from_u8(opt->values[pos]));
+            }
+        }
+        const std::vector<wxString> locations = build_filament_ams_locations();
+        if ((size_t)(idx - 1) < locations.size())
+            location = format_ams_location(locations[idx - 1]);
+    }
+
+    // Compose: "<name> — <color> — <AMS location>" (omitting any empty parts).
+    wxString out = label;
+    auto append = [&out](const wxString& part) {
+        if (part.IsEmpty()) return;
+        if (!out.IsEmpty()) out += " — ";
+        out += part;
+    };
+    if (label.IsEmpty()) out = color_name; else append(color_name);
+    append(location);
+    return out;
+}
+
 bool BitmapChoiceRenderer::Render(wxRect rect, wxDC* dc, int state)
 {
-//    int xoffset = 0;
+    int xoffset = 0;
 
     const wxBitmap& icon = m_value.GetBitmap();
     if (icon.IsOk())
     {
         dc->DrawBitmap(icon, rect.x, rect.y + (rect.height - icon.GetHeight()) / 2);
-//        xoffset = icon.GetWidth() + 4;
+        xoffset = icon.GetWidth() + 4;
 
         if (rect.height == 0)
           rect.height = icon.GetHeight();
     }
 
+    // BBS: filament name (left, after the swatch) and the nozzle side (right-aligned at the cell edge).
 #ifdef _WIN32
     // workaround for Windows DarkMode : Don't respect to the state & wxDATAVIEW_CELL_SELECTED to avoid update of the text color
-//    RenderText(m_value.GetText(), xoffset, rect, dc, state & wxDATAVIEW_CELL_SELECTED ? 0 : state);
+    const int text_state = state & wxDATAVIEW_CELL_SELECTED ? 0 : state;
 #else
-//    RenderText(m_value.GetText(), xoffset, rect, dc, state);
+    const int text_state = state;
 #endif
+
+    const wxString name   = get_filament_label_for_extruder_text(m_value.GetText());
+    wxString       suffix = name.IsEmpty() ? wxString() : get_filament_nozzle_suffix(atoi(m_value.GetText().c_str()));
+    suffix.Trim(false); // drop the leading space used when appended inline
+
+    int suffix_w = 0;
+    if (!suffix.IsEmpty())
+        suffix_w = dc->GetTextExtent(suffix).x;
+
+    if (!name.IsEmpty()) {
+        // Reserve room on the right for the side label so the name doesn't run under it.
+        wxRect name_rect = rect;
+        if (suffix_w > 0)
+            name_rect.width = std::max(0, name_rect.width - (suffix_w + 8));
+        RenderText(name, xoffset, name_rect, dc, text_state);
+    }
+
+    if (suffix_w > 0) {
+        // Right-align the side label at the cell's right edge.
+        const int xo = std::max(xoffset, rect.width - suffix_w - 2);
+        RenderText(suffix, xo, rect, dc, text_state);
+    }
 
     return true;
 }
 
 wxSize BitmapChoiceRenderer::GetSize() const
 {
-    wxSize sz;// = GetTextExtent(m_value.GetText());
+    const wxString label = get_filament_cell_label(m_value.GetText());
+    wxSize sz = label.IsEmpty() ? wxSize(0, 0) : GetTextExtent(label);
 
     if (m_value.GetBitmap().IsOk()) {
         sz.x += m_value.GetBitmap().GetWidth() + 4;
-        sz.y = m_value.GetBitmap().GetHeight() + 4;
+        sz.y = std::max(sz.y, m_value.GetBitmap().GetHeight() + 4);
     }
 
     return sz;
@@ -305,6 +583,12 @@ wxWindow* BitmapChoiceRenderer::CreateEditorCtrl(wxWindow* parent, wxRect labelR
     if (can_create_editor_ctrl && !can_create_editor_ctrl())
         return nullptr;
 
+    // BBS: filaments (and their nozzle map) may have been synced since the rows were last
+    // painted. Repaint the filament column now so the cells behind reflect the latest
+    // sync state, matching the up-to-date labels shown in the dropdown we are about to open.
+    if (Slic3r::GUI::ObjectList* obj_list = Slic3r::GUI::wxGetApp().obj_list())
+        obj_list->Refresh();
+
     std::vector<wxBitmap*> icons = get_extruder_color_icons();
     if (icons.empty())
         return nullptr;
@@ -312,16 +596,49 @@ wxWindow* BitmapChoiceRenderer::CreateEditorCtrl(wxWindow* parent, wxRect labelR
     DataViewBitmapText data;
     data << value;
 
+    // BBS: keep item text visible (no CB_NO_TEXT) so the filament name shows next to each color swatch
     ::ComboBox *c_editor = new ::ComboBox(parent, wxID_ANY, wxEmptyString,
         labelRect.GetTopLeft(), wxSize(labelRect.GetWidth(), -1),
-        0, nullptr, wxCB_READONLY | CB_NO_DROP_ICON | CB_NO_TEXT);
+        0, nullptr, wxCB_READONLY | CB_NO_DROP_ICON);
     c_editor->GetDropDown().SetUseContentWidth(true);
 
     if (has_default_extruder && has_default_extruder())
         c_editor->Append(_L("default"), *get_default_extruder_color_icon());
 
-    for (size_t i = 0; i < icons.size(); i++)
-        c_editor->Append(wxString::Format("%d", i+1), *icons[i]);
+    // BBS: filament colors and AMS locations for the hover tooltip.
+    std::vector<std::string> fila_colors;
+    if (Slic3r::PresetBundle* pb = Slic3r::GUI::wxGetApp().preset_bundle) {
+        if (const auto* opt = pb->project_config.option<Slic3r::ConfigOptionStrings>("filament_colour"))
+            fila_colors = opt->values;
+    }
+    const std::vector<wxString> ams_locations = build_filament_ams_locations();
+
+    for (size_t i = 0; i < icons.size(); i++) {
+        // BBS: label each choice with the filament name (left) and the nozzle side (right-aligned),
+        // falling back to the index only when no filament name is available.
+        const int      idx   = (int)i + 1;
+        const wxString name  = get_filament_label_for_extruder_text(wxString::Format("%d", idx));
+        const wxString label = name.IsEmpty() ? wxString::Format("%d", idx) : name;
+        const int item_index = c_editor->Append(label, *icons[i]);
+
+        // BBS: nozzle side (e.g. "(L)"/"(R)") drawn right-aligned so the sides line up vertically.
+        wxString suffix = get_filament_nozzle_suffix(idx);
+        suffix.Trim(false); // drop the leading space used for inline rendering
+        if (!suffix.IsEmpty())
+            c_editor->SetItemRightText(item_index, suffix);
+
+        // BBS: tooltip shows the readable color name and the AMS location (e.g. "Black — AMS HT-B").
+        wxString tip;
+        if (i < fila_colors.size())
+            tip = get_color_display_name(from_u8(fila_colors[i]));
+        if (i < ams_locations.size()) {
+            const wxString loc = format_ams_location(ams_locations[i]);
+            if (!loc.IsEmpty())
+                tip = tip.IsEmpty() ? loc : (tip + " — " + loc);
+        }
+        if (!tip.IsEmpty())
+            c_editor->SetItemTooltip(item_index, tip);
+    }
 
     if (has_default_extruder && has_default_extruder())
         c_editor->SetSelection(atoi(data.GetText().c_str()));
@@ -350,10 +667,18 @@ bool BitmapChoiceRenderer::GetValueFromEditorCtrl(wxWindow* ctrl, wxVariant& val
     int selection = c->GetSelection();
     if (selection < 0)
         return false;
-   
+
     DataViewBitmapText bmpText;
 
-    bmpText.SetText(c->GetString(selection));
+    // BBS: the visible item label is now the filament name, but the stored value must remain
+    // the numeric extruder index. Derive it from the selection position, not the label text.
+    int extruder_number;
+    if (has_default_extruder && has_default_extruder())
+        extruder_number = selection;      // index 0 == "default" (stored as "0")
+    else
+        extruder_number = selection + 1;  // no "default" item, first entry is extruder 1
+
+    bmpText.SetText(wxString::Format("%d", extruder_number));
     bmpText.SetBitmap(c->GetItemBitmap(selection));
 
     value << bmpText;

--- a/src/slic3r/GUI/ExtraRenderers.hpp
+++ b/src/slic3r/GUI/ExtraRenderers.hpp
@@ -196,5 +196,12 @@ wxString get_filament_column_tooltip(const wxString& extruder_text);
 // " (L)" (left), " (R)" (right), or empty for single-nozzle / unknown.
 wxString get_filament_nozzle_suffix(int extruder_idx_1based);
 
+// BBS: readable name for a colour hex ("#1F8EB4" -> "Sky Blue"), nearest of a small table.
+wxString get_color_display_name(const wxString& hex);
+
+// BBS: for each project filament (0-based), the AMS tray it is loaded in ("A1", "HT-B", "Ext"),
+// using the synced AMS list with a 1:1 assignment. Empty string when the filament isn't matched.
+std::vector<wxString> build_filament_ams_locations();
+
 
 #endif // slic3r_GUI_ExtraRenderers_hpp_

--- a/src/slic3r/GUI/ExtraRenderers.hpp
+++ b/src/slic3r/GUI/ExtraRenderers.hpp
@@ -188,4 +188,13 @@ private:
 };
 
 
+// BBS: human-readable tooltip for the filament column, given the extruder text
+// ("1", "2", ... or "default"): "<filament name> (L/R) — <color name>".
+wxString get_filament_column_tooltip(const wxString& extruder_text);
+
+// BBS: nozzle-side suffix for a 1-based filament index on a synced dual-nozzle printer:
+// " (L)" (left), " (R)" (right), or empty for single-nozzle / unknown.
+wxString get_filament_nozzle_suffix(int extruder_idx_1based);
+
+
 #endif // slic3r_GUI_ExtraRenderers_hpp_

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -5,6 +5,7 @@
 #include "GUI_Factories.hpp"
 #include "GUI_ObjectList.hpp"
 #include "GUI_App.hpp"
+#include "ExtraRenderers.hpp"
 #include "I18N.hpp"
 #include "Plater.hpp"
 #include "ObjectDataViewModel.hpp"
@@ -942,6 +943,8 @@ void MenuFactory::append_menu_item_change_extruder(wxMenu* menu)
             } else {
                 item_name = from_u8(preset->label(false));
             }
+            // BBS: on a synced dual-nozzle printer, show which nozzle this filament is on.
+            item_name += get_filament_nozzle_suffix(i);
         }
 
         if (is_active_extruder) {
@@ -2358,6 +2361,8 @@ void MenuFactory::append_menu_item_change_filament(wxMenu* menu)
             } else {
                 item_name = from_u8(preset->label(false));
             }
+            // BBS: on a synced dual-nozzle printer, show which nozzle this filament is on.
+            item_name += get_filament_nozzle_suffix(i);
         }
 
         if (is_active_extruder) {

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -14,6 +14,7 @@
 #include "OptionsGroup.hpp"
 #include "Tab.hpp"
 #include "wxExtensions.hpp"
+#include "ExtraRenderers.hpp"
 #include "libslic3r/Model.hpp"
 #include "GLCanvas3D.hpp"
 #include "Selection.hpp"
@@ -389,7 +390,7 @@ void ObjectList::create_objects_ctrl()
     m_columns_width[colName] = 22;
     m_columns_width[colHeight] = 3;
     m_columns_width[colPrint] = 3;
-    m_columns_width[colFilament] = 5;
+    m_columns_width[colFilament] = 14;
     m_columns_width[colSupportPaint] = 3;
     m_columns_width[colFuzzySkin]    = 3;
     m_columns_width[colSinking] = 3;
@@ -431,7 +432,7 @@ void ObjectList::create_objects_ctrl()
                m_objects_model->GetItemType(GetSelection()) == itLayer;
     });
     AppendColumn(new wxDataViewColumn(_L("Fila."), bmp_choice_renderer,
-        colFilament, m_columns_width[colFilament] * em, wxALIGN_CENTER_HORIZONTAL, 0));
+        colFilament, m_columns_width[colFilament] * em, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE));
 
     // BBS
     AppendBitmapColumn(" ", colSupportPaint, wxOSX ? wxDATAVIEW_CELL_EDITABLE : wxDATAVIEW_CELL_INERT, m_columns_width[colSupportPaint] * em,
@@ -655,6 +656,11 @@ void ObjectList::set_tooltip_for_item(const wxPoint& pt)
     else if (col->GetModelColumn() == (unsigned int)colSinking) {
         if (node->HasSinking())
             tooltip = _(L("Click the icon to shift this object to the bed"));
+    }
+    // BBS: show the filament name + nozzle side + readable color name instead of the
+    // raw internal cell value (which otherwise leaks as "<wxCustomRendererObject ...>").
+    else if (col->GetModelColumn() == (unsigned int)colFilament) {
+        tooltip = get_filament_column_tooltip(node->GetExtruder());
     }
     else if (col->GetModelColumn() == (unsigned int)colName && (pt.x >= 2 * wxGetApp().em_unit() && pt.x <= 4 * wxGetApp().em_unit()))
     {

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -151,6 +151,7 @@
 #include "Widgets/Button.hpp"
 #include "Widgets/StaticBox.hpp"
 #include "Widgets/ComboBox.hpp"
+#include "ExtraRenderers.hpp"
 #include "Widgets/StaticGroup.hpp"
 #include "Widgets/MultiNozzleSync.hpp"
 
@@ -1375,8 +1376,14 @@ static struct DynamicFilamentList : DynamicList
         int old_slot  = (old_index >= 0 && old_index < (int)slot_map.size()) ? slot_map[old_index] : -1;
         cb->Clear();
         cb->Append(_L("Default"));
-        for (auto i : items) {
-            cb->Append(i.first, i.second ? *i.second : wxNullBitmap);
+        for (size_t k = 0; k < items.size(); ++k) {
+            const int combo_idx = cb->Append(items[k].first, items[k].second ? *items[k].second : wxNullBitmap);
+            // BBS: match the object-list filament menu: right-aligned nozzle side on dual-nozzle printers.
+            const int slot = (k + 1 < slot_map.size()) ? slot_map[k + 1] : 0;
+            wxString suffix = get_filament_nozzle_suffix(slot);
+            suffix.Trim(false);
+            if (!suffix.IsEmpty())
+                cb->SetItemRightText(combo_idx, suffix);
         }
 
         int restored = index_of(wxString::Format("%d", old_slot));
@@ -1416,10 +1423,17 @@ static struct DynamicFilamentList : DynamicList
         for (int i = 0; i < (int)presets.size(); ++i) {
             if (wxGetApp().preset_bundle->is_mixed_filament(i))
                 continue;
+            // BBS: show the filament display name (e.g. "PLA Matte"), matching the object-list menu,
+            // falling back to the filament type when no name is available.
+            auto preset = wxGetApp().preset_bundle->filaments.find_preset(presets[i]);
             wxString str;
-            std::string type;
-            wxGetApp().preset_bundle->filaments.find_preset(presets[i])->get_filament_type(type);
-            str << type;
+            if (preset != nullptr)
+                str = from_u8(preset->display_name());
+            if (str.IsEmpty() && preset != nullptr) {
+                std::string type;
+                preset->get_filament_type(type);
+                str = from_u8(type);
+            }
             items.push_back({str, icons[i]});
             slot_map.push_back(i + 1); // 1-based filament slot
         }
@@ -4311,7 +4325,11 @@ std::map<int, DynamicPrintConfig> Sidebar::build_filament_ams_list(MachineObject
     if (obj->ams_support_virtual_tray) {
         int extruder = 0x10000; // Main (first) extruder at right
         for (auto & vt_tray : obj->vt_slot) {
-            filament_ams_list.emplace(extruder + stoi(vt_tray.id), build_tray_config(vt_tray, "Ext",vt_tray.id, "0"));//254 or 255
+            // BBS: only include an external spool slot when a spool is actually present.
+            // Empty slots would otherwise add phantom "Ext" filaments (and a spurious left
+            // assignment) even when the user has no external spools.
+            if (vt_tray.is_exists && !vt_tray.setting_id.empty())
+                filament_ams_list.emplace(extruder + stoi(vt_tray.id), build_tray_config(vt_tray, "Ext",vt_tray.id, "0"));//254 or 255
             extruder = 0;
         }
     }
@@ -4328,23 +4346,40 @@ std::map<int, DynamicPrintConfig> Sidebar::build_filament_ams_list(MachineObject
         return std::string();
     };
 
+    // Determine each AMS's physical nozzle exactly like the Left/Right Nozzle view does:
+    // for switch machines use the current switcher position, otherwise the uniquely bound
+    // extruder (NOT the static binded-extruder set, which can point at the wrong nozzle for
+    // a switchable AMS such as the AMS-HT). Extruder id 0 (main) is on the right, 1 on the left.
+    const bool fila_switch_flag = is_fila_switch_ready();
     auto list = obj->GetFilaSystem()->GetAmsList();
     for (const auto& ams : list) {
-        for (auto extruder_id : ams.second->GetBindedExtruderSet()) {
-            int extruder = extruder_id ? 0 : 0x10000; // Main (first) extruder at right
-            for (auto tray : ams.second->GetTrays()) {
-                int ams_id = -1;
-                int slot_id = -1;
-                try {
-                    ams_id  = std::stoi(ams.first);
-                    slot_id = std::stoi(tray.first);
-                    filament_ams_list.emplace(extruder + (ams_id * 4 + slot_id), build_tray_config(*tray.second, get_ams_name(ams_id, slot_id), std::to_string(ams_id), std::to_string(slot_id)));
-                } catch(...) {
-                    BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << "invalid ams_id:"<< ams.first << " or slot_id:" << tray.first;
-                }
+        int extruder_id;
+        if (fila_switch_flag) {
+            auto switcher_pos = ams.second->GetSwitcherPos();
+            if (!switcher_pos)
+                continue;
+            extruder_id = obj->is_main_extruder_on_left() ? (1 - static_cast<int>(switcher_pos.value()))
+                                                          : static_cast<int>(switcher_pos.value());
+        } else {
+            const auto& uniq_extruder_id = ams.second->GetUniqueBindedExtruderId();
+            if (!uniq_extruder_id)
+                continue;
+            extruder_id = uniq_extruder_id.value();
+        }
+        int extruder = extruder_id ? 0 : 0x10000; // Main (first) extruder at right
+        for (auto tray : ams.second->GetTrays()) {
+            int ams_id = -1;
+            int slot_id = -1;
+            try {
+                ams_id  = std::stoi(ams.first);
+                slot_id = std::stoi(tray.first);
+                filament_ams_list.emplace(extruder + (ams_id * 4 + slot_id), build_tray_config(*tray.second, get_ams_name(ams_id, slot_id), std::to_string(ams_id), std::to_string(slot_id)));
+            } catch(...) {
+                BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << "invalid ams_id:"<< ams.first << " or slot_id:" << tray.first;
             }
         }
     }
+
     return filament_ams_list;
 }
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -152,6 +152,7 @@
 #include "Widgets/StaticBox.hpp"
 #include "Widgets/ComboBox.hpp"
 #include "ExtraRenderers.hpp"
+#include "EncodedFilament.hpp"
 #include "Widgets/StaticGroup.hpp"
 #include "Widgets/MultiNozzleSync.hpp"
 
@@ -581,13 +582,25 @@ static void PositionLabelOverStaticBox(wxPoint top_left, HoverLabel *label_)
 struct ExtruderGroup : StaticGroup
 {
     ExtruderGroup(wxWindow * parent, int index, wxString const &title);
+
+    // BBS: on macOS the static box reports a large intrinsic best width (~299px) which
+    // wxStaticBoxSizer uses as a hard minimum, so two nozzle boxes can't share a narrow
+    // sidebar evenly (the row sizer squeezes the last one). The actual content needs far
+    // less, so report a tiny best width and let the content drive the real size — this lets
+    // the Left/Right Nozzle boxes shrink together symmetrically.
+    wxSize DoGetBestSize() const override { return wxSize(1, wxStaticBox::DoGetBestSize().y); }
+
     int m_index;
     wxBoxSizer *sizer        = nullptr;
     HoverLabel *      hover_label  = nullptr;
     ScalableButton *  btn_edit     = nullptr;
     ComboBox *        combo_diameter = nullptr;
     ComboBox *        combo_flow = nullptr;
-    AMSPreview *      ams[4]       = {nullptr};
+    // BBS: max AMS-unit previews per nozzle (H2C supports up to 4 AMS/AMS2-Pro + 8 AMS-HT).
+    static constexpr size_t MAX_AMS_PREVIEW = 24;
+    AMSPreview *      ams[MAX_AMS_PREVIEW] = {nullptr};
+    AMSinfo           ams_shown[MAX_AMS_PREVIEW]; // BBS: AMSinfo currently shown in each preview slot
+    int               last_panel_w = -1; // BBS: last panel width used to lay out the AMS row
     wxStaticText     *ams_not_installed_msg{nullptr};
     ScalableButton *  btn_up{nullptr};
     ScalableButton *  btn_down{nullptr};
@@ -621,6 +634,9 @@ struct ExtruderGroup : StaticGroup
 
     void update_ams();
 
+    // BBS: clicking an AMS preview highlights the matching project filament(s) in the sidebar.
+    void on_ams_clicked(size_t slot);
+
     void sync_ams(MachineObject const *obj, std::vector<DevAms *> const &ams4, std::vector<DevAms *> const &ams1);
 
     void Rescale()
@@ -631,7 +647,7 @@ struct ExtruderGroup : StaticGroup
         btn_down->msw_rescale();
         combo_diameter->Rescale();
         combo_flow->Rescale();
-        for (int i = 0; i < 4; ++i)
+        for (size_t i = 0; i < MAX_AMS_PREVIEW; ++i)
             ams[i]->msw_rescale();
     }
 };
@@ -1580,6 +1596,9 @@ ExtruderGroup::ExtruderGroup(wxWindow * parent, int index, wxString const &title
     if (index >= 0) label_diameter->SetMinSize({FromDIP(80), -1});
     auto combo_diameter = new ComboBox(this, wxID_ANY, wxString(""), wxDefaultPosition, wxDefaultSize, 0, nullptr, wxCB_READONLY);
     combo_diameter->GetDropDown().SetUseContentWidth(true);
+    // BBS: small min width so the two nozzle frames can shrink to share the sidebar evenly;
+    // the combo still expands to fill when there is room.
+    if (index >= 0) combo_diameter->SetMinSize({FromDIP(56), -1});
     this->combo_diameter = combo_diameter;
     wxStaticText *label_flow = new wxStaticText(this, wxID_ANY, _L("Flow"));
     label_flow->SetFont(Label::Body_14);
@@ -1587,6 +1606,7 @@ ExtruderGroup::ExtruderGroup(wxWindow * parent, int index, wxString const &title
     if (index >= 0) label_flow->SetMinSize({FromDIP(80), -1});
     auto combo_flow = new ComboBox(this, wxID_ANY, wxString(""), wxDefaultPosition, wxDefaultSize, 0, nullptr, wxCB_READONLY);
     combo_flow->GetDropDown().SetUseContentWidth(true);
+    if (index >= 0) combo_flow->SetMinSize({FromDIP(56), -1});
     combo_flow->Bind(wxEVT_COMBOBOX, [this, index, combo_flow](wxCommandEvent &evt) {
         auto printer_tab = dynamic_cast<TabPrinter *>(wxGetApp().get_tab(Preset::TYPE_PRINTER));
         NozzleVolumeType volume_type = NozzleVolumeType(intptr_t(combo_flow->GetClientData(evt.GetInt())));
@@ -1634,11 +1654,15 @@ ExtruderGroup::ExtruderGroup(wxWindow * parent, int index, wxString const &title
     ams_not_installed_msg->SetForegroundColour("#262E30");
 
     // AMS group
-    for (size_t i = 0; i < 4; ++i) {
+    for (size_t i = 0; i < MAX_AMS_PREVIEW; ++i) {
         AMSinfo info;
         info.ams_type = DevAmsType::AMS;
         ams[i] = new AMSPreview(this, wxID_ANY, info);
         ams[i]->Close();
+        ams[i]->Bind(wxEVT_LEFT_DOWN, [this, i](wxMouseEvent &e) {
+            e.Skip();
+            on_ams_clicked(i);
+        });
     }
 
     hsizer_ams = new wxBoxSizer(wxHORIZONTAL);
@@ -1691,6 +1715,22 @@ ExtruderGroup::ExtruderGroup(wxWindow * parent, int index, wxString const &title
         this->sizer = vsizer;
     }
     AMSCountPopupWindow::UpdateAMSCount(index < 0 ? 0 : index, this);
+
+    // BBS: recompute how many AMS fit as the frame width changes, so a wider sidebar shows
+    // more AMS and a narrower one pages them (keeping the two nozzle frames equal width).
+    if (index >= 0) {
+        Bind(wxEVT_SIZE, [this](wxSizeEvent &e) {
+            e.Skip();
+            // Re-pack the AMS row when the panel width changes (based on the stable PARENT panel
+            // width, not this frame's own size, to avoid a layout feedback loop).
+            wxWindow *panel = GetParent();
+            const int panelW = panel ? panel->GetClientSize().x : GetClientSize().x;
+            if (panelW != last_panel_w) {
+                last_panel_w = panelW;
+                update_ams();
+            }
+        });
+    }
 }
 
 void ExtruderGroup::SetEditEnabled(bool enable)
@@ -1749,27 +1789,93 @@ void ExtruderGroup::update_ams()
     if (btn_edit == nullptr)
         return;
 
-    page_num  = (ams_n4 * 2 + ams_n1 + 3) / 4;
-    size_t i4 = page_cur * 2;
-    size_t i1 = 0;
-    if (i4 > ams_n4) {
-        i1 = (i4 - ams_n4) * 2;
-        i4 = ams_n4;
-    }
+    // BBS: pack AMS into the available width by their real pixel widths (4-slot = 52, 1-slot = 28,
+    // each plus a 1px gap). This makes the displayed count track the panel width smoothly and the
+    // paging button appear only when an AMS genuinely doesn't fit.
+    const int w4 = FromDIP(52) + FromDIP(1);
+    const int w1 = FromDIP(28) + FromDIP(1);
 
-    size_t left  = 4;
+    // Flat list of AMS to show (4-slot first, then 1-slot), each with its width.
+    struct Entry { AMSinfo info; int width; };
+    std::vector<Entry> all;
+    all.reserve(ams_n4 + ams_n1);
+    for (size_t i = 0; i < ams_n4; ++i) all.push_back({i < ams_4.size() ? ams_4[i] : info4, w4});
+    for (size_t i = 0; i < ams_n1; ++i) all.push_back({i < ams_1.size() ? ams_1[i] : info1, w1});
+
+    // The AMS row gets ~half the panel, minus the "AMS" label and margins.
+    wxWindow *panel = GetParent();
+    const int panelW    = panel ? panel->GetClientSize().x : GetClientSize().x;
+    const int avail_full = std::max(w1, panelW / 2 - FromDIP(8) - FromDIP(50));
+
+    auto pack = [&](int av) {
+        std::vector<size_t> starts;
+        size_t i = 0;
+        while (i < all.size()) {
+            starts.push_back(i);
+            int used = 0; size_t cnt = 0;
+            while (i < all.size() && cnt < MAX_AMS_PREVIEW && (used == 0 || used + all[i].width <= av)) {
+                used += all[i].width; ++i; ++cnt;
+            }
+        }
+        if (starts.empty()) starts.push_back(0);
+        return starts;
+    };
+
+    // Two-pass: pack without the paging button; if it needs more than one page, re-pack with
+    // room reserved for the button so it doesn't overlap the AMS.
+    std::vector<size_t> page_start = pack(avail_full);
+    if (page_start.size() > 1)
+        page_start = pack(std::max(w1, avail_full - FromDIP(22)));
+
+    page_num = page_start.size();
+    if (page_cur >= page_num) page_cur = page_num - 1;
+
+    // BBS: AMS unit display name from its id ("AMS A", "AMS HT-A").
+    auto ams_name = [](const std::string &id) -> wxString {
+        int aid = -1;
+        try { aid = std::stoi(id); } catch (...) {}
+        if (aid >= 128) return wxString::Format("AMS HT-%c", (char) ('A' + (aid - 128)));
+        if (aid >= 0)   return wxString::Format("AMS %c", (char) ('A' + aid));
+        return _L("AMS");
+    };
+
+    const size_t start = page_start[page_cur];
+    const size_t end   = (page_cur + 1 < page_num) ? page_start[page_cur + 1] : all.size();
     size_t index = 0;
-    for (size_t i = i4; i < ams_n4 && left > 0; ++i, ++index, left -= 2) {
-        ams[index]->Update(i < ams_4.size() ? ams_4[i] : info4);
+    for (size_t k = start; k < end && index < MAX_AMS_PREVIEW; ++k, ++index) {
+        const AMSinfo &nfo = all[k].info;
+        ams_shown[index]   = nfo; // remember which AMS this preview shows, for click highlighting
+        ams[index]->Update(nfo);
         ams[index]->Refresh();
         ams[index]->Open();
+
+        // BBS: tooltip with the AMS name and each loaded slot's filament + colour name, one per line.
+        FilamentColorCodeQuery *color_query = wxGetApp().get_filament_color_code_query();
+        wxString tip = ams_name(nfo.ams_id);
+        for (const auto &can : nfo.cans) {
+            if (can.filament_id.empty() && can.material_name.IsEmpty())
+                continue; // empty slot
+
+            // Prefer the real Bambu roll colour name (e.g. "Sunflower Yellow"); fall back to the
+            // nearest readable colour name when the filament isn't in the Bambu colour database.
+            std::vector<wxString> hexes;
+            if (!can.material_cols.empty())
+                for (const auto &c : can.material_cols) hexes.push_back(c.GetAsString(wxC2S_HTML_SYNTAX));
+            else
+                hexes.push_back(can.material_colour.GetAsString(wxC2S_HTML_SYNTAX));
+
+            wxString color_name;
+            if (color_query && !can.filament_id.empty())
+                color_name = color_query->GetFilaColorName(can.filament_id, hexes, can.ctype);
+            if (color_name.IsEmpty())
+                color_name = get_color_display_name(can.material_colour.GetAsString(wxC2S_HTML_SYNTAX));
+
+            const wxString line = can.material_name.IsEmpty() ? color_name : (can.material_name + "  " + color_name);
+            tip += "\n" + line;
+        }
+        ams[index]->SetToolTip(tip);
     }
-    for (size_t i = i1; i < ams_n1 && left > 0; ++i, ++index, --left) {
-        ams[index]->Update(i < ams_1.size() ? ams_1[i] : info1);
-        ams[index]->Refresh();
-        ams[index]->Open();
-    }
-    for (; index < 4; ++index)
+    for (; index < MAX_AMS_PREVIEW; ++index)
         ams[index]->Close();
 
     ams_not_installed_msg->Show(ams_n4 == 0 && ams_n1 == 0);
@@ -1783,7 +1889,7 @@ void ExtruderGroup::update_ams()
         hsizer_ams->Add(ams_not_installed_msg, 0, wxALIGN_CENTER);
         hsizer_ams->AddStretchSpacer(1);
     }
-    for (size_t i = 0; i < 4; ++i) {
+    for (size_t i = 0; i < MAX_AMS_PREVIEW; ++i) {
         if (ams[i]->IsShown())
             hsizer_ams->Add(this->ams[i], 0, wxLEFT, FromDIP(1));
     }
@@ -1804,6 +1910,60 @@ void ExtruderGroup::update_ams()
     }
 
     sizer->Layout();
+}
+
+void ExtruderGroup::on_ams_clicked(size_t slot)
+{
+    if (slot >= MAX_AMS_PREVIEW || ams[slot] == nullptr || !ams[slot]->IsShown())
+        return;
+
+    // Only meaningful when the printer info is currently synced; otherwise the AMS list is stale
+    // and would highlight filaments that don't match the actual AMS setup.
+    Plater *plater = wxGetApp().plater();
+    if (plater == nullptr || !plater->get_machine_sync_status())
+        return;
+
+    const AMSinfo &nfo = ams_shown[slot];
+
+    // The clicked AMS's tray names ("A1".."A4" for a 4-slot AMS, "HT-A" for an HT), derived from
+    // its ams_id exactly as Sidebar::build_filament_ams_list does.
+    int aid = -1;
+    try { aid = std::stoi(nfo.ams_id); } catch (...) { return; }
+    std::set<wxString> ams_trays;
+    if (aid >= 0 && aid < 26) {
+        const char letter = (char) ('A' + aid);
+        for (int s = 1; s <= 4; ++s) ams_trays.insert(wxString::Format("%c%d", letter, s));
+    } else if (aid >= 128 && aid < 153) {
+        ams_trays.insert(wxString::Format("HT-%c", (char) ('A' + (aid - 128))));
+    } else {
+        return;
+    }
+
+    // Authoritative 1:1 mapping of each project filament -> its AMS tray. Using this (rather than
+    // loose colour matching) means a slot can't match several same-coloured filaments and
+    // filaments from other AMS units aren't caught.
+    const std::vector<wxString> locations = build_filament_ams_locations();
+
+    auto &combos = plater->sidebar().combos_filament();
+    // Clear any highlight from a previous AMS click so only this AMS's filaments stay lit.
+    for (auto *c : combos)
+        if (c) c->ClearHighlight();
+    std::vector<PlaterPresetComboBox*> matched;
+    for (size_t i = 0; i < locations.size() && i < combos.size(); ++i) {
+        auto *c = combos[i];
+        if (c == nullptr || !ams_trays.count(locations[i]))
+            continue;
+        // Only highlight filaments actually synced from an AMS (same flag as the sync badge);
+        // a filament whose preset wasn't synced shouldn't light up just because its colour matches.
+        if (c->GetFlag(c->GetSelection()) != (int) PresetComboBox::FilamentAMSType::FROM_AMS)
+            continue;
+        c->FlashHighlight();
+        matched.push_back(c);
+    }
+
+    // Scroll the filament area so all matched filaments are visible if they were off-screen.
+    if (!matched.empty())
+        plater->sidebar().ensure_filament_combos_visible(matched);
 }
 
 void ExtruderGroup::sync_ams(MachineObject const *obj, std::vector<DevAms *> const &ams4, std::vector<DevAms *> const &ams1)
@@ -2277,6 +2437,7 @@ void Sidebar::priv::update_sync_status(const MachineObject *obj)
             right_extruder->ShowBadge(false);
             right_extruder->sync_ams(obj, {}, {});
         }
+
     }
 
     StateColor synced_colour(std::pair<wxColour, int>(wxColour("#CECECE"), StateColor::Normal));
@@ -5001,6 +5162,52 @@ void Sidebar::udpate_combos_filament_badge() {
         c->ShowBadge(ok);
     }
 
+}
+
+void Sidebar::ensure_filament_combos_visible(const std::vector<PlaterPresetComboBox*>& combos)
+{
+    wxScrolledWindow* sw = p->m_physical_scroll_area;
+    if (sw == nullptr || combos.empty())
+        return;
+
+    int ppuX = 0, ppuY = 0;
+    sw->GetScrollPixelsPerUnit(&ppuX, &ppuY);
+    if (ppuY <= 0)
+        return; // not vertically scrollable (all filaments already fit)
+
+    const int sw_screen_y = sw->GetScreenPosition().y;
+    const int client      = sw->GetClientSize().y;
+    const int cur_py      = sw->GetViewStart().y * ppuY;
+
+    // Bounding vertical range of all target combos, relative to the visible viewport (screen
+    // coords handle the intermediate panels/sizers the combos are nested in).
+    int top = INT_MAX, bottom = INT_MIN;
+    for (auto* c : combos) {
+        if (c == nullptr)
+            continue;
+        const int rel = c->GetScreenPosition().y - sw_screen_y;
+        top    = std::min(top, rel);
+        bottom = std::max(bottom, rel + c->GetSize().y);
+    }
+    if (top == INT_MAX)
+        return;
+
+    int new_py = cur_py;
+    if (bottom - top <= client) {
+        // The whole matched range fits: show both ends, preferring to align the top.
+        if (top < 0)
+            new_py = cur_py + top;                     // bring the top match into view
+        else if (bottom > client)
+            new_py = cur_py + (bottom - client);       // bring the bottom match into view
+    } else {
+        // Too tall to fit: align the topmost match.
+        new_py = cur_py + top;
+    }
+    if (new_py < 0)
+        new_py = 0;
+
+    if (new_py != cur_py)
+        sw->Scroll(-1, new_py / ppuY);
 }
 
 // ---- Mixed Filament sidebar methods ----

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -261,6 +261,8 @@ public:
     std::vector<PlaterPresetComboBox*>&   combos_filament();
     void                                 clear_combos_filament_badge();
     void                                 udpate_combos_filament_badge();
+    // BBS: scroll the physical-filament area so the given filament combos are all visible.
+    void                                 ensure_filament_combos_visible(const std::vector<PlaterPresetComboBox*>& combos);
 
     // Mixed Filament sidebar
     void add_mixed_filament();

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -947,6 +947,49 @@ PlaterPresetComboBox::~PlaterPresetComboBox()
     // BBS.
     if (clr_picker)
         clr_picker->Destroy();
+
+    if (m_highlight_timer) {
+        m_highlight_timer->Stop();
+        delete m_highlight_timer;
+        m_highlight_timer = nullptr;
+    }
+}
+
+// BBS: briefly outline this combo (e.g. when its matching AMS preview is clicked).
+void PlaterPresetComboBox::FlashHighlight()
+{
+    if (!m_highlighting) {
+        m_highlight_saved_border   = border_color;
+        m_highlight_saved_border_w = border_width;
+        m_highlighting             = true;
+    }
+    border_color.setColorForStates(wxColour(0x00, 0xAE, 0x42), 0); // Bambu green outline
+    if (border_width < 2)
+        border_width = 2;
+    Refresh();
+
+    if (m_highlight_timer == nullptr) {
+        m_highlight_timer = new wxTimer();
+        m_highlight_timer->Bind(wxEVT_TIMER, [this](wxTimerEvent &) {
+            border_color   = m_highlight_saved_border;
+            border_width   = m_highlight_saved_border_w;
+            m_highlighting = false;
+            Refresh();
+        });
+    }
+    m_highlight_timer->StartOnce(1500);
+}
+
+void PlaterPresetComboBox::ClearHighlight()
+{
+    if (!m_highlighting)
+        return;
+    if (m_highlight_timer)
+        m_highlight_timer->Stop();
+    border_color   = m_highlight_saved_border;
+    border_width   = m_highlight_saved_border_w;
+    m_highlighting = false;
+    Refresh();
 }
 
 static void run_wizard(ConfigWizard::StartPage sp)

--- a/src/slic3r/GUI/PresetComboBoxes.hpp
+++ b/src/slic3r/GUI/PresetComboBoxes.hpp
@@ -213,9 +213,20 @@ public:
     void sync_colour_config(const std::vector<std::string> &clrs, bool is_gradient);
     void sys_color_changed() override;
 
+    // BBS: briefly outline this combo to draw attention (e.g. clicked the matching AMS).
+    void FlashHighlight();
+    // BBS: immediately cancel any active highlight and restore the normal border.
+    void ClearHighlight();
+
 private:
     // BBS
     wxColor m_color;
+
+    // BBS: transient highlight state for FlashHighlight()
+    wxTimer*   m_highlight_timer{nullptr};
+    StateColor m_highlight_saved_border;
+    int        m_highlight_saved_border_w{1};
+    bool       m_highlighting{false};
 };
 
 

--- a/src/slic3r/GUI/Widgets/ComboBox.cpp
+++ b/src/slic3r/GUI/Widgets/ComboBox.cpp
@@ -287,6 +287,12 @@ void ComboBox::SetItemTooltip(unsigned int n, wxString const &value) {
     if (n == drop.GetSelection()) drop.SetToolTip(value);
 }
 
+void ComboBox::SetItemRightText(unsigned int n, wxString const &value) {
+    if (n >= items.size()) return;
+    items[n].text_right = value;
+    drop.Invalidate();
+}
+
 wxBitmap ComboBox::GetItemBitmap(unsigned int n) { return items[n].icon; }
 
 void ComboBox::SetItemBitmap(unsigned int n, wxBitmap const &bitmap)

--- a/src/slic3r/GUI/Widgets/ComboBox.hpp
+++ b/src/slic3r/GUI/Widgets/ComboBox.hpp
@@ -75,6 +75,8 @@ public:
     wxString GetItemTooltip(unsigned int n) const;
     void     SetItemTooltip(unsigned int n, wxString const &value);
 
+    void     SetItemRightText(unsigned int n, wxString const &value);
+
     wxString GetItemAlias(unsigned int n) const;
     void     SetItemAlias(unsigned int n, wxString const &value);
 

--- a/src/slic3r/GUI/Widgets/DropDown.cpp
+++ b/src/slic3r/GUI/Widgets/DropDown.cpp
@@ -394,13 +394,20 @@ void DropDown::render(wxDC &dc)
         auto text = group.IsEmpty()
                         ? (item.group.IsEmpty() ? item.text : item.group)
                         : (item.text.StartsWith(group) && !group.EndsWith(' ') ? item.text.substr(group.size()).Trim(false) : item.text);
+        // optional right-aligned text (e.g. a nozzle side label) reserved at the row's right edge
+        int right_text_w = 0;
+        if (!text_off && !item.text_right.IsEmpty()) {
+            dc.SetFont(GetFont());
+            right_text_w = dc.GetTextExtent(item.text_right).x;
+        }
         if (!text_off && !text.IsEmpty()) {
             wxSize tSize = dc.GetMultiLineTextExtent(text);
-            if (pt.x + tSize.x > rcContent.GetRight()) {
+            const int avail_right = rcContent.GetRight() - (right_text_w > 0 ? right_text_w + 8 : 0);
+            if (pt.x + tSize.x > avail_right) {
                 if (is_hover && item.tip.IsEmpty())
                     SetToolTip(text);
                 text = wxControl::Ellipsize(text, dc, wxELLIPSIZE_END,
-                                            rcContent.GetRight() - pt.x);
+                                            avail_right - pt.x);
             }
             pt.y += (rcContent.height - textSize.y) / 2;
             dc.SetFont(GetFont());
@@ -412,6 +419,14 @@ void DropDown::render(wxDC &dc)
                 pt.y = rcContent.y + (rcContent.height - szBmp.y) / 2;
                 dc.DrawBitmap(arrow_bitmap.bmp(), pt);
             }
+        }
+        if (right_text_w > 0) {
+            wxPoint rpt;
+            rpt.x = rcContent.GetRight() - right_text_w - 5;
+            rpt.y = rcContent.y + (rcContent.height - textSize.y) / 2;
+            dc.SetFont(GetFont());
+            dc.SetTextForeground(is_dimmed ? wxColour(0xCE, 0xCE, 0xCE) : text_color.colorForStates(states2));
+            dc.DrawText(item.text_right, rpt);
         }
         rcContent.y += rowSize.y;
     }
@@ -509,6 +524,8 @@ void DropDown::messureSize()
             size1 = dc.GetMultiLineTextExtent(text);
             if (group.IsEmpty() && !item.group.IsEmpty())
                 size1.x += 5 + arrow_bitmap.GetBmpWidth();
+            if (!item.text_right.IsEmpty())
+                size1.x += dc.GetTextExtent(item.text_right).x + 8;
         }
         if (item.icon.IsOk()) {
             wxSize size2 = GetBmpSize(item.icon);

--- a/src/slic3r/GUI/Widgets/DropDown.hpp
+++ b/src/slic3r/GUI/Widgets/DropDown.hpp
@@ -30,6 +30,7 @@ public:
         wxString group{};
         wxString alias{};
         wxString tip{};
+        wxString text_right{};// optional text drawn right-aligned at the row's right edge
         int      flag{0};
         int      style{ 0 };// the style of item
     };


### PR DESCRIPTION
## Summary

Improves the **Left/Right Nozzle AMS preview** in the sidebar (a follow-up to #11221, which this stacks on top of).

- **Equal-width nozzle frames** — both nozzle frames now resize symmetrically; works around a macOS `wxStaticBoxSizer` minimum-width quirk that made one side collapse earlier than the other.
- **Width-aware AMS paging** — AMS icons are packed by their real pixel widths and the overflow is paged, so the visible count grows/shrinks smoothly with the panel width and the paging button only appears when an AMS genuinely doesn't fit. Per-nozzle capacity raised to 24 previews (covers 4 AMS/AMS2-Pro + 8 AMS-HT).
- **AMS tooltips** — hovering an AMS shows its name and each loaded slot's filament with the readable Bambu colour name (via `FilamentColorCodeQuery`), falling back to the nearest colour name.
- **Click-to-highlight** — clicking an AMS preview highlights the matching project filament(s) and scrolls the filament list so they're all visible. Matching uses the authoritative 1:1 tray assignment (not loose colour matching) and is gated on the synced `FROM_AMS` flag, so unsynced filaments and same-coloured filaments from other AMS units aren't caught.

## Notes

- **Stacked on #11221.** Until that PR merges, this PR's diff also shows its single commit; GitHub will trim it automatically once #11221 lands. The new work is in the three commits starting with `Expose colour-name and AMS-tray-location helpers`.
- Scope is GUI-only (`Plater`, `PresetComboBoxes`, `ExtraRenderers`); no build-system or unrelated changes.

## Testing

Built and run on macOS (arm64) against a connected H2C: synced AMS, verified equal frames, paging while resizing the sidebar, colour-name tooltips, and click-to-highlight + scroll for AMS/AMS2-Pro and AMS-HT units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
