### PR TITLE
fix: correct spelling typos in user-facing strings

### DIFF
--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -163,7 +163,7 @@ void ConfigManipulation::check_filament_scarf_setting(DynamicPrintConfig *config
 
     }
     if (post_warning) {
-        const wxString msg_text = _(L("Should not large than 100%.\nReset to defualt"));
+        const wxString msg_text = _(L("Should not large than 100%.\nReset to default"));
         MessageDialog  dialog(nullptr, msg_text, "", wxICON_WARNING | wxOK);
         is_msg_dlg_already_exist = true;
         dialog.ShowModal();

--- a/src/slic3r/GUI/Jobs/PlaterWorker.hpp
+++ b/src/slic3r/GUI/Jobs/PlaterWorker.hpp
@@ -90,7 +90,7 @@ class PlaterWorker: public Worker {
             if (eptr) try {
                 std::rethrow_exception(eptr);
             }  catch (std::exception &e) {
-                show_error(m_plater, _L("An unexpected error occured") + ": " + e.what());
+                show_error(m_plater, _L("An unexpected error occurred") + ": " + e.what());
                 eptr = nullptr;
             }
         }

--- a/src/slic3r/GUI/MediaPlayCtrl.cpp
+++ b/src/slic3r/GUI/MediaPlayCtrl.cpp
@@ -373,7 +373,7 @@ void MediaPlayCtrl::Play()
 
     if (m_lan_proto <= MachineObject::LVL_Disable && (m_lan_mode || !m_remote_proto)) {
         Stop(m_lan_proto == MachineObject::LVL_None
-            ? _L("Problem occured. Please update the printer firmware and try again.")
+            ? _L("Problem occurred. Please update the printer firmware and try again.")
             : _L("LAN Only Liveview is off. Please turn on the liveview on printer screen."));
         return;
     }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -1984,7 +1984,7 @@ bool Sidebar::priv::sync_extruder_list(bool &only_external_material, bool is_man
         if (obj->is_nozzle_flow_type_supported()) {
             if (obj->GetExtderSystem()->GetNozzleFlowType(index) == NozzleFlowType::NONE_FLOWTYPE) {
                 MessageDialog dlg(this->plater, _L("There are unset nozzle types. Please set the nozzle types of all extruders before synchronizing."),
-                                  _L("Sync extruder infomation"), wxICON_WARNING | wxOK);
+                                  _L("Sync extruder information"), wxICON_WARNING | wxOK);
                 dlg.ShowModal();
                 continue;
             }

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -7835,7 +7835,7 @@ void Tab::sync_excluder()
         }
     }
     if (config_to_apply.empty()) {
-        MessageDialog md(wxGetApp().plater(), _L("No modifications need to be copied."), _L("Copy paramters"), wxICON_INFORMATION | wxOK);
+        MessageDialog md(wxGetApp().plater(), _L("No modifications need to be copied."), _L("Copy parameters"), wxICON_INFORMATION | wxOK);
         md.ShowModal();
         return;
     }
@@ -7843,7 +7843,7 @@ void Tab::sync_excluder()
     std::string pt = m_preset_bundle->printers.get_edited_preset().get_printer_type(m_preset_bundle);
     std::string active_nozzle_name = DevPrinterConfigUtil::get_toolhead_display_name(pt, active_index, ToolHeadComponent::Nozzle, ToolHeadNameCase::LowerCase);
     std::string other_nozzle_name  = DevPrinterConfigUtil::get_toolhead_display_name(pt, 1 - active_index, ToolHeadComponent::Nozzle, ToolHeadNameCase::LowerCase);
-    wxString title  = wxString::Format(_L("Modify paramters of %s"), _L(active_nozzle_name));
+    wxString title  = wxString::Format(_L("Modify parameters of %s"), _L(active_nozzle_name));
     wxString header = wxString::Format(_L("Do you want to modify the following parameters of the %s to that of the %s?"),
                                        _L(active_nozzle_name), _L(other_nozzle_name));
     UnsavedChangesDialog dlg(title, header, &config_origin, from_index, dest_index, active_index == 0, active_nozzle);

