### PR TITLE
fix(ui): expand option row height for wrapped multi-line labels

### DIFF
--- a/src/slic3r/GUI/OG_CustomCtrl.cpp
+++ b/src/slic3r/GUI/OG_CustomCtrl.cpp
@@ -101,13 +101,20 @@ void OG_CustomCtrl::init_ctrl_lines()
         else if (opt_group->label_width != 0 && (!line.label.IsEmpty() || option_set.front().opt.gui_type == ConfigOptionDef::GUIType::legend) )
         {
             wxSize label_sz = GetTextExtent(line.label);
-            if (opt_group->split_multi_line) {
-                if (option_set.size() > 1) // BBS
-                    height = (label_sz.y + m_v_gap2) * option_set.size() + m_v_gap - m_v_gap2;
-                else
-                    height = label_sz.y * (label_sz.GetWidth() > int(opt_group->label_width * m_em_unit) ? 2 : 1) + m_v_gap;
+            if (opt_group->split_multi_line && option_set.size() > 1) { // BBS
+                height = (label_sz.y + m_v_gap2) * option_set.size() + m_v_gap - m_v_gap2;
             } else {
-                height = label_sz.y * (label_sz.GetWidth() > int(opt_group->label_width * m_em_unit) ? 2 : 1) + m_v_gap;
+                // #11259: reserve the full height of the (possibly wrapped) label.
+                // The previous "(width > column ? 2 : 1)" heuristic assumed a label
+                // wraps to at most two lines, so longer labels (e.g. some translations)
+                // that wrap to three or more lines were drawn on top of the next option
+                // row. Measure the actually wrapped height using the same helper and
+                // width that CtrlLine::render uses to draw the label.
+                wxClientDC dc(this);
+                dc.SetFont(m_font);
+                wxString multiline_text;
+                const wxSize wrapped_sz = Label::split_lines(dc, int(opt_group->label_width * m_em_unit), line.label, multiline_text);
+                height = wrapped_sz.y + m_v_gap;
             }
             ctrl_lines.emplace_back(CtrlLine(height, this, line, false, opt_group->staticbox));
         }


### PR DESCRIPTION
### Problem

In the slicer settings panel, option **labels overlap each other** when a label is long enough to wrap across several lines. It is most visible in non‑English UIs (reported for pt‑BR in #11259): labels such as *"Altura inicial da camada"*, *"Subcamada de cor mista"*, *"Superfície superior"* or *"Preenchimento sólido interno"* are drawn on top of the following option row. It happens regardless of monitor resolution and at 100 % display scaling.

### Root cause

`OG_CustomCtrl::init_ctrl_lines()` reserves each row's height with a heuristic:

```cpp
height = label_sz.y * (label_sz.GetWidth() > int(opt_group->label_width * m_em_unit) ? 2 : 1) + m_v_gap;
```

This assumes a label wraps to **at most two lines**. `CtrlLine::render()`, however, wraps the label with `Label::split_lines(...)` (unlimited lines) and **vertically centers it inside the reserved `height`** (`v_pos + (height - label_size.y) / 2`). When a label wraps to **three or more lines**, `label_size.y > height`, the centering offset goes negative and the label overflows onto the neighbouring row.

### Fix

Reserve the *actual* wrapped height, measured with the **same helper and width** the renderer uses (`Label::split_lines` at `label_width * m_em_unit`), plus the existing vertical gap `m_v_gap`. Single‑line and two‑line rows are unchanged (their reserved height is identical to before); only labels that wrap to 3+ lines now get the room they are drawn in. The BBS multi‑option‑per‑line branch is left untouched.

### Note

I traced this statically against the render path and kept the change minimal; I could not visually verify a built binary here. A quick check with long/translated labels (e.g. pt‑BR) in a narrow settings column would be appreciated. The separate "print plate button clipped at the top‑right on small screens" symptom from #11259 is a horizontal‑space issue and is **not** addressed here.

Closes #11259
