### PR TITLE
Raise Cool Plate SuperTack bed temp for X2D PLA Basic and PETG HF (#11430)

### DIFF
--- a/resources/profiles/BBL/filament/Bambu PETG HF @BBL X2D 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PETG HF @BBL X2D 0.2 nozzle.json
@@ -156,10 +156,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "60"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "70"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.2 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PETG HF @BBL X2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PETG HF @BBL X2D 0.4 nozzle.json
@@ -138,10 +138,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "60"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "70"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.4 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PETG HF @BBL X2D.json
+++ b/resources/profiles/BBL/filament/Bambu PETG HF @BBL X2D.json
@@ -138,10 +138,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "60"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "70"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.6 nozzle",

--- a/resources/profiles/BBL/filament/Bambu PLA Basic @BBL X2D 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PLA Basic @BBL X2D 0.2 nozzle.json
@@ -144,10 +144,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "40"
+        "45"
     ],
     "supertack_plate_temp_initial_layer": [
-        "40"
+        "45"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.2 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PLA Basic @BBL X2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PLA Basic @BBL X2D 0.4 nozzle.json
@@ -123,10 +123,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "40"
+        "45"
     ],
     "supertack_plate_temp_initial_layer": [
-        "40"
+        "45"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.4 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PLA Basic @BBL X2D.json
+++ b/resources/profiles/BBL/filament/Bambu PLA Basic @BBL X2D.json
@@ -123,10 +123,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "40"
+        "45"
     ],
     "supertack_plate_temp_initial_layer": [
-        "40"
+        "45"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.6 nozzle",


### PR DESCRIPTION
### What

Raise the Cool Plate SuperTack bed temperature in the X2D filament profiles:

* Bambu PLA Basic @BBL X2D: 40 to 45 °C
* Bambu PETG HF @BBL X2D: 60 to 70 °C

Both `supertack_plate_temp` and `supertack_plate_temp_initial_layer`, across the base, 0.2 and 0.4 nozzle variants (6 files).

### Why

45 °C (PLA) and 70 °C (PETG HF) are the filament defaults on the SuperTack plate: PETG HF comes from `fdm_filament_pet` (70), and open frame printers such as the A1 inherit 45/70 on the exact same plate. The X2D profiles currently override these down to 40/60, and the reporter (#11430) sees bed adhesion issues at those values while the A1 with the same plate and material works at 45/70.

### Honest context for maintainers

The 40/60 override is not X2D specific: the other enclosed printers (H2C, H2D, H2DP, H2S, P2S) also override to 40/60. This PR only touches the X2D as requested in #11430, so afterwards the X2D would be the one enclosed printer at 45/70. If the intent behind the lower value is chamber warmth, note it is questionable for PLA where the chamber is not actively heated. You may prefer to apply the same change to the whole enclosed class or keep the distinction. The values themselves are within the normal PLA/PETG bed range and are not risky.

Data only change (profile JSON), not GUI build tested here; CI covers profile validation.

Closes #11430
