### PR TITLE
feat(text): filter font list to faces supporting the current text (macOS)

### DIFF
--- a/docs/superpowers/specs/2026-07-09-font-list-filter-design.md
+++ b/docs/superpowers/specs/2026-07-09-font-list-filter-design.md
@@ -1,0 +1,46 @@
+# Text tool: "only fonts supporting current text" filter
+
+Date: 2026-07-09 · Status: approved by user (option 1)
+
+## Problem
+
+The text-emboss font combo lists every installed face (~470 after the
+macOS weight-name additions). Most cannot render 한글; picking one silently
+falls back to the bundled backup font (Nanum Gothic), which reads as
+"the font does not change".
+
+## Design
+
+A checkbox under the font combo: **입력 문구 지원 폰트만** (only fonts
+supporting the current text). When enabled, the combo hides faces that
+cannot render the characters of the current text. It composes with the
+existing name-search filter. Empty text disables the effect. The state
+persists in app config (`text_only_supported_fonts`). macOS only.
+
+## Coverage check
+
+`CTFontCopyCharacterSet` per face — the font's cmap coverage, the same
+table the emboss engine (stb_truetype) reads glyphs from. No file IO;
+~470 faces in ≈0.1 s. Recomputed only when the set of distinct
+characters in the text changes (sampled, max 16 distinct chars,
+whitespace ignored). A face whose name resolution falls back to a
+default font simply reports that font's coverage and is filtered out
+for Korean text — safe failure direction.
+
+## Components
+
+- `CurFacenames` (GLGizmoText.cpp): add `supports_text` (per-face flag,
+  parallel to `faces`) and `support_key` (chars of last computation).
+  Not serialized to the fonts.cereal cache.
+- `update_text_support(CurFacenames&, const std::string&)` — anonymous
+  namespace, `__APPLE__` only; fills `supports_text`.
+- `GLGizmoText::m_only_supported_fonts` — loaded from app config in the
+  constructor, written on toggle.
+- `draw_font_list()` — renders the checkbox, calls
+  `update_text_support` while the combo popup is open, and skips
+  non-supporting faces in the item loop (both plain and search-filtered
+  paths).
+
+## Not in scope
+
+Windows/Linux coverage check, favorites, language presets.

--- a/src/slic3r/GUI/Gizmos/GLGizmoText.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoText.cpp
@@ -300,6 +300,12 @@ struct CurFacenames
     // check when new font was installed
     size_t hash = 0;
 
+    // per-face flag: can the face render the current text?
+    // parallel to faces, recomputed by update_text_support(), not cached to disk
+    std::vector<uint8_t> supports_text = {};
+    // distinct characters supports_text was computed for
+    std::wstring support_key = {};
+
     // filtration pattern
     // std::string       search = "";
     // std::vector<bool> hide; // result of filtration
@@ -310,6 +316,9 @@ struct GLGizmoText::Facenames : public CurFacenames
 bool                    store(const CurFacenames &facenames);
 bool                    load(CurFacenames &facenames,const std::vector<wxString>& delete_bad_font_list);
 void                    init_face_names(CurFacenames &face_names);
+#ifdef __APPLE__
+void                    update_text_support(CurFacenames &face_names, const std::string &text);
+#endif
 void                    init_truncated_names(CurFacenames &face_names, float max_width);
 std::optional<wxString> get_installed_face_name(const std::optional<std::string> &face_name_opt, CurFacenames &face_names);
 void                    draw_font_preview(FaceName &face, const std::string &text, CurFacenames &faces, const CurGuiCfg &cfg, bool is_visible);
@@ -431,6 +440,7 @@ GLGizmoText::GLGizmoText(GLCanvas3D& parent, unsigned int sprite_id)
     if (GUI::wxGetApp().app_config->get_bool("support_backup_fonts")) {
         Slic3r::GUI::BackupFonts::generate_backup_fonts();
     }
+    m_only_supported_fonts = GUI::wxGetApp().app_config->get_bool("text_only_supported_fonts");
 }
 
 GLGizmoText::~GLGizmoText()
@@ -2708,6 +2718,11 @@ void GLGizmoText::draw_font_list()
         if (m_face_names->texture_id == 0)
             init_font_name_texture();
 
