### PR TITLE
Request PA history for main AMS extruder

### DIFF
--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -1192,13 +1192,15 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
     if (obj->GetCalib()->IsVersionInited() && !obj->GetCalib()->IsPAHistoryReady()) {
         PACalibExtruderInfo cali_info;
         int ext_id = obj->GetFilaSystem()->GetExtruderIdByAmsId(std::to_string(ams_id));
-        if (ext_id > 0) {
-            cali_info.nozzle_diameter = obj->GetExtderSystem()->GetNozzleDiameter(ext_id);
-            cali_info.use_extruder_id = false;
-            cali_info.use_nozzle_volume_type = false;
-            CalibUtils::emit_get_PA_calib_infos(cali_info);
-            m_pa_data_pending = true;
+        if (!obj->GetExtderSystem()->GetExtderById(ext_id)) {
+            BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " get extruder id failed when requesting PA history";
+            ext_id = 0;
         }
+        cali_info.nozzle_diameter = obj->GetExtderSystem()->GetNozzleDiameter(ext_id);
+        cali_info.use_extruder_id = false;
+        cali_info.use_nozzle_volume_type = false;
+        CalibUtils::emit_get_PA_calib_infos(cali_info);
+        m_pa_data_pending = true;
     } else {
         m_pa_data_pending = false;
     }


### PR DESCRIPTION
## Summary

This PR ensures PA calibration history is requested for AMS slots bound to the main extruder.

## Why

The AMS filament settings dialog requests PA calibration history when the calibration table has not been loaded yet. However, the request was only sent when the resolved extruder id was greater than zero.

For AMS slots bound to the main extruder, the resolved extruder id can be `0`, which means the PA history request could be skipped and the PA profile dropdown could remain limited to the default entry until another UI path loads the history.

Related to #10643

## Implementation

- Remove the `ext_id > 0` gate before requesting PA history.
- Reuse the same fallback style already used in the dialog when resolving the AMS extruder nozzle diameter.
- Fall back to extruder `0` if the resolved extruder id is not available.
- Keep the existing pending refresh flow via `m_pa_data_pending` and `TryRefreshPAProfiles()` unchanged.

## Test plan

- Build Bambu Studio.
- Open the Device tab.
- Edit an AMS slot bound to the main extruder.
- Confirm that PA calibration history is requested when it is not loaded yet.
- Confirm that the PA profile dropdown is refreshed after history becomes ready.
- Confirm that K/N values still update when selecting a PA profile.
