### PR TITLE
fix: settings search jumps to per-extruder/filament options (#11200)

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3924,9 +3924,15 @@ void Sidebar::search()
     p->searcher.search();
 }
 
-void Sidebar::jump_to_option(const std::string& opt_key, Preset::Type type, const std::wstring& category)
+void Sidebar::jump_to_option(const std::string& opt_key_with_idx, Preset::Type type, const std::wstring& category)
 {
     //const Search::Option& opt = p->searcher.get_option(opt_key, type);
+    // The settings search keys vector options with a "#<variant>" suffix (e.g.
+    // "filament_xxx#0"), but the option groups are keyed by the bare option key, so
+    // strip the suffix before locating/activating the option, otherwise the jump
+    // silently fails for per-extruder/filament settings (#11200). substr(0, npos)
+    // returns the whole string when there is no '#', so bare keys are unaffected.
+    const std::string opt_key = opt_key_with_idx.substr(0, opt_key_with_idx.find('#'));
     if (type == Preset::TYPE_PRINT) {
         auto tab = dynamic_cast<TabPrintModel*>(wxGetApp().params_panel()->get_current_tab());
         if (tab && tab->has_key(opt_key)) {


### PR DESCRIPTION
## Summary
Clicking a settings-search suggestion for a per-extruder/filament (vector) option does nothing, the setting is never shown (#11200).

**Root cause:** the searcher keys vector options with a `#<variant>` suffix (e.g. `filament_xxx#0`), and `Search::Option::opt_key()` keeps that suffix. But `Tab::activate_option` matches against the **bare** option key (`o.opt.opt_key == opt_key`), so the suffixed key never matches and the option/page is not activated. Scalar options (no `#` suffix) jump fine, which is why only some results "aren't there".

**Fix:** strip the `#<variant>` suffix in `Sidebar::jump_to_option` before locating/activating the option. `substr(0, find('#'))` returns the whole key when there is no `#`, so the many direct callers that pass bare keys are unaffected.

> ⚠️ Untested at runtime (I can't build locally), reasoning is from the code path. A quick check (search e.g. "filament" in the process settings search, click a result → it should now scroll to that setting) would be appreciated.

Fixes #11200