+#ifdef __APPLE__
+        if (m_only_supported_fonts)
+            update_text_support(*m_face_names, m_text);
+#endif
+
         int show_items_count = is_filtered ? filtered_items_idx.size() : m_face_names->faces.size();
 
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
@@ -2716,6 +2731,10 @@ void GLGizmoText::draw_font_list()
 
         for (int i = 0; i < show_items_count; i++) {
             int             idx          = is_filtered ? filtered_items_idx[i] : i;
+#ifdef __APPLE__
+            if (m_only_supported_fonts && idx < (int) m_face_names->supports_text.size() && !m_face_names->supports_text[idx])
+                continue;
+#endif
             FaceName &      face         = m_face_names->faces[idx];
             const wxString &wx_face_name = face.wx_name;
 
@@ -2771,9 +2790,18 @@ void GLGizmoText::draw_font_list()
         bad.insert(it, face->wx_name);
         m_face_names->faces.erase(face);
         m_face_names->faces_names.erase(m_face_names->faces_names.begin() + (*del_index));
+        // also drop the parallel support flag to keep indices aligned
+        if (*del_index < m_face_names->supports_text.size())
+            m_face_names->supports_text.erase(m_face_names->supports_text.begin() + (*del_index));
         // update cached file
         store(*m_face_names);
     }
+
+#ifdef __APPLE__
+    // filter for the long face list: hide fonts unable to render current text
+    if (m_imgui->bbl_checkbox(_L("Only fonts for current text"), m_only_supported_fonts))
+        wxGetApp().app_config->set_bool("text_only_supported_fonts", m_only_supported_fonts);
+#endif
 
 #ifdef ALLOW_ADD_FONT_BY_FILE
     ImGui::SameLine();
@@ -3628,6 +3656,42 @@ void append_macos_face_fullnames(wxArrayString &facenames)
         facenames.Add(full);
     }
     CFRelease(descriptors);
+}
+
+// Recompute which faces can render the given text, using each font's
+// character set (the cmap coverage - the same table the emboss engine
+// reads glyph outlines from). No font file is opened. Recomputes only
+// when the set of distinct characters in the text changes.
+void update_text_support(CurFacenames &face_names, const std::string &text)
+{
+    // sample of distinct characters, whitespace ignored, capped for speed
+    std::wstring ws = boost::nowide::widen(text);
+    std::wstring key;
+    for (wchar_t wc : ws) {
+        if (wc == ' ' || wc == '\n' || wc == '\r' || wc == '\t') continue;
+        if (key.find(wc) == std::wstring::npos) key.push_back(wc);
+        if (key.size() >= 16) break;
+    }
+    std::sort(key.begin(), key.end());
+    if (key == face_names.support_key && face_names.supports_text.size() == face_names.faces.size()) return;
+    face_names.support_key = key;
+    face_names.supports_text.assign(face_names.faces.size(), 1);
+    if (key.empty()) return; // nothing to check, all faces pass
+
+    for (size_t i = 0; i < face_names.faces.size(); ++i) {
+        uint8_t &supported = face_names.supports_text[i];
+        CFStringRef name = CFStringCreateWithCString(kCFAllocatorDefault, face_names.faces[i].wx_name.utf8_str(), kCFStringEncodingUTF8);
+        if (name == NULL) { supported = 0; continue; }
+        CTFontRef font = CTFontCreateWithName(name, 0.0, nullptr);
+        CFRelease(name);
+        if (font == NULL) { supported = 0; continue; }
+        CFCharacterSetRef charset = CTFontCopyCharacterSet(font);
+        CFRelease(font);
+        if (charset == NULL) { supported = 0; continue; }
+        for (wchar_t wc : key)
+            if (!CFCharacterSetIsLongCharacterMember(charset, (UTF32Char) wc)) { supported = 0; break; }
+        CFRelease(charset);
+    }
 }
 #endif // __APPLE__
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoText.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoText.cpp
@@ -28,6 +28,11 @@
 #include <wx/hashmap.h>
 #include <wx/utils.h>
 
+#ifdef __APPLE__
+#include <CoreText/CoreText.h>
+#include <wx/osx/core/cfstring.h> // wxCFStringRef
+#endif
+
 #include <numeric>
 #include <codecvt>
 #include <boost/log/trivial.hpp>
