### PR TITLE
Preserve per-triangle painting through Boolean, merge and Simplify

### DIFF
--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -2840,26 +2840,27 @@ ModelObjectPtrs ModelObject::merge_volumes(std::vector<int>& vol_indeces)
 
 #if 1
     TriangleMesh mesh;
-    // BBS: preserve painting across the merge. its_merge() appends faces in
-    // order (only vertex indices are offset), so face f of the merged mesh maps
-    // exactly to the captured per-part triangles below. Capture before
-    // reset_mesh() empties the source volumes.
-    std::vector<std::string> merged_supported, merged_seam, merged_mmu, merged_fuzzy;
+    // Preserve painting across the merge. Each part is collected in object frame with
+    // the filament it prints in, so a part that is unpainted but assigned a different
+    // filament keeps its color once the parts share a single volume. The copy itself
+    // stays an exact per-face one, the merged mesh being the parts concatenated.
+    // Source meshes are released only after the copy has read them (see below).
+    std::vector<PaintSourceVolume> paint_sources;
     for (int i : vol_indeces) {
         auto volume = volumes[i];
         if (!volume->mesh().empty()) {
-            const size_t nf = volume->mesh().its.indices.size();
-            for (size_t f = 0; f < nf; ++f) {
-                merged_supported.emplace_back(volume->supported_facets.get_triangle_as_string((int)f));
-                merged_seam.emplace_back(volume->seam_facets.get_triangle_as_string((int)f));
-                merged_mmu.emplace_back(volume->mmu_segmentation_facets.get_triangle_as_string((int)f));
-                merged_fuzzy.emplace_back(volume->fuzzy_skin_facets.get_triangle_as_string((int)f));
-            }
-            const auto volume_matrix = volume->get_matrix();
-            TriangleMesh mesh_(volume->mesh());
-            mesh_.transform(volume_matrix, true);
-            volume->reset_mesh();
+            PaintSourceVolume s;
+            s.mesh                  = &volume->mesh();
+            s.supported             = &volume->supported_facets;
+            s.seam                  = &volume->seam_facets;
+            s.mmu                   = &volume->mmu_segmentation_facets;
+            s.fuzzy                 = &volume->fuzzy_skin_facets;
+            s.source_to_destination = volume->get_matrix();
+            s.base_filament         = volume->extruder_id(); // bake solid part color into paint
+            paint_sources.push_back(s);
 
+            TriangleMesh mesh_(volume->mesh());
+            mesh_.transform(volume->get_matrix(), true);
             mesh.merge(mesh_);
         }
     }
@@ -2874,13 +2875,18 @@ ModelObjectPtrs ModelObject::merge_volumes(std::vector<int>& vol_indeces)
 #endif
 
     ModelVolume* vol = upper->add_volume(mesh);
