### PR TITLE
Add Eryone filament profiles for P1S and H2D

### DIFF
--- a/resources/profiles/BBL.json
+++ b/resources/profiles/BBL.json
@@ -7554,6 +7554,134 @@
         {
             "name": "Generic TPU for AMS @BBL X2D 0.4 nozzle",
             "sub_path": "filament/Generic TPU for AMS @BBL X2D 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone ABS+-HS @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone ABS+-HS @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone ABS-GF @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone ABS-GF @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone ASA-CF @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone ASA-CF @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone ASA-GF @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone ASA-GF @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PA-CF @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PA-CF @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PETG @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PETG @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PETG-Burnt Titanium @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PETG-Burnt Titanium @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PETG-CF @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PETG-CF @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone petg-Galaxy @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone petg-Galaxy @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PETG-GF @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PETG-GF @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PETG-Matte @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PETG-Matte @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PLA+ @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PLA+ @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PLA+HS @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PLA+HS @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PLA-Matte @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PLA-Matte @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PLA-Matte HS @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PLA-Matte HS @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PLA-Silk @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PLA-Silk @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone pla-Ultra Silk @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone pla-Ultra Silk @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone ppa-cf @BBL P1S 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone ppa-cf @BBL P1S 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone ABS-GF @BBL H2D 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone ABS-GF @BBL H2D 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone ASA-CF @BBL H2D 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone ASA-CF @BBL H2D 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone ASA-GF @BBL H2D 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone ASA-GF @BBL H2D 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PA-CF @BBL H2D 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PA-CF @BBL H2D 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PETG @BBL H2D 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PETG @BBL H2D 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PETG-Burnt Titanium @BBL H2D 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PETG-Burnt Titanium @BBL H2D 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PETG-CF @BBL H2D 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PETG-CF @BBL H2D 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone petg-Galaxy @BBL H2D 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone petg-Galaxy @BBL H2D 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PETG-GF @BBL H2D 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PETG-GF @BBL H2D 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PETG-Lite @BBL H2D 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PETG-Lite @BBL H2D 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PETG-Matte @BBL H2D 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PETG-Matte @BBL H2D 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PLA+ @BBL H2D 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PLA+ @BBL H2D 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone PLA+HS @BBL H2D 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone PLA+HS @BBL H2D 0.4 nozzle.json"
+        },
+        {
+            "name": "Eryone pla-Ultra Silk @BBL H2D 0.4 nozzle",
+            "sub_path": "filament/ERYONE/Eryone pla-Ultra Silk @BBL H2D 0.4 nozzle.json"
         }
     ],
     "machine_list": [

--- a/resources/profiles/BBL/filament/ERYONE/Eryone ABS+-HS @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone ABS+-HS @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone ABS+-HS @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone ABS+-HS @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone ABS+-HS @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone ABS+-HS @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu ABS @base",
+    "from": "system",
+    "setting_id": "GPSA01",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "0.94",
+        "0.94"
+    ],
+    "filament_max_volumetric_speed": [
+        "24",
+        "24"
+    ],
+    "nozzle_temperature": [
+        "260",
+        "260"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "260",
+        "260"
+    ],
+    "hot_plate_temp": "90",
+    "hot_plate_temp_initial_layer": "90",
+    "fan_max_speed": "20",
+    "fan_min_speed": "0",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEA01"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone ABS-GF @BBL H2D 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone ABS-GF @BBL H2D 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone ABS-GF @BBL H2D 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone ABS-GF @BBL H2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone ABS-GF @BBL H2D 0.4 nozzle.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "Eryone ABS-GF @BBL H2D 0.4 nozzle",
+    "inherits": "Bambu ABS @base",
+    "from": "system",
+    "setting_id": "GPSB01",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "fan_max_speed": [
+        "20"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "filament_change_length": [
+        "4"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "20",
+        "20"
+    ],
+    "filament_prime_volume": [
+        "30"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
+    "filament_tower_ironing_area": [
+        "8"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "270",
+        "270"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "270",
+        "270"
+    ],
+    "overhang_fan_speed": [
+        "50"
+    ],
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "supertack_plate_temp": [
+        "60"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "60"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "hot_plate_temp": "90",
+    "hot_plate_temp_initial_layer": "90",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEB01"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone ABS-GF @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone ABS-GF @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone ABS-GF @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone ABS-GF @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone ABS-GF @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone ABS-GF @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu ABS @base",
+    "from": "system",
+    "setting_id": "GPSA02",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "0.94",
+        "0.94"
+    ],
+    "filament_max_volumetric_speed": [
+        "14",
+        "14"
+    ],
+    "nozzle_temperature": [
+        "265",
+        "265"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "265",
+        "265"
+    ],
+    "hot_plate_temp": "90",
+    "hot_plate_temp_initial_layer": "90",
+    "fan_max_speed": "20",
+    "fan_min_speed": "0",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEA02"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone ASA-CF @BBL H2D 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone ASA-CF @BBL H2D 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone ASA-CF @BBL H2D 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone ASA-CF @BBL H2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone ASA-CF @BBL H2D 0.4 nozzle.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "Eryone ASA-CF @BBL H2D 0.4 nozzle",
+    "inherits": "Bambu ASA @base",
+    "from": "system",
+    "setting_id": "GPSB02",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "fan_max_speed": [
+        "20"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "filament_change_length": [
+        "4"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "15",
+        "15"
+    ],
+    "filament_prime_volume": [
+        "30"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
+    "filament_tower_ironing_area": [
+        "8"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "265",
+        "265"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "265",
+        "265"
+    ],
+    "overhang_fan_speed": [
+        "50"
+    ],
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "supertack_plate_temp": [
+        "60"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "60"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "hot_plate_temp": "90",
+    "hot_plate_temp_initial_layer": "90",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEB02"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone ASA-CF @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone ASA-CF @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone ASA-CF @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone ASA-CF @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone ASA-CF @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone ASA-CF @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu ASA @base",
+    "from": "system",
+    "setting_id": "GPSA03",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "0.94",
+        "0.94"
+    ],
+    "filament_max_volumetric_speed": [
+        "15",
+        "15"
+    ],
+    "nozzle_temperature": [
+        "270",
+        "270"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "270",
+        "270"
+    ],
+    "hot_plate_temp": "90",
+    "hot_plate_temp_initial_layer": "90",
+    "fan_max_speed": "20",
+    "fan_min_speed": "0",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEA03"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone ASA-GF @BBL H2D 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone ASA-GF @BBL H2D 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone ASA-GF @BBL H2D 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone ASA-GF @BBL H2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone ASA-GF @BBL H2D 0.4 nozzle.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "Eryone ASA-GF @BBL H2D 0.4 nozzle",
+    "inherits": "Bambu ASA @base",
+    "from": "system",
+    "setting_id": "GPSB03",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "fan_max_speed": [
+        "20"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "filament_change_length": [
+        "4"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "24",
+        "24"
+    ],
+    "filament_prime_volume": [
+        "30"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
+    "filament_tower_ironing_area": [
+        "8"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "260",
+        "260"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "260",
+        "260"
+    ],
+    "overhang_fan_speed": [
+        "50"
+    ],
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "supertack_plate_temp": [
+        "60"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "60"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "hot_plate_temp": "90",
+    "hot_plate_temp_initial_layer": "90",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEB03"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone ASA-GF @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone ASA-GF @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone ASA-GF @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone ASA-GF @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone ASA-GF @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone ASA-GF @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu ASA @base",
+    "from": "system",
+    "setting_id": "GPSA04",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "0.95",
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "17",
+        "17"
+    ],
+    "nozzle_temperature": [
+        "260",
+        "260"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "260",
+        "260"
+    ],
+    "hot_plate_temp": "90",
+    "hot_plate_temp_initial_layer": "90",
+    "fan_max_speed": "20",
+    "fan_min_speed": "0",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEA04"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PA-CF @BBL H2D 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PA-CF @BBL H2D 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PA-CF @BBL H2D 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PA-CF @BBL H2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PA-CF @BBL H2D 0.4 nozzle.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "Eryone PA-CF @BBL H2D 0.4 nozzle",
+    "inherits": "Bambu PA-CF @base",
+    "from": "system",
+    "setting_id": "GPSB04",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "fan_max_speed": [
+        "10"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "filament_change_length": [
+        "4"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "15",
+        "15"
+    ],
+    "filament_prime_volume": [
+        "30"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
+    "filament_tower_ironing_area": [
+        "8"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "290",
+        "290"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "290",
+        "290"
+    ],
+    "overhang_fan_speed": [
+        "50"
+    ],
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "supertack_plate_temp": [
+        "60"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "60"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "hot_plate_temp": "80",
+    "hot_plate_temp_initial_layer": "80",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEB04"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PA-CF @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PA-CF @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PA-CF @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PA-CF @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PA-CF @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone PA-CF @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu PA-CF @base",
+    "from": "system",
+    "setting_id": "GPSA05",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "0.93",
+        "0.93"
+    ],
+    "filament_max_volumetric_speed": [
+        "10",
+        "10"
+    ],
+    "nozzle_temperature": [
+        "270",
+        "270"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "270",
+        "270"
+    ],
+    "hot_plate_temp": "80",
+    "hot_plate_temp_initial_layer": "80",
+    "fan_max_speed": "10",
+    "fan_min_speed": "0",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEA05"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG @BBL H2D 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG @BBL H2D 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PETG @BBL H2D 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG @BBL H2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG @BBL H2D 0.4 nozzle.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "Eryone PETG @BBL H2D 0.4 nozzle",
+    "inherits": "Bambu PETG Basic @base",
+    "from": "system",
+    "setting_id": "GPSB05",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "fan_max_speed": [
+        "50"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "filament_change_length": [
+        "4"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "20",
+        "20"
+    ],
+    "filament_prime_volume": [
+        "30"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
+    "filament_tower_ironing_area": [
+        "8"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "245",
+        "245"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "245",
+        "245"
+    ],
+    "overhang_fan_speed": [
+        "50"
+    ],
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "supertack_plate_temp": [
+        "60"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "60"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "hot_plate_temp": "70",
+    "hot_plate_temp_initial_layer": "70",
+    "close_fan_the_first_x_layers": "3",
+    "full_fan_speed_layer": "2",
+    "filament_id": "GFEB05"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PETG @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone PETG @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu PETG Basic @base",
+    "from": "system",
+    "setting_id": "GPSA06",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "0.9975",
+        "0.9975"
+    ],
+    "filament_max_volumetric_speed": [
+        "18",
+        "18"
+    ],
+    "nozzle_temperature": [
+        "240",
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "240",
+        "240"
+    ],
+    "hot_plate_temp": "70",
+    "hot_plate_temp_initial_layer": "70",
+    "fan_max_speed": "50",
+    "fan_min_speed": "30",
+    "close_fan_the_first_x_layers": "3",
+    "full_fan_speed_layer": "2",
+    "filament_id": "GFEA06"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Burnt Titanium @BBL H2D 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Burnt Titanium @BBL H2D 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PETG-Burnt Titanium @BBL H2D 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Burnt Titanium @BBL H2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Burnt Titanium @BBL H2D 0.4 nozzle.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "Eryone PETG-Burnt Titanium @BBL H2D 0.4 nozzle",
+    "inherits": "Bambu PETG Basic @base",
+    "from": "system",
+    "setting_id": "GPSB06",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "fan_max_speed": [
+        "50"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "filament_change_length": [
+        "4"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "18",
+        "18"
+    ],
+    "filament_prime_volume": [
+        "30"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
+    "filament_tower_ironing_area": [
+        "8"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "245",
+        "245"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "245",
+        "245"
+    ],
+    "overhang_fan_speed": [
+        "50"
+    ],
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "supertack_plate_temp": [
+        "60"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "60"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "hot_plate_temp": "70",
+    "hot_plate_temp_initial_layer": "70",
+    "close_fan_the_first_x_layers": "3",
+    "full_fan_speed_layer": "2",
+    "filament_id": "GFEB06"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Burnt Titanium @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Burnt Titanium @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PETG-Burnt Titanium @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Burnt Titanium @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Burnt Titanium @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone PETG-Burnt Titanium @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu PETG Basic @base",
+    "from": "system",
+    "setting_id": "GPSA07",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "0.96",
+        "0.96"
+    ],
+    "filament_max_volumetric_speed": [
+        "20",
+        "20"
+    ],
+    "nozzle_temperature": [
+        "245",
+        "245"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "245",
+        "245"
+    ],
+    "hot_plate_temp": "70",
+    "hot_plate_temp_initial_layer": "70",
+    "fan_max_speed": "50",
+    "fan_min_speed": "30",
+    "close_fan_the_first_x_layers": "3",
+    "full_fan_speed_layer": "2",
+    "filament_id": "GFEA07"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-CF @BBL H2D 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-CF @BBL H2D 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PETG-CF @BBL H2D 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-CF @BBL H2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-CF @BBL H2D 0.4 nozzle.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "Eryone PETG-CF @BBL H2D 0.4 nozzle",
+    "inherits": "Bambu PETG-CF @base",
+    "from": "system",
+    "setting_id": "GPSB07",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "fan_max_speed": [
+        "50"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "filament_change_length": [
+        "4"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "18",
+        "18"
+    ],
+    "filament_prime_volume": [
+        "30"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
+    "filament_tower_ironing_area": [
+        "8"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "250",
+        "250"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "250",
+        "250"
+    ],
+    "overhang_fan_speed": [
+        "50"
+    ],
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "supertack_plate_temp": [
+        "60"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "60"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "hot_plate_temp": "70",
+    "hot_plate_temp_initial_layer": "70",
+    "close_fan_the_first_x_layers": "3",
+    "full_fan_speed_layer": "2",
+    "filament_id": "GFEB07"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-CF @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-CF @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PETG-CF @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-CF @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-CF @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone PETG-CF @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu PETG-CF @base",
+    "from": "system",
+    "setting_id": "GPSA08",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "0.97",
+        "0.97"
+    ],
+    "filament_max_volumetric_speed": [
+        "15",
+        "15"
+    ],
+    "nozzle_temperature": [
+        "250",
+        "250"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "250",
+        "250"
+    ],
+    "hot_plate_temp": "70",
+    "hot_plate_temp_initial_layer": "70",
+    "fan_max_speed": "50",
+    "fan_min_speed": "30",
+    "close_fan_the_first_x_layers": "3",
+    "full_fan_speed_layer": "2",
+    "filament_id": "GFEA08"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-GF @BBL H2D 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-GF @BBL H2D 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PETG-GF @BBL H2D 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-GF @BBL H2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-GF @BBL H2D 0.4 nozzle.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "Eryone PETG-GF @BBL H2D 0.4 nozzle",
+    "inherits": "Bambu PETG Basic @base",
+    "from": "system",
+    "setting_id": "GPSB08",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "fan_max_speed": [
+        "50"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "filament_change_length": [
+        "4"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "17",
+        "17"
+    ],
+    "filament_prime_volume": [
+        "30"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
+    "filament_tower_ironing_area": [
+        "8"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "250",
+        "250"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "250",
+        "250"
+    ],
+    "overhang_fan_speed": [
+        "50"
+    ],
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "supertack_plate_temp": [
+        "60"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "60"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "hot_plate_temp": "70",
+    "hot_plate_temp_initial_layer": "70",
+    "close_fan_the_first_x_layers": "3",
+    "full_fan_speed_layer": "2",
+    "filament_id": "GFEB08"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-GF @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-GF @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PETG-GF @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-GF @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-GF @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone PETG-GF @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu PETG Basic @base",
+    "from": "system",
+    "setting_id": "GPSA09",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "0.95",
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "13",
+        "13"
+    ],
+    "nozzle_temperature": [
+        "245",
+        "245"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "245",
+        "245"
+    ],
+    "hot_plate_temp": "70",
+    "hot_plate_temp_initial_layer": "70",
+    "fan_max_speed": "50",
+    "fan_min_speed": "30",
+    "close_fan_the_first_x_layers": "3",
+    "full_fan_speed_layer": "2",
+    "filament_id": "GFEA09"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Lite @BBL H2D 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Lite @BBL H2D 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PETG-Lite @BBL H2D 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Lite @BBL H2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Lite @BBL H2D 0.4 nozzle.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "Eryone PETG-Lite @BBL H2D 0.4 nozzle",
+    "inherits": "Bambu PETG Basic @base",
+    "from": "system",
+    "setting_id": "GPSB09",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "fan_max_speed": [
+        "50"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "filament_change_length": [
+        "4"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "16",
+        "16"
+    ],
+    "filament_prime_volume": [
+        "30"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
+    "filament_tower_ironing_area": [
+        "8"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "240",
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "240",
+        "240"
+    ],
+    "overhang_fan_speed": [
+        "50"
+    ],
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "supertack_plate_temp": [
+        "60"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "60"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "hot_plate_temp": "70",
+    "hot_plate_temp_initial_layer": "70",
+    "close_fan_the_first_x_layers": "3",
+    "full_fan_speed_layer": "2",
+    "filament_id": "GFEB09"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Matte @BBL H2D 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Matte @BBL H2D 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PETG-Matte @BBL H2D 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Matte @BBL H2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Matte @BBL H2D 0.4 nozzle.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "Eryone PETG-Matte @BBL H2D 0.4 nozzle",
+    "inherits": "Bambu PETG Matte @base",
+    "from": "system",
+    "setting_id": "GPSB10",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "fan_max_speed": [
+        "50"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "filament_change_length": [
+        "4"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "22",
+        "22"
+    ],
+    "filament_prime_volume": [
+        "30"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
+    "filament_tower_ironing_area": [
+        "8"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "245",
+        "245"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "245",
+        "245"
+    ],
+    "overhang_fan_speed": [
+        "50"
+    ],
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "supertack_plate_temp": [
+        "60"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "60"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "hot_plate_temp": "70",
+    "hot_plate_temp_initial_layer": "70",
+    "close_fan_the_first_x_layers": "3",
+    "full_fan_speed_layer": "2",
+    "filament_id": "GFEB10"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Matte @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Matte @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PETG-Matte @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Matte @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PETG-Matte @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone PETG-Matte @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu PETG Matte @base",
+    "from": "system",
+    "setting_id": "GPSA10",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "0.99",
+        "0.99"
+    ],
+    "filament_max_volumetric_speed": [
+        "21",
+        "21"
+    ],
+    "nozzle_temperature": [
+        "255",
+        "255"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "255",
+        "255"
+    ],
+    "hot_plate_temp": "70",
+    "hot_plate_temp_initial_layer": "70",
+    "fan_max_speed": "50",
+    "fan_min_speed": "30",
+    "close_fan_the_first_x_layers": "3",
+    "full_fan_speed_layer": "2",
+    "filament_id": "GFEA10"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PLA+ @BBL H2D 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PLA+ @BBL H2D 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PLA+ @BBL H2D 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PLA+ @BBL H2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PLA+ @BBL H2D 0.4 nozzle.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "Eryone PLA+ @BBL H2D 0.4 nozzle",
+    "inherits": "Bambu PLA Basic @base",
+    "from": "system",
+    "setting_id": "GPSB11",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "80"
+    ],
+    "filament_change_length": [
+        "4"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "20",
+        "20"
+    ],
+    "filament_prime_volume": [
+        "30"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
+    "filament_tower_ironing_area": [
+        "8"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "220",
+        "220"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220",
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "50"
+    ],
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "supertack_plate_temp": [
+        "60"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "60"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "hot_plate_temp": "55",
+    "hot_plate_temp_initial_layer": "55",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEB11"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PLA+ @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PLA+ @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PLA+ @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PLA+ @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PLA+ @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone PLA+ @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu PLA Basic @base",
+    "from": "system",
+    "setting_id": "GPSA11",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "0.95",
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "17",
+        "17"
+    ],
+    "nozzle_temperature": [
+        "210",
+        "210"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "210",
+        "210"
+    ],
+    "hot_plate_temp": "55",
+    "hot_plate_temp_initial_layer": "55",
+    "fan_max_speed": "100",
+    "fan_min_speed": "80",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEA11"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PLA+HS @BBL H2D 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PLA+HS @BBL H2D 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PLA+HS @BBL H2D 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PLA+HS @BBL H2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PLA+HS @BBL H2D 0.4 nozzle.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "Eryone PLA+HS @BBL H2D 0.4 nozzle",
+    "inherits": "Bambu PLA Basic @base",
+    "from": "system",
+    "setting_id": "GPSB12",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "80"
+    ],
+    "filament_change_length": [
+        "4"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "20",
+        "20"
+    ],
+    "filament_prime_volume": [
+        "30"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
+    "filament_tower_ironing_area": [
+        "8"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "215",
+        "215"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "215",
+        "215"
+    ],
+    "overhang_fan_speed": [
+        "50"
+    ],
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "supertack_plate_temp": [
+        "60"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "60"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "hot_plate_temp": "55",
+    "hot_plate_temp_initial_layer": "55",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEB12"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PLA+HS @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PLA+HS @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PLA+HS @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PLA+HS @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PLA+HS @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone PLA+HS @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu PLA Basic @base",
+    "from": "system",
+    "setting_id": "GPSA12",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "1.1",
+        "1.1"
+    ],
+    "filament_max_volumetric_speed": [
+        "15",
+        "15"
+    ],
+    "nozzle_temperature": [
+        "220",
+        "220"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220",
+        "220"
+    ],
+    "hot_plate_temp": "55",
+    "hot_plate_temp_initial_layer": "55",
+    "fan_max_speed": "100",
+    "fan_min_speed": "80",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEA12"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PLA-Matte @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PLA-Matte @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PLA-Matte @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PLA-Matte @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PLA-Matte @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone PLA-Matte @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu PLA Matte @base",
+    "from": "system",
+    "setting_id": "GPSA13",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "1.07",
+        "1.07"
+    ],
+    "filament_max_volumetric_speed": [
+        "22",
+        "22"
+    ],
+    "nozzle_temperature": [
+        "225",
+        "225"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "225",
+        "225"
+    ],
+    "hot_plate_temp": "55",
+    "hot_plate_temp_initial_layer": "55",
+    "fan_max_speed": "100",
+    "fan_min_speed": "80",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEA13"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PLA-Matte HS @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PLA-Matte HS @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PLA-Matte HS @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PLA-Matte HS @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PLA-Matte HS @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone PLA-Matte HS @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu PLA Basic @base",
+    "from": "system",
+    "setting_id": "GPSA14",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "1.01",
+        "1.01"
+    ],
+    "filament_max_volumetric_speed": [
+        "22",
+        "22"
+    ],
+    "nozzle_temperature": [
+        "215",
+        "215"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "215",
+        "215"
+    ],
+    "hot_plate_temp": "55",
+    "hot_plate_temp_initial_layer": "55",
+    "fan_max_speed": "100",
+    "fan_min_speed": "80",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEA14"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PLA-Silk @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PLA-Silk @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone PLA-Silk @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone PLA-Silk @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone PLA-Silk @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone PLA-Silk @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu PLA Silk+ @base",
+    "from": "system",
+    "setting_id": "GPSA15",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "0.98",
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "13",
+        "13"
+    ],
+    "nozzle_temperature": [
+        "225",
+        "225"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "225",
+        "225"
+    ],
+    "hot_plate_temp": "55",
+    "hot_plate_temp_initial_layer": "55",
+    "fan_max_speed": "100",
+    "fan_min_speed": "80",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEA15"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone petg-Galaxy @BBL H2D 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone petg-Galaxy @BBL H2D 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone petg-Galaxy @BBL H2D 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone petg-Galaxy @BBL H2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone petg-Galaxy @BBL H2D 0.4 nozzle.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "Eryone petg-Galaxy @BBL H2D 0.4 nozzle",
+    "inherits": "Bambu PETG Basic @base",
+    "from": "system",
+    "setting_id": "GPSB13",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "fan_max_speed": [
+        "50"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "filament_change_length": [
+        "4"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "18",
+        "18"
+    ],
+    "filament_prime_volume": [
+        "30"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
+    "filament_tower_ironing_area": [
+        "8"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "250",
+        "250"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "250",
+        "250"
+    ],
+    "overhang_fan_speed": [
+        "50"
+    ],
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "supertack_plate_temp": [
+        "60"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "60"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "hot_plate_temp": "70",
+    "hot_plate_temp_initial_layer": "70",
+    "close_fan_the_first_x_layers": "3",
+    "full_fan_speed_layer": "2",
+    "filament_id": "GFEB13"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone petg-Galaxy @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone petg-Galaxy @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone petg-Galaxy @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone petg-Galaxy @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone petg-Galaxy @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone petg-Galaxy @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu PETG Basic @base",
+    "from": "system",
+    "setting_id": "GPSA16",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "0.96",
+        "0.96"
+    ],
+    "filament_max_volumetric_speed": [
+        "20",
+        "20"
+    ],
+    "nozzle_temperature": [
+        "250",
+        "250"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "250",
+        "250"
+    ],
+    "hot_plate_temp": "70",
+    "hot_plate_temp_initial_layer": "70",
+    "fan_max_speed": "50",
+    "fan_min_speed": "30",
+    "close_fan_the_first_x_layers": "3",
+    "full_fan_speed_layer": "2",
+    "filament_id": "GFEA16"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone pla-Ultra Silk @BBL H2D 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone pla-Ultra Silk @BBL H2D 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone pla-Ultra Silk @BBL H2D 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone pla-Ultra Silk @BBL H2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone pla-Ultra Silk @BBL H2D 0.4 nozzle.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "Eryone pla-Ultra Silk @BBL H2D 0.4 nozzle",
+    "inherits": "Bambu PLA Silk+ @base",
+    "from": "system",
+    "setting_id": "GPSB14",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "80"
+    ],
+    "filament_change_length": [
+        "4"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_max_volumetric_speed": [
+        "20",
+        "20"
+    ],
+    "filament_prime_volume": [
+        "30"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
+    "filament_tower_ironing_area": [
+        "8"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "nozzle_temperature": [
+        "230",
+        "230"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "230",
+        "230"
+    ],
+    "overhang_fan_speed": [
+        "50"
+    ],
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "supertack_plate_temp": [
+        "60"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "60"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "hot_plate_temp": "55",
+    "hot_plate_temp_initial_layer": "55",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEB14"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone pla-Ultra Silk @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone pla-Ultra Silk @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone pla-Ultra Silk @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone pla-Ultra Silk @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone pla-Ultra Silk @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone pla-Ultra Silk @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu PLA Silk+ @base",
+    "from": "system",
+    "setting_id": "GPSA17",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "0.97",
+        "0.97"
+    ],
+    "filament_max_volumetric_speed": [
+        "12.3",
+        "12.3"
+    ],
+    "nozzle_temperature": [
+        "225",
+        "225"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "225",
+        "225"
+    ],
+    "hot_plate_temp": "55",
+    "hot_plate_temp_initial_layer": "55",
+    "fan_max_speed": "100",
+    "fan_min_speed": "80",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEA17"
+}

--- a/resources/profiles/BBL/filament/ERYONE/Eryone ppa-cf @BBL P1S 0.4 nozzle.info
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone ppa-cf @BBL P1S 0.4 nozzle.info
@@ -1,0 +1,2 @@
+[filament]
+name = Eryone ppa-cf @BBL P1S 0.4 nozzle

--- a/resources/profiles/BBL/filament/ERYONE/Eryone ppa-cf @BBL P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/ERYONE/Eryone ppa-cf @BBL P1S 0.4 nozzle.json
@@ -1,0 +1,83 @@
+{
+    "type": "filament",
+    "name": "Eryone ppa-cf @BBL P1S 0.4 nozzle",
+    "inherits": "Bambu PPA-CF @base",
+    "from": "system",
+    "setting_id": "GPSA18",
+    "instantiation": "true",
+    "filament_vendor": [
+        "Eryone"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18",
+        "18"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "50"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "0.6"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "include": [
+        "fdm_filament_template_direct_dual"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\nM142 P1 R35 S40\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_flow_ratio": [
+        "0.96",
+        "0.96"
+    ],
+    "filament_max_volumetric_speed": [
+        "9",
+        "9"
+    ],
+    "nozzle_temperature": [
+        "290",
+        "290"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "290",
+        "290"
+    ],
+    "hot_plate_temp": "100",
+    "hot_plate_temp_initial_layer": "100",
+    "fan_max_speed": "10",
+    "fan_min_speed": "0",
+    "close_fan_the_first_x_layers": "1",
+    "full_fan_speed_layer": "0",
+    "filament_id": "GFEA18"
+}


### PR DESCRIPTION
你好bambu studio团队，我是Eryone技术，我增加了ERYONE品牌的材料参数文件，PLA+, PLA+HS, PLA-Matte, PLA-Matte HS, PLA-Silk, pla-Ultra Silk，PETG, PETG-Burnt Titanium, PETG-CF, PETG-GF, PETG-Lite, PETG-Matte, petg-Galaxy，ABS+-HS, ABS-GF，ASA-CF, ASA-GF，PA-CF，ppa-cf。帮忙审核下谢谢