@@ -598,8 +603,17 @@ EmbossStyles GLGizmoText::create_default_styles()
 
 bool GLGizmoText::select_facename(const wxString &facename, bool update_text)
 {
-    if (!wxFontEnumerator::IsValidFacename(facename))
+    if (!wxFontEnumerator::IsValidFacename(facename)) {
+#ifdef __APPLE__
+        // On macOS the enumerator knows only family names, so weight-qualified
+        // or localized names stored in projects ("Pretendard Black", "나눔고딕")
+        // are rejected here although CoreText resolves them to the correct font
+        // file. Continue and let set_wx_font() decide: when CoreText cannot
+        // resolve the name, the font file lookup fails and false is returned.
+#else
         return false;
+#endif
+    }
     // Select font
     wxFont wx_font(wxFontInfo().FaceName(facename).Encoding(CurFacenames::encoding));
     if (!wx_font.IsOk())
@@ -1670,6 +1684,14 @@ void GLGizmoText::load_init_text(bool first_open_text)
                         }
                     }
                 }
+                // Style recovery above can replace the font by a style-name
+                // match from app config or by a family approximation, although
+                // the volume records the exact face it was created with
+                // (e.g. "Pretendard Black" which get_installed_face_name can
+                // not validate). Re-apply it; when the name cannot be resolved
+                // to a font file the current font is kept.
+                if (!is_old_text_info(text_info) && !m_font_name.empty())
+                    select_facename(wxString::FromUTF8(m_font_name.c_str()), false);
                 if (m_is_serializing) { // undo redo
                     m_style_manager.get_style().angle = calc_angle(selection);
                     m_rotate_angle                    = get_angle_from_current_style();
@@ -3566,6 +3588,49 @@ bool draw_button(const IconManager::VIcons &icons, IconType type, bool disable)
     return Slic3r::GUI::button(get_icon(icons, type, IconState::activable), get_icon(icons, type, IconState::hovered), get_icon(icons, type, IconState::disabled), disable);
 }
 
+#ifdef __APPLE__
+// Windows GDI lists heavier weights as own families ("Pretendard Black",
+// "Apple SD Gothic Neo Heavy") while the macOS enumerator collapses them into
+// one family entry, so those faces would not be selectable at all. Append
+// full names of the extra faces; select_facename()/create_font_file() resolve
+// them through CTFontCreateWithName.
+void append_macos_face_fullnames(wxArrayString &facenames)
+{
+    CTFontCollectionRef collection = CTFontCollectionCreateFromAvailableFonts(nullptr);
+    if (collection == nullptr) return;
+    CFArrayRef descriptors = CTFontCollectionCreateMatchingFontDescriptors(collection);
+    CFRelease(collection);
+    if (descriptors == nullptr) return;
+
+    std::set<wxString> known(facenames.begin(), facenames.end());
+    // styles reachable from the family entry itself (regular + bold/italic buttons)
+    const std::set<wxString> plain_styles = {"Regular", "Bold", "Italic", "Bold Italic", "Oblique", "Bold Oblique"};
+    for (CFIndex i = 0; i < CFArrayGetCount(descriptors); ++i) {
+        CTFontDescriptorRef descriptor = (CTFontDescriptorRef) CFArrayGetValueAtIndex(descriptors, i);
+        CFStringRef family_ref = (CFStringRef) CTFontDescriptorCopyAttribute(descriptor, kCTFontFamilyNameAttribute);
+        if (family_ref == NULL) continue;
+        wxString family = wxCFStringRef::AsString(family_ref);
+        CFRelease(family_ref);
+        if (family.empty() || family[0] == '.') continue; // hidden system fonts
+
+        CTFontRef ct_font = CTFontCreateWithFontDescriptor(descriptor, 0.0, nullptr);
+        if (ct_font == NULL) continue;
+        CFStringRef full_ref = CTFontCopyName(ct_font, kCTFontFullNameKey);
+        CFRelease(ct_font);
+        if (full_ref == NULL) continue;
+        wxString full = wxCFStringRef::AsString(full_ref);
+        CFRelease(full_ref);
+
+        if (full.empty() || full[0] == '.' || full == family) continue;
+        wxString style = full.StartsWith(family + " ") ? full.Mid(family.length() + 1) : full;
+        if (plain_styles.find(style) != plain_styles.end()) continue;
+        if (!known.insert(full).second) continue;
+        facenames.Add(full);
+    }
+    CFRelease(descriptors);
+}
+#endif // __APPLE__
+
 void init_face_names(CurFacenames &face_names)
 {
     Timer t("enumerate_fonts");
@@ -3597,6 +3662,9 @@ void init_face_names(CurFacenames &face_names)
                                 << concat(face_names.bad);
     });
     wxArrayString            facenames = wxFontEnumerator::GetFacenames(face_names.encoding);
