### PR TITLE
feat(gui): add dark mode theme selector (Light / Dark / Follow system)

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -265,7 +265,7 @@ void AppConfig::set_defaults()
 
 #ifdef SUPPORT_DARK_MODE
     if (get("dark_color_mode").empty())
-        set("dark_color_mode", "0");
+        set("dark_color_mode", "2");
 #endif
 
 //#ifdef SUPPORT_SYS_MENU

--- a/src/slic3r/GUI/DeviceWeb/ViewModels/FilamentManager/FilamentManagerVM.cpp
+++ b/src/slic3r/GUI/DeviceWeb/ViewModels/FilamentManager/FilamentManagerVM.cpp
@@ -195,7 +195,7 @@ void FilamentManagerVM::ReportState(const std::string& submod, const std::string
 
 nlohmann::json FilamentManagerVM::HandleInit(const std::string& action, const nlohmann::json& /*payload*/)
 {
-    bool dark = wxGetApp().app_config->get("dark_color_mode") == "1";
+    bool dark = wxGetApp().dark_mode();
     nlohmann::json data;
     data["theme"]   = dark ? "dark" : "light";
     data["spools"]  = build_spool_list();
@@ -662,7 +662,7 @@ nlohmann::json FilamentManagerVM::HandleColors(const std::string& action, const 
 void FilamentManagerVM::OnSysColorChanged()
 {
     if (!m_bridge) return;
-    bool dark = wxGetApp().app_config->get("dark_color_mode") == "1";
+    bool dark = wxGetApp().dark_mode();
     nlohmann::json data;
     data["theme"] = dark ? "dark" : "light";
     m_bridge->ReportMsg(MakeResp("init", "theme_changed", 0, "", data));

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -1647,7 +1647,7 @@ bool GLCanvas3D::init()
         return false;
 
     // init dark mode status
-    on_change_color_mode(wxGetApp().app_config->get("dark_color_mode") == "1", false);
+    on_change_color_mode(wxGetApp().dark_mode(), false);
 
     BOOST_LOG_TRIVIAL(info) <<__FUNCTION__<< " enter";
     glsafe(::glClearColor(1.0f, 1.0f, 1.0f, 1.0f));

--- a/src/slic3r/GUI/GLTexture.cpp
+++ b/src/slic3r/GUI/GLTexture.cpp
@@ -263,7 +263,7 @@ bool GLTexture::load_from_svg_files_as_sprites_array(const std::vector<std::stri
     if (filenames.empty() || states.empty() || sprite_size_px == 0)
         return false;
 
-    bool dark_mode = wxGetApp().app_config->get("dark_color_mode") == "1";
+    bool dark_mode = wxGetApp().dark_mode();
 
     // every tile needs to have a 1px border around it to avoid artifacts when linear sampling on its edges
     unsigned int sprite_size_px_ex = sprite_size_px + 1;

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3122,26 +3122,18 @@ bool GUI_App::on_init_inner()
     load_language(wxString(), true);
 #ifdef _MSW_DARK_MODE
 
-    // One-time migration to the Light/Dark/Follow-system selector. Before it existed,
-    // dark_mode() followed the OS appearance whenever dark_color_mode was not "1". Run this
-    // after the config has been loaded so it sees the user's real dark_color_mode (and an
-    // absent dark_mode_follow_system), and only an explicit "Dark" opts out of following the OS.
-    if (app_config->get("dark_mode_follow_system").empty())
-        app_config->set("dark_mode_follow_system", app_config->get("dark_color_mode") == "1" ? "0" : "1");
-
+#ifndef __WINDOWS__
     {
-        wxSystemAppearance app = wxSystemSettings::GetAppearance();
-#ifdef __WINDOWS__
-        if (app_config->get("dark_mode_follow_system") == "1") {
-            app_config->set("dark_color_mode", app.IsDark() ? "1" : "0");
-            app_config->save();
-        }
-#else
-        GUI::wxGetApp().app_config->set("dark_color_mode", app.IsDark() ? "1" : "0");
-        GUI::wxGetApp().app_config->save();
-#endif
-    }
+        wxSystemAppearance app =
+            wxSystemSettings::GetAppearance();
 
+        app_config->set(
+            "dark_color_mode",
+            app.IsDark() ? "1" : "0"
+        );
+        app_config->save();
+    }
+#endif // !__WINDOWS__
 
     bool init_dark_color_mode = dark_mode();
     bool init_sys_menu_enabled = app_config->get("sys_menu_enabled") == "1";
@@ -3778,10 +3770,17 @@ bool GUI_App::dark_mode()
     // is detected as dark mode. We must run on at least 10.14 where the
     // proper dark mode was first introduced.
     return wxPlatformInfo::Get().CheckOSVersion(10, 14) && mac_dark_mode();
+#elif defined(__WINDOWS__)
+    const std::string color_mode =
+        wxGetApp().app_config->get("dark_color_mode");
+
+    return color_mode == "2" ?
+        check_dark_mode() :
+        color_mode == "1";
 #else
-    if (wxGetApp().app_config->get("dark_mode_follow_system") == "1")
-        return check_dark_mode();
-    return wxGetApp().app_config->get("dark_color_mode") == "1";
+    return wxGetApp().app_config->get("dark_color_mode") == "1" ?
+        true :
+        check_dark_mode();
     //const unsigned luma = get_colour_approx_luma(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
     //return luma < 128;
 #endif

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3122,11 +3122,25 @@ bool GUI_App::on_init_inner()
     load_language(wxString(), true);
 #ifdef _MSW_DARK_MODE
 
-#ifndef __WINDOWS__
-    wxSystemAppearance app = wxSystemSettings::GetAppearance();
-    GUI::wxGetApp().app_config->set("dark_color_mode", app.IsDark() ? "1" : "0");
-    GUI::wxGetApp().app_config->save();
-#endif // __APPLE__
+    // One-time migration to the Light/Dark/Follow-system selector. Before it existed,
+    // dark_mode() followed the OS appearance whenever dark_color_mode was not "1". Run this
+    // after the config has been loaded so it sees the user's real dark_color_mode (and an
+    // absent dark_mode_follow_system), and only an explicit "Dark" opts out of following the OS.
+    if (app_config->get("dark_mode_follow_system").empty())
+        app_config->set("dark_mode_follow_system", app_config->get("dark_color_mode") == "1" ? "0" : "1");
+
+    {
+        wxSystemAppearance app = wxSystemSettings::GetAppearance();
+#ifdef __WINDOWS__
+        if (app_config->get("dark_mode_follow_system") == "1") {
+            app_config->set("dark_color_mode", app.IsDark() ? "1" : "0");
+            app_config->save();
+        }
+#else
+        GUI::wxGetApp().app_config->set("dark_color_mode", app.IsDark() ? "1" : "0");
+        GUI::wxGetApp().app_config->save();
+#endif
+    }
 
 
     bool init_dark_color_mode = dark_mode();
@@ -3765,7 +3779,9 @@ bool GUI_App::dark_mode()
     // proper dark mode was first introduced.
     return wxPlatformInfo::Get().CheckOSVersion(10, 14) && mac_dark_mode();
 #else
-    return wxGetApp().app_config->get("dark_color_mode") == "1" ? true : check_dark_mode();
+    if (wxGetApp().app_config->get("dark_mode_follow_system") == "1")
+        return check_dark_mode();
+    return wxGetApp().app_config->get("dark_color_mode") == "1";
     //const unsigned luma = get_colour_approx_luma(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
     //return luma < 128;
 #endif

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3019,11 +3019,25 @@ bool GUI_App::on_init_inner()
     load_language(wxString(), true);
 #ifdef _MSW_DARK_MODE
 
-#ifndef __WINDOWS__
-    wxSystemAppearance app = wxSystemSettings::GetAppearance();
-    GUI::wxGetApp().app_config->set("dark_color_mode", app.IsDark() ? "1" : "0");
-    GUI::wxGetApp().app_config->save();
-#endif // __APPLE__
+    // One-time migration to the Light/Dark/Follow-system selector. Before it existed,
+    // dark_mode() followed the OS appearance whenever dark_color_mode was not "1". Run this
+    // after the config has been loaded so it sees the user's real dark_color_mode (and an
+    // absent dark_mode_follow_system), and only an explicit "Dark" opts out of following the OS.
+    if (app_config->get("dark_mode_follow_system").empty())
+        app_config->set("dark_mode_follow_system", app_config->get("dark_color_mode") == "1" ? "0" : "1");
+
+    {
+        wxSystemAppearance app = wxSystemSettings::GetAppearance();
+#ifdef __WINDOWS__
+        if (app_config->get("dark_mode_follow_system") == "1") {
+            app_config->set("dark_color_mode", app.IsDark() ? "1" : "0");
+            app_config->save();
+        }
+#else
+        GUI::wxGetApp().app_config->set("dark_color_mode", app.IsDark() ? "1" : "0");
+        GUI::wxGetApp().app_config->save();
+#endif
+    }
 
 
     bool init_dark_color_mode = dark_mode();
@@ -3649,7 +3663,9 @@ bool GUI_App::dark_mode()
     // proper dark mode was first introduced.
     return wxPlatformInfo::Get().CheckOSVersion(10, 14) && mac_dark_mode();
 #else
-    return wxGetApp().app_config->get("dark_color_mode") == "1" ? true : check_dark_mode();
+    if (wxGetApp().app_config->get("dark_mode_follow_system") == "1")
+        return check_dark_mode();
+    return wxGetApp().app_config->get("dark_color_mode") == "1";
     //const unsigned luma = get_colour_approx_luma(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
     //return luma < 128;
 #endif

--- a/src/slic3r/GUI/GUI_Utils.cpp
+++ b/src/slic3r/GUI/GUI_Utils.cpp
@@ -279,6 +279,14 @@ void update_dark_ui(wxWindow* window)
 }
 #endif
 
+#ifdef _WIN32
+bool should_follow_system_theme()
+{
+    return wxGetApp().app_config &&
+           wxGetApp().app_config->get("dark_color_mode") == "2";
+}
+#endif
+
 void update_dark_config()
 {
 #ifdef __WINDOWS__

--- a/src/slic3r/GUI/GUI_Utils.cpp
+++ b/src/slic3r/GUI/GUI_Utils.cpp
@@ -237,15 +237,26 @@ wxFont get_default_font_for_dpi(const wxWindow *window, int dpi)
 }
 
 bool check_dark_mode() {
-#if 0 //#ifdef _WIN32  // #ysDarkMSW - Allow it when we deside to support the sustem colors for application
-    wxRegKey rk(wxRegKey::HKCU,
-        "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize");
-    if (rk.Exists() && rk.HasValue("AppsUseLightTheme")) {
+#ifdef _WIN32
+    wxRegKey rk(
+        wxRegKey::HKCU,
+        "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"
+    );
+
+    if (
+        rk.Exists() &&
+        rk.HasValue("AppsUseLightTheme")
+    ) {
         long value = -1;
-        rk.QueryValue("AppsUseLightTheme", &value);
+
+        rk.QueryValue(
+            "AppsUseLightTheme",
+            &value
+        );
+
         return value <= 0;
     }
-#endif
+#endif // _WIN32
 #if wxCHECK_VERSION(3,1,3)
     return wxSystemSettings::GetAppearance().IsDark();
 #else
@@ -259,7 +270,7 @@ bool check_dark_mode() {
 void update_dark_ui(wxWindow* window)
 {
 #ifdef SUPPORT_DARK_MODE
-    bool is_dark = wxGetApp().app_config->get("dark_color_mode") == "1";
+    bool is_dark = wxGetApp().dark_mode();
 #else
     bool is_dark = false;
 #endif
@@ -270,10 +281,21 @@ void update_dark_ui(wxWindow* window)
 
 void update_dark_config()
 {
-    wxSystemAppearance app = wxSystemSettings::GetAppearance();
-    GUI::wxGetApp().app_config->set("dark_color_mode", app.IsDark() ? "1" : "0");
+#ifdef __WINDOWS__
+    // Keep dark_color_mode == "2" while refreshing the
+    // effective system appearance.
+    wxGetApp().Update_dark_mode_flag();
+#else
+    wxSystemAppearance app =
+        wxSystemSettings::GetAppearance();
+
+    GUI::wxGetApp().app_config->set(
+        "dark_color_mode",
+        app.IsDark() ? "1" : "0"
+    );
     GUI::wxGetApp().app_config->save();
     wxGetApp().Update_dark_mode_flag();
+#endif // __WINDOWS__
 }
 
 

--- a/src/slic3r/GUI/GUI_Utils.hpp
+++ b/src/slic3r/GUI/GUI_Utils.hpp
@@ -201,16 +201,10 @@ public:
 
         this->Bind(wxEVT_SYS_COLOUR_CHANGED, [this](wxSysColourChangedEvent& event)
         {
-#ifdef __WINDOWS__
-            if (GUI::wxGetApp().app_config &&
-                GUI::wxGetApp().app_config->get("dark_mode_follow_system") == "1") {
-                update_dark_config();
-                on_sys_color_changed();
-            }
-#else
+#ifndef __WINDOWS__
             update_dark_config();
             on_sys_color_changed();
-#endif
+#endif // !__WINDOWS__
             event.Skip();
         });
 
@@ -330,16 +324,29 @@ private:
         m_prev_scale_factor = m_scale_factor;
     }
 
-#if 0 //#ifdef _WIN32  // #ysDarkMSW - Allow it when we deside to support the sustem colors for application
-    bool HandleSettingChange(WXWPARAM wParam, WXLPARAM lParam) override
+#ifdef _WIN32
+    bool HandleSettingChange(
+        WXWPARAM wParam,
+        WXLPARAM lParam
+    ) override
     {
-        update_dark_ui(this);
-        on_sys_color_changed();
+        const bool handled =
+            P::HandleSettingChange(wParam, lParam);
 
-        // let the system handle it
-        return false;
+        if (
+            GUI::wxGetApp().app_config &&
+            GUI::wxGetApp().app_config->get(
+                "dark_color_mode"
+            ) == "2"
+        ) {
+            update_dark_config();
+            update_dark_ui(this);
+            on_sys_color_changed();
+        }
+
+        return handled;
     }
-#endif
+#endif // _WIN32
 
 };
 

--- a/src/slic3r/GUI/GUI_Utils.hpp
+++ b/src/slic3r/GUI/GUI_Utils.hpp
@@ -97,6 +97,7 @@ bool check_dark_mode();
 void update_dark_config();
 #ifdef _WIN32
 void update_dark_ui(wxWindow* window);
+bool should_follow_system_theme();
 #endif
 
 #if !wxVERSION_EQUAL_OR_GREATER_THAN(3,1,3)
@@ -333,12 +334,7 @@ private:
         const bool handled =
             P::HandleSettingChange(wParam, lParam);
 
-        if (
-            GUI::wxGetApp().app_config &&
-            GUI::wxGetApp().app_config->get(
-                "dark_color_mode"
-            ) == "2"
-        ) {
+        if (should_follow_system_theme()) {
             update_dark_config();
             update_dark_ui(this);
             on_sys_color_changed();

--- a/src/slic3r/GUI/GUI_Utils.hpp
+++ b/src/slic3r/GUI/GUI_Utils.hpp
@@ -201,12 +201,17 @@ public:
 
         this->Bind(wxEVT_SYS_COLOUR_CHANGED, [this](wxSysColourChangedEvent& event)
         {
-#ifndef __WINDOWS__
+#ifdef __WINDOWS__
+            if (GUI::wxGetApp().app_config &&
+                GUI::wxGetApp().app_config->get("dark_mode_follow_system") == "1") {
                 update_dark_config();
                 on_sys_color_changed();
-                event.Skip();
-#endif // __WINDOWS__
-
+            }
+#else
+            update_dark_config();
+            on_sys_color_changed();
+#endif
+            event.Skip();
         });
 
         if (std::is_same<wxDialog, P>::value) {

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2670,10 +2670,8 @@ void MainFrame::on_sys_color_changed()
     // update label colors in respect to the system mode
     wxGetApp().init_label_colours();
 
-#ifndef __WINDOWS__
     wxGetApp().force_colors_update();
     wxGetApp().update_ui_from_settings();
-#endif //__APPLE__
 
 #ifdef __WXMSW__
     wxGetApp().UpdateDarkUI(m_tabpanel);

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2614,10 +2614,8 @@ void MainFrame::on_sys_color_changed()
     // update label colors in respect to the system mode
     wxGetApp().init_label_colours();
 
-#ifndef __WINDOWS__
     wxGetApp().force_colors_update();
     wxGetApp().update_ui_from_settings();
-#endif //__APPLE__
 
 #ifdef __WXMSW__
     wxGetApp().UpdateDarkUI(m_tabpanel);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -7134,7 +7134,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
     //BBS :partplatelist construction
     , partplate_list(this->q, &model)
 {
-    m_is_dark = wxGetApp().app_config->get_bool("dark_color_mode");
+    m_is_dark = wxGetApp().dark_mode();
     m_aui_mgr.SetManagedWindow(q);
     m_aui_mgr.SetDockSizeConstraint(1, 1);
     // m_aui_mgr.GetArtProvider()->SetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE, 0);
@@ -15553,7 +15553,7 @@ void Plater::priv::on_apple_change_color_mode(wxSysColourChangedEvent& evt) {
 }
 
 void Plater::priv::on_change_color_mode(SimpleEvent& evt) {
-    m_is_dark = wxGetApp().app_config->get("dark_color_mode") == "1";
+    m_is_dark = wxGetApp().dark_mode();
     sidebar->on_change_color_mode(m_is_dark);
     view3D->get_canvas3d()->on_change_color_mode(m_is_dark);
     preview->get_canvas3d()->on_change_color_mode(m_is_dark);

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -746,33 +746,46 @@ wxBoxSizer *PreferencesDialog::create_item_switch(wxString title, wxWindow *pare
     return m_sizer_switch;
 }
 
-wxBoxSizer* PreferencesDialog::create_item_darkmode_checkbox(wxString title, wxWindow* parent, wxString tooltip, int padding_left, std::string param)
+wxBoxSizer* PreferencesDialog::create_item_darkmode_combobox(wxString title, wxWindow* parent, wxString tooltip, int padding_left)
 {
-    wxBoxSizer* m_sizer_checkbox = new wxBoxSizer(wxHORIZONTAL);
+    // A single read-only combobox replacing the former dark-mode checkbox, letting the
+    // user pick Light / Dark / Follow system. "Follow system" makes dark_mode() track the
+    // OS appearance; the two underlying config keys are driven from here.
+    std::vector<wxString> label_list = { _L("Light"), _L("Dark"), _L("Follow system") };
 
-    m_sizer_checkbox->Add(0, 0, 0, wxEXPAND | wxLEFT, 23);
+    wxBoxSizer* m_sizer_combox = new wxBoxSizer(wxHORIZONTAL);
+    m_sizer_combox->Add(0, 0, 0, wxEXPAND | wxLEFT, 23);
 
-    auto checkbox = new ::CheckBox(parent);
-    m_checkbox_list[m_checkbox_list.size()] = checkbox;
-    checkbox->SetValue((app_config->get(param) == "1") ? true : false);
-    m_dark_mode_ckeckbox = checkbox;
+    auto combo_title = new wxStaticText(parent, wxID_ANY, title, wxDefaultPosition, DESIGN_TITLE_SIZE, 0);
+    combo_title->SetForegroundColour(DESIGN_GRAY900_COLOR);
+    combo_title->SetFont(::Label::Body_13);
+    combo_title->SetToolTip(tooltip);
+    combo_title->Wrap(-1);
+    m_sizer_combox->Add(combo_title, 0, wxALIGN_CENTER | wxALL, 3);
 
-    m_sizer_checkbox->Add(checkbox, 0, wxALIGN_CENTER, 0);
-    m_sizer_checkbox->Add(0, 0, 0, wxEXPAND | wxLEFT, 8);
+    auto combobox = new ::ComboBox(parent, wxID_ANY, wxEmptyString, wxDefaultPosition, DESIGN_LARGE_COMBOBOX_SIZE, 0, nullptr, wxCB_READONLY);
+    m_combobox_list[m_combobox_list.size()] = combobox;
+    combobox->SetFont(::Label::Body_13);
+    combobox->GetDropDown().SetFont(::Label::Body_13);
+    for (auto& label : label_list)
+        combobox->Append(label);
 
-    auto checkbox_title = new wxStaticText(parent, wxID_ANY, title, wxDefaultPosition, wxDefaultSize, 0);
-    checkbox_title->SetForegroundColour(DESIGN_GRAY900_COLOR);
-    checkbox_title->SetFont(::Label::Body_13);
+    // Initial selection: Follow system > Dark > Light.
+    int sel = 0;
+    if (app_config->get("dark_mode_follow_system") == "1")
+        sel = 2;
+    else if (app_config->get("dark_color_mode") == "1")
+        sel = 1;
+    combobox->SetSelection(sel);
 
-    auto size = checkbox_title->GetTextExtent(title);
-    checkbox_title->SetMinSize(wxSize(size.x + FromDIP(40), -1));
-    checkbox_title->Wrap(-1);
-    m_sizer_checkbox->Add(checkbox_title, 0, wxALIGN_CENTER | wxALL, 3);
-
+    m_sizer_combox->Add(combobox, 0, wxALIGN_CENTER, 0);
 
     //// save config
-    checkbox->Bind(wxEVT_TOGGLEBUTTON, [this, checkbox, param](wxCommandEvent& e) {
-        app_config->set(param, checkbox->GetValue() ? "1" : "0");
+    combobox->GetDropDown().Bind(wxEVT_COMBOBOX, [this](wxCommandEvent& e) {
+        int idx = e.GetSelection();
+        app_config->set("dark_mode_follow_system", idx == 2 ? "1" : "0");
+        if (idx != 2)  // Light/Dark set the colour explicitly; Follow system lets the OS decide.
+            app_config->set("dark_color_mode", idx == 1 ? "1" : "0");
         app_config->save();
         wxGetApp().Update_dark_mode_flag();
 
@@ -787,8 +800,8 @@ wxBoxSizer* PreferencesDialog::create_item_darkmode_checkbox(wxString title, wxW
         e.Skip();
         });
 
-    checkbox->SetToolTip(tooltip);
-    return m_sizer_checkbox;
+    combobox->SetToolTip(tooltip);
+    return m_sizer_combox;
 }
 
 void PreferencesDialog::set_dark_mode()
@@ -1459,7 +1472,7 @@ wxWindow* PreferencesDialog::create_general_page()
     //dark mode
 #ifdef _WIN32
     auto title_darkmode = create_item_title(_L("Dark Mode"), page, _L("Dark Mode"));
-    auto item_darkmode = create_item_darkmode_checkbox(_L("Enable dark mode"), page,_L("Enable dark mode"), 50, "dark_color_mode");
+    auto item_darkmode = create_item_darkmode_combobox(_L("Dark mode"), page, _L("Choose the interface theme: light, dark, or follow the system setting."), 50);
 #endif
 
 #if 0

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -797,13 +797,14 @@ wxBoxSizer *PreferencesDialog::create_item_darkmode_combobox(
     for (const wxString &label : labels)
         combobox->Append(label);
 
-    // Initial selection priority: Follow system, Dark, Light.
-    if (app_config->get("dark_mode_follow_system") == "1")
-        combobox->SetSelection(2);
-    else if (app_config->get("dark_color_mode") == "1")
-        combobox->SetSelection(1);
-    else
-        combobox->SetSelection(0);
+    const std::string color_mode =
+        app_config->get("dark_color_mode");
+
+    combobox->SetSelection(
+        color_mode == "2" ? 2 :
+        color_mode == "1" ? 1 :
+        0
+    );
 
     sizer->Add(
         combobox,
@@ -818,16 +819,9 @@ wxBoxSizer *PreferencesDialog::create_item_darkmode_combobox(
             const int selection = event.GetSelection();
 
             app_config->set(
-                "dark_mode_follow_system",
-                selection == 2 ? "1" : "0"
+                "dark_color_mode",
+                std::to_string(selection)
             );
-
-            if (selection != 2) {
-                app_config->set(
-                    "dark_color_mode",
-                    selection == 1 ? "1" : "0"
-                );
-            }
 
             app_config->save();
             wxGetApp().Update_dark_mode_flag();
@@ -1435,7 +1429,7 @@ wxWindow *PreferencesDialog::create_general_tab()
     auto                  item_currency = create_item_combobox(_L("Units"), scrolled, _L("Units"), "use_inches", Units, {"0", "1"});
 
 #ifdef _WIN32
-    auto item_darkmode = create_item_darkmode_combobox(_L("Dark mode"), scrolled, _L("Choose the interface theme: light, dark, or follow the system setting."));
+    auto item_darkmode = create_item_darkmode_combobox(_L("Theme"), scrolled, _L("Choose the interface theme: light, dark, or follow the system setting."));
 #endif
 
     std::vector<wxString>    FlushOptionLabels = {_L("All"), _L("Color change"), _L("Disabled")};

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -744,47 +744,115 @@ wxBoxSizer *PreferencesDialog::create_item_switch(wxString title, wxWindow *pare
     return m_sizer_switch;
 }
 
-wxBoxSizer* PreferencesDialog::create_item_darkmode_checkbox(wxString title, wxWindow* parent, wxString tooltip, int padding_left, std::string param)
+wxBoxSizer *PreferencesDialog::create_item_darkmode_combobox(
+    wxString title, wxWindow *parent, wxString tooltip)
 {
-    wxBoxSizer* m_sizer_checkbox = new wxBoxSizer(wxHORIZONTAL);
-    m_sizer_checkbox->SetMinSize(wxSize(-1, FromDIP(ITEM_MIN_HEIGHT)));
+    const std::vector<wxString> labels = {
+        _L("Light"),
+        _L("Dark"),
+        _L("Follow system")
+    };
 
-    auto checkbox = new ::CheckBox(parent);
-    m_checkbox_list[m_checkbox_list.size()] = checkbox;
-    checkbox->SetValue((app_config->get(param) == "1") ? true : false);
-    m_dark_mode_ckeckbox = checkbox;
+    auto *sizer = new wxBoxSizer(wxHORIZONTAL);
+    sizer->AddSpacer(FromDIP(ITEM_LEFT_PADDING));
+    sizer->SetMinSize(wxSize(-1, FromDIP(ITEM_MIN_HEIGHT)));
 
-    auto checkbox_title = new wxStaticText(parent, wxID_ANY, title, wxDefaultPosition, wxDefaultSize, 0);
-    checkbox_title->SetForegroundColour(ThemeColor::TextPrimary);
-    checkbox_title->SetFont(::Label::Body_13);
+    auto *combo_title = new wxStaticText(
+        parent,
+        wxID_ANY,
+        title,
+        wxDefaultPosition,
+        wxSize(FromDIP(TITLE_WIDTH), -1),
+        0
+    );
 
-    auto size = checkbox_title->GetTextExtent(title);
-    checkbox_title->SetMinSize(wxSize(size.x + FromDIP(40), -1));
-    checkbox_title->Wrap(-1);
+    combo_title->SetForegroundColour(ThemeColor::TextPrimary);
+    combo_title->SetFont(::Label::Body_13);
+    combo_title->SetToolTip(tooltip);
+    combo_title->Wrap(-1);
 
-    m_sizer_checkbox->AddSpacer(FromDIP(ITEM_LEFT_PADDING));
-    m_sizer_checkbox->Add(checkbox_title, wxSizerFlags().CenterVertical().Proportion(1));
-    m_sizer_checkbox->Add(checkbox, wxSizerFlags().CenterVertical().Border(wxRIGHT, FromDIP(ITEM_RIGHT_PADDING)));
+    sizer->Add(
+        combo_title,
+        wxSizerFlags()
+            .CenterVertical()
+            .Proportion(1)
+    );
 
-    //// save config
-    checkbox->Bind(wxEVT_TOGGLEBUTTON, [this, checkbox, param](wxCommandEvent& e) {
-        app_config->set(param, checkbox->GetValue() ? "1" : "0");
-        app_config->save();
-        wxGetApp().Update_dark_mode_flag();
+    auto *combobox = new ::ComboBox(
+        parent,
+        wxID_ANY,
+        wxEmptyString,
+        wxDefaultPosition,
+        wxSize(FromDIP(LARGE_COMBOBOX_WIDTH), -1),
+        0,
+        nullptr,
+        wxCB_READONLY
+    );
 
-        //dark mode
+    m_combobox_list[m_combobox_list.size()] = combobox;
+
+    combobox->SetFont(::Label::Body_13);
+    combobox->GetDropDown().SetFont(::Label::Body_13);
+
+    for (const wxString &label : labels)
+        combobox->Append(label);
+
+    // Initial selection priority: Follow system, Dark, Light.
+    if (app_config->get("dark_mode_follow_system") == "1")
+        combobox->SetSelection(2);
+    else if (app_config->get("dark_color_mode") == "1")
+        combobox->SetSelection(1);
+    else
+        combobox->SetSelection(0);
+
+    sizer->Add(
+        combobox,
+        wxSizerFlags()
+            .CenterVertical()
+            .Border(wxRIGHT, FromDIP(ITEM_RIGHT_PADDING))
+    );
+
+    combobox->GetDropDown().Bind(
+        wxEVT_COMBOBOX,
+        [this](wxCommandEvent &event) {
+            const int selection = event.GetSelection();
+
+            app_config->set(
+                "dark_mode_follow_system",
+                selection == 2 ? "1" : "0"
+            );
+
+            if (selection != 2) {
+                app_config->set(
+                    "dark_color_mode",
+                    selection == 1 ? "1" : "0"
+                );
+            }
+
+            app_config->save();
+            wxGetApp().Update_dark_mode_flag();
+
 #ifdef _MSW_DARK_MODE
-        wxGetApp().force_colors_update();
-        wxGetApp().update_ui_from_settings();
-        set_dark_mode();
+            wxGetApp().force_colors_update();
+            wxGetApp().update_ui_from_settings();
+            set_dark_mode();
 #endif
-        SimpleEvent evt = SimpleEvent(EVT_GLCANVAS_COLOR_MODE_CHANGED);
-        wxPostEvent(wxGetApp().plater(), evt);
-        e.Skip();
-        });
 
-    checkbox->SetToolTip(tooltip);
-    return m_sizer_checkbox;
+            SimpleEvent canvas_event(
+                EVT_GLCANVAS_COLOR_MODE_CHANGED
+            );
+            wxPostEvent(
+                wxGetApp().plater(),
+                canvas_event
+            );
+
+            event.Skip();
+        }
+    );
+
+    combobox->SetToolTip(tooltip);
+
+    return sizer;
 }
 
 void PreferencesDialog::set_dark_mode()
@@ -1367,7 +1435,7 @@ wxWindow *PreferencesDialog::create_general_tab()
     auto                  item_currency = create_item_combobox(_L("Units"), scrolled, _L("Units"), "use_inches", Units, {"0", "1"});
 
 #ifdef _WIN32
-    auto item_darkmode = create_item_darkmode_checkbox(_L("Enable dark mode"), scrolled, _L("Enable dark mode"), 50, "dark_color_mode");
+    auto item_darkmode = create_item_darkmode_combobox(_L("Dark mode"), scrolled, _L("Choose the interface theme: light, dark, or follow the system setting."));
 #endif
 
     std::vector<wxString>    FlushOptionLabels = {_L("All"), _L("Color change"), _L("Disabled")};

--- a/src/slic3r/GUI/Preferences.hpp
+++ b/src/slic3r/GUI/Preferences.hpp
@@ -95,7 +95,6 @@ public:
     // debug mode
     ::CheckBox * m_developer_mode_ckeckbox   = {nullptr};
     ::CheckBox * m_internal_developer_mode_ckeckbox = {nullptr};
-    ::CheckBox * m_dark_mode_ckeckbox        = {nullptr};
     ::TextInput *m_backup_interval_textinput = {nullptr};
 
     wxString m_developer_mode_def;
@@ -113,7 +112,7 @@ public:
     wxBoxSizer *create_item_language_combobox(wxString title, wxWindow *parent, wxString tooltip, int padding_left, std::string param, std::vector<const wxLanguageInfo *> vlist);
     wxBoxSizer *create_item_loglevel_combobox(wxString title, wxWindow *parent, wxString tooltip, std::vector<wxString> vlist);
     wxBoxSizer *create_item_checkbox(wxString title, wxWindow *parent, wxString tooltip, int padding_left, std::string param);
-    wxBoxSizer *create_item_darkmode_checkbox(wxString title, wxWindow *parent, wxString tooltip, int padding_left, std::string param);
+    wxBoxSizer *create_item_darkmode_combobox(wxString title, wxWindow *parent, wxString tooltip, int padding_left);
     void set_dark_mode();
     wxBoxSizer *create_item_button(wxString title, wxString title2, wxWindow *parent, wxString tooltip, std::function<void()> onclick);
     wxWindow* create_item_downloads(wxWindow* parent, int padding_left, std::string param);

--- a/src/slic3r/GUI/Preferences.hpp
+++ b/src/slic3r/GUI/Preferences.hpp
@@ -80,7 +80,6 @@ public:
     // debug mode
     ::CheckBox * m_developer_mode_ckeckbox   = {nullptr};
     ::CheckBox * m_internal_developer_mode_ckeckbox = {nullptr};
-    ::CheckBox * m_dark_mode_ckeckbox        = {nullptr};
 
     wxString m_developer_mode_def;
     wxString m_internal_developer_mode_def;
@@ -96,7 +95,7 @@ public:
     wxBoxSizer *create_item_language_combobox(wxString title, wxWindow *parent, wxString tooltip, int padding_left, std::string param, std::vector<const wxLanguageInfo *> vlist);
     wxBoxSizer *create_item_loglevel_combobox(wxString title, wxWindow *parent, wxString tooltip, std::vector<wxString> vlist);
     wxBoxSizer *create_item_checkbox(wxString title, wxWindow *parent, wxString tooltip, int padding_left, std::string param);
-    wxBoxSizer *create_item_darkmode_checkbox(wxString title, wxWindow *parent, wxString tooltip, int padding_left, std::string param);
+    wxBoxSizer *create_item_darkmode_combobox(wxString title, wxWindow *parent, wxString tooltip);
     void        set_dark_mode();
     wxWindow* create_item_downloads(wxWindow* parent, int padding_left, std::string param);
     wxBoxSizer *create_item_input(wxString title, wxString title2, wxWindow *parent, wxString tooltip, std::string param, std::function<void(wxString)> onchange = {});

--- a/src/slic3r/GUI/PrivacyUpdateDialog.cpp
+++ b/src/slic3r/GUI/PrivacyUpdateDialog.cpp
@@ -168,7 +168,7 @@ void PrivacyUpdateDialog::RunScript(std::string script)
 {
     WebView::RunScript(m_vebview_release_note, script);
     std::string switch_dark_mode_script = "SwitchDarkMode(";
-    switch_dark_mode_script += wxGetApp().app_config->get("dark_color_mode") == "1" ? "true" : "false";
+    switch_dark_mode_script += wxGetApp().dark_mode() ? "true" : "false";
     switch_dark_mode_script += ");";
     WebView::RunScript(m_vebview_release_note, switch_dark_mode_script);
     script.clear();

--- a/src/slic3r/GUI/fila_manager/wgtFilaManagerPanel.cpp
+++ b/src/slic3r/GUI/fila_manager/wgtFilaManagerPanel.cpp
@@ -102,7 +102,7 @@ void wgtFilaManagerPanel::msw_rescale() {}
 void wgtFilaManagerPanel::on_sys_color_changed()
 {
     if (m_bridge_ready) {
-        bool dark = wxGetApp().app_config->get("dark_color_mode") == "1";
+        bool dark = wxGetApp().dark_mode();
         push_to_web("theme_changed", {{"theme", dark ? "dark" : "light"}});
     }
 }
@@ -224,7 +224,7 @@ void wgtFilaManagerPanel::register_handlers()
     m_handlers["init"] = [this](int seq, const nlohmann::json& /*data*/) {
         if (!m_bridge_ready) m_bridge_ready = true;
 
-        bool dark = wxGetApp().app_config->get("dark_color_mode") == "1";
+        bool dark = wxGetApp().dark_mode();
         nlohmann::json result;
         result["theme"]   = dark ? "dark" : "light";
         result["spools"]  = build_spool_list();


### PR DESCRIPTION
## Summary

Adds a Windows theme selector with:

- Light
- Dark
- Follow system

The preference is stored exclusively in `dark_color_mode`:

- `0` = Light
- `1` = Dark
- `2` = Follow system

New Windows installations default to **Follow system**. Existing explicit Light or Dark preferences remain unchanged.

Windows 11 theme changes are handled through the native `WM_SETTINGCHANGE` path. The effective Windows application theme is read from `AppsUseLightTheme` under:

`HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize`

All UI consumers use `GUI_App::dark_mode()` so Follow system is interpreted consistently.

The Preferences row is labelled **Theme**.

## Test plan

- Confirm a new configuration selects Follow system by default.
- Select Light and restart Bambu Studio.
- Select Dark and restart Bambu Studio.
- Select Follow system and restart Bambu Studio.
- While Follow system is selected, switch Windows 11 between Light and Dark.
- Confirm Bambu Studio updates without restarting.
- Confirm `dark_color_mode` remains `2` in Follow system mode.
