### PR TITLE
feat: add "Clear recent projects" menu entry (#11401)

### DIFF
--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2909,6 +2909,15 @@ void MainFrame::init_menubar_as_editor()
 
         Bind(wxEVT_UPDATE_UI, [this](wxUpdateUIEvent& evt) { evt.Enable(can_open_project() && (m_recent_projects.GetCount() > 0)); }, recent_projects_submenu->GetId());
 
+        // #11401: let users clear the recent projects list from the UI
+        append_menu_item(fileMenu, wxID_ANY, _L("Clear recent projects"), _L("Clear the recent projects list"),
+            [this](wxCommandEvent&) {
+                while (m_recent_projects.GetCount() > 0)
+                    m_recent_projects.RemoveFileFromHistory(m_recent_projects.GetCount() - 1);
+                wxGetApp().app_config->set_recent_projects(std::vector<std::string>());
+                wxGetApp().app_config->save();
+            }, "", nullptr, [this]() { return m_recent_projects.GetCount() > 0; }, this);
+
         // BBS: close save project
 #ifndef __APPLE__
         append_menu_item(fileMenu, wxID_ANY, _L("Save Project") + "\t" + ctrl + "S", _L("Save current project to file"),


### PR DESCRIPTION
### What
Closes #11401. Adds a "Clear recent projects" entry to the File menu so the recent projects list can be cleared from the UI. Until now the only way was to delete config files by hand.

### Change
The new item sits next to the existing "Recent projects" submenu. When clicked it removes every entry from the in-memory FileHistory, clears the persisted recent_projects config and saves. It is disabled when the list is already empty, using the same condition as the submenu.

### Note
No GUI build here, so I have not clicked it in a running build. CI covers compilation. It reuses existing, already-used APIs (FileHistory::RemoveFileFromHistory, AppConfig::set_recent_projects and save), so the risk is low. Happy to move it inside the submenu instead if you prefer that placement.
