### PR TITLE
fix: repair CI workflows independent of the Windows toolchain

### DIFF
--- a/.github/workflows/build_bambu.yml
+++ b/.github/workflows/build_bambu.yml
@@ -101,7 +101,7 @@ jobs:
           ./BuildMac.sh -s -x -a universal -t 10.15 -1
 
       - name: pack mac app
-        if: github.ref != 'refs/heads/main' && (inputs.os == 'macos-15-intel' || inputs.os == 'macos-15' || inputs.os == 'macos-26')
+        if: github.ref != 'refs/heads/master' && (inputs.os == 'macos-15-intel' || inputs.os == 'macos-15' || inputs.os == 'macos-26')
         working-directory: ${{ github.workspace }}
         run: zip -r BambuStudio_Mac_${{inputs.arch}}_${{ env.ver }}.zip ${{ github.workspace }}/build
 
@@ -115,7 +115,7 @@ jobs:
   # Windows
       - name: setup MSVC
         if: inputs.os == 'windows-latest'
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Install nsis and pkgconfig
         if: inputs.os == 'windows-latest'

--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: setup dev on Windows
         if: inputs.os == 'windows-latest'
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Get the date on Ubuntu and macOS
         if: inputs.os != 'windows-latest'
@@ -81,7 +81,7 @@ jobs:
         run: |
           find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
           sudo rm -rf /Library/Frameworks/Python.framework/
-          brew install --force python3 && brew unlink python3 && brew unlink python3 && brew link --overwrite python3
+          brew install --force python3 && brew unlink python3 && brew link --overwrite python3
       
       - name: Free disk space
         if: inputs.os == 'macos-15'

--- a/.github/workflows/winget_updater.yml
+++ b/.github/workflows/winget_updater.yml
@@ -6,7 +6,7 @@ jobs:
   publish:
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal9/winget-releaser@main
+      - uses: vedantmgoyal9/winget-releaser@v2
         with:
           identifier: Bambulab.BambuStudio
           version: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Summary

Split out from #10863 so these fixes can land independently of the Windows toolchain change.

#10863 is about pinning the Windows jobs to a working VS runner, and @MackBambu is now adding Visual Studio 2026 support upstream, so that part may get superseded/reworked. The changes here have nothing to do with the Windows runner and fix CI that's broken on its own - no reason to hold them behind the VS work.

- **build_ubuntu**: `ubuntu-20.04` → `ubuntu-22.04`. `ubuntu-20.04` was removed from GitHub-hosted runners in April 2025, so the Linux AppImage job fails immediately on the missing image. Artifact name bumped to match.
- **build_ubuntu**: `podman buildx build` → `podman build`. `podman` has no `buildx` subcommand, so the container AppImage step errors at runtime.
- **build_bambu**: mac-pack condition `refs/heads/main` → `refs/heads/master`. The repo default branch is `master`, so the `!=` comparison was always true and the Mac zip was packed on every push.
- **build_bambu, build_deps**: `microsoft/setup-msbuild@v2` → `@v3`. v2 runs on the deprecated Node.js 20.
- **build_deps**: drop the duplicated `brew unlink python3`.
- **winget_updater**: pin `vedantmgoyal9/winget-releaser@main` → `@v2` (floating `@main` → stable release).

## Test plan

- Pure runner/action/branch-name corrections, no build logic changed.
- The Windows-runner pin (`windows-latest` → a working VS image) is intentionally **not** here - it stays in #10863 pending @MackBambu's VS 2026 work.
