### PR TITLE
feat: configurable default action on the print button (#11187)

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -207,6 +207,8 @@ void AppConfig::set_defaults()
         set_bool("import_single_svg_and_split", true);
     if (get("user_bed_type").empty())
         set_bool("user_bed_type", true);
+    if (get("default_print_action").empty())
+        set("default_print_action", "print_plate");
     if (get("grabber_size_factor").empty())
         set("grabber_size_factor", "1.0");
     if (get("assembly_part_number_label_font_size").empty())

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1959,12 +1959,26 @@ wxBoxSizer* MainFrame::create_side_tools()
     m_slice_select = eSlicePlate;
     m_print_select = ePrintPlate;
 
+    // #11187: the default action on the print button is configurable in Preferences
+    // ("Default print action"). Fall back to "Print plate" for empty/unknown values.
+    wxString print_btn_label = _L("Print plate");
+    if (wxGetApp().app_config) {
+        const std::string default_action = wxGetApp().app_config->get("default_print_action");
+        if (default_action == "print_all") {
+            m_print_select = ePrintAll;          print_btn_label = _L("Print all");
+        } else if (default_action == "send") {
+            m_print_select = eSendToPrinter;     print_btn_label = _L("Send");
+        } else if (default_action == "send_all") {
+            m_print_select = eSendToPrinterAll;  print_btn_label = _L("Send all");
+        }
+    }
+
     auto slice_panel = new wxPanel(this,wxID_ANY,wxDefaultPosition,wxDefaultSize,wxTRANSPARENT_WINDOW);
     auto print_panel = new wxPanel(this,wxID_ANY,wxDefaultPosition,wxDefaultSize,wxTRANSPARENT_WINDOW);
 
     m_slice_btn = new SideButton(slice_panel, _L("Slice plate"), "");
     m_slice_option_btn = new SideButton(slice_panel, "", "sidebutton_dropdown", 0, FromDIP(14));
-    m_print_btn = new SideButton(print_panel, _L("Print plate"), "");
+    m_print_btn = new SideButton(print_panel, print_btn_label, "");
     m_print_option_btn = new SideButton(print_panel, "", "sidebutton_dropdown", 0, FromDIP(14));
 
     auto slice_sizer = new wxBoxSizer(wxHORIZONTAL);

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1326,6 +1326,12 @@ wxWindow* PreferencesDialog::create_general_page()
     std::vector<wxString> FlushOptionLabels = {_L("All"),_L("Color change"),_L("Disabled")};
     std::vector<std::string> FlushOptionValues = { "all","color change","disabled" };
     auto item_auto_flush = create_item_combobox(_L("Auto Flush"), page, _L("Auto calculate flush volumes"), "auto_calculate_flush", FlushOptionLabels, FlushOptionValues);
+
+    std::vector<wxString> DefaultPrintActionLabels = {_L("Print plate"), _L("Print all"), _L("Send"), _L("Send all")};
+    std::vector<std::string> DefaultPrintActionValues = {"print_plate", "print_all", "send", "send_all"};
+    auto item_default_print_action = create_item_combobox(_L("Default print action"), page,
+        _L("Action selected by default on the print button. You can still change it from the button's dropdown."),
+        "default_print_action", DefaultPrintActionLabels, DefaultPrintActionValues);
     //auto item_hints = create_item_checkbox(_L("Show \"Tip of the day\" notification after start"), page, _L("If enabled, useful hints are displayed at startup."), 50, "show_hints");
     auto item_multi_machine = create_item_checkbox(_L("Multi-device Management(Take effect after restarting Studio)."), page, _L("With this option enabled, you can send a task to multiple devices at the same time and manage multiple devices."), 50, "enable_multi_machine");
     auto item_fila_manager = create_item_checkbox(_L("Filament Manager") + " (" + _L("Take effect after restarting Studio") + ")", page,
@@ -1505,6 +1511,7 @@ wxWindow* PreferencesDialog::create_general_page()
     sizer_page->Add(item_region, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_currency, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_auto_flush, 0, wxTOP, FromDIP(3));
+    sizer_page->Add(item_default_print_action, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_single_instance, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_bed_type_follow_preset, 0, wxTOP, FromDIP(3));
     //sizer_page->Add(item_hints, 0, wxTOP, FromDIP(3));

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1374,6 +1374,12 @@ wxWindow *PreferencesDialog::create_general_tab()
     std::vector<std::string> FlushOptionValues = {"all", "color change", "disabled"};
     auto item_auto_flush = create_item_combobox(_L("Auto Flush"), scrolled, _L("Auto calculate flush volumes"), "auto_calculate_flush", FlushOptionLabels, FlushOptionValues);
 
+    std::vector<wxString> DefaultPrintActionLabels = {_L("Print plate"), _L("Print all"), _L("Send"), _L("Send all")};
+    std::vector<std::string> DefaultPrintActionValues = {"print_plate", "print_all", "send", "send_all"};
+    auto item_default_print_action = create_item_combobox(_L("Default print action"), scrolled,
+        _L("Action selected by default on the print button. You can still change it from the button's dropdown."),
+        "default_print_action", DefaultPrintActionLabels, DefaultPrintActionValues);
+
     auto item_single_instance = create_item_checkbox(_L("Keep only one Bambu Studio instance"), scrolled,
 #if __APPLE__
                                                      _L("On OSX there is always only one instance of app running by default. However it is allowed to run multiple instances "
@@ -1426,6 +1432,7 @@ wxWindow *PreferencesDialog::create_general_tab()
     sizer->Add(item_region, flags);
     sizer->Add(item_currency, flags);
     sizer->Add(item_auto_flush, flags);
+    sizer->Add(item_default_print_action, flags);
 #ifdef _WIN32
     sizer->Add(item_darkmode, flags);
 #endif


### PR DESCRIPTION
## Summary

Closes #11187. Adds a **Default print action** preference so users who always use the same action (e.g. "Send all") don't have to pick it from the print button's dropdown every time.

A new combobox on the General preferences page lets you choose the action that's pre-selected on the print button:

- **Print plate** (default, unchanged behaviour)
- **Print all**
- **Send**
- **Send all**

On startup the print button initialises its label and selection (`m_print_select`) from this setting. The dropdown still works exactly as before, so users can switch per session; this only changes which option is selected by default.

## Implementation

- `AppConfig`: new `default_print_action` key, default `"print_plate"` (so existing users see no change).
- `MainFrame`: reads the setting when building the print button and sets both the label and `m_print_select` accordingly (maps to `ePrintAll` / `eSendToPrinter` / `eSendToPrinterAll`).
- `Preferences`: the combobox.

## Test plan

- Pure preference + initial-selection change; no change to the print/send execution paths.
- Default value reproduces the current "Print plate" default exactly.
- I don't have a GUI build environment here, so I traced the wiring through the code rather than capturing a run, happy to adjust labels/placement to your conventions.

