### PR TITLE
fix: restore custom bed texture after undo/redo (#11211)

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -16935,6 +16935,12 @@ void Plater::priv::update_after_undo_redo(const UndoRedo::Snapshot& snapshot, bo
 
     wxGetApp().obj_list()->update_after_undo_redo();
 
+    // #11211: the custom bed (logo) texture is not part of the undo snapshot, so it is lost
+    // when the plates are rebuilt on deserialize. Re-apply it from the (undo-independent)
+    // config. set_bed_shape() only re-sets the logo filename when the bed shape itself is
+    // unchanged, so this is cheap in the common case.
+    q->set_bed_shape();
+
     if (wxGetApp().get_mode() == comSimple && model_has_advanced_features(this->model)) {
         // If the user jumped to a snapshot that require user interface with advanced features, switch to the advanced mode without asking.
         // There is a little risk of surprising the user, as he already must have had the advanced or advanced mode active for such a snapshot to be taken.


### PR DESCRIPTION
## Summary
The custom bed (logo) texture disappears after an undo (#11211).

**Root cause:** the plate logo texture filename (`PartPlate::m_logo_texture_filename`) is not part of the undo snapshot, `PartPlateList::serialize` does not include it and the per-plate `serialize` is commented out, so when the plates are rebuilt on deserialize the texture filename is lost. `update_after_undo_redo()` never re-applies it.

**Fix:** re-apply the bed texture from the config (which is *not* part of the model undo stack and therefore survives the undo) in `update_after_undo_redo()` via `set_bed_shape()`. Its internal guard only re-sets the logo texture filename when the bed shape is unchanged (the common case for a model-level undo), so this is cheap and does not rebuild the bed geometry.

> ⚠️ I can't build/run locally, so this is **untested at runtime**, the reasoning is from the code path. A quick check (load a custom bed texture, add/copy an object, undo → texture should remain) would be appreciated.

Fixes #11211

