### PR TITLE
ci: build and attach native Linux packages (.deb / .rpm / Arch) to releases

### DIFF
--- a/.github/workflows/release_linux_packages.yml
+++ b/.github/workflows/release_linux_packages.yml
@@ -1,0 +1,96 @@
+name: Release Linux native packages
+
+# Builds native Linux packages by compiling BambuStudio from source in each
+# distribution's own container (so the binary links against that distro's system
+# libraries), then uploads the resulting .deb / .rpm / .pkg.tar.zst to the
+# release. This is the "proper" native package path (not an AppImage wrapper):
+# the GTK/GLib/X11/etc. libraries are declared as package dependencies and used
+# from the system rather than bundled. See issue #11321.
+#
+# Heavy job (full deps + slicer build per distro), so it only runs on release
+# publish or manual dispatch, with the dependency build cached between runs.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to attach packages to (e.g. v02.07.01.62)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 240
+    container:
+      image: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Debian .deb
+            image: debian:trixie
+            bootstrap: apt-get update -qq && apt-get install -y --no-install-recommends sudo git git-lfs curl ca-certificates xz-utils
+            package_script: scripts/build_deb.sh
+            glob: build/*.deb
+          - name: Fedora .rpm
+            image: fedora:42
+            bootstrap: dnf install -y sudo git git-lfs curl rpm-build xz
+            package_script: scripts/build_rpm.sh
+            glob: build/*.rpm
+          - name: Arch .pkg.tar.zst
+            image: archlinux:latest
+            bootstrap: pacman -Sy --noconfirm --needed sudo git git-lfs curl base-devel
+            package_script: scripts/build_pkg_arch.sh
+            glob: build/*.pkg.tar.zst
+    env:
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+    steps:
+      - name: Bootstrap container
+        run: |
+          ${{ matrix.bootstrap }}
+          git config --global --add safe.directory '*'
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
+
+      - name: Cache built dependencies
+        id: cache-deps
+        uses: actions/cache@v4
+        with:
+          path: deps/build/destdir
+          key: native-pkg-deps-${{ matrix.image }}-${{ hashFiles('deps/CMakeLists.txt', 'deps/**/*.cmake') }}
+
+      - name: Install build dependencies
+        run: ./BuildLinux.sh -u
+
+      - name: Build dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: ./BuildLinux.sh -d
+
+      - name: Build BambuStudio
+        run: |
+          export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
+          ./BuildLinux.sh -s
+          # Assemble build/package/ (binary + libs + resources) that the
+          # packaging scripts consume.
+          (cd build && ./src/BuildLinuxImage.sh -i)
+
+      - name: Build native package
+        run: bash ${{ matrix.package_script }}
+
+      - name: Upload package to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG }}
+          files: ${{ matrix.glob }}
+          fail_on_unmatched_files: true

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Build a .deb package from the already-compiled build/package/ directory.
+# Run after BuildLinux.sh -si (or -sif) has completed.
+set -e
+
+ROOT=$(dirname "$(readlink -f "$0")")/..
+
+BASE=$(grep 'set(SLIC3R_VERSION_BASE' "$ROOT/version.inc" | cut -d '"' -f2)
+if [ -z "$BASE" ]; then
+    echo "Error: could not read version from version.inc" >&2
+    exit 1
+fi
+COUNT=$(git -C "$ROOT" rev-list --count HEAD 2>/dev/null || echo "0")
+VERSION="${BASE}.${COUNT}"
+
+PKGNAME="bambustudio"
+ARCH="amd64"
+APPDIR="$ROOT/build/package"
+PKGDIR="$ROOT/build/${PKGNAME}_${VERSION}_${ARCH}"
+OUTFILE="$ROOT/build/${PKGNAME}_${VERSION}_${ARCH}.deb"
+
+if [ ! -f "$APPDIR/bin/bambu-studio" ]; then
+    echo "Error: build/package/bin/bambu-studio not found." >&2
+    echo "Run './BuildLinux.sh -si' first." >&2
+    exit 1
+fi
+
+echo "Building .deb for BambuStudio ${VERSION}..."
+rm -rf "$PKGDIR"
+
+# Directory structure
+mkdir -p "$PKGDIR/DEBIAN"
+mkdir -p "$PKGDIR/usr/bin"
+mkdir -p "$PKGDIR/usr/lib/$PKGNAME/bin"   # binary lives here so parent().parent() == /usr/lib/bambustudio
+mkdir -p "$PKGDIR/usr/share/applications"
+mkdir -p "$PKGDIR/usr/share/icons/hicolor/192x192/apps"
+mkdir -p "$PKGDIR/usr/share/icons/hicolor/128x128/apps"
+mkdir -p "$PKGDIR/usr/share/icons/hicolor/32x32/apps"
+
+# Binary goes into bin/ so the resource-path calculation
+# (parent_path().parent_path() / "resources") resolves to
+# /usr/lib/bambustudio/resources — matching where we install resources.
+cp "$APPDIR/bin/bambu-studio" "$PKGDIR/usr/lib/$PKGNAME/bin/"
+
+# Bundled app-specific libs — exclude GTK/GLib/X11/Wayland/DBus/udev
+# because those are system libraries declared in Depends; bundling them
+# causes LD_LIBRARY_PATH to override the system versions and crash on GTK init.
+find "$APPDIR/bin" -name "*.so*" \
+    ! -name "libgtk*"     ! -name "libgdk*"      ! -name "libgdk-pixbuf*" \
+    ! -name "libglib*"    ! -name "libgobject*"   ! -name "libgio*" \
+    ! -name "libgmodule*" ! -name "libgthread*"   ! -name "libgthread*" \
+    ! -name "libX*"       ! -name "libxcb*"       ! -name "libxkbcommon*" \
+    ! -name "libwayland*" \
+    ! -name "libdbus*"    ! -name "libudev*"      \
+    ! -name "libsecret*"  ! -name "libfontconfig*" \
+    ! -name "libfreetype*" ! -name "libpango*"    ! -name "libcairo*" \
+    ! -name "libatk*"     ! -name "libharfbuzz*"  \
+    -exec cp {} "$PKGDIR/usr/lib/$PKGNAME/" \;
+
+# App resources (alongside the bin/ directory, not inside it)
+cp -r "$APPDIR/resources" "$PKGDIR/usr/lib/$PKGNAME/"
+
+# Launcher wrapper
+cat > "$PKGDIR/usr/bin/$PKGNAME" <<'WRAPPER'
+#!/bin/bash
+export LD_LIBRARY_PATH="/usr/lib/bambustudio${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+exec /usr/lib/bambustudio/bin/bambu-studio "$@"
+WRAPPER
+chmod 755 "$PKGDIR/usr/bin/$PKGNAME"
+
+# Desktop entry — fix AppImage-specific Exec= path for system install
+sed 's|^Exec=.*|Exec=/usr/bin/bambustudio %U|' \
+    "$APPDIR/BambuStudio.desktop" \
+    > "$PKGDIR/usr/share/applications/$PKGNAME.desktop"
+
+# Icons
+for SIZE in 192x192 128x128 32x32; do
+    SRC="$APPDIR/usr/share/icons/hicolor/$SIZE/apps/BambuStudio.png"
+    DST="$PKGDIR/usr/share/icons/hicolor/$SIZE/apps/$PKGNAME.png"
+    [ -f "$SRC" ] && cp "$SRC" "$DST"
+done
+
+# Installed-Size in KiB (must be computed after usr/ is populated)
+INSTALLED_KB=$(du -sk "$PKGDIR/usr" | cut -f1)
+
+# DEBIAN/control
+cat > "$PKGDIR/DEBIAN/control" <<EOF
+Package: $PKGNAME
+Version: $VERSION
+Architecture: $ARCH
+Maintainer: Bambu Lab <https://bambulab.com>
+Installed-Size: $INSTALLED_KB
+Depends: libgl1, libgtk-3-0, libglib2.0-0, libdbus-1-3, libudev1, libsecret-1-0, libwebkit2gtk-4.1-0 | libwebkit2gtk-4.0-37, libxkbcommon0, libgstreamer1.0-0, libgstreamer-plugins-base1.0-0, gstreamer1.0-plugins-good, gstreamer1.0-gl, zenity
+Section: graphics
+Priority: optional
+Homepage: https://bambulab.com
+Description: BambuStudio 3D printing slicer
+ BambuStudio is a cutting-edge, feature-rich slicing software.
+ Supports Bambu Lab 3D printers. Based on PrusaSlicer.
+EOF
+
+# DEBIAN/postinst
+cat > "$PKGDIR/DEBIAN/postinst" <<'EOF'
+#!/bin/bash
+update-desktop-database /usr/share/applications 2>/dev/null || true
+update-mime-database /usr/share/mime 2>/dev/null || true
+EOF
+chmod 755 "$PKGDIR/DEBIAN/postinst"
+
+# DEBIAN/postrm
+cat > "$PKGDIR/DEBIAN/postrm" <<'EOF'
+#!/bin/bash
+update-desktop-database /usr/share/applications 2>/dev/null || true
+update-mime-database /usr/share/mime 2>/dev/null || true
+EOF
+chmod 755 "$PKGDIR/DEBIAN/postrm"
+
+dpkg-deb --build --root-owner-group "$PKGDIR" "$OUTFILE"
+echo "Created: $OUTFILE"

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Build a .deb package from the already-compiled build/package/ directory.
+# Run after BuildLinux.sh -si (or -sif) has completed.
+set -e
+
+ROOT=$(dirname "$(readlink -f "$0")")/..
+
+BASE=$(grep -E 'set\(SLIC3R_VERSION(_BASE)? ' "$ROOT/version.inc" | cut -d '"' -f2)
+if [ -z "$BASE" ]; then
+    echo "Error: could not read version from version.inc" >&2
+    exit 1
+fi
+COUNT=$(git -C "$ROOT" rev-list --count HEAD 2>/dev/null || echo "0")
+VERSION="${BASE}.${COUNT}"
+
+PKGNAME="bambustudio"
+ARCH="amd64"
+APPDIR="$ROOT/build/package"
+PKGDIR="$ROOT/build/${PKGNAME}_${VERSION}_${ARCH}"
+OUTFILE="$ROOT/build/${PKGNAME}_${VERSION}_${ARCH}.deb"
+
+if [ ! -f "$APPDIR/bin/bambu-studio" ]; then
+    echo "Error: build/package/bin/bambu-studio not found." >&2
+    echo "Run './BuildLinux.sh -si' first." >&2
+    exit 1
+fi
+
+echo "Building .deb for BambuStudio ${VERSION}..."
+rm -rf "$PKGDIR"
+
+# Directory structure
+mkdir -p "$PKGDIR/DEBIAN"
+mkdir -p "$PKGDIR/usr/bin"
+mkdir -p "$PKGDIR/usr/lib/$PKGNAME/bin"   # binary lives here so parent().parent() == /usr/lib/bambustudio
+mkdir -p "$PKGDIR/usr/share/applications"
+mkdir -p "$PKGDIR/usr/share/icons/hicolor/192x192/apps"
+mkdir -p "$PKGDIR/usr/share/icons/hicolor/128x128/apps"
+mkdir -p "$PKGDIR/usr/share/icons/hicolor/32x32/apps"
+
+# Binary goes into bin/ so the resource-path calculation
+# (parent_path().parent_path() / "resources") resolves to
+# /usr/lib/bambustudio/resources — matching where we install resources.
+cp "$APPDIR/bin/bambu-studio" "$PKGDIR/usr/lib/$PKGNAME/bin/"
+
+# Bundled app-specific libs — exclude GTK/GLib/X11/Wayland/DBus/udev
+# because those are system libraries declared in Depends; bundling them
+# causes LD_LIBRARY_PATH to override the system versions and crash on GTK init.
+find "$APPDIR/bin" -name "*.so*" \
+    ! -name "libgtk*"     ! -name "libgdk*"      ! -name "libgdk-pixbuf*" \
+    ! -name "libglib*"    ! -name "libgobject*"   ! -name "libgio*" \
+    ! -name "libgmodule*" ! -name "libgthread*"   ! -name "libgthread*" \
+    ! -name "libX*"       ! -name "libxcb*"       ! -name "libxkbcommon*" \
+    ! -name "libwayland*" \
+    ! -name "libdbus*"    ! -name "libudev*"      \
+    ! -name "libsecret*"  ! -name "libfontconfig*" \
+    ! -name "libfreetype*" ! -name "libpango*"    ! -name "libcairo*" \
+    ! -name "libatk*"     ! -name "libharfbuzz*"  \
+    -exec cp {} "$PKGDIR/usr/lib/$PKGNAME/" \;
+
+# App resources (alongside the bin/ directory, not inside it)
+cp -r "$APPDIR/resources" "$PKGDIR/usr/lib/$PKGNAME/"
+
+# Launcher wrapper
+cat > "$PKGDIR/usr/bin/$PKGNAME" <<'WRAPPER'
+#!/bin/bash
+export LD_LIBRARY_PATH="/usr/lib/bambustudio${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+exec /usr/lib/bambustudio/bin/bambu-studio "$@"
+WRAPPER
+chmod 755 "$PKGDIR/usr/bin/$PKGNAME"
+
+# Desktop entry — fix AppImage-specific Exec= path for system install
+sed 's|^Exec=.*|Exec=/usr/bin/bambustudio %U|' \
+    "$APPDIR/BambuStudio.desktop" \
+    > "$PKGDIR/usr/share/applications/$PKGNAME.desktop"
+
+# Icons
+for SIZE in 192x192 128x128 32x32; do
+    SRC="$APPDIR/usr/share/icons/hicolor/$SIZE/apps/BambuStudio.png"
+    DST="$PKGDIR/usr/share/icons/hicolor/$SIZE/apps/$PKGNAME.png"
+    [ -f "$SRC" ] && cp "$SRC" "$DST"
+done
+
+# Installed-Size in KiB (must be computed after usr/ is populated)
+INSTALLED_KB=$(du -sk "$PKGDIR/usr" | cut -f1)
+
+# DEBIAN/control
+cat > "$PKGDIR/DEBIAN/control" <<EOF
+Package: $PKGNAME
+Version: $VERSION
+Architecture: $ARCH
+Maintainer: Bambu Lab <https://bambulab.com>
+Installed-Size: $INSTALLED_KB
+Depends: libgl1, libgtk-3-0t64 | libgtk-3-0, libglib2.0-0t64 | libglib2.0-0, libdbus-1-3, libudev1, libsecret-1-0, libwebkit2gtk-4.1-0 | libwebkit2gtk-4.0-37, libxkbcommon0, libgstreamer1.0-0, libgstreamer-plugins-base1.0-0, gstreamer1.0-plugins-good, gstreamer1.0-gl, zenity
+Section: graphics
+Priority: optional
+Homepage: https://bambulab.com
+Description: BambuStudio 3D printing slicer
+ BambuStudio is a cutting-edge, feature-rich slicing software.
+ Supports Bambu Lab 3D printers. Based on PrusaSlicer.
+EOF
+
+# DEBIAN/postinst
+cat > "$PKGDIR/DEBIAN/postinst" <<'EOF'
+#!/bin/bash
+update-desktop-database /usr/share/applications 2>/dev/null || true
+update-mime-database /usr/share/mime 2>/dev/null || true
+EOF
+chmod 755 "$PKGDIR/DEBIAN/postinst"
+
+# DEBIAN/postrm
+cat > "$PKGDIR/DEBIAN/postrm" <<'EOF'
+#!/bin/bash
+update-desktop-database /usr/share/applications 2>/dev/null || true
+update-mime-database /usr/share/mime 2>/dev/null || true
+EOF
+chmod 755 "$PKGDIR/DEBIAN/postrm"
+
+dpkg-deb --build --root-owner-group "$PKGDIR" "$OUTFILE"
+echo "Created: $OUTFILE"

