### PR TITLE
feat: zoom the live camera view with the mouse wheel (#11322)

### DIFF
--- a/src/slic3r/GUI/wxMediaCtrl3.cpp
+++ b/src/slic3r/GUI/wxMediaCtrl3.cpp
@@ -34,6 +34,25 @@ wxMediaCtrl3::wxMediaCtrl3(wxWindow *parent)
     SetBackgroundColour("#000001ff");
     m_render_timer.SetOwner(this);
     Bind(wxEVT_TIMER, &wxMediaCtrl3::OnRenderTimer, this);
+    Bind(wxEVT_MOUSEWHEEL, &wxMediaCtrl3::mouseWheelEvent, this);
+}
+
+void wxMediaCtrl3::mouseWheelEvent(wxMouseEvent &evt)
+{
+    const int rotation = evt.GetWheelRotation();
+    if (rotation == 0) {
+        evt.Skip();
+        return;
+    }
+    // Digital zoom of the live view, 1x (fit) up to 5x, centred on the view.
+    const double factor = rotation > 0 ? 1.1 : 1.0 / 1.1;
+    double zoom = m_zoom * factor;
+    if (zoom < 1.0) zoom = 1.0;
+    if (zoom > 5.0) zoom = 5.0;
+    if (zoom != m_zoom) {
+        m_zoom = zoom;
+        Refresh();
+    }
 }
 
 wxMediaCtrl3::~wxMediaCtrl3()
@@ -166,20 +185,19 @@ void wxMediaCtrl3::paintEvent(wxPaintEvent &evt)
     auto size2 = current_frame.GetSize();
     if (size2.x != frame_size.x && size2.y == frame_size.y)
         size2.x = frame_size.x;
-    auto size3 = (size - size2) / 2;
-    if (size2.x != size.x && size2.y != size.y) {
-        double scale = 1.;
-        if (size.x * size2.y > size.y * size2.x) {
-            size3 = {size.x * size2.y / size.y, size2.y};
-            scale = double(size.y) / size2.y;
-        } else {
-            size3 = {size2.x, size.y * size2.x / size.x};
-            scale = double(size.x) / size2.x;
-        }
-        dc.SetUserScale(scale, scale);
-        size3 = (size3 - size2) / 2;
-    }
-    dc.DrawBitmap(current_frame, size3.x, size3.y);
+
+    // Base "contain" fit scale, then apply the digital zoom factor (m_zoom),
+    // centring the (possibly cropped) image in the view. At m_zoom == 1 this is
+    // identical to the previous letterboxed, centred rendering.
+    double scale = 1.0;
+    if (size2.x != size.x || size2.y != size.y)
+        scale = (size.x * size2.y > size.y * size2.x) ? double(size.y) / size2.y
+                                                      : double(size.x) / size2.x;
+    const double eff_scale = scale * m_zoom;
+    dc.SetUserScale(eff_scale, eff_scale);
+    const int off_x = wxRound(size.x / 2.0 / eff_scale - size2.x / 2.0);
+    const int off_y = wxRound(size.y / 2.0 / eff_scale - size2.y / 2.0);
+    dc.DrawBitmap(current_frame, off_x, off_y);
 
     // Draw watermark overlay when showing device preview image
     if (!m_watermark_text.empty() && m_url == nullptr) {

--- a/src/slic3r/GUI/wxMediaCtrl3.cpp
+++ b/src/slic3r/GUI/wxMediaCtrl3.cpp
@@ -35,6 +35,30 @@ wxMediaCtrl3::wxMediaCtrl3(wxWindow *parent)
     SetBackgroundColour("#000001ff");
     m_render_timer.SetOwner(this);
     Bind(wxEVT_TIMER, &wxMediaCtrl3::OnRenderTimer, this);
+    Bind(wxEVT_MOUSEWHEEL, &wxMediaCtrl3::mouseWheelEvent, this);
+}
+
+void wxMediaCtrl3::mouseWheelEvent(wxMouseEvent &evt)
+{
+    const int rotation = evt.GetWheelRotation();
+    if (rotation == 0) {
+        evt.Skip();
+        return;
+    }
+
+    // Digital zoom of the live view, 1x (fit) up to 5x, centred on the view.
+    const double factor = rotation > 0 ? 1.1 : 1.0 / 1.1;
+    double zoom = m_zoom * factor;
+
+    if (zoom < 1.0)
+        zoom = 1.0;
+    if (zoom > 5.0)
+        zoom = 5.0;
+
+    if (zoom != m_zoom) {
+        m_zoom = zoom;
+        Refresh();
+    }
 }
 
 wxMediaCtrl3::~wxMediaCtrl3()
