### PR TITLE
fix: snap support_top_z_distance to layer multiple in non-independent…

### DIFF
--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -3948,14 +3948,12 @@ void TreeSupport::generate_contact_points()
 
     const coordf_t layer_height = config.layer_height.value;
     coordf_t       z_distance_top = this->top_z_distance;
-  //  if (!m_support_params.independent_layer_height) {
-  //      z_distance_top = round(z_distance_top / layer_height) * layer_height;
-  //  // BBS: add extra distance if thick bridge is enabled
-  //  // Note: normal support uses print_z, but tree support uses integer layers, so we need to subtract layer_height
-  //  if (!m_slicing_params.soluble_interface && m_object_config->thick_bridges) {
-  //      z_distance_top += m_object->layers()[0]->regions()[0]->region().bridging_height_avg(m_object->print()->config()) - layer_height;
-		//}
-  //  }
+    if (!m_support_params.independent_layer_height) {
+        z_distance_top = std::round(z_distance_top / layer_height) * layer_height;
+        // If the configured gap rounds to zero, use one layer minimum so the gap node is still created.
+        if (z_distance_top < EPSILON && this->top_z_distance > EPSILON)
+            z_distance_top = layer_height;
+    }
     const int z_distance_top_layers = round_up_divide(scale_(z_distance_top), scale_(layer_height)) + 1; //Support must always be 1 layer below overhang.
     int gap_layers = z_distance_top == 0 ? 0 : 1;
 


### PR DESCRIPTION
this is a fix for #11392 

In non-independent support layer height mode (e.g. when the prime tower is enabled), z_distance_top was passed raw to the gap-node accumulation loop, which always rounded UP to the nearest layer height. Any configured value between 0 and layer_height produced a gap of exactly one layer regardless of the setting.

Restore the nearest-multiple rounding that was commented out in 39ae64fc5 so the gap snaps to the physically achievable multiple closest to the configured value. When the value rounds to zero (e.g. 0.1 mm with 0.3 mm layers), clamp to one layer minimum so the gap node is still generated. Independent mode is unaffected and continues to produce the exact configured distance.