### PR TITLE
fix: Boolean difference silently does nothing on near-coplanar/step cuts (#11410)

### DIFF
--- a/src/libslic3r/MeshBoolean.cpp
+++ b/src/libslic3r/MeshBoolean.cpp
@@ -854,12 +854,31 @@ bool do_boolean(McutMesh& srcMesh, const McutMesh& cutMesh, const std::string& b
         if (boolean_opts == "UNION" || boolean_opts == "A_NOT_B") {
             for (size_t i = 0; i < src_parts.size(); i++) {
                 auto src_part = triangle_mesh_to_mcut(src_parts[i]);
+                // TriangleMesh-domain accumulator so a failed mcut difference can fall back to CGAL.
+                indexed_triangle_set acc = src_parts[i];
                 for (size_t j = 0; j < cut_parts.size(); j++) {
                     if (cancel_cb && cancel_cb()) {
                         return false;
                     }
                     auto cut_part = triangle_mesh_to_mcut(cut_parts[j]);
-                    do_boolean_single(*src_part, *cut_part, boolean_opts, cancel_cb, temp_progress_cb);
+                    bool ok = do_boolean_single(*src_part, *cut_part, boolean_opts, cancel_cb, temp_progress_cb);
+                    if (boolean_opts == "A_NOT_B") {
+                        if (!ok) {
+                            // mcut produced no fragment for this difference. This happens for
+                            // near-coplanar / step cuts where its LOCATION_ABOVE fragment filter
+                            // selects zero connected components (issue #11410); until now the
+                            // subtraction was silently dropped, leaving the model unchanged.
+                            // Fall back to the more robust CGAL corefinement so the cut still applies.
+                            try {
+                                cgal::minus(acc, cut_parts[j]);
+                                src_part = triangle_mesh_to_mcut(acc);
+                            } catch (const std::exception &e) {
+                                BOOST_LOG_TRIVIAL(error) << "MCUT A_NOT_B produced nothing, CGAL fallback failed: " << e.what();
+                            }
+                        } else {
+                            acc = mcut_to_triangle_mesh(*src_part).its;
+                        }
+                    }
                     ++count_index;
                 }
                 TriangleMesh tri_part = mcut_to_triangle_mesh(*src_part);

--- a/src/libslic3r/MeshBoolean.cpp
+++ b/src/libslic3r/MeshBoolean.cpp
@@ -620,8 +620,11 @@ MCAPI_ATTR void MCAPI_CALL mcDebugOutput(McDebugSource source,
 }
 
 
-bool do_boolean_single(McutMesh &srcMesh, const McutMesh &cutMesh, const std::string &boolean_opts, const BooleanCancelCB& cancel_cb, const BooleanProgressCB& progress_cb)
+static bool do_boolean_single_impl(McutMesh &srcMesh, const McutMesh &cutMesh, const std::string &boolean_opts, const BooleanCancelCB& cancel_cb, const BooleanProgressCB& progress_cb, bool *dispatch_failed)
 {
+    if (dispatch_failed)
+        *dispatch_failed = false;
+
     // create context
     McContext context = MC_NULL_HANDLE;
     McResult  err     = mcCreateContext(&context, 0);
@@ -671,6 +674,9 @@ bool do_boolean_single(McutMesh &srcMesh, const McutMesh &cutMesh, const std::st
         progress_cb(10.0f);
     }
     if (err != MC_NO_ERROR) {
+        if (dispatch_failed)
+            *dispatch_failed = true;
+
         BOOST_LOG_TRIVIAL(debug) << "MCUT mcDispatch fails! err=" << err;
         mcReleaseContext(context);
         if (boolean_opts == "UNION") {
@@ -821,6 +827,17 @@ bool do_boolean_single(McutMesh &srcMesh, const McutMesh &cutMesh, const std::st
     return true;
 }
 
+bool do_boolean_single(McutMesh &srcMesh, const McutMesh &cutMesh, const std::string &boolean_opts, const BooleanCancelCB& cancel_cb, const BooleanProgressCB& progress_cb)
+{
+    return do_boolean_single_impl(
+        srcMesh,
+        cutMesh,
+        boolean_opts,
+        cancel_cb,
+        progress_cb,
+        nullptr);
+}
+
 bool do_boolean(McutMesh& srcMesh, const McutMesh& cutMesh, const std::string& boolean_opts, const BooleanCancelCB& cancel_cb, const BooleanProgressCB& progress_cb, const BooleanFailedCB& failed_cb)
 {
     try {
@@ -854,12 +871,110 @@ bool do_boolean(McutMesh& srcMesh, const McutMesh& cutMesh, const std::string& b
         if (boolean_opts == "UNION" || boolean_opts == "A_NOT_B") {
             for (size_t i = 0; i < src_parts.size(); i++) {
                 auto src_part = triangle_mesh_to_mcut(src_parts[i]);
+                indexed_triangle_set acc = src_parts[i];
                 for (size_t j = 0; j < cut_parts.size(); j++) {
                     if (cancel_cb && cancel_cb()) {
                         return false;
                     }
+
                     auto cut_part = triangle_mesh_to_mcut(cut_parts[j]);
-                    do_boolean_single(*src_part, *cut_part, boolean_opts, cancel_cb, temp_progress_cb);
+                    bool dispatch_failed = false;
+                    bool ok = do_boolean_single_impl(
+                        *src_part,
+                        *cut_part,
+                        boolean_opts,
+                        cancel_cb,
+                        temp_progress_cb,
+                        &dispatch_failed);
+
+                    // do_boolean_single_impl() also returns false on cancellation.
+                    // Never reinterpret a user cancel as a geometric mcut failure.
+                    if (cancel_cb && cancel_cb()) {
+                        return false;
+                    }
+
+                    if (boolean_opts == "A_NOT_B") {
+                        if (!ok && dispatch_failed) {
+                            // #11410: the reporter's model fails in mcDispatch and contains
+                            // self-intersecting geometry. Feeding the same input directly into
+                            // CGAL PMP corefinement is not a valid fallback because that path
+                            // deliberately rejects self-intersections.
+                            //
+                            // Try to normalize only the offending geometry with the existing
+                            // libigl/CGAL self-union path, then retry the original mcut operation.
+                            TriangleMesh repaired_src(acc);
+                            TriangleMesh repaired_cut(cut_parts[j]);
+
+                            const bool src_self_intersects = cgal::does_self_intersect(repaired_src);
+                            const bool cut_self_intersects = cgal::does_self_intersect(repaired_cut);
+
+                            BOOST_LOG_TRIVIAL(info)
+                                << "MCUT A_NOT_B failed; self-intersection check: src="
+                                << src_self_intersects
+                                << ", cut=" << cut_self_intersects;
+
+                            bool repaired = false;
+
+                            if (src_self_intersects) {
+                                MeshBoolean::self_union(repaired_src);
+                                repaired = true;
+                            }
+
+                            if (cut_self_intersects) {
+                                MeshBoolean::self_union(repaired_cut);
+                                repaired = true;
+                            }
+
+                            if (cancel_cb && cancel_cb()) {
+                                return false;
+                            }
+
+                            if (!repaired) {
+                                throw Slic3r::RuntimeError(
+                                    "MCUT mesh boolean failed and no self-intersection was found.");
+                            }
+
+                            const bool src_still_self_intersects =
+                                cgal::does_self_intersect(repaired_src);
+                            const bool cut_still_self_intersects =
+                                cgal::does_self_intersect(repaired_cut);
+
+                            BOOST_LOG_TRIVIAL(info)
+                                << "MCUT A_NOT_B after repair: src self-intersection="
+                                << src_still_self_intersects
+                                << ", cut self-intersection="
+                                << cut_still_self_intersects;
+
+                            if (src_still_self_intersects || cut_still_self_intersects) {
+                                throw Slic3r::RuntimeError(
+                                    "Mesh self-intersection repair failed.");
+                            }
+
+                            src_part = triangle_mesh_to_mcut(repaired_src.its);
+                            cut_part = triangle_mesh_to_mcut(repaired_cut.its);
+
+                            dispatch_failed = false;
+                            ok = do_boolean_single_impl(
+                                *src_part,
+                                *cut_part,
+                                boolean_opts,
+                                cancel_cb,
+                                temp_progress_cb,
+                                &dispatch_failed);
+
+                            if (cancel_cb && cancel_cb()) {
+                                return false;
+                            }
+
+                            if (!ok) {
+                                throw Slic3r::RuntimeError(
+                                    "MCUT mesh boolean failed after self-intersection repair.");
+                            }
+                        }
+
+                        acc = mcut_to_triangle_mesh(*src_part).its;
+                    }
+
                     ++count_index;
                 }
                 TriangleMesh tri_part = mcut_to_triangle_mesh(*src_part);


### PR DESCRIPTION
### What

Fixes #11410.

The interactive Boolean Difference operation can silently leave the source mesh unchanged when mcut fails on problematic input geometry.

For the reporter's original model, the actual failure occurs in `mcDispatch` with `MC_INVALID_OPERATION` (`err=-2`). The affected input contains self-intersections, so directly falling back to CGAL PMP corefinement is not viable either: the existing CGAL path deliberately rejects self-intersecting input, and disabling that protection can crash inside `corefine_and_compute_difference`.

### Root cause

`MeshBoolean::mcut::do_boolean()` performs `A_NOT_B` operations through `do_boolean_single()`.

On the reporter's model:

1. `mcDispatch` fails with `MC_INVALID_OPERATION`.
2. `do_boolean_single()` returns `false`.
3. The previous `A_NOT_B` path did not distinguish this dispatch failure from other false-return paths.
4. The unchanged source part could therefore be merged back, making the Boolean operation appear to succeed without applying the cut.

A direct `cgal::minus()` fallback does not solve the problem because the input is self-intersecting. The CGAL PMP path uses `throw_on_self_intersection(true)` for good reason; relaxing that guard can crash during corefinement.

### Fix

Keep the existing public `do_boolean_single()` API and use an internal implementation that additionally reports whether `mcDispatch` itself failed.

For `A_NOT_B`, recovery is only attempted for an actual `mcDispatch` failure:

- preserve cancellation semantics before entering recovery
- check the source and cutter for self-intersections
- normalize only the affected mesh(es) using the existing `MeshBoolean::self_union()` path
- verify that the repaired meshes no longer self-intersect
- convert the repaired meshes back to mcut input
- retry the original mcut Boolean Difference operation
- report a hard failure if repair or the retry does not succeed

Other false-return paths are intentionally left unchanged.

`UNION` and `INTERSECTION` behavior is unchanged.

### Cancellation

`do_boolean_single()` can also return `false` when the user cancels an operation.

The recovery path therefore checks `cancel_cb()` immediately after the mcut call and again around repair/retry. A cancellation returns from `do_boolean()` and is never reinterpreted as a geometry failure.

### Validation

The current PR head was validated with both Linux and Windows CI builds.

The reporter's original 3MF from #11410 was also tested interactively with the current Windows PR build:

- the original reporter model loaded successfully
- Mesh Boolean Difference / Subtraction was executed on the reported source and cutter
- the subtraction completed successfully
- the expected cut was applied
- no "Operation Failed" dialog appeared
- Bambu Studio remained responsive after the operation
- the application was then closed normally
- process exit code was 0
- no Windows Application Error / WER crash event or crash dump was produced

This specifically validates the repair-and-retry path on the same Windows platform and reporter geometry that previously failed with `mcDispatch err=-2`.

Closes #11410