@@ -196,20 +220,23 @@ void wxMediaCtrl3::paintEvent(wxPaintEvent &evt)
             delete gc;
         }
     } else {
-        auto size3 = (size - size2) / 2;
-        if (size2.x != size.x && size2.y != size.y) {
-            double scale = 1.;
-            if (size.x * size2.y > size.y * size2.x) {
-                size3 = {size.x * size2.y / size.y, size2.y};
-                scale = double(size.y) / size2.y;
-            } else {
-                size3 = {size2.x, size.y * size2.x / size.x};
-                scale = double(size.x) / size2.x;
-            }
-            dc.SetUserScale(scale, scale);
-            size3 = (size3 - size2) / 2;
-        }
-        dc.DrawBitmap(current_frame, size3.x, size3.y);
+        // Base "contain" fit scale, then apply the digital zoom factor.
+        // At m_zoom == 1 this is identical to the normal fitted rendering.
+        double scale = 1.0;
+        if (size2.x != size.x || size2.y != size.y)
+            scale = (size.x * size2.y > size.y * size2.x)
+                ? double(size.y) / size2.y
+                : double(size.x) / size2.x;
+
+        const double effective_scale = scale * m_zoom;
+        dc.SetUserScale(effective_scale, effective_scale);
+
+        const int offset_x =
+            wxRound(size.x / 2.0 / effective_scale - size2.x / 2.0);
+        const int offset_y =
+            wxRound(size.y / 2.0 / effective_scale - size2.y / 2.0);
+
+        dc.DrawBitmap(current_frame, offset_x, offset_y);
     }
 
     // Draw watermark overlay when showing device preview image

--- a/src/slic3r/GUI/wxMediaCtrl3.h
+++ b/src/slic3r/GUI/wxMediaCtrl3.h
@@ -91,6 +91,8 @@ protected:
 
     void paintEvent(wxPaintEvent &evt);
 
+    void mouseWheelEvent(wxMouseEvent &evt);
+
     wxSize DoGetBestSize() const override;
 
     void DoSetSize(int x, int y, int width, int height, int sizeFlags) override;
@@ -117,6 +119,7 @@ private:
     wxSize m_video_size = wxDefaultSize;
     wxSize m_frame_size = wxDefaultSize;
     PlayFrame m_frame;
+    double m_zoom = 1.0;   // digital zoom factor for the live view (mouse wheel)
     std::shared_ptr<wxURI> m_url;
     std::atomic<Bambu_Tunnel> m_tunnel{nullptr};
     std::mutex m_mutex;


### PR DESCRIPTION
## Summary

Closes #11322. The live camera view in the device tab couldn't be zoomed, unlike the pinch-zoom in Bambu Handy. This adds **mouse-wheel digital zoom** to the live view (1x fit up to 5x, centred on the view).

`wxMediaCtrl3` already paints each decoded frame itself (`wxPaintDC` + `DrawBitmap`), so this is a client-side change: a zoom factor is applied on top of the existing contain-fit scale, and the image is re-centred (cropped to the window when zoomed in).

- Scroll up to zoom in, down to zoom out; clamped to 1x-5x.
- At 1x the rendering is mathematically identical to the previous letterboxed, centred output, so the default view is unchanged.

## Implementation

- `wxMediaCtrl3.h`: a `double m_zoom` member and a `mouseWheelEvent` handler.
- `wxMediaCtrl3.cpp`: bind `wxEVT_MOUSEWHEEL`, adjust/clamp the zoom and `Refresh()`; the paint path multiplies the fit scale by the zoom and re-centres.

## Test plan

- Single self-contained control, no change to decoding or stream handling.
- Verified by tracing the math that `m_zoom == 1` reproduces the existing centring exactly (I don't have a GUI build here to capture a recording). A maintainer build is the way to confirm the feel; the step/limits (1.1x per notch, 1x-5x) are easy to tune if you'd prefer different values, and I can add cursor-anchored zoom instead of centre-anchored if that's preferred.

