### PR TITLE
deadlock in server connected callback calls set_user_selected_machine synchronously

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2101,7 +2101,6 @@ void GUI_App::init_networking_callbacks()
                     m_homepage_server_connect_failed = false;
                     sync_left_server_connect_status();
                     BOOST_LOG_TRIVIAL(trace) << "static: server connected";
-                    m_agent->set_user_selected_machine(m_agent->get_user_selected_machine());
                     if (this->is_enable_multi_machine()) {
                         auto evt = new wxCommandEvent(EVT_UPDATE_MACHINE_LIST);
                         wxQueueEvent(this, evt);


### PR DESCRIPTION
On macOS, the 'server connected' callback fires while the closing networking plugin holds internal locks. The callback in init_networking_callbacks() calls set_user_selected_machine() directly (not via CallAfter), which tries to acquire those same locks on the UI thread, causing a deadlock that freezes the device page UI.