--- a/src/slic3r/GUI/Widgets/AMSControl.cpp
+++ b/src/slic3r/GUI/Widgets/AMSControl.cpp
@@ -1816,7 +1816,7 @@ void AMSControl::on_filament_load(wxCommandEvent &event)
     const auto& filament_id = get_filament_id(m_current_ams, GetCurrentCan(m_current_ams));
     if (filament_id.empty())
     {
-        MessageDialog msg_dlg(nullptr, _L("Filament type is unknown which is required to perform this action. Please set target filament's informations."),
+        MessageDialog msg_dlg(nullptr, _L("Filament type is unknown which is required to perform this action. Please set target filament's information."),
                               wxEmptyString, wxICON_WARNING | wxOK);
         msg_dlg.ShowModal();
         return;

--- a/src/slic3r/Utils/Duet.cpp
+++ b/src/slic3r/Utils/Duet.cpp
@@ -85,7 +85,7 @@ bool Duet::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn e
 			int err_code = dsf ? (status == 201 ? 0 : 1) : get_err_code_from_body(body);
 			if (err_code != 0) {
 				BOOST_LOG_TRIVIAL(error) << boost::format("Duet: Request completed but error code was received: %1%") % err_code;
-				error_fn(format_error(body, L("Unknown error occured"), 0));
+				error_fn(format_error(body, L("Unknown error occurred"), 0));
 				res = false;
 			} else if (upload_data.post_action == PrintHostPostUploadAction::StartPrint) {
 				wxString errormsg;
@@ -154,7 +154,7 @@ Duet::ConnectionType Duet::connect(wxString &msg) const
 					msg = format_error(body, L("Could not get resources to create a new connection"), 0);
 					break;
 				default:
-					msg = format_error(body, L("Unknown error occured"), 0);
+					msg = format_error(body, L("Unknown error occurred"), 0);
 					break;
 			}
 

--- a/src/slic3r/Utils/FlashAir.cpp
+++ b/src/slic3r/Utils/FlashAir.cpp
@@ -119,7 +119,7 @@ bool FlashAir::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, Error
 			res = boost::icontains(body, "SUCCESS");
 			if (! res) {
 				BOOST_LOG_TRIVIAL(error) << boost::format("%1%: Request completed but no SUCCESS message was received.") % name;
-				error_fn(format_error(body, L("Unknown error occured"), 0));
+				error_fn(format_error(body, L("Unknown error occurred"), 0));
 			}
 		})
 		.perform_sync();
@@ -140,7 +140,7 @@ bool FlashAir::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, Error
             res = boost::icontains(body, "SUCCESS");
             if (! res) {
                 BOOST_LOG_TRIVIAL(error) << boost::format("%1%: Request completed but no SUCCESS message was received.") % name;
-                error_fn(format_error(body, L("Unknown error occured"), 0));
+                error_fn(format_error(body, L("Unknown error occurred"), 0));
             }
         })
         .perform_sync();
@@ -156,7 +156,7 @@ bool FlashAir::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, Error
 			res = boost::icontains(body, "SUCCESS");
 			if (! res) {
 				BOOST_LOG_TRIVIAL(error) << boost::format("%1%: Request completed but no SUCCESS message was received.") % name;
-				error_fn(format_error(body, L("Unknown error occured"), 0));
+				error_fn(format_error(body, L("Unknown error occurred"), 0));
 			}
 		})
 		.on_error([&](std::string body, std::string error, unsigned status) {

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -1942,7 +1942,7 @@ void HelioBackgroundProcess::helio_threaded_process_start(std::mutex&           
                                                                                                     create_presigned_url_res.url);
 
             if (upload_file_res.success && !was_canceled()) {
-                status = Slic3r::PrintBase::SlicingStatus(10, _u8L("Helio: file succesfully uploaded"));
+                status = Slic3r::PrintBase::SlicingStatus(10, _u8L("Helio: file successfully uploaded"));
                 evt    = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
                 wxQueueEvent(GUI::wxGetApp().plater(), evt);
 

--- a/src/slic3r/Utils/MKS.cpp
+++ b/src/slic3r/Utils/MKS.cpp
@@ -82,7 +82,7 @@ bool MKS::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn er
 		int err_code = get_err_code_from_body(body);
 		if (err_code != 0) {
 			BOOST_LOG_TRIVIAL(error) << boost::format("MKS: Request completed but error code was received: %1%") % err_code;
-			error_fn(format_error(body, L("Unknown error occured"), 0));
+			error_fn(format_error(body, L("Unknown error occurred"), 0));
 			res = false;
 		}
 		else if (upload_data.post_action == PrintHostPostUploadAction::StartPrint) {


### PR DESCRIPTION
Corrects several spelling mistakes in translatable UI strings (`_L`/`_u8L`/`L`):

| Typo | Fixed | Location |
|---|---|---|
| `occured` | `occurred` | MKS/Duet/FlashAir upload errors, MediaPlayCtrl, PlaterWorker |
| `paramters` | `parameters` | Tab.cpp dialogs |
| `informations` | `information` | AMSControl |
| `infomation` | `information` | Plater extruder sync |
| `succesfully` | `successfully` | HelioDragon upload status |
| `defualt` | `default` | ConfigManipulation |

Only source strings are changed — no `.po`/`.pot` edits, so the translation pipeline can regenerate them. No functional changes.