### PR TITLE
feat: allow enabling dark mode on Linux

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3097,9 +3097,14 @@ bool GUI_App::on_init_inner()
 #ifdef _MSW_DARK_MODE
 
 #ifndef __WINDOWS__
-    wxSystemAppearance app = wxSystemSettings::GetAppearance();
-    GUI::wxGetApp().app_config->set("dark_color_mode", app.IsDark() ? "1" : "0");
-    GUI::wxGetApp().app_config->save();
+    // Seed dark mode from the system appearance on first run only. Afterwards the
+    // user's explicit choice (Preferences > Dark Mode, now available on Linux too)
+    // is kept instead of being overwritten by the system appearance on every start.
+    if (GUI::wxGetApp().app_config->get("dark_color_mode").empty()) {
+        wxSystemAppearance app = wxSystemSettings::GetAppearance();
+        GUI::wxGetApp().app_config->set("dark_color_mode", app.IsDark() ? "1" : "0");
+        GUI::wxGetApp().app_config->save();
+    }
 #endif // __APPLE__
 
 

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1464,8 +1464,8 @@ wxWindow* PreferencesDialog::create_general_page()
     auto title_media = create_item_title(_L("Media"), page, _L("Media"));
     auto item_auto_stop_liveview = create_item_checkbox(_L("Keep liveview when printing."), page, _L("By default, Liveview will pause after 15 minutes of inactivity on the computer. Check this box to disable this feature during printing."), 50, "auto_stop_liveview");
 
-    //dark mode
-#ifdef _WIN32
+    //dark mode (native on macOS; manual toggle on Windows and Linux)
+#ifndef __APPLE__
     auto title_darkmode = create_item_title(_L("Dark Mode"), page, _L("Dark Mode"));
     auto item_darkmode = create_item_darkmode_checkbox(_L("Enable dark mode"), page,_L("Enable dark mode"), 50, "dark_color_mode");
 #endif
@@ -1576,7 +1576,7 @@ wxWindow* PreferencesDialog::create_general_page()
     sizer_page->Add(title_media, 0, wxTOP| wxEXPAND, FromDIP(20));
     sizer_page->Add(item_auto_stop_liveview, 0, wxEXPAND, FromDIP(3));
 
-#ifdef _WIN32
+#ifndef __APPLE__
     sizer_page->Add(title_darkmode, 0, wxTOP | wxEXPAND, FromDIP(20));
     sizer_page->Add(item_darkmode, 0, wxEXPAND, FromDIP(3));
 #endif


### PR DESCRIPTION
## Summary

On Linux there's no way to turn on dark mode: the Preferences "Dark Mode" toggle is guarded by `#ifdef _WIN32`, even though the dark rendering path is compiled on all platforms (`SUPPORT_DARK_MODE` is defined unconditionally). So Linux users can't enable dark mode from the UI at all.

It's also worse than just a hidden toggle: on non-Windows, `GUI_App` overwrites `dark_color_mode` with `wxSystemSettings::GetAppearance().IsDark()` on **every** startup. On Linux wxGTK derives that purely from the GTK theme (it doesn't see e.g. KDE's `color-scheme: prefer-dark`), so even if a user sets the config by hand it gets reset on the next launch.

## Changes

- **Show the dark-mode toggle on Linux** as well (`#ifndef __APPLE__` instead of `#ifdef _WIN32`). macOS is left out on purpose: there `dark_mode()` uses the native appearance and ignores this config, so a toggle would do nothing.
- **Seed `dark_color_mode` from the system appearance on first run only**, so a user's explicit choice in Preferences persists across restarts instead of being overwritten every start. On first run the behaviour is unchanged (it still follows the detected system appearance).

This mirrors how the toggle already works on Windows (`dark_mode()` is `config == "1" ? true : check_dark_mode()` on both).

## Test plan

- Linux: Preferences now shows "Dark Mode > Enable dark mode"; toggling it and restarting keeps the chosen state instead of snapping back to the GTK-theme-derived default.
- Windows: unchanged (the toggle and startup seeding behaved this way already).
- macOS: unchanged (no toggle shown; native appearance still drives `dark_mode()`).
- I don't have a Windows/macOS GUI build here, so I verified the preprocessor/flow by tracing the code; the Linux behaviour is the target of this change.

Note: as before, on Linux the live re-theme of native widgets still depends on the GTK theme; a full switch is cleanest after a restart. This PR is about making the option reachable and persistent, which it wasn't.
