### PR TITLE
fix(gui): correct layer-range editor text contrast in dark mode

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectLayers.cpp
+++ b/src/slic3r/GUI/GUI_ObjectLayers.cpp
@@ -351,6 +351,10 @@ LayerRangeEditor::LayerRangeEditor( ObjectLayers* parent,
 {
     this->SetFont(wxGetApp().normal_font());
     wxGetApp().UpdateDarkUI(this);
+    if (wxGetApp().dark_mode()) {
+        SetBackgroundColour(wxGetApp().get_window_default_clr());
+        SetForegroundColour(wxGetApp().get_label_clr_default());
+    }
 
     // Reset m_enter_pressed flag to _false_, when value is editing
     this->Bind(wxEVT_TEXT, [this](wxEvent&) { m_enter_pressed = false; }, this->GetId());


### PR DESCRIPTION
Split out from #10818 (which the review asked to break into separate PRs).

## Summary
The height-range layer editor kept default (light) background/foreground colours in dark mode, making its text hard to read. This applies the dark window/label colours when dark mode is active. 1 file.