+#ifdef __APPLE__
+    append_macos_face_fullnames(facenames);
+#endif
     size_t                   hash      = boost::hash_range(facenames.begin(), facenames.end());
     // Zero value is used as uninitialized hash
     if (hash == 0) hash = 1;

--- a/src/slic3r/GUI/Gizmos/GLGizmoText.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoText.hpp
@@ -107,6 +107,8 @@ private:
     //font deal
     struct Facenames; // forward declaration
     std::unique_ptr<Facenames> m_face_names;
+    // hide fonts unable to render current text in the face name combo (macOS)
+    bool m_only_supported_fonts = false;
     // Keep information about stored styles and loaded actual style to compare with
     Emboss::StyleManager     m_style_manager;
     std::shared_ptr<std::atomic<bool>> m_job_cancel                 = nullptr;

--- a/src/slic3r/GUI/Jobs/CreateFontNameImageJob.cpp
+++ b/src/slic3r/GUI/Jobs/CreateFontNameImageJob.cpp
@@ -208,8 +208,14 @@ void Slic3r::GUI::BackupFonts::generate_backup_fonts() {
 Slic3r::Emboss::FontFileWithCache Slic3r::GUI::BackupFonts::gener_font_with_cache(const wxString &font_name, const wxFontEncoding &encoding)
 {
     Emboss::FontFileWithCache font_file_with_cache;
-    if (!wxFontEnumerator::IsValidFacename(font_name))
+    if (!wxFontEnumerator::IsValidFacename(font_name)) {
+#ifndef __APPLE__
         return font_file_with_cache;
+#endif
+        // macOS: the enumerator knows only family names; weight-qualified
+        // names ("Pretendard Black") are resolved by CoreText inside
+        // create_font_file() which fails for names it cannot resolve.
+    }
     // Select font
     wxFont wx_font(wxFontInfo().FaceName(font_name).Encoding(encoding));
     if (!wx_font.IsOk()) return font_file_with_cache;

--- a/src/slic3r/Utils/EmbossStyleManager.cpp
+++ b/src/slic3r/Utils/EmbossStyleManager.cpp
@@ -586,6 +586,9 @@ bool StyleManager::set_wx_font(const wxFont &wx_font) {
 bool StyleManager::set_wx_font(const wxFont &wx_font, std::unique_ptr<FontFile> font_file)
 {
     if (font_file == nullptr) return false;
+    // For TrueType collections (macOS .ttc) find which font in the file the
+    // face name selects; always overwrite to drop an index from a previous font.
+    std::optional<unsigned int> collection_number = WxFontUtils::get_collection_index(wx_font, *font_file);
     m_style_cache.wx_font = wx_font; // copy
     m_style_cache.font_file =
         FontFileWithCache(std::move(font_file));
@@ -594,6 +597,7 @@ bool StyleManager::set_wx_font(const wxFont &wx_font, std::unique_ptr<FontFile> 
     style.type = WxFontUtils::get_current_type();
     // update string path
     style.path = WxFontUtils::store_wxFont(wx_font);
+    style.prop.collection_number = collection_number;
     WxFontUtils::update_property(style.prop, wx_font);
     clear_imgui_font();
     return true;

--- a/src/slic3r/Utils/WxFontUtils.cpp
+++ b/src/slic3r/Utils/WxFontUtils.cpp
@@ -8,6 +8,7 @@
 #include <wx/uri.h>
 #include <wx/fontutil.h> // wxNativeFontInfo
 #include <wx/osx/core/cfdictionary.h>
+#include "imgui/imstb_truetype.h" // read PostScript names from font collections
 #elif defined(__linux__)
 #include "slic3r/Utils/FontConfigHelp.hpp"
 #endif
@@ -42,11 +43,58 @@ bool is_valid_ttf(std::string_view file_path)
     return true;
 }
 
+// Resolve the wx font to a concrete CoreText descriptor (caller releases).
+// wxNativeFontInfo keeps the face name as font *family*, so weight-qualified
+// or localized names ("Pretendard Black", "Apple SD Gothic Neo Heavy") do not
+// match as a family. Fall back to CTFontCreateWithName which also matches
+// full and PostScript names; verify the result carries the requested name,
+// because CoreText silently substitutes a default font for unknown names.
+CTFontDescriptorRef create_matched_descriptor(const wxFont &font)
+{
+    const wxNativeFontInfo *info = font.GetNativeFontInfo();
+    if (info == nullptr) return nullptr;
+    CTFontDescriptorRef descriptor = info->GetCTFontDescriptor();
+    CFURLRef url = (CFURLRef) CTFontDescriptorCopyAttribute(descriptor, kCTFontURLAttribute);
+    if (url != NULL) {
+        CFRelease(url);
+        CFRetain(descriptor);
+        return descriptor;
+    }
+
+    wxString facename = font.GetFaceName();
+    if (facename.empty()) return nullptr;
+    CFStringRef name = CFStringCreateWithCString(kCFAllocatorDefault, facename.utf8_str(), kCFStringEncodingUTF8);
+    if (name == NULL) return nullptr;
+    ScopeGuard sg_name([&name]() { CFRelease(name); });
+    CTFontRef ct_font = CTFontCreateWithName(name, 0.0, nullptr);
+    if (ct_font == NULL) return nullptr;
+    ScopeGuard sg_font([&ct_font]() { CFRelease(ct_font); });
+
+    bool matches = false;
+    const CFStringRef name_keys[] = {kCTFontFullNameKey, kCTFontFamilyNameKey, kCTFontPostScriptNameKey};
+    for (CFStringRef key : name_keys) {
+        CFStringRef font_name = CTFontCopyName(ct_font, key);
+        if (font_name == NULL) continue;
+        matches = CFStringCompare(font_name, name, kCFCompareCaseInsensitive) == kCFCompareEqualTo;
+        CFRelease(font_name);
+        if (matches) break;
+    }
+    if (!matches) { // localized name ("나눔고딕")
+        CFStringRef display_name = CTFontCopyDisplayName(ct_font);
+        if (display_name != NULL) {
+            matches = CFStringCompare(display_name, name, kCFCompareCaseInsensitive) == kCFCompareEqualTo;
+            CFRelease(display_name);
+        }
+    }
+    if (!matches) return nullptr;
+    return CTFontCopyFontDescriptor(ct_font);
+}
+
 // get filepath from wxFont on Mac OsX
 std::string get_file_path(const wxFont& font) {
-    const wxNativeFontInfo *info = font.GetNativeFontInfo();
-    if (info == nullptr) return {};
-    CTFontDescriptorRef descriptor = info->GetCTFontDescriptor();
+    CTFontDescriptorRef descriptor = create_matched_descriptor(font);
+    if (descriptor == nullptr) return {};
+    ScopeGuard sg_desc([&descriptor]() { CFRelease(descriptor); });
     CFURLRef typeref = (CFURLRef)CTFontDescriptorCopyAttribute(descriptor, kCTFontURLAttribute);
     if (typeref == NULL) return {};
     ScopeGuard sg([&typeref]() { CFRelease(typeref); });
@@ -60,8 +108,61 @@ std::string get_file_path(const wxFont& font) {
     BOOST_LOG_TRIVIAL(trace) << "input uri(" << file_uri.c_str() << ") convert to path(" << path.c_str() << ") string(" << path_str << ").";
     return path_str;
 }
+
+// PostScript name (name table id 6) of one font inside a font file / collection
+std::string get_font_ps_name(const unsigned char *data, unsigned int index)
+{
+    int offset = stbtt_GetFontOffsetForIndex(data, (int) index);
+    if (offset < 0) return {};
+    stbtt_fontinfo info;
+    if (stbtt_InitFont(&info, data, offset) == 0) return {};
+    int length = 0;
+    // Microsoft platform(3), Unicode BMP(1), english(0x409) -> UTF-16BE
+    const char *name = stbtt_GetFontNameString(&info, &length, 3, 1, 0x409, 6);
+    if (name != nullptr) {
+        std::string result;
+        result.reserve(length / 2);
+        for (int i = 1; i < length; i += 2) result.push_back(name[i]);
+        return result;
+    }
+    // Macintosh platform(1), Roman(0), english(0) -> single byte
+    name = stbtt_GetFontNameString(&info, &length, 1, 0, 0, 6);
+    if (name != nullptr) return std::string(name, length);
+    return {};
+}
 } // namespace
 #endif // __APPLE__
+
+std::optional<unsigned int> WxFontUtils::get_collection_index(const wxFont &font, const Emboss::FontFile &font_file)
+{
+#ifdef __APPLE__
+    // Only TrueType collections (.ttc) need a font index; CoreText knows the
+    // selected face only by name, so match its PostScript name against the
+    // names of the fonts packed in the loaded file.
+    if (font_file.infos.size() <= 1) return {};
+    if (font_file.data == nullptr || font_file.data->empty()) return {};
+    CTFontDescriptorRef descriptor = create_matched_descriptor(font);
+    if (descriptor == nullptr) return {};
+    CTFontDescriptorRef matched = CTFontDescriptorCreateMatchingFontDescriptor(descriptor, nullptr);
+    CFRelease(descriptor);
+    if (matched == nullptr) return {};
+    CFStringRef ps_name_ref = (CFStringRef) CTFontDescriptorCopyAttribute(matched, kCTFontNameAttribute);
+    CFRelease(matched);
+    if (ps_name_ref == NULL) return {};
+    std::string ps_name = wxCFStringRef::AsString(ps_name_ref).utf8_string();
+    CFRelease(ps_name_ref);
+    if (ps_name.empty()) return {};
+
+    const unsigned char *data = font_file.data->data();
+    for (unsigned int i = 0; i < font_file.infos.size(); ++i)
+        if (get_font_ps_name(data, i) == ps_name) return i;
+    return {};
+#else
+    (void) font;
+    (void) font_file;
+    return {};
+#endif
+}
 
 bool WxFontUtils::can_load(const wxFont &font)
 {

--- a/src/slic3r/Utils/WxFontUtils.hpp
+++ b/src/slic3r/Utils/WxFontUtils.hpp
@@ -26,6 +26,11 @@ public:
     // os specific load of wxFont
     static std::unique_ptr<::Slic3r::Emboss::FontFile> create_font_file(const wxFont &font);
 
+    // For TrueType collections (.ttc) find index of the face selected by the
+    // wx font inside the loaded file (macOS only, nullopt elsewhere or when
+    // the file contains a single font / face can't be identified).
+    static std::optional<unsigned int> get_collection_index(const wxFont &font, const ::Slic3r::Emboss::FontFile &font_file);
+
     static EmbossStyle::Type get_current_type();
     static EmbossStyle       create_emboss_style(const wxFont &font, const std::string &name = "");
 


### PR DESCRIPTION
> Stacked on #11455 (includes its commit) — the first commit here is that PR; this one adds the filter feature on top.

## Motivation

The Text tool font list shows every installed face (several hundred entries), but for non-Latin text most of them cannot render the input at all: the emboss code silently substitutes glyphs from the bundled backup fonts, so many users perceive it as "changing the font does nothing" (for Korean, everything renders as Nanum Gothic).

## Feature

A checkbox under the font combo — **"Only fonts for current text"**:

- hides faces that cannot render the characters of the current text; with Korean text this cuts the list from ~470 faces to the actual Korean-capable ones,
- composes with the existing name-search filter,
- empty text shows the full list,
- state persists in app config (`text_only_supported_fonts`).

Coverage is read from each font's character set via `CTFontCopyCharacterSet` — the same cmap table the emboss engine reads glyph outlines from — so no font file is opened. All installed faces are checked in ~15 ms, and the result is recomputed only when the set of distinct characters in the text changes (sampled, max 16 distinct chars).

macOS only for now; the checkbox is not shown on other platforms.

## Testing (macOS 15, arm64)

- Korean input + filter on → list reduces to Korean-capable faces (AppleGothic, Apple SD Gothic Neo weights, Nanum family, Pretendard, Noto Sans KR, …); Latin-only and script-specific fonts (Arial, Noto Sans Gothic, …) are hidden.
- ASCII input → filter has no visible effect (all faces pass).
- Verified check correctness against glyph lookup with stb_truetype on 11 known fonts (0 mismatches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)