-    // BBS: re-apply the painting captured above onto the merged volume.
-    for (size_t f = 0; f < merged_mmu.size() && f < mesh.its.indices.size(); ++f) {
-        if (!merged_supported[f].empty()) vol->supported_facets.set_triangle_from_string((int)f, merged_supported[f]);
-        if (!merged_seam[f].empty())      vol->seam_facets.set_triangle_from_string((int)f, merged_seam[f]);
-        if (!merged_mmu[f].empty())       vol->mmu_segmentation_facets.set_triangle_from_string((int)f, merged_mmu[f]);
-        if (!merged_fuzzy[f].empty())     vol->fuzzy_skin_facets.set_triangle_from_string((int)f, merged_fuzzy[f]);
-    }
+    // Reproject the source paint (brush strokes + baked solid part color) onto the
+    // merged mesh, then free the source meshes (deferred so the reproject could read
+    // them). base_filament on each source bakes the part's solid color into paint so
+    // it survives the collapse into this single volume.
+    if (!paint_sources.empty())
+        (void) reproject_paint_from_volumes(vol->mesh(), paint_sources,
+            vol->supported_facets, vol->seam_facets,
+            vol->mmu_segmentation_facets, vol->fuzzy_skin_facets,
+            nullptr, nullptr, nullptr, /*concatenated_result=*/true);
+    for (int i : vol_indeces)
+        if (!volumes[i]->mesh().empty())
+            volumes[i]->reset_mesh();
     for (int i = 0; i < volumes.size();i++) {
         if (std::find(vol_indeces.begin(), vol_indeces.end(), i) != vol_indeces.end()) {
             vol->name = "Merged Parts";

--- a/src/libslic3r/PaintReproject.cpp
+++ b/src/libslic3r/PaintReproject.cpp
@@ -1864,4 +1864,293 @@ bool reproject_paint_geometric(const TriangleMesh     &src_mesh,
     return true;
 }
 
+// ---------------------------------------------------------------------------
+// Boolean: merged-source reprojection.
+// ---------------------------------------------------------------------------
+namespace {
+// Append every painted triangle of `src` onto `dst`, shifting its triangle ids by
+// `face_offset`. FacetsAnnotation stores triangle ids strictly increasing, and
+// sources are visited in order with a running offset, so the combined ids also stay
+// strictly increasing (required by set_triangle_from_string).
+// Bake an operand's assigned filament into every unpainted area of its colour map,
+// keeping its brush strokes. A merged/boolean result is one volume with one extruder,
+// so anything left unpainted would take that single colour instead of the part's own.
+static void fill_operand_colour(const TriangleMesh &mesh, const FacetsAnnotation *src_mmu,
+                                int base_filament, FacetsAnnotation &out)
+{
+    TriangleSelector sel(mesh);
+    if (src_mmu != nullptr && ! src_mmu->empty())
+        sel.deserialize(src_mmu->get_data(), false);
+    sel.fill_unpainted(EnforcerBlockerType(base_filament));
+    out.set(sel);
+}
+
+static void append_shifted_annotation(FacetsAnnotation &dst, const FacetsAnnotation &src, int face_offset)
+{
+    if (src.empty())
+        return;
+    for (const std::pair<int, int> &entry : src.get_data().first) {
+        const int         tid = entry.first;
+        const std::string s   = src.get_triangle_as_string(tid);
+        if (! s.empty())
+            dst.set_triangle_from_string(face_offset + tid, s);
+    }
+}
+} // namespace
+
+bool reproject_paint_from_volumes(const TriangleMesh                   &dst_mesh,
+                                  const std::vector<PaintSourceVolume> &sources,
+                                  FacetsAnnotation                     &dst_supported,
+                                  FacetsAnnotation                     &dst_seam,
+                                  FacetsAnnotation                     &dst_mmu,
+                                  FacetsAnnotation                     &dst_fuzzy,
+                                  const PaintReprojectProgressCallback &progress,
+                                  const PaintReprojectCancelCallback   &cancel,
+                                  const Transform3d                    *dst_world_matrix,
+                                  bool                                  concatenated_result)
+{
+    if (cancel && cancel())
+        return false;
+
+    // Merge every painted operand mesh (in the destination frame) and its four
+    // annotation layers into a single combined source. FacetsAnnotation's constructors
+    // are private (ModelVolume-only); PaintKeepPrepared is the public holder provided for
+    // exactly this "build annotations outside a volume" case.
+    PaintKeepPrepared combined;
+    int               face_offset = 0;
+
+    for (const PaintSourceVolume &src : sources) {
+        if (src.mesh == nullptr || src.mesh->its.indices.empty())
+            continue;
+        // Merge annotations first: face_offset is the number of faces already merged.
+        // Each operand's colour is filled in its own frame first, so every operand keeps
+        // its own filament (a fill over the merged map could only use a single one).
+        PaintKeepPrepared        filled;
+        const FacetsAnnotation  *mmu_src = src.mmu;
+        if (src.base_filament > 0) {
+            fill_operand_colour(*src.mesh, src.mmu, src.base_filament, filled.mmu);
+            mmu_src = &filled.mmu;
+        }
+        if (src.supported) append_shifted_annotation(combined.supported, *src.supported, face_offset);
+        if (src.seam)      append_shifted_annotation(combined.seam,      *src.seam,      face_offset);
+        if (mmu_src)       append_shifted_annotation(combined.mmu,       *mmu_src,       face_offset);
+        if (src.fuzzy)     append_shifted_annotation(combined.fuzzy,     *src.fuzzy,     face_offset);
+        TriangleMesh m = *src.mesh;
+        m.transform(src.source_to_destination, true /*fix_left_handed*/);
+        combined.mesh.merge(m);
+        face_offset += int(src.mesh->its.indices.size());
+    }
+
+    if (combined.mesh.its.indices.empty()) {
+        dst_supported.reset();
+        dst_seam.reset();
+        dst_mmu.reset();
+        dst_fuzzy.reset();
+        return true;
+    }
+
+    // Merge fast path: the destination mesh is exactly the operands concatenated in
+    // order, so face f of the result IS face f of the combined source. Copy the paint
+    // by index - nearest-surface sampling is per-triangle ambiguous where the parts
+    // overlap (coincident interior faces), which shows up as a torn/triangulated result.
+    if (concatenated_result && dst_mesh.its.indices.size() == combined.mesh.its.indices.size()) {
+        // Copy face by face. assign() is guarded by a timestamp comparison and silently
+        // does nothing between two freshly built annotations, which would drop the paint.
+        dst_supported.reset();
+        dst_seam.reset();
+        dst_mmu.reset();
+        dst_fuzzy.reset();
+        for (int f = 0; f < int(dst_mesh.its.indices.size()); ++f) {
+            std::string s;
+            if (! (s = combined.supported.get_triangle_as_string(f)).empty()) dst_supported.set_triangle_from_string(f, s);
+            if (! (s = combined.seam.get_triangle_as_string(f)).empty())      dst_seam.set_triangle_from_string(f, s);
+            if (! (s = combined.mmu.get_triangle_as_string(f)).empty())       dst_mmu.set_triangle_from_string(f, s);
+            if (! (s = combined.fuzzy.get_triangle_as_string(f)).empty())     dst_fuzzy.set_triangle_from_string(f, s);
+        }
+        return true;
+    }
+
+    // Boolean: the destination is rebuilt from overlapping operands. A single merged
+    // source makes the sampler mix colours where operands overlap - a result face near
+    // both parts gets subdivided into a jumble of both filaments. Instead, attribute
+    // each destination face to the ONE operand whose surface it lies on (nearest
+    // surface; unambiguous for a boolean result, which keeps only outer surfaces), then
+    // reproject each operand's paint onto the whole destination and keep, per face, only
+    // its attributed operand's result. Single-source-per-operand reprojection has no
+    // overlap ambiguity, so every face is a faithful copy of its own part's paint.
+    struct Operand { TriangleMesh mesh; PaintKeepPrepared ann; int base_filament = 0; };
+    std::vector<Operand> ops;
+    ops.reserve(sources.size());
+    for (const PaintSourceVolume &src : sources) {
+        if (src.mesh == nullptr || src.mesh->its.indices.empty())
+            continue;
+        ops.emplace_back();
+        Operand &op = ops.back();
+        op.mesh = *src.mesh;
+        op.mesh.transform(src.source_to_destination, true /*fix_left_handed*/);
+        op.base_filament = src.base_filament;
+        if (src.supported && ! src.supported->empty()) op.ann.supported.assign(*src.supported);
+        if (src.seam      && ! src.seam->empty())      op.ann.seam.assign(*src.seam);
+        if (src.fuzzy     && ! src.fuzzy->empty())     op.ann.fuzzy.assign(*src.fuzzy);
+        if (src.base_filament > 0)
+            fill_operand_colour(*src.mesh, src.mmu, src.base_filament, op.ann.mmu);
+        else if (src.mmu && ! src.mmu->empty())
+            op.ann.mmu.assign(*src.mmu);
+    }
+
+    dst_supported.reset();
+    dst_seam.reset();
+    dst_mmu.reset();
+    dst_fuzzy.reset();
+    if (ops.empty())
+        return true;
+
+    const int dst_nf = int(dst_mesh.its.indices.size());
+
+    // Distance from every destination face to every operand surface, so a face can be
+    // resolved against the operand it actually lies on, nearest first.
+    std::vector<std::vector<float>> op_distance(ops.size(), std::vector<float>(size_t(dst_nf), 0.f));
+    // Whether an operand actually covers a face, rather than merely lying near it: the
+    // closest point has to fall inside one of its faces, not on that face's edge. Two
+    // parts sharing a plane are a hair away from each other's patches all along the
+    // seam, so distance alone lets one part's colour bleed past its own outline.
+    std::vector<std::vector<char>> op_covers(ops.size(), std::vector<char>(size_t(dst_nf), 1));
+    if (ops.size() > 1) {
+        for (size_t i = 0; i < ops.size(); ++i) {
+            const AABBTreeIndirect::Tree3f tree =
+                AABBTreeIndirect::build_aabb_tree_over_indexed_triangle_set(
+                    ops[i].mesh.its.vertices, ops[i].mesh.its.indices);
+            for (int f = 0; f < dst_nf; ++f) {
+                const Vec3i &tri = dst_mesh.its.indices[f];
+                const Vec3f  centroid = (dst_mesh.its.vertices[tri[0]] + dst_mesh.its.vertices[tri[1]] +
+                                         dst_mesh.its.vertices[tri[2]]) / 3.0f;
+                // Sample the centroid and the three corners pulled in towards it. Testing the
+                // centroid alone misreads a face that only reaches into this operand with part
+                // of itself, which is exactly what happens where the boolean did not cut along
+                // the seam between two coplanar parts.
+                const Vec3f samples[4] = { centroid,
+                                           centroid + (dst_mesh.its.vertices[tri[0]] - centroid) * 0.75f,
+                                           centroid + (dst_mesh.its.vertices[tri[1]] - centroid) * 0.75f,
+                                           centroid + (dst_mesh.its.vertices[tri[2]] - centroid) * 0.75f };
+                char covers = 0;
+                for (int s = 0; s < 4; ++s) {
+                    size_t hit_face = 0; Vec3f closest;
+                    const double d2 = AABBTreeIndirect::squared_distance_to_indexed_triangle_set(
+                        ops[i].mesh.its.vertices, ops[i].mesh.its.indices, tree, samples[s], hit_face, closest);
+                    if (s == 0)
+                        op_distance[i][size_t(f)] = d2 < 0.0 ? std::numeric_limits<float>::max() : float(d2);
+                    if (covers || d2 < 0.0 || d2 > 1.0e-6 || hit_face >= ops[i].mesh.its.indices.size())
+                        continue;
+                    const Vec3i &sf = ops[i].mesh.its.indices[hit_face];
+                    const Vec3f &A  = ops[i].mesh.its.vertices[sf[0]];
+                    const Vec3f  v0 = ops[i].mesh.its.vertices[sf[1]] - A;
+                    const Vec3f  v1 = ops[i].mesh.its.vertices[sf[2]] - A;
+                    const Vec3f  v2 = closest - A;
+                    const float  d00 = v0.dot(v0), d01 = v0.dot(v1), d11 = v1.dot(v1);
+                    const float  d20 = v2.dot(v0), d21 = v2.dot(v1);
+                    const float  den = d00 * d11 - d01 * d01;
+                    if (std::abs(den) > 0.f) {
+                        const float v = (d11 * d20 - d01 * d21) / den;
+                        const float w = (d00 * d21 - d01 * d20) / den;
+                        const float u = 1.f - v - w;
+                        const float e = 1.0e-4f;
+                        if (u > e && v > e && w > e)
+                            covers = 1;
+                    }
+                }
+                op_covers[i][size_t(f)] = covers;
+            }
+        }
+    }
+    // Surface extent of each operand, used to break ties. Where operand surfaces
+    // coincide - two parts sharing a coplanar face, such as both sitting on the build
+    // plane - the distance cannot tell them apart, and the smaller, more local part is
+    // the one whose colour belongs on that patch.
+    std::vector<double> op_extent(ops.size(), 0.0);
+    for (size_t i = 0; i < ops.size(); ++i)
+        op_extent[i] = ops[i].mesh.bounding_box().size().norm();
+    // Quantized so coincident surfaces compare equal, and so the comparator stays a
+    // strict weak ordering (a raw epsilon test would not be transitive).
+    auto distance_key = [](float d) {
+        return (long long) std::llround(std::min<double>(double(d), 1.0e12) * 1.0e6);
+    };
+    auto operands_nearest_first = [&](int f) {
+        std::vector<int> order(ops.size());
+        for (size_t i = 0; i < ops.size(); ++i) order[i] = int(i);
+        std::sort(order.begin(), order.end(), [&](int a, int b) {
+            const int ca = op_covers[size_t(a)][size_t(f)] ? 0 : 1;
+            const int cb = op_covers[size_t(b)][size_t(f)] ? 0 : 1;
+            if (ca != cb) return ca < cb;
+            const long long ka = distance_key(op_distance[size_t(a)][size_t(f)]);
+            const long long kb = distance_key(op_distance[size_t(b)][size_t(f)]);
+            if (ka != kb) return ka < kb;
+            if (op_extent[size_t(a)] != op_extent[size_t(b)]) return op_extent[size_t(a)] < op_extent[size_t(b)];
+            return a < b;
+        });
+        return order;
+    };
+
+    // Reproject every operand's paint onto the whole destination (single source each,
+    // so no overlap ambiguity), then keep per face only its attributed operand's paint.
+    std::vector<PaintKeepPrepared> per_op(ops.size());
+    for (size_t i = 0; i < ops.size(); ++i) {
+        if (cancel && cancel())
+            return false;
+        // One operand at a time through the accurate geometric path: it refines along
+        // colour boundaries, so brush detail survives however the boolean re-triangulated
+        // the result. Passing every operand as one merged source instead would let one
+        // operand's colour overwrite another's where they overlap; a single source per
+        // call has no such conflict, and faces out of this operand's reach are simply
+        // left unpainted for the nearer operand to fill in below.
+        if (! reproject_paint_geometric(
+                ops[i].mesh, ops[i].ann.supported, ops[i].ann.seam, ops[i].ann.mmu, ops[i].ann.fuzzy,
+                dst_mesh, Transform3d::Identity(),
+                per_op[i].supported, per_op[i].seam, per_op[i].mmu, per_op[i].fuzzy,
+                nullptr, cancel, dst_world_matrix))
+            return false;
+    }
+
+    // Take, per destination face, only its attributed operand's reprojected paint.
+    // Where that operand produced nothing for a face it owns (the sampler culls faces
+    // beyond its reach), fall back to the operand's plain filament so the face still
+    // carries its own part's colour instead of the result volume's single extruder.
+    // Resolve every destination face against the nearest operand that actually has paint
+    // there. Taking only the single nearest operand would blank a face whose nearest
+    // operand is out of sampling reach, even though the other operand covers it.
+    auto take_nearest = [&](const std::vector<int> &order, int f,
+                            FacetsAnnotation PaintKeepPrepared::*layer, FacetsAnnotation &dst) {
+        for (int i : order) {
+            const std::string s = (per_op[size_t(i)].*layer).get_triangle_as_string(f);
+            if (! s.empty()) { dst.set_triangle_from_string(f, s); return i; }
+        }
+        return -1;
+    };
+    std::vector<int> plain_fill(size_t(dst_nf), 0);
+    bool             any_plain_fill = false;
+    for (int f = 0; f < dst_nf; ++f) {
+        const std::vector<int> order = operands_nearest_first(f);
+        take_nearest(order, f, &PaintKeepPrepared::supported, dst_supported);
+        take_nearest(order, f, &PaintKeepPrepared::seam,      dst_seam);
+        take_nearest(order, f, &PaintKeepPrepared::fuzzy,     dst_fuzzy);
+        if (take_nearest(order, f, &PaintKeepPrepared::mmu, dst_mmu) < 0) {
+            // No operand reached this face: give it the nearest operand's plain colour
+            // so it still prints as its own part rather than the result's one extruder.
+            const int filament = ops[size_t(order.front())].base_filament;
+            if (filament > 0) { plain_fill[size_t(f)] = filament; any_plain_fill = true; }
+        }
+    }
+    if (any_plain_fill) {
+        TriangleSelector colour(dst_mesh);
+        if (! dst_mmu.empty())
+            colour.deserialize(dst_mmu.get_data(), false);
+        for (int f = 0; f < dst_nf; ++f)
+            if (plain_fill[size_t(f)] > 0)
+                colour.set_facet(f, EnforcerBlockerType(plain_fill[size_t(f)]));
+        dst_mmu.set(colour);
+    }
+
+
+    return true;
+}
+
 } // namespace Slic3r

--- a/src/libslic3r/PaintReproject.hpp
+++ b/src/libslic3r/PaintReproject.hpp
@@ -38,11 +38,10 @@ using PaintReprojectCancelCallback   = std::function<bool()>;
 //                                    coordinate frame (up to dst_to_src), so
 //                                    provenance and sampling use the nearest
 //                                    source face / nearest 3D point.
-//
-// Boolean is not wired up yet, but reproject_paint_geometric is the intended
-// extension point: pass the boolean result as the destination mesh and each
-// participating operand mesh as a source (nearest-distance source selection or
-// a merged source selector can be layered on later).
+//   * reproject_paint_from_volumes -- boolean/merge: the destination is rebuilt
+//                                    from several operands at once, so it layers
+//                                    nearest-distance source selection over
+//                                    reproject_paint_geometric (see below).
 // ---------------------------------------------------------------------------
 
 // Cutting: provenance from the explicit destination->source face map, measured
@@ -86,6 +85,47 @@ using PaintReprojectCancelCallback   = std::function<bool()>;
                                              const PaintReprojectProgressCallback &progress = nullptr,
                                              const PaintReprojectCancelCallback   &cancel   = nullptr,
                                              const Transform3d      *dst_world_matrix = nullptr);
