### PR TITLE
Prefer the matching AMS slot with the least remaining filament

### DIFF
--- a/src/libslic3r/ProjectTask.hpp
+++ b/src/libslic3r/ProjectTask.hpp
@@ -48,6 +48,7 @@ struct FilamentInfo
     float       used_g{0.f};
     int         tray_id{0}; // start with 0
     float       distance{0.f};
+    int         remain{-1};    // filament remain on the mapped tray: 0~100, -1 = unknown / not reported by the printer
     int         ctype = 0;
     std::vector<std::string> colors = std::vector<std::string>();
     int         mapping_result = 0;

--- a/src/slic3r/GUI/DeviceCore/DevMapping.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevMapping.cpp
@@ -80,6 +80,7 @@ namespace Slic3r
         result.setting_id = tray.filament_setting_id.empty() ? tray.setting_id : tray.filament_setting_id;
         result.ctype = tray.ctype;
         result.colors = tray.cols;
+        result.remain = tray.remain; // 0~100, -1 when the printer does not report a remain (e.g. non-genuine spools)
 
         /*for new ams mapping*/
         result.ams_id = std::to_string(ams_id);
@@ -105,6 +106,24 @@ namespace Slic3r
                 result.id = ams_id * 4 + slot_id;
             }
         }
+    }
+
+    // Tie-break helper for ams_filament_mapping(): returns true when 'candidate' should
+    // replace 'picked' on an exact distance tie because it has less filament remaining,
+    // so partially-used spools are consumed first.
+    // Rules:
+    //  - only when the candidate tray is an exact filament_id match for the sliced filament;
+    //  - only when both trays report a valid remain (>= 0, e.g. genuine/RFID spools);
+    //    an unknown remain (-1) keeps the legacy lowest-slot-first behavior;
+    //  - a tray reporting remain == 0 is never deliberately preferred: a non-empty
+    //    candidate wins over an empty picked tray, never the other way around.
+    static bool _prefer_tray_by_remain(const FilamentInfo& filament, const FilamentInfo& candidate, const FilamentInfo& picked)
+    {
+        if (filament.filament_id != candidate.filament_id)
+            return false;
+        if (candidate.remain <= 0 || picked.remain < 0)
+            return false;
+        return picked.remain == 0 || candidate.remain < picked.remain;
     }
 
     int DevMappingUtil::ams_filament_mapping(const MachineObject* obj, const std::vector<FilamentInfo>& filaments, std::vector<FilamentInfo>& result, std::vector<bool> map_opt, std::vector<int> exclude_id, bool nozzle_has_ams_then_ignore_ext)
@@ -322,6 +341,14 @@ namespace Slic3r
                             picked_src_idx = i;
                             picked_tar_idx = j;
                         }
+                        // Same color/type and equal distance: prefer the matching tray with the
+                        // least remaining filament, see _prefer_tray_by_remain() for the rules.
+                        else if (min_val == distance_map[i][j].distance
+                                 && _prefer_tray_by_remain(filaments[i], tray_filaments[j], tray_filaments[picked_tar_idx]))
+                        {
+                            picked_src_idx = i;
+                            picked_tar_idx = j;
+                        }
                     }
                 }
 
@@ -340,6 +367,13 @@ namespace Slic3r
                                 tray_filaments[picked_tar_idx].distance = min_val;
                             }
                             else if (min_val == distance_map[i][j].distance && filaments[picked_src_idx].filament_id != tray_filaments[picked_tar_idx].filament_id && filaments[i].filament_id == tray_filaments[j].filament_id)
+                            {
+                                picked_src_idx = i;
+                                picked_tar_idx = j;
+                            }
+                            // Prefer the matching tray with the least remaining filament (see above).
+                            else if (min_val == distance_map[i][j].distance
+                                     && _prefer_tray_by_remain(filaments[i], tray_filaments[j], tray_filaments[picked_tar_idx]))
                             {
                                 picked_src_idx = i;
                                 picked_tar_idx = j;

--- a/src/slic3r/GUI/DeviceCore/DevMapping.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevMapping.cpp
@@ -80,6 +80,7 @@ namespace Slic3r
         result.setting_id = tray.filament_setting_id.empty() ? tray.setting_id : tray.filament_setting_id;
         result.ctype = tray.ctype;
         result.colors = tray.cols;
+        result.remain = tray.remain; // 0~100, -1 when the printer does not report a remain (e.g. non-genuine spools)
 
         /*for new ams mapping*/
         result.ams_id = std::to_string(ams_id);
@@ -322,6 +323,19 @@ namespace Slic3r
                             picked_src_idx = i;
                             picked_tar_idx = j;
                         }
