### PR TITLE
feat: add Preferences toggle to hide the daily tips panel (#11402)

### DIFF
--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1610,11 +1610,11 @@ void PreferencesDialog::create_gui_page()
 
     auto title_index_and_tip = create_item_title(_L("Home page and daily tips"), page, _L("Home page and daily tips"));
     auto item_home_page      = create_item_checkbox(_L("Show home page on startup"), page, _L("Show home page on startup"), 50, "show_home_page");
-    //auto item_daily_tip      = create_item_checkbox(_L("Show daily tip on startup"), page, _L("Show daily tip on startup"), 50, "show_daily_tips");
+    auto item_daily_tip      = create_item_checkbox(_L("Show daily tips"), page, _L("Show the daily tips panel in the slicing progress window."), 50, "show_daily_tips");
 
     sizer_page->Add(title_index_and_tip, 0, wxTOP, 26);
     sizer_page->Add(item_home_page, 0, wxTOP, 6);
-    //sizer_page->Add(item_daily_tip, 0, wxTOP, 6);
+    sizer_page->Add(item_daily_tip, 0, wxTOP, 6);
 
     page->SetSizer(sizer_page);
     page->Layout();

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1595,6 +1595,11 @@ wxWindow *PreferencesDialog::create_3d_tab()
                                                        "camera_fullscreen_active_monitor_only");
     sizer->Add(item_camera_fullscreen, flags); // [refactor-review]
 
+    auto item_daily_tip = create_item_checkbox(_L("Show daily tips"), scrolled,
+                                               _L("Show the daily tips panel in the slicing progress window."), 50,
+                                               "show_daily_tips");
+    sizer->Add(item_daily_tip, flags);
+
     sizer->AddSpacer(FromDIP(20));
     scrolled->SetSizer(sizer);
     scrolled->FitInside();

--- a/src/slic3r/GUI/SlicingProgressNotification.cpp
+++ b/src/slic3r/GUI/SlicingProgressNotification.cpp
@@ -231,7 +231,9 @@ void NotificationManager::SlicingProgressNotification::render(GLCanvas3D& canvas
 	float right_gap = right_margin + (move_from_overlay ? overlay_width + m_line_height * 5 : 0);
 	m_window_pos = ImVec2((float)cnv_size.get_width() - right_gap - m_window_width, (float)cnv_size.get_height() - m_top_y);
 	imgui.set_next_window_pos(m_window_pos.x, m_window_pos.y, ImGuiCond_Always, 0.0f, 0.0f);
-	m_window_height = progress_panel_height + m_dailytips_panel->get_size().y + progress_child_window_padding.y + dailytips_child_window_padding.y + bottom_padding.y;
+	// #11402: allow users to fully hide the daily tips panel via Preferences. Default (true) keeps the old layout.
+	const bool show_daily_tips = wxGetApp().app_config->get("show_daily_tips") == "true";
+	m_window_height = progress_panel_height + (show_daily_tips ? (m_dailytips_panel->get_size().y + dailytips_child_window_padding.y) : 0.f) + progress_child_window_padding.y + bottom_padding.y;
 	m_top_y = initial_y + m_window_height;
 	ImGui::SetNextWindowSizeConstraints(ImVec2(m_window_width, m_window_height), ImVec2(m_window_width, m_window_height));
 
@@ -287,22 +289,24 @@ void NotificationManager::SlicingProgressNotification::render(GLCanvas3D& canvas
 			}
 			ImGui::EndChild();
 
-			// Separator Line
-			ImVec2 separator_min = ImVec2(ImGui::GetCursorScreenPos().x + progress_child_window_padding.x, ImGui::GetCursorScreenPos().y);
-			ImVec2 separator_max = ImVec2(ImGui::GetCursorScreenPos().x + progress_child_window_padding.x + progress_panel_width, ImGui::GetCursorScreenPos().y);
-			ImGui::GetCurrentWindow()->DrawList->AddLine(separator_min, separator_max, ImColor(238, 238, 238, (int)(255 * m_current_fade_opacity)));
+			if (show_daily_tips) {
+				// Separator Line
+				ImVec2 separator_min = ImVec2(ImGui::GetCursorScreenPos().x + progress_child_window_padding.x, ImGui::GetCursorScreenPos().y);
+				ImVec2 separator_max = ImVec2(ImGui::GetCursorScreenPos().x + progress_child_window_padding.x + progress_panel_width, ImGui::GetCursorScreenPos().y);
+				ImGui::GetCurrentWindow()->DrawList->AddLine(separator_min, separator_max, ImColor(238, 238, 238, (int)(255 * m_current_fade_opacity)));
 
-			child_name = "##DailyTipsPanel" + std::to_string(parent_window->ID);
-			ImVec2 dailytips_pos = ImGui::GetCursorScreenPos() + dailytips_child_window_padding;
-			ImVec2 dailytips_size = ImVec2(dailytips_panel_width, dailytips_panel_height);
-			m_dailytips_panel->set_position(dailytips_pos);
-			m_dailytips_panel->set_size(dailytips_size);
-			m_dailytips_panel->set_fade_opacity(m_current_fade_opacity);
-			ImGui::SetNextWindowPos(dailytips_pos);
-			if (ImGui::BeginChild(child_name.c_str(), ImVec2(dailytips_panel_width, dailytips_panel_height), false, child_window_flags)) {
-				render_dailytips_panel(dailytips_pos, dailytips_size);
+				child_name = "##DailyTipsPanel" + std::to_string(parent_window->ID);
+				ImVec2 dailytips_pos = ImGui::GetCursorScreenPos() + dailytips_child_window_padding;
+				ImVec2 dailytips_size = ImVec2(dailytips_panel_width, dailytips_panel_height);
+				m_dailytips_panel->set_position(dailytips_pos);
+				m_dailytips_panel->set_size(dailytips_size);
+				m_dailytips_panel->set_fade_opacity(m_current_fade_opacity);
+				ImGui::SetNextWindowPos(dailytips_pos);
+				if (ImGui::BeginChild(child_name.c_str(), ImVec2(dailytips_panel_width, dailytips_panel_height), false, child_window_flags)) {
+					render_dailytips_panel(dailytips_pos, dailytips_size);
+				}
+				ImGui::EndChild();
 			}
-			ImGui::EndChild();
 		}
 
 		if (ImGui::IsMouseHoveringRect(ImGui::GetWindowPos(), ImGui::GetWindowPos() + ImGui::GetWindowSize(), true)) {


### PR DESCRIPTION
### What
Closes #11402. Adds a Preferences checkbox to turn off the daily tips panel shown in the slicing progress notification. There was no way to disable it before.

### Why it was missing
The `show_daily_tips` preference already exists (it defaults to true in AppConfig) and a checkbox for it was written but left commented out in Preferences, with nothing ever reading the preference. The panel only reads `show_hints`, which controls its expand/collapse state, not whether it appears at all. So there really was no Settings control, which is what the reporter hit.

### Change
* Preferences: uncomment the checkbox, relabelled to "Show daily tips" with a clearer tooltip.
* SlicingProgressNotification: gate the panel on `show_daily_tips`. When it is off, the notification height drops the panel contribution and the separator line plus the panel render are skipped.

The preference defaults to true, so the default path is the same as before (the height formula reduces to the original expression when the flag is true). Only the new opt-out branch is added, so it cannot regress the current behaviour.

### Note
I do not have a GUI build here, so I have not visually confirmed the notification layout with the panel hidden. CI covers compilation, and since default behaviour is unchanged the risk is limited to the disabled state. Happy to adjust the label or wording.