--- a/scripts/build_pkg_arch.sh
+++ b/scripts/build_pkg_arch.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Build an Arch Linux .pkg.tar.zst from the already-compiled build/package/ directory.
+# Run after BuildLinux.sh -s has completed.
+set -e
+
+ROOT=$(dirname "$(readlink -f "$0")")/..
+
+BASE=$(grep 'set(SLIC3R_VERSION_BASE' "$ROOT/version.inc" | cut -d '"' -f2)
+if [ -z "$BASE" ]; then
+    echo "Error: could not read version from version.inc" >&2
+    exit 1
+fi
+COUNT=$(git -C "$ROOT" rev-list --count HEAD 2>/dev/null || echo "0")
+VERSION="${BASE}.${COUNT}"
+
+ARCH=$(uname -m)
+APPDIR="$ROOT/build/package"
+PKGNAME="bambustudio"
+PKGDIR="$ROOT/build/pkgbuild"
+
+if [ ! -f "$APPDIR/bin/bambu-studio" ]; then
+    echo "Error: build/package/bin/bambu-studio not found." >&2
+    echo "Run './BuildLinux.sh -sf' first." >&2
+    exit 1
+fi
+
+echo "Building .pkg.tar.zst for BambuStudio ${VERSION}..."
+rm -rf "$PKGDIR"
+# Use a staging dir OUTSIDE of pkg/ — makepkg clears pkg/<pkgname>/ before
+# calling package(), so pre-populating that path would leave it empty.
+STAGING="$PKGDIR/staging"
+mkdir -p "$STAGING/usr/bin"
+mkdir -p "$STAGING/usr/lib/${PKGNAME}"
+mkdir -p "$STAGING/usr/share/applications"
+for SIZE in 32x32 128x128 192x192; do
+    mkdir -p "$STAGING/usr/share/icons/hicolor/${SIZE}/apps"
+done
+
+install -m 755 "$APPDIR/bin/bambu-studio" "$STAGING/usr/lib/${PKGNAME}/"
+find "$APPDIR/bin" -name "*.so*" -exec install -m 755 {} "$STAGING/usr/lib/${PKGNAME}/" \;
+cp -r "$APPDIR/resources" "$STAGING/usr/lib/${PKGNAME}/"
+
+cat > "$STAGING/usr/bin/${PKGNAME}" << 'WRAPPER'
+#!/bin/bash
+export LD_LIBRARY_PATH="/usr/lib/bambustudio${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+exec /usr/lib/bambustudio/bambu-studio "$@"
+WRAPPER
+chmod 755 "$STAGING/usr/bin/${PKGNAME}"
+
+sed 's|^Exec=.*|Exec=/usr/bin/'"${PKGNAME}"' %U|' \
+    "$APPDIR/BambuStudio.desktop" \
+    > "$STAGING/usr/share/applications/${PKGNAME}.desktop"
+
+for SIZE in 32x32 128x128 192x192; do
+    SRC="$APPDIR/usr/share/icons/hicolor/${SIZE}/apps/BambuStudio.png"
+    DST="$STAGING/usr/share/icons/hicolor/${SIZE}/apps/${PKGNAME}.png"
+    [ -f "$SRC" ] && install -m 644 "$SRC" "$DST"
+done
+
+# Write PKGBUILD — package() copies from our staging dir into makepkg's pkgdir
+STAGING_ABS="$(realpath "$STAGING")"
+cat > "$PKGDIR/PKGBUILD" << EOF
+pkgname=${PKGNAME}
+pkgver=${VERSION//-/_}
+pkgrel=1
+pkgdesc="BambuStudio 3D printing slicer"
+arch=('${ARCH}')
+url="https://bambulab.com"
+license=('AGPL3')
+depends=('gtk3' 'glib2' 'dbus' 'libsecret' 'webkit2gtk-4.1' 'libxkbcommon' 'mesa')
+# !debug: don't split a separate -debug package; !strip: keep the already-built
+# binaries intact (stripping here would split debug symbols out into a tiny
+# second package and the upload step could pick the wrong one).
+options=('!debug' '!strip')
+
+package() {
+    cp -r "${STAGING_ABS}/." "\${pkgdir}/"
+}
+EOF
+
+cd "$PKGDIR"
+# makepkg refuses to run as root. In the GitHub Actions container we run as root,
+# so create a temporary unprivileged user and run makepkg as that user.
+if [[ $EUID -eq 0 ]]; then
+    useradd -m builduser 2>/dev/null || true
+    chown -R builduser "$PKGDIR"
+    su builduser -c "cd '$PKGDIR' && makepkg --noextract --nodeps --nocheck -f" 2>&1
+else
+    makepkg --noextract --nodeps --nocheck -f 2>&1
+fi
+
+# Match only the main package (bambustudio-<version>), never bambustudio-debug-*.
+# The version always starts with a digit, so anchor the pattern on that.
+PKG=$(find "$PKGDIR" -name "${PKGNAME}-[0-9]*.pkg.tar.zst" ! -name "${PKGNAME}-debug-*" | head -1)
+if [ -z "$PKG" ]; then
+    echo "Error: no .pkg.tar.zst found after makepkg" >&2
+    exit 1
+fi
+cp "$PKG" "$ROOT/build/"
+echo "Created: $ROOT/build/$(basename "$PKG")"

--- a/scripts/build_pkg_arch.sh
+++ b/scripts/build_pkg_arch.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Build an Arch Linux .pkg.tar.zst from the already-compiled build/package/ directory.
+# Run after BuildLinux.sh -s has completed.
+set -e
+
+ROOT=$(dirname "$(readlink -f "$0")")/..
+
+BASE=$(grep -E 'set\(SLIC3R_VERSION(_BASE)? ' "$ROOT/version.inc" | cut -d '"' -f2)
+if [ -z "$BASE" ]; then
+    echo "Error: could not read version from version.inc" >&2
+    exit 1
+fi
+COUNT=$(git -C "$ROOT" rev-list --count HEAD 2>/dev/null || echo "0")
+VERSION="${BASE}.${COUNT}"
+
+ARCH=$(uname -m)
+APPDIR="$ROOT/build/package"
+PKGNAME="bambustudio"
+PKGDIR="$ROOT/build/pkgbuild"
+
+if [ ! -f "$APPDIR/bin/bambu-studio" ]; then
+    echo "Error: build/package/bin/bambu-studio not found." >&2
+    echo "Run './BuildLinux.sh -sf' first." >&2
+    exit 1
+fi
+
+echo "Building .pkg.tar.zst for BambuStudio ${VERSION}..."
+rm -rf "$PKGDIR"
+# Use a staging dir OUTSIDE of pkg/ — makepkg clears pkg/<pkgname>/ before
+# calling package(), so pre-populating that path would leave it empty.
+STAGING="$PKGDIR/staging"
+mkdir -p "$STAGING/usr/bin"
+mkdir -p "$STAGING/usr/lib/${PKGNAME}"
+mkdir -p "$STAGING/usr/share/applications"
+for SIZE in 32x32 128x128 192x192; do
+    mkdir -p "$STAGING/usr/share/icons/hicolor/${SIZE}/apps"
+done
+
+install -m 755 "$APPDIR/bin/bambu-studio" "$STAGING/usr/lib/${PKGNAME}/"
+find "$APPDIR/bin" -name "*.so*" -exec install -m 755 {} "$STAGING/usr/lib/${PKGNAME}/" \;
+cp -r "$APPDIR/resources" "$STAGING/usr/lib/${PKGNAME}/"
+
+cat > "$STAGING/usr/bin/${PKGNAME}" << 'WRAPPER'
+#!/bin/bash
+export LD_LIBRARY_PATH="/usr/lib/bambustudio${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+exec /usr/lib/bambustudio/bambu-studio "$@"
+WRAPPER
+chmod 755 "$STAGING/usr/bin/${PKGNAME}"
+
+sed 's|^Exec=.*|Exec=/usr/bin/'"${PKGNAME}"' %U|' \
+    "$APPDIR/BambuStudio.desktop" \
+    > "$STAGING/usr/share/applications/${PKGNAME}.desktop"
+
+for SIZE in 32x32 128x128 192x192; do
+    SRC="$APPDIR/usr/share/icons/hicolor/${SIZE}/apps/BambuStudio.png"
+    DST="$STAGING/usr/share/icons/hicolor/${SIZE}/apps/${PKGNAME}.png"
+    [ -f "$SRC" ] && install -m 644 "$SRC" "$DST"
+done
+
+# Write PKGBUILD — package() copies from our staging dir into makepkg's pkgdir
+STAGING_ABS="$(realpath "$STAGING")"
+cat > "$PKGDIR/PKGBUILD" << EOF
+pkgname=${PKGNAME}
+pkgver=${VERSION//-/_}
+pkgrel=1
+pkgdesc="BambuStudio 3D printing slicer"
+arch=('${ARCH}')
+url="https://bambulab.com"
+license=('AGPL3')
+depends=('gtk3' 'glib2' 'dbus' 'libsecret' 'webkit2gtk-4.1' 'libxkbcommon' 'mesa' 'glu')
+# !debug: don't split a separate -debug package; !strip: keep the already-built
+# binaries intact (stripping here would split debug symbols out into a tiny
+# second package and the upload step could pick the wrong one).
+options=('!debug' '!strip')
+
+package() {
+    cp -r "${STAGING_ABS}/." "\${pkgdir}/"
+}
+EOF
+
+cd "$PKGDIR"
+# makepkg refuses to run as root. In the GitHub Actions container we run as root,
+# so create a temporary unprivileged user and run makepkg as that user.
+if [[ $EUID -eq 0 ]]; then
+    useradd -m builduser 2>/dev/null || true
+    chown -R builduser "$PKGDIR"
+    su builduser -c "cd '$PKGDIR' && makepkg --noextract --nodeps --nocheck -f" 2>&1
+else
+    makepkg --noextract --nodeps --nocheck -f 2>&1
+fi
+
+# Match only the main package (bambustudio-<version>), never bambustudio-debug-*.
+# The version always starts with a digit, so anchor the pattern on that.
+PKG=$(find "$PKGDIR" -name "${PKGNAME}-[0-9]*.pkg.tar.zst" ! -name "${PKGNAME}-debug-*" | head -1)
+if [ -z "$PKG" ]; then
+    echo "Error: no .pkg.tar.zst found after makepkg" >&2
+    exit 1
+fi
+cp "$PKG" "$ROOT/build/"
+echo "Created: $ROOT/build/$(basename "$PKG")"

--- a/scripts/build_rpm.sh
+++ b/scripts/build_rpm.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Build a .rpm package from the already-compiled build/package/ directory.
+# Run after BuildLinux.sh -s has completed.
+set -e
+
+ROOT=$(dirname "$(readlink -f "$0")")/..
+
+BASE=$(grep 'set(SLIC3R_VERSION_BASE' "$ROOT/version.inc" | cut -d '"' -f2)
+if [ -z "$BASE" ]; then
+    echo "Error: could not read version from version.inc" >&2
+    exit 1
+fi
+COUNT=$(git -C "$ROOT" rev-list --count HEAD 2>/dev/null || echo "0")
+VERSION="${BASE}.${COUNT}"
+
+ARCH=$(uname -m)
+APPDIR="$ROOT/build/package"
+RPMNAME="bambustudio"
+RELEASE="1"
+RPMTOP="$ROOT/build/rpmbuild"
+
+if [ ! -f "$APPDIR/bin/bambu-studio" ]; then
+    echo "Error: build/package/bin/bambu-studio not found." >&2
+    echo "Run './BuildLinux.sh -sf' first." >&2
+    exit 1
+fi
+
+echo "Building .rpm for BambuStudio ${VERSION}..."
+mkdir -p "$RPMTOP"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+# Generate spec file via Python to avoid bash/RPM macro escaping conflicts
+# Variables are passed via environment to keep the heredoc fully quoted.
+export RPMNAME RPMTOP VERSION RELEASE ARCH APPDIR
+python3 - <<'PYEOF'
+import os, textwrap
+
+rpmname   = os.environ['RPMNAME']
+version   = os.environ['VERSION']
+release   = os.environ['RELEASE']
+arch      = os.environ['ARCH']
+appdir    = os.environ['APPDIR']
+rpmtop    = os.environ['RPMTOP']
+
+spec = textwrap.dedent(f"""
+    %define __brp_check_rpaths %{{nil}}
+    %define __brp_strip_static_archive %{{nil}}
+
+    Name:       {rpmname}
+    Version:    {version}
+    Release:    {release}%{{?dist}}
+    Summary:    BambuStudio 3D printing slicer
+    License:    AGPLv3
+    URL:        https://bambulab.com
+    BuildArch:  {arch}
+    Requires:   mesa-libGL, gtk3, glib2, dbus-libs, systemd-libs, libsecret, (webkit2gtk4.1 or webkit2gtk4), libxkbcommon
+
+    %description
+    BambuStudio is a cutting-edge, feature-rich slicing software.
+    Supports Bambu Lab 3D printers. Based on PrusaSlicer.
+
+    %install
+    APPDIR="{appdir}"
+
+    install -d %{{buildroot}}/usr/bin
+    install -d %{{buildroot}}/usr/lib/{rpmname}
+    install -d %{{buildroot}}/usr/share/applications
+    for SIZE in 32x32 128x128 192x192; do
+        install -d %{{buildroot}}/usr/share/icons/hicolor/${{SIZE}}/apps
+    done
+
+    install -m 755 "${{APPDIR}}/bin/bambu-studio" %{{buildroot}}/usr/lib/{rpmname}/
+    find "${{APPDIR}}/bin" -name "*.so*" -exec install -m 755 {{}} %{{buildroot}}/usr/lib/{rpmname}/ \\;
+    cp -r "${{APPDIR}}/resources" %{{buildroot}}/usr/lib/{rpmname}/
+
+    cat > %{{buildroot}}/usr/bin/{rpmname} << 'WRAPPER'
+    #!/bin/bash
+    export LD_LIBRARY_PATH="/usr/lib/{rpmname}${{LD_LIBRARY_PATH:+:${{LD_LIBRARY_PATH}}}}"
+    exec /usr/lib/{rpmname}/bambu-studio "$@"
+    WRAPPER
+    chmod 755 %{{buildroot}}/usr/bin/{rpmname}
+    sed -i '1s/^    //' %{{buildroot}}/usr/bin/{rpmname}
+
+    sed 's|^Exec=.*|Exec=/usr/bin/{rpmname} %%U|' \\
+        "${{APPDIR}}/BambuStudio.desktop" \\
+        > %{{buildroot}}/usr/share/applications/{rpmname}.desktop
+
+    for SIZE in 32x32 128x128 192x192; do
+        SRC="${{APPDIR}}/usr/share/icons/hicolor/${{SIZE}}/apps/BambuStudio.png"
+        DST="%{{buildroot}}/usr/share/icons/hicolor/${{SIZE}}/apps/{rpmname}.png"
+        [ -f "${{SRC}}" ] && install -m 644 "${{SRC}}" "${{DST}}"
+    done
+
+    %files
+    /usr/bin/{rpmname}
+    /usr/lib/{rpmname}/
+    /usr/share/applications/{rpmname}.desktop
+    /usr/share/icons/hicolor/32x32/apps/{rpmname}.png
+    /usr/share/icons/hicolor/128x128/apps/{rpmname}.png
+    /usr/share/icons/hicolor/192x192/apps/{rpmname}.png
+
+    %post
+    update-desktop-database /usr/share/applications 2>/dev/null || true
+
+    %postun
+    update-desktop-database /usr/share/applications 2>/dev/null || true
+""").lstrip()
+
+# Remove leading indentation from spec body (textwrap.dedent strips common indent)
+with open(f"{rpmtop}/SPECS/{rpmname}.spec", "w") as f:
+    f.write(spec)
+
+print(f"Spec written to {rpmtop}/SPECS/{rpmname}.spec")
+PYEOF
+
+rpmbuild -bb \
+    --define "_topdir $RPMTOP" \
+    "$RPMTOP/SPECS/$RPMNAME.spec"
+
+RPM=$(find "$RPMTOP/RPMS" -name "${RPMNAME}-*.rpm" | head -1)
+if [ -z "$RPM" ]; then
+    echo "Error: no .rpm found after rpmbuild" >&2
+    exit 1
+fi
+cp "$RPM" "$ROOT/build/"
+echo "Created: $ROOT/build/$(basename "$RPM")"

--- a/scripts/build_rpm.sh
+++ b/scripts/build_rpm.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Build a .rpm package from the already-compiled build/package/ directory.
+# Run after BuildLinux.sh -s has completed.
+set -e
+
+ROOT=$(dirname "$(readlink -f "$0")")/..
+
+BASE=$(grep -E 'set\(SLIC3R_VERSION(_BASE)? ' "$ROOT/version.inc" | cut -d '"' -f2)
+if [ -z "$BASE" ]; then
+    echo "Error: could not read version from version.inc" >&2
+    exit 1
+fi
+COUNT=$(git -C "$ROOT" rev-list --count HEAD 2>/dev/null || echo "0")
+VERSION="${BASE}.${COUNT}"
+
+ARCH=$(uname -m)
+APPDIR="$ROOT/build/package"
+RPMNAME="bambustudio"
+RELEASE="1"
+RPMTOP="$ROOT/build/rpmbuild"
+
+if [ ! -f "$APPDIR/bin/bambu-studio" ]; then
+    echo "Error: build/package/bin/bambu-studio not found." >&2
+    echo "Run './BuildLinux.sh -sf' first." >&2
+    exit 1
+fi
+
+echo "Building .rpm for BambuStudio ${VERSION}..."
+mkdir -p "$RPMTOP"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+# Generate spec file via Python to avoid bash/RPM macro escaping conflicts
+# Variables are passed via environment to keep the heredoc fully quoted.
+export RPMNAME RPMTOP VERSION RELEASE ARCH APPDIR
+python3 - <<'PYEOF'
+import os, textwrap
+
+rpmname   = os.environ['RPMNAME']
+version   = os.environ['VERSION']
+release   = os.environ['RELEASE']
+arch      = os.environ['ARCH']
+appdir    = os.environ['APPDIR']
+rpmtop    = os.environ['RPMTOP']
+
+spec = textwrap.dedent(f"""
+    %define __brp_check_rpaths %{{nil}}
+    %define __brp_strip_static_archive %{{nil}}
+
+    Name:       {rpmname}
+    Version:    {version}
+    Release:    {release}%{{?dist}}
+    Summary:    BambuStudio 3D printing slicer
+    License:    AGPLv3
+    URL:        https://bambulab.com
+    BuildArch:  {arch}
+    Requires:   mesa-libGL, gtk3, glib2, dbus-libs, systemd-libs, libsecret, (webkit2gtk4.1 or webkit2gtk4), libxkbcommon
+
+    %description
+    BambuStudio is a cutting-edge, feature-rich slicing software.
+    Supports Bambu Lab 3D printers. Based on PrusaSlicer.
+
+    %install
+    APPDIR="{appdir}"
+
+    install -d %{{buildroot}}/usr/bin
+    install -d %{{buildroot}}/usr/lib/{rpmname}
+    install -d %{{buildroot}}/usr/share/applications
+    for SIZE in 32x32 128x128 192x192; do
+        install -d %{{buildroot}}/usr/share/icons/hicolor/${{SIZE}}/apps
+    done
+
+    install -m 755 "${{APPDIR}}/bin/bambu-studio" %{{buildroot}}/usr/lib/{rpmname}/
+    find "${{APPDIR}}/bin" -name "*.so*" -exec install -m 755 {{}} %{{buildroot}}/usr/lib/{rpmname}/ \\;
+    cp -r "${{APPDIR}}/resources" %{{buildroot}}/usr/lib/{rpmname}/
+
+    cat > %{{buildroot}}/usr/bin/{rpmname} << 'WRAPPER'
+    #!/bin/bash
+    export LD_LIBRARY_PATH="/usr/lib/{rpmname}${{LD_LIBRARY_PATH:+:${{LD_LIBRARY_PATH}}}}"
+    exec /usr/lib/{rpmname}/bambu-studio "$@"
+    WRAPPER
+    chmod 755 %{{buildroot}}/usr/bin/{rpmname}
+    sed -i '1s/^    //' %{{buildroot}}/usr/bin/{rpmname}
+
+    sed 's|^Exec=.*|Exec=/usr/bin/{rpmname} %%U|' \\
+        "${{APPDIR}}/BambuStudio.desktop" \\
+        > %{{buildroot}}/usr/share/applications/{rpmname}.desktop
+
+    for SIZE in 32x32 128x128 192x192; do
+        SRC="${{APPDIR}}/usr/share/icons/hicolor/${{SIZE}}/apps/BambuStudio.png"
+        DST="%{{buildroot}}/usr/share/icons/hicolor/${{SIZE}}/apps/{rpmname}.png"
+        [ -f "${{SRC}}" ] && install -m 644 "${{SRC}}" "${{DST}}"
+    done
+
+    %files
+    /usr/bin/{rpmname}
+    /usr/lib/{rpmname}/
+    /usr/share/applications/{rpmname}.desktop
+    /usr/share/icons/hicolor/32x32/apps/{rpmname}.png
+    /usr/share/icons/hicolor/128x128/apps/{rpmname}.png
+    /usr/share/icons/hicolor/192x192/apps/{rpmname}.png
+
+    %post
+    update-desktop-database /usr/share/applications 2>/dev/null || true
+
+    %postun
+    update-desktop-database /usr/share/applications 2>/dev/null || true
+""").lstrip()
+
+# Remove leading indentation from spec body (textwrap.dedent strips common indent)
+with open(f"{rpmtop}/SPECS/{rpmname}.spec", "w") as f:
+    f.write(spec)
+
+print(f"Spec written to {rpmtop}/SPECS/{rpmname}.spec")
+PYEOF
+
+rpmbuild -bb \
+    --define "_topdir $RPMTOP" \
+    "$RPMTOP/SPECS/$RPMNAME.spec"
+
+RPM=$(find "$RPMTOP/RPMS" -name "${RPMNAME}-*.rpm" | head -1)
+if [ -z "$RPM" ]; then
+    echo "Error: no .rpm found after rpmbuild" >&2
+    exit 1
+fi
+cp "$RPM" "$ROOT/build/"
+echo "Created: $ROOT/build/$(basename "$RPM")"


### PR DESCRIPTION
## Summary

Closes #11321. Publishes native Linux packages alongside the AppImage on every release, so Debian/Ubuntu, Fedora/RHEL and Arch users can install with their own package manager and get desktop/MIME integration.

This builds **proper distro-native packages**, not an AppImage wrapper: BambuStudio is compiled from source inside each distribution's own container, so the GTK/GLib/X11/etc. libraries are declared as package dependencies and used from the system rather than bundled.

When a release is published (or on manual dispatch against a tag) it produces and attaches:

- `bambustudio_<ver>_amd64.deb` (Debian/Ubuntu)
- `bambustudio-<ver>-1.x86_64.rpm` (Fedora/RHEL/openSUSE)
- `bambu-studio-bin-<ver>-1-x86_64.pkg.tar.zst` (Arch)

## How it works

Each distro builds in its own container (`debian:trixie`, `fedora:42`, `archlinux:latest`) and reuses the existing build entry point:

1. `./BuildLinux.sh -u`, install build dependencies
2. `./BuildLinux.sh -d`, build the bundled dependencies (cached between runs)
3. `./BuildLinux.sh -s`, build the slicer
4. `BuildLinuxImage.sh -i`, assemble `build/package/` (binary + libs + resources)
5. one packaging script per format turns that tree into the native package

The three packaging scripts (`scripts/build_deb.sh`, `build_rpm.sh`, `build_pkg_arch.sh`) install the compiled binary under `/usr/lib/bambustudio`, ship a `/usr/bin` wrapper, a `.desktop` entry and icons, and deliberately **exclude** GTK/GLib/X11/Wayland/DBus/fontconfig/etc. from the bundled libs so the system copies are used (declared via `Depends`/`Requires`/`depends`). These are the same scripts I've been using on my fork, where the packages have been live and installable for a while.

## Test plan / notes

- It's a heavy job (full deps + slicer compile per distro), so it's gated to release publish + manual dispatch, with `deps/build/destdir` cached per distro to keep subsequent runs reasonable.
- I can't run this repo's Actions myself, so a maintainer **`workflow_dispatch` against the latest tag** is the way to validate end to end. The packaging scripts are proven on my fork's custom build images; the main thing to confirm here is that `BuildLinux.sh -u` provisions cleanly on the stock `debian:trixie` / `fedora:42` / `archlinux:latest` base images. Happy to switch to prebuilt dep images or adjust anything to match your conventions.
- External repo hosting (signed APT repo / PPA / COPR / AUR / Homebrew) is a separate follow-up since that needs per-org secrets and hosting decisions.

