### PR TITLE
fix: correct filament vendor typo '3Dgunius' -> '3Dgenius' (#5752)

### DIFF
--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -38,7 +38,7 @@ namespace GUI {
 
 static const std::vector<std::string> filament_vendors = {"Polymaker", "OVERTURE", "Kexcelled", "HATCHBOX",  "eSUN",       "SUNLU",    "Prusament", "Creality", "Protopasta",
                                                           "Anycubic",  "Basf",     "ELEGOO",    "INLAND",    "FLASHFORGE", "FusRock", "AMOLEN",   "MIKA3D",    "3DXTECH",
-                                                          "Duramic", "Priline",   "Eryone",   "3Dgunius",  "Novamaker", "Justmaker",  "Giantarm", "iProspect", "LDO"};
+                                                          "Duramic", "Priline",   "Eryone",   "3Dgenius",  "Novamaker", "Justmaker",  "Giantarm", "iProspect", "LDO"};
 
 static const std::vector<std::string> filament_types = {"PLA",    "PLA+",  "PLA Tough", "PETG",  "ABS",    "ASA",    "FLEX",        "HIPS",   "PA",     "PACF",
                                                         "NYLON",  "PVA",   "PC",        "PCABS", "PCTG",   "PCCF",   "PP",          "PEI",    "PET",    "PETG",


### PR DESCRIPTION
## Summary
The custom-filament vendor list in `CreatePresetsDialog` listed the brand **3Dgenius** misspelled as **3Dgunius**. This corrects the spelling.

Single-character source fix in the selectable vendor list; existing user presets store their own vendor string and are unaffected.

Fixes #5752