+
+// One painted operand feeding a boolean result: its mesh, its four annotation
+// layers, and the transform that maps this operand's mesh-local coordinates into
+// the destination (boolean result) mesh-local frame. Any annotation pointer may be
+// null (treated as unpainted for that layer).
+struct PaintSourceVolume {
+    const TriangleMesh     *mesh                  = nullptr;
+    const FacetsAnnotation *supported             = nullptr;
+    const FacetsAnnotation *seam                  = nullptr;
+    const FacetsAnnotation *mmu                   = nullptr;
+    const FacetsAnnotation *fuzzy                 = nullptr;
+    Transform3d             source_to_destination = Transform3d::Identity();
+    // Filament (1-based) this operand is assigned to. When > 0, the operand's bulk
+    // (color-unpainted) faces are baked into the color map as this filament, so a
+    // part's SOLID color survives collapse into one volume (a boolean/merge result
+    // holds only one base filament). 0 = do not bake (color-paint only).
+    int                     base_filament         = 0;
+};
+
+// Boolean/merge: the result is rebuilt from several operands and no per-face source map
+// exists. Each operand is reprojected on its own through reproject_paint_geometric - one
+// source per call, so operands cannot overwrite one another where they overlap - and every
+// destination face then takes the paint of the nearest operand that covers it. An operand
+// covers a face only when the closest point falls inside one of its own faces, which stops
+// paint spreading past a part's outline where two parts share a plane; a tie there goes to
+// the smaller part. A face no operand reached, such as surface newly cut by the boolean,
+// takes the plain filament of its nearest operand.
+//
+// progress / cancel / dst_world_matrix behave as in reproject_paint_geometric.
+// concatenated_result marks a destination that is exactly the operands concatenated (a
+// merge), where the paint is an exact per-face copy rather than a resampling.
+[[nodiscard]] bool reproject_paint_from_volumes(const TriangleMesh                   &dst_mesh,
+                                                const std::vector<PaintSourceVolume> &sources,
+                                                FacetsAnnotation                     &dst_supported,
+                                                FacetsAnnotation                     &dst_seam,
+                                                FacetsAnnotation                     &dst_mmu,
+                                                FacetsAnnotation                     &dst_fuzzy,
+                                                const PaintReprojectProgressCallback &progress = nullptr,
+                                                const PaintReprojectCancelCallback   &cancel   = nullptr,
+                                                const Transform3d                    *dst_world_matrix = nullptr,
+                                                bool                                  concatenated_result = false);
 
 } // namespace Slic3r
 