+                        // Same color/type/filament_id and equal distance: prefer the tray with the
+                        // least remaining filament so partially-used spools are consumed first.
+                        // Only applies when both trays report a valid remain (genuine/RFID spools);
+                        // an unknown remain (-1) keeps the previous lowest-slot-first behavior.
+                        else if (min_val == distance_map[i][j].distance
+                                 && filaments[i].filament_id == tray_filaments[j].filament_id
+                                 && tray_filaments[picked_tar_idx].remain >= 0
+                                 && tray_filaments[j].remain >= 0
+                                 && tray_filaments[j].remain < tray_filaments[picked_tar_idx].remain)
+                        {
+                            picked_src_idx = i;
+                            picked_tar_idx = j;
+                        }
                     }
                 }
 
@@ -340,6 +354,16 @@ namespace Slic3r
                                 tray_filaments[picked_tar_idx].distance = min_val;
                             }
                             else if (min_val == distance_map[i][j].distance && filaments[picked_src_idx].filament_id != tray_filaments[picked_tar_idx].filament_id && filaments[i].filament_id == tray_filaments[j].filament_id)
+                            {
+                                picked_src_idx = i;
+                                picked_tar_idx = j;
+                            }
+                            // Prefer the matching tray with the least remaining filament (see above).
+                            else if (min_val == distance_map[i][j].distance
+                                     && filaments[i].filament_id == tray_filaments[j].filament_id
+                                     && tray_filaments[picked_tar_idx].remain >= 0
+                                     && tray_filaments[j].remain >= 0
+                                     && tray_filaments[j].remain < tray_filaments[picked_tar_idx].remain)
                             {
                                 picked_src_idx = i;
                                 picked_tar_idx = j;


### PR DESCRIPTION
## Prefer the matching AMS slot with the least remaining filament

### Problem
When two or more AMS slots are loaded with the **same filament** (same type + same color), Bambu Studio's auto-mapping always assigns the print to the **lowest-numbered slot**, regardless of how much filament each spool has left.

This is a long-standing annoyance for users who keep a partially-used spool and a fresh spool of the same filament in the AMS: the slicer maps to the full spool first, leaving the partial spool to linger forever. The only workarounds today are to manually remap on the send dialog every time (easy to miss, see #992) or to physically arrange spools so the emptier one sits in the lowest slot.

Refs #992, #2075.

### Root cause
In `DevMappingUtil::ams_filament_mapping()` (`src/slic3r/GUI/DeviceCore/DevMapping.cpp`), when several trays match a sliced filament with an identical color/type distance, the tie is broken only by exact `filament_id` match. If that is still equal, the winner is simply whichever tray comes first in iteration order — i.e. the lowest slot index. Remaining amount is never considered.

### Fix
Add a secondary tie-break, implemented in a small shared helper `_prefer_tray_by_remain()`: when the color/type distance is equal **and** the `filament_id` matches, prefer the tray with the **smaller `remain`** value, so partially-used spools are consumed first.

The printer already reports per-tray remaining percentage (`DevAmsTray::remain`, populated from MQTT in `DeviceManager.cpp`). This value is propagated into `FilamentInfo` via `_parse_tray_info()` and used in the tie-break.

**Safety / backward compatibility:**
- The new rule only fires on an *exact distance tie* among same-`filament_id` trays. The scoring function and all existing mapping decisions are untouched.
- It only applies when **both** candidate trays report a valid `remain` (`>= 0`). Spools that don't report a remaining amount (e.g. most non-genuine spools) keep the previous lowest-slot-first behavior. In practice this means the new behavior kicks in for genuine/RFID spools where the remaining amount is actually known — exactly the case where it is useful and correct.
- An **empty tray (`remain == 0`) is never deliberately preferred**; conversely, a non-empty candidate wins over an empty picked tray, so auto-mapping never knowingly starts a print on an empty spool (review feedback).

### Changes
- `src/libslic3r/ProjectTask.hpp`: add `int remain{-1}` to `FilamentInfo`.
- `src/slic3r/GUI/DeviceCore/DevMapping.cpp`: copy `tray.remain` in `_parse_tray_info()`; add `_prefer_tray_by_remain()` and call it from the tie-break in both mapping passes.

### Testing
Manual: load two slots with the same filament (one partial, one full) on an RFID-reporting AMS, slice a single-color model, and send. The mapping now targets the partial spool. With remain unavailable, mapping is unchanged.

### Notes
This changes only the *initial* slot selection at send time. The mid-print auto-refill / backup failover order is firmware-controlled and out of scope.
