### PR TITLE
fix(svg): prevent use-after-free when dragging a "Surround surface" SVG over an object

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoSVG.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSVG.cpp
@@ -2168,6 +2168,10 @@ void GLGizmoSVG::register_single_mesh_pick()
         }
         auto world_tran = v->get_instance_transformation() * v->get_volume_transformation();
         auto mesh       = const_cast<TriangleMesh *>(v->ori_mesh);
+        // PickRaycaster dereferences mesh unconditionally (MeshRaycaster(*mesh)); a
+        // volume without an original mesh would crash the raycaster setup.
+        if (mesh == nullptr)
+            continue;
         if (m_mesh_raycaster_map.find(v) != m_mesh_raycaster_map.end()) {
             m_mesh_raycaster_map[v]->world_tran.set_from_transform(world_tran.get_matrix());
         } else {

--- a/src/slic3r/GUI/SurfaceDrag.cpp
+++ b/src/slic3r/GUI/SurfaceDrag.cpp
@@ -654,6 +654,19 @@ bool dragging(const Vec2d                 &mouse_pos,
               const RaycastManager        &raycast_manager,
               const std::optional<double> &up_limit)
 {
+    // Re-resolve the dragged volume from the current selection before using it.
+    // An asynchronous job - notably the "use surface" mesh recompute that is queued
+    // at the end of every surface drag - can reload the scene and delete/recreate
+    // this GLVolume while a subsequent drag is in progress. The pointer cached in
+    // surface_drag would then dangle and dereferencing it (below) is a use-after-free.
+    // get_selected_gl_volume() always returns a live volume from the current scene
+    // (matched by composite_id) or nullptr, so this keeps the drag pointing at valid
+    // memory instead of crashing.
+    if (GLVolume *gl_volume = get_selected_gl_volume(canvas))
+        surface_drag.gl_volume = gl_volume;
+    else
+        return false;
+
     Vec2d offseted_mouse = mouse_pos + surface_drag.mouse_offset_without_sla_shift;
     std::optional<RaycastManager::Hit> hit = ray_from_camera(
         raycast_manager, offseted_mouse, camera, &surface_drag.condition);


### PR DESCRIPTION
## Problem

BambuStudio frequently crashes while **dragging an SVG decal across the surface of an object**, but only when the SVG's placement mode is set to **"Surround surface"** (`Edit SVG` → *Use surface* / `use_surface`). Dragging the same SVG in flat mode never crashes. The crash is intermittent — it happens "often," not every time — which is the signature of a use-after-free landing on memory that has sometimes already been reused.

I do not have an ASan/heap trace for this one; the diagnosis below is from reading the code path, in the same spirit as #11052. The fix is defensive and correct regardless of whether the exact mechanism is as described.

## Root cause

A timing-dependent use-after-free of the dragged `GLVolume`:

1. In "Surround surface" mode — and only there — finishing a surface drag queues an **asynchronous** `UpdateSurfaceVolumeJob` (the CGAL surface re-cut). See `GLGizmoSVG::on_mouse_for_translate` → `process_job()`:

   ```cpp
   // End with surface dragging?
   if (was_dragging && !is_dragging) {
       if (m_volume->emboss_shape->projection.use_surface)
           process_job();        // queues UpdateSurfaceVolumeJob (worker thread)
   ```

2. When that background job finalizes, `UpdateJob::update_volume` calls `set_mesh()` + `set_new_unique_id()` on the SVG volume and then `Plater::changed_object()` → `reload_scene()`.

3. `reload_scene()` matches old `GLVolume`s to the new model state by `geometry_id`. Because the SVG volume's id and mesh just changed, its old `GLVolume` no longer matches and is **deleted** (and a fresh one created):

   ```cpp
   if (mvs == nullptr || force_full_scene_refresh) {
       ...
       m_volumes.release_volume(volume);
       delete volume;            // old SVG GLVolume freed here
   }
   ```

4. `SurfaceDrag::gl_volume` is a raw `GLVolume*` captured once at `start_dragging`. If the user begins the **next** drag before the background cut finishes (exactly what happens when repeatedly moving an SVG around a surface), the job finalizes *mid-drag*, freeing that volume. The next `SurfaceDrag::dragging()` call then dereferences the dangling pointer:

   ```cpp
   const ModelVolume *volume = get_model_volume(*surface_drag.gl_volume, ...); // reads freed GLVolume::object_idx() → UAF
   ```

A single slow, deliberate drag does not crash, because the job is queued only *after* `surface_drag` is reset — the race needs the async cut still running when the next drag starts. Flat mode never queues that job, so it is unaffected.

## Fix

Two changes, both small and defensive:

- **`SurfaceDrag::dragging()`** — re-resolve the dragged volume from the live selection via `get_selected_gl_volume()` at the top of every call. That helper returns a `GLVolume` from the *current* scene (matched by `composite_id`) or `nullptr`, so the pointer can never dangle; if the volume is genuinely gone the drag aborts safely instead of crashing. This is shared code, so it also fixes the identical race in the **text-emboss** surface drag.

- **`GLGizmoSVG::register_single_mesh_pick()`** — skip volumes whose `ori_mesh` is `nullptr` before passing them to `PickRaycaster`, whose constructor dereferences the mesh unconditionally (`MeshRaycaster(*mesh)`). Secondary hardening of the surface-drag raycaster setup.

No functional change on the healthy path.

## Relationship to other SVG-surface crashes

This is a **distinct** crash from the apply-time "Use surface" crashes — #6403, #10376, #7782, #5995 — which occur in the CGAL `cut_surface` path when the surface projection is *computed* (the deep-recursion stack overflow addressed by #10847). This PR does not fix those; it specifically addresses the use-after-free that happens while **moving** an already-placed surface-mode SVG. The two are complementary.

## Test plan

- [x] Static analysis of the drag/reload lifetime; change is type-checked against existing `get_selected_gl_volume(canvas)` call sites in `SurfaceDrag.cpp`.
- [ ] Local compile not yet run (full build is heavy); compile verification by a maintainer/CI appreciated.
- [ ] Functional repro: rapidly drag a "Surround surface" SVG decal back and forth across a curved object — previously crashed intermittently, should no longer.