--- a/src/libslic3r/TriangleSelector.cpp
+++ b/src/libslic3r/TriangleSelector.cpp
@@ -2296,6 +2296,16 @@ void TriangleSelector::seed_fill_apply_on_triangles(EnforcerBlockerType new_stat
         }
 }
 
+void TriangleSelector::fill_unpainted(EnforcerBlockerType state)
+{
+    for (Triangle &triangle : m_triangles) {
+        if (triangle.is_split() || !triangle.valid())
+            continue;
+        if (triangle.get_state() == EnforcerBlockerType::NONE)
+            triangle.set_state(state);
+    }
+}
+
 void TriangleSelector::shift_states_above(EnforcerBlockerType threshold, int delta)
 {
     for (Triangle &triangle : m_triangles) {

--- a/src/libslic3r/TriangleSelector.hpp
+++ b/src/libslic3r/TriangleSelector.hpp
@@ -367,6 +367,13 @@ public:
     // Shift all triangle states >= threshold by delta (used when inserting filaments)
     void shift_states_above(EnforcerBlockerType threshold, int delta);
 
+    // Set every unpainted (NONE) triangle to the given state, keeping painted detail.
+    // Used when volumes with different filaments collapse into a single volume: an
+    // unpainted area falls back to the merged volume's one extruder, so each source's
+    // own filament has to be baked in explicitly. Painting only whole facets is not
+    // enough - a facet carrying a brush stroke keeps unpainted areas around it.
+    void fill_unpainted(EnforcerBlockerType state);
+
 protected:
     // Triangle and info about how it's split.
     class Triangle {

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -43,6 +43,7 @@
 #include "Gizmos/GLGizmoScale.hpp"
 #include "Gizmos/GLGizmoMeshBoolean.hpp"
 #include "libslic3r/TriangleMeshDeal.hpp"
+#include "libslic3r/PaintReproject.hpp"
 namespace Slic3r
 {
 namespace GUI
@@ -3574,6 +3575,32 @@ void ObjectList::boolean()
     if (new_object->instances.empty())
         new_object->add_instance();
     ModelVolume* new_volume = new_object->add_volume(mesh);
+
+    // Carry the painting onto the boolean result. combine_mesh_fff() unions the object's
+    // parts in world frame, so each part is mapped through its own volume matrix and the
+    // instance transform; add_volume() above would otherwise leave the result unpainted.
+    {
+        const Transform3d instance_matrix = object->instances.empty() ?
+            Transform3d::Identity() : object->instances.front()->get_matrix();
+        std::vector<PaintSourceVolume> sources;
+        for (const ModelVolume *v : object->volumes) {
+            if (v == nullptr || ! v->is_model_part())
+                continue;
+            PaintSourceVolume source;
+            source.mesh                  = &v->mesh();
+            source.supported             = &v->supported_facets;
+            source.seam                  = &v->seam_facets;
+            source.mmu                   = &v->mmu_segmentation_facets;
+            source.fuzzy                 = &v->fuzzy_skin_facets;
+            source.source_to_destination = instance_matrix * v->get_matrix();
+            source.base_filament         = v->extruder_id();
+            sources.push_back(source);
+        }
+        // Result of a cancelled reprojection is discarded, leaving the paint unset.
+        (void) reproject_paint_from_volumes(new_volume->mesh(), sources,
+                                            new_volume->supported_facets, new_volume->seam_facets,
+                                            new_volume->mmu_segmentation_facets, new_volume->fuzzy_skin_facets);
+    }
 
     // BBS: ensure on bed but no need to ensure locate in the center around origin
     new_object->ensure_on_bed();

--- a/src/slic3r/GUI/Gizmos/GLGizmoMeshBoolean.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMeshBoolean.cpp
@@ -1,6 +1,7 @@
 #include "GLGizmoMeshBoolean.hpp"
 #include "slic3r/GUI/UIHelpers/MeshBooleanUI.hpp"
 #include "libslic3r/MeshBoolean.hpp"
+#include "libslic3r/PaintReproject.hpp"
 #include "slic3r/GUI/GLCanvas3D.hpp"
 #include "slic3r/GUI/GUI.hpp"
 #include "slic3r/GUI/GUI_ObjectList.hpp"
@@ -1151,6 +1152,59 @@ void BooleanOperationEngine::update_delete_list(BooleanOperationResult& result,
     }
 }
 
+// Shared paint reprojection for boolean results. Maps each operand's paint into the
+// result volume's local frame (source_to_destination = dst_world^-1 * operand_world)
+// and reprojects it via the geometric sampler. Used by BOTH the sync
+// (apply_result_to_model) and the async completion paths - the async path is the
+// default and creates result volumes directly, bypassing apply_result_to_model, so
+// without this call there the boolean result loses all paint.
+static void reproject_boolean_paint(ModelVolume *new_volume,
+                                    const Transform3d &dst_world,
+                                    const std::vector<std::pair<ModelVolume *, Transform3d>> &operands)
+{
+    if (new_volume == nullptr || operands.empty())
+        return;
+    // Nothing to carry when no operand is painted and they all print in one filament: the
+    // result volume's own extruder already stands for them. A part that is unpainted but
+    // assigned a different filament still has to be carried, or it loses its colour.
+    bool any_paint = false, mixed_filament = false;
+    int  first_filament = -1;
+    for (const auto &op : operands) {
+        if (op.first == nullptr)
+            continue;
+        if (! op.first->mmu_segmentation_facets.empty() || ! op.first->supported_facets.empty() ||
+            ! op.first->seam_facets.empty() || ! op.first->fuzzy_skin_facets.empty())
+            any_paint = true;
+        const int filament = op.first->extruder_id();
+        if (first_filament < 0)
+            first_filament = filament;
+        else if (filament != first_filament)
+            mixed_filament = true;
+    }
+    if (! any_paint && ! mixed_filament)
+        return;
+    const Transform3d dst_world_inv = dst_world.inverse();
+    std::vector<PaintSourceVolume> sources;
+    sources.reserve(operands.size());
+    for (const auto &op : operands) {
+        if (op.first == nullptr)
+            continue;
+        PaintSourceVolume s;
+        s.mesh                  = &op.first->mesh();
+        s.supported             = &op.first->supported_facets;
+        s.seam                  = &op.first->seam_facets;
+        s.mmu                   = &op.first->mmu_segmentation_facets;
+        s.fuzzy                 = &op.first->fuzzy_skin_facets;
+        s.source_to_destination = dst_world_inv * op.second;
+        s.base_filament         = op.first->extruder_id(); // bake solid part color into paint
+        sources.push_back(s);
+    }
+    (void) reproject_paint_from_volumes(new_volume->mesh(), sources,
+        new_volume->supported_facets, new_volume->seam_facets,
+        new_volume->mmu_segmentation_facets, new_volume->fuzzy_skin_facets,
+        nullptr, nullptr, &dst_world);
+}
+
 //NOTE: keep watching
 void BooleanOperationEngine::apply_result_to_model(const BooleanOperationResult& result,
                                                   ModelObject* target_object,
@@ -1229,6 +1283,33 @@ void BooleanOperationEngine::apply_result_to_model(const BooleanOperationResult&
         return true;
     };
 
+    // Carry painting (colour / support / seam / fuzzy skin) from the boolean operands onto
+    // each rebuilt result volume. For a difference only the A group contributes: the B tool
+    // carves new surface, which belongs to the part that remains, not to the tool.
+    auto instance_matrix_of = [](const ModelObject *obj) -> Transform3d {
+        return (obj != nullptr && !obj->instances.empty() && obj->instances[0]) ?
+            obj->instances[0]->get_matrix(false) : Transform3d::Identity();
+    };
+    auto reproject_paint_onto = [&](ModelVolume *new_volume) {
+        if (new_volume == nullptr)
+            return;
+        std::vector<std::pair<ModelVolume *, Transform3d>> operands;
+        auto add_object_parts = [&](ModelObject *o) {
+            if (o == nullptr)
+                return;
+            for (ModelVolume *v : o->volumes)
+                if (v != nullptr && v != new_volume && v->is_model_part())
+                    operands.emplace_back(v, instance_matrix_of(o) * v->get_matrix());
+        };
+        if (settings.target_mode == BooleanTargetMode::Part)
+            add_object_parts(target_object);
+        else if (mode == MeshBooleanOperation::Difference)
+            for (ModelObject *o : a_group_objects) add_object_parts(o);
+        else
+            for (ModelObject *o : participating_objects) add_object_parts(o);
+        reproject_boolean_paint(new_volume, instance_matrix_of(target_object) * new_volume->get_matrix(), operands);
+    };
+
     // ===== STEP 2: Create new result volumes =====
     // Collect sources that need to be replaced (deleted after new volumes are created)
     std::vector<ModelVolume*> sources_to_replace;
@@ -1243,6 +1324,9 @@ void BooleanOperationEngine::apply_result_to_model(const BooleanOperationResult&
         ModelVolume* new_volume = create_result_volume(target_object, result.result_meshes[i], source_volume);
         if (!new_volume) continue;
         new_volume->set_type(ModelVolumeType::MODEL_PART);
+
+        // Preserve the operands' painting on the rebuilt result.
+        reproject_paint_onto(new_volume);
 
         // Mark source for replacement if policy allows
         if (should_replace_source(source_volume)) {
@@ -2731,6 +2815,28 @@ void GLGizmoMeshBoolean::apply_boolean_result_from_job(const BooleanJobData& job
             // Force result to be MODEL_PART (same as sync version)
             new_volume->set_type(ModelVolumeType::MODEL_PART);
 
+            // Preserve operand paint on the async boolean result (this path bypasses
+            // apply_result_to_model). Operand world transforms come straight from the
+            // job data - exactly what the boolean engine baked.
+            {
+                Transform3d target_inst = Transform3d::Identity();
+                if (target_object && !target_object->instances.empty() && target_object->instances[0])
+                    target_inst = target_object->instances[0]->get_matrix(false);
+                const Transform3d dst_world = target_inst * new_volume->get_matrix();
+                std::vector<std::pair<ModelVolume *, Transform3d>> operands;
+                auto add_grp = [&](const auto &grp) {
+                    for (const auto &vd : grp) {
+                        ModelObject *o  = find_object_by_volume_id(vd.volume_id);
+                        ModelVolume *ov = o ? find_volume_in_object(o, vd.volume_id) : nullptr;
+                        if (ov && ov != new_volume) operands.emplace_back(ov, vd.transformation);
+                    }
+                };
+                add_grp(job_data.volumes_a);
+                if (job_data.operation_mode != MeshBooleanOperation::Difference)
+                    add_grp(job_data.volumes_b);
+                reproject_boolean_paint(new_volume, dst_world, operands);
+            }
+
             // Determine if source should be replaced based on operation mode
             bool should_replace = false;
             if (job_data.operation_mode == MeshBooleanOperation::Difference) {
@@ -2874,6 +2980,24 @@ void GLGizmoMeshBoolean::apply_boolean_result_from_job(const BooleanJobData& job
             if (new_volume) {
                 // Force result to be MODEL_PART
                 new_volume->set_type(ModelVolumeType::MODEL_PART);
+
+                // Preserve operand paint on the async (object-mode) boolean result.
+                Transform3d new_inst = Transform3d::Identity();
+                if (!new_obj->instances.empty() && new_obj->instances[0])
+                    new_inst = new_obj->instances[0]->get_matrix(false);
+                const Transform3d dst_world = new_inst * new_volume->get_matrix();
+                std::vector<std::pair<ModelVolume *, Transform3d>> operands;
+                auto add_grp = [&](const auto &grp) {
+                    for (const auto &vd : grp) {
+                        ModelObject *o  = find_object_by_volume_id(vd.volume_id);
+                        ModelVolume *ov = o ? find_volume_in_object(o, vd.volume_id) : nullptr;
+                        if (ov && ov != new_volume) operands.emplace_back(ov, vd.transformation);
+                    }
+                };
+                add_grp(job_data.volumes_a);
+                if (job_data.operation_mode != MeshBooleanOperation::Difference)
+                    add_grp(job_data.volumes_b);
+                reproject_boolean_paint(new_volume, dst_world, operands);
             }
         }
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoSimplify.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSimplify.cpp
@@ -549,12 +549,19 @@ void GLGizmoSimplify::apply_simplify() {
 
     auto plater = wxGetApp().plater();
     plater->take_snapshot(GUI::format("Simplify %1%", m_volume->name));
-    plater->clear_before_change_mesh(object_idx);
+    // NOTE: do NOT call clear_before_change_mesh() here - it resets the painted
+    // color/MMU, supports, seam and fuzzy-skin on every volume of the object.
+    // set_mesh_keep_paint() below reprojects that paint onto the simplified mesh
+    // (same geometric sampler repair uses), so pre-clearing it would defeat the
+    // preservation and wipe the paint.
 
     ModelVolume* mv = get_model_volume(selection, wxGetApp().model());
     assert(mv == m_volume);
 
-    mv->set_mesh(std::move(*m_state.result));
+    // Preserve painted color/MMU, supports, seam and fuzzy-skin through the
+    // decimation: reproject the paint onto the simplified mesh (same geometric
+    // sampler repair and Boolean use) instead of dropping it on a bare set_mesh.
+    mv->set_mesh_keep_paint(TriangleMesh(std::move(*m_state.result)));
     m_state.result.reset();
     mv->calculate_convex_hull();
     mv->invalidate_convex_hull_2d();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -22749,7 +22749,15 @@ TriangleMesh Plater::combine_mesh_fff(const ModelObject& mo, int instance_id, st
         csg::mpartsPositive | csg::mpartsNegative);
     csg::BooleanFailReason fail_reason;
     std::string fail_msg = check_boolean_possible(mo.const_volumes(), fail_reason);
-    if (fail_msg.empty() || fail_reason == csg::BooleanFailReason::NotBoundAVolume) {
+    // The pre-check runs CGAL, which rejects a self-intersecting part outright, while the
+    // boolean below runs mcut, which copes with far messier meshes. A CGAL verdict alone
+    // should not block the attempt: try mcut anyway. It is wrapped in try/catch and its
+    // result is only accepted when non-empty, so a mesh mcut cannot handle still falls
+    // through to the merge fallback and warning below, exactly as before. This turns former
+    // hard failures into successes without changing what already worked.
+    if (fail_msg.empty()
+        || fail_reason == csg::BooleanFailReason::NotBoundAVolume
+        || fail_reason == csg::BooleanFailReason::SelfIntersect) {
         try {
             MeshBoolean::mcut::McutMeshPtr meshPtr = csg::perform_csgmesh_booleans_mcut(Range{std::begin(csgmesh), std::end(csgmesh)});
             mesh                                   = MeshBoolean::mcut::mcut_to_triangle_mesh(*meshPtr);


### PR DESCRIPTION
Follow-up to #11105, which brought painting through merge, split, merge-to-multipart and repair. This covers the remaining mesh-rebuilding operations: **Boolean** (union / intersection / difference, both the gizmo and the right-click menu), **merge into single part**, and **Simplify**.

Rebased onto current master.

### Approach

`PaintReproject.hpp` already described this as the intended extension point:

> *"Boolean is not wired up yet, but `reproject_paint_geometric` is the intended extension point: pass the boolean result as the destination mesh and each participating operand mesh as a source (nearest-distance source selection or a merged source selector can be layered on later)."*

`reproject_paint_from_volumes()` implements the nearest-distance source selection described there. Each operand is reprojected **on its own** through `reproject_paint_geometric` - a single source per call, so operands cannot overwrite one another where they overlap - and each destination face then takes the paint of the nearest operand that **covers** it. An operand only counts as covering a face when the closest point lies inside one of its own faces, which stops paint spreading past a part's outline where two parts share a plane; a tie there goes to the smaller part. A face no operand reached, such as surface newly cut by a boolean, takes the plain filament of its nearest operand. The header comment is updated accordingly.

### Solid part color

A boolean or merge result is a single volume with a single extruder, so any area left unpainted silently takes that one color. `TriangleSelector::fill_unpainted()` bakes each operand's own filament into its unpainted areas while leaving painted detail untouched.

This also fixes **color loss in merge-into-single-part**: the per-face copy left the area *around* each brush stroke unpainted, and those faces fell back to the merged volume's extruder, so a part merged with a differently-colored one lost its color.

Simplify keeps its paint via `ModelVolume::set_mesh_keep_paint()` instead of `set_mesh()`. The `clear_before_change_mesh()` call that preceded it reset the paint on every volume of the object, which defeated the reprojection.

### Second commit: self-intersecting parts

`check_boolean_possible()` runs CGAL, whose `does_self_intersect()` rejects a part outright, while the boolean that follows runs mcut, which copes with far messier meshes. Because a CGAL verdict skipped the attempt entirely, a model with even a couple of overlapping triangles never reached mcut - the operation fell through to the branch that merges the parts' meshes and reports a failure, so the user asked for a boolean and silently got the parts concatenated, overlap included.

Allowing `SelfIntersect` through lets mcut try. The call is already wrapped in try/catch and its result is only accepted when non-empty, so a mesh mcut cannot handle still lands in the same merge fallback and warning as before. This only turns former hard failures into successes. Note `combine_mesh_fff()` is shared with STL export, so a self-intersecting model now exports the boolean result rather than the merged fallback. Kept as a separate commit so it can be dropped independently.

### Testing

Verified by decoding the per-triangle annotations out of saved 3MFs rather than by eye. Two parts on different filaments, each brush-painted, then each operation run and saved:

| Operation | Faces | Unpainted | Result |
|---|---|---|---|
| Union | 48 | 0 | correct per-part color, 16 faces retain brush detail |
| Intersection | 22 | 0 | 0 mismatches against per-plane source ownership |
| Difference | 36 | 0 | cut walls take the kept part's filament |
| Merge into single part | 24 | 0 | exactly the source's 12 brush-painted faces |
| Merge -> Simplify | 24 | 0 | detail survives decimation |
| Merge -> Split to object | 24 | 0 | |
| Merge -> Split -> Merge multipart | 24 | 0 | |
| Union (part mode) + slice | 48 | 0 | colors reach the slicer |

Cut and repair were re-checked for regressions and are unchanged; the surface a cut newly creates stays unpainted, as before.

Also exercised on a real 45,680-triangle sculpted model: unpainted faces dropped from 68.2% to 0.1%, brush detail rose from 704 to 1,063 faces as the boolean subdivided along existing paint boundaries, and the operation succeeded on a mesh that self-intersects.

### Demos

Boolean Union (toolbar)
<img width="800" height="425" alt="Boolean Union Toolbar" src="https://github.com/user-attachments/assets/0eb7a312-76a5-4db6-bc5e-c03b56ade59e" />

Boolean Intersection (toolbar)
<img width="800" height="425" alt="Boolean Intersection Toolbar" src="https://github.com/user-attachments/assets/62f71e12-a7cc-4201-bdff-03c66c7147dc" />

Boolean Subtraction (toolbar)
<img width="800" height="425" alt="Boolean Subtraction Toolbar" src="https://github.com/user-attachments/assets/9db34067-a1e8-4bd5-bdee-810722c79088" />

Right-click Boolean
<img width="800" height="425" alt="Right Click Boolean" src="https://github.com/user-attachments/assets/bc7b87db-7e82-4841-abb7-30e8f0685d3d" />

Simplify, high to low resolution
<img width="800" height="425" alt="Simplify high-low res" src="https://github.com/user-attachments/assets/57df26ca-7f1c-4b65-8b1d-2698faea9602" />

Merge into single part - the operation this PR fixes for parts on different filaments (clip from #11105, showing the original merge preservation)
<img width="1838" height="885" alt="merge into single part paint preservation" src="https://github.com/user-attachments/assets/47310319-123d-42ab-9481-d55eb17b6d89" />

Repair (unchanged by this PR, shown for continuity with #11105)
<img width="800" height="425" alt="Repair" src="https://github.com/user-attachments/assets/d38b7844-618d-4ac1-94c1-1ea88fc94574" />
