### PR TITLE
fix: Compare Presets ignores High Flow-only filament changes (#11311)

### DIFF
--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -2164,7 +2164,10 @@ void DiffPresetDialog::update_tree()
         }
 
         // Collect dirty options.
-        const bool deep_compare = (type == Preset::TYPE_PRINTER || type == Preset::TYPE_SLA_MATERIAL);
+        // Match the deep-compare set used by the save/unsaved-changes flow above, so per-variant
+        // vector options (e.g. filament values that differ only in the High Flow nozzle variant)
+        // are diffed per index and show the value that actually changed instead of always index 0.
+        const bool deep_compare = (type == Preset::TYPE_PRINTER || type == Preset::TYPE_PRINT || type == Preset::TYPE_FILAMENT || type == Preset::TYPE_SLA_MATERIAL);
         auto dirty_options = type == Preset::TYPE_PRINTER && left_pt == ptFFF &&
                              left_config.opt<ConfigOptionStrings>("extruder_colour")->values.size() < right_congig.opt<ConfigOptionStrings>("extruder_colour")->values.size() ?
                              presets->dirty_options(right_preset, left_preset, deep_compare) :


### PR DESCRIPTION
### What

Fixes #11311. In the Compare Presets dialog, a filament setting that was changed **only** on the High Flow nozzle variant showed the unchanged *standard*-flow value instead of the value that actually differs.

### Root cause

`DiffPresetDialog::update_tree()` enabled the per-index deep compare only for printer and SLA-material presets:

```cpp
const bool deep_compare = (type == Preset::TYPE_PRINTER || type == Preset::TYPE_SLA_MATERIAL);
```

For filament presets it fell back to the shallow `config.diff`, which returns the bare option key. Filament settings that vary by nozzle variant live in `filament_options_with_variant` and are stored as one value per `filament_extruder_variant` (Standard, High Flow, …). The shallow diff still flags such an option as different, but `get_string_value` then has no `#idx` suffix to work with and defaults to index 0, i.e. the standard-flow value. So a High-Flow-only change is reported as "different" while both columns display the identical standard value.

### Fix

Align the deep-compare set here with the one already used by the save / unsaved-changes flow a few hundred lines above in the same file, which already includes `TYPE_PRINT` and `TYPE_FILAMENT`. `deep_diff` then emits `opt_key#idx` for the exact differing variant and `get_string_value` renders that index, the same mechanism already used for per-extruder printer options, and the `#idx` label path in `OptionsSearcher::get_option` already handles these keys.

One line, matching an existing sibling call site, so no new display code is introduced.

### Note

I verified the data path by tracing `deep_diff` / `get_string_value` / `get_option`, but haven't run it against the reporter's exact preset. Since this only opts filament into the same code path the save dialog already uses, behaviour should match how per-variant differences are shown there. Happy to adjust the variant labelling if you'd prefer the rows to spell out "High Flow" explicitly rather than the shared index labelling.
