### PR TITLE
Allow custom filament presets in AMS slot selection

### DIFF
--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -1004,8 +1004,9 @@ void AMSMaterialsSetting::get_filaments_info(const MachineObject*               
 
     // First pass: system presets.
     collect_pass(true);
-    // Second pass: user presets.
-    if (obj->is_support_user_preset) {
+    // Second pass: user presets. Third-party AMS slots should also be able to
+    // select compatible custom filaments created in Filament Manager.
+    if (obj->is_support_user_preset || m_is_third) {
         collect_pass(false);
     }
 }


### PR DESCRIPTION
## Summary

This PR allows compatible custom/user filament presets from Filament Manager to appear in the AMS filament selection dialog for third-party AMS slots.

## Why

Currently, users who have already created and calibrated third-party filaments in Filament Manager may still need to manually recreate Brand / Material / Color information in the Device tab before assigning the spool to an AMS slot.

This change makes the existing AMS filament dropdown include compatible user presets when editing third-party AMS slot information.

Fixes #11468

## Implementation

- Keep the existing system preset pass unchanged.
- Include compatible user presets when the printer supports user presets or when the edited slot is a third-party AMS slot.
- Reuse the existing AMS filament selection and assignment flow.

## Test plan

- Build Bambu Studio.
- Create or import a custom filament profile in Filament Manager.
- Open Device tab.
- Edit a third-party AMS slot.
- Confirm that the custom filament appears in the Filament dropdown.
- Select it and confirm the slot assignment.
- Verify Brand / Material / Color and PA calibration selection still behave as before.
