### PR TITLE
fix: project description editor never loads, blocking project save (#11302)

### DIFF
--- a/resources/web/model_new/js/ckeditor_config.js
+++ b/resources/web/model_new/js/ckeditor_config.js
@@ -162,13 +162,24 @@ const editorConfig = {
 	language: editorLanguage
 };
 
-script.onload = () => {
+let editorsInitialized = false;
+function initEditors() {
+	if (editorsInitialized) return;
+	editorsInitialized = true;
 	ClassicEditor.create(document.querySelector('#editor'), editorConfig).then( editor => {
 		window.projectEditor = editor;
 	});
 	ClassicEditor.create(document.querySelector('#profile-editor'), editorConfig).then( editor => {
 		window.profileEditor = editor;
 	});
-};
+}
+
+// Initialise the editors once the translation file has loaded. If it fails to
+// load (e.g. the resolved locale has no translation file such as "en-us", which
+// happens when editor.html is opened without a ?lang= and the webview reports
+// navigator.language as en-US), still initialise the editors so the description
+// field is usable instead of leaving the page without an editor.
+script.onload = initEditors;
+script.onerror = initEditors;
 
 document.head.appendChild(script);


### PR DESCRIPTION
## Summary

Closes #11302. In the Project tab, the Description field is required but there's no editor to type into, and saving fails with "The project description is empty" with no way to fix it (see the screenshots in the issue).

## Root cause

The description editors (CKEditor) are created in `resources/web/model_new/js/ckeditor_config.js`, but only inside the `onload` handler of a dynamically-loaded translation file:

```js
script.src = `../include/ckeditor5/translations/${editorLanguage}.umd.js`;
script.onload = () => { ClassicEditor.create('#editor', ...); ... };
```

`editor.html` is navigated to without a `?lang=` query, so `editorLanguage` falls back to `navigator.language`, which the webview commonly reports as `en-US`. That resolves to `translations/en-us.umd.js`, which doesn't exist (only `en`, `en-au`, `en-gb` ship). A missing file fires `onerror`, not `onload`, so the editors are never created: no description field appears, and the required-field validation then blocks saving for everyone in this situation, regardless of UI language.

## Fix

Initialise the editors on both `onload` and `onerror` (guarded so they're created only once). If the translation file fails to load, the editors still come up (in English) instead of leaving the page with no description editor at all.

## Test plan

- JS-only change in `ckeditor_config.js`, syntax-checked with `node --check`.
- Open the Project tab → Edit: the description editor now appears and a project can be saved, even when the resolved locale has no CKEditor translation file. When the translation does load, behaviour is unchanged (the guard prevents double init).
