### PR TITLE
Add Make Overhang Printable

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1014,6 +1014,7 @@ static std::vector<std::string> s_Preset_print_options {
     "layer_height", "initial_layer_print_height", "wall_loops", "slice_closing_radius", "spiral_mode", "spiral_mode_smooth", "spiral_mode_max_xy_smoothing", "slicing_mode",
     "top_shell_layers", "top_shell_thickness", "bottom_shell_layers", "bottom_shell_thickness", "ensure_vertical_shell_thickness", "reduce_crossing_wall", "detect_thin_wall",
     "detect_overhang_wall", "top_color_penetration_layers", "bottom_color_penetration_layers",
+    "make_overhang_printable", "make_overhang_printable_angle", "make_overhang_printable_hole_size",
     "infill_instead_top_bottom_surfaces",
     "smooth_speed_discontinuity_area","smooth_coefficient", "seam_position", "seam_placement_away_from_overhangs", "wall_sequence", "is_infill_first", "sparse_infill_density", "fill_multiline",
     "sparse_infill_pattern", "sparse_infill_anchor", "sparse_infill_anchor_max", "top_surface_pattern", "monotonic_travel_into_wall",

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -579,6 +579,7 @@ private:
     std::unordered_map<int, std::unordered_map<int,double>> calc_estimated_filament_print_time() const;
 
     void slice_volumes();
+    void apply_conical_overhang();
     //BBS
     ExPolygons _shrink_contour_holes(double contour_delta, double hole_delta, const ExPolygons& polys) const;
     // BBS

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4332,6 +4332,34 @@ void PrintConfigDef::init_fff_params()
     def->mode = comDevelop;
     def->set_default_value(new ConfigOptionBool(true));
 
+    def           = this->add("make_overhang_printable", coBool);
+    def->label    = L("Make overhang printable");
+    def->category = L("Quality");
+    def->tooltip  = L("Modify the geometry to print overhangs without support material.");
+    def->mode     = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
+
+    def           = this->add("make_overhang_printable_angle", coFloat);
+    def->label    = L("Make overhang printable maximum angle");
+    def->category = L("Quality");
+    def->tooltip  = L("Maximum angle of overhangs to allow after making steeper overhangs printable. "
+                       "90\u00b0 will not change the model, while 0\u00b0 will replace all overhangs with conical material.");
+    def->sidetext = L("\u00b0");
+    def->mode     = comAdvanced;
+    def->min      = 0.;
+    def->max      = 90.;
+    def->set_default_value(new ConfigOptionFloat(55.));
+
+    def           = this->add("make_overhang_printable_hole_size", coFloat);
+    def->label    = L("Make overhang printable hole area");
+    def->category = L("Quality");
+    def->tooltip  = L("Maximum area of a hole in the model base to preserve from conical material. "
+                       "A value of 0 will fill all holes in the model base.");
+    def->sidetext = L("mm\u00b2");
+    def->mode     = comAdvanced;
+    def->min      = 0.;
+    def->set_default_value(new ConfigOptionFloat(0.));
+
     def = this->add("smooth_speed_discontinuity_area", coBool);
     def->label = L("Smooth speed discontinuity area");
     def->category = L("Quality");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1009,6 +1009,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionEnum<TopOneWallType>, top_one_wall_type))
     ((ConfigOptionPercent,            top_area_threshold))
     ((ConfigOptionBool,               only_one_wall_first_layer))
+    ((ConfigOptionFloat,              make_overhang_printable_angle))
+    ((ConfigOptionFloat,              make_overhang_printable_hole_size))
     // OrcaSlicer
     ((ConfigOptionPercent,            seam_gap))
     ((ConfigOptionPercent,            wipe_speed))
@@ -1127,6 +1129,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloatsNullable, slowdown_end_acc))
     ((ConfigOptionFloatOrPercent, sparse_infill_anchor))
     ((ConfigOptionFloatOrPercent, sparse_infill_anchor_max))
+    ((ConfigOptionBool, make_overhang_printable))
     //OrcaSlicer
     ((ConfigOptionFloatsNullable, top_solid_infill_flow_ratio))
     ((ConfigOptionFloat, initial_layer_flow_ratio))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1146,7 +1146,10 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "interlocking_beam_layer_count"
             || opt_key == "interlocking_depth"
             || opt_key == "interlocking_boundary_avoidance"
-            || opt_key == "interlocking_beam_width") {
+            || opt_key == "interlocking_beam_width"
+            || opt_key == "make_overhang_printable"
+            || opt_key == "make_overhang_printable_angle"
+            || opt_key == "make_overhang_printable_hole_size") {
             steps.emplace_back(posSlice);
 		} else if (
                opt_key == "elefant_foot_compensation"

--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -1161,6 +1161,9 @@ void PrintObject::slice_volumes()
         m_layers.back()->upper_layer = nullptr;
     m_print->throw_if_canceled();
 
+    this->apply_conical_overhang();
+    m_print->throw_if_canceled();
+
     // Is any ModelVolume MMU painted?
     if (const auto& volumes = this->model_object()->volumes;
         m_print->config().filament_diameter.size() > 1 && // BBS
@@ -1365,6 +1368,60 @@ void PrintObject::slice_volumes()
 
     m_print->throw_if_canceled();
     BOOST_LOG_TRIVIAL(debug) << "Slicing volumes - make_slices in parallel - end";
+}
+
+void PrintObject::apply_conical_overhang()
+{
+    if (m_layers.empty()) return;
+
+    const double angle = this->config().make_overhang_printable_angle.value;
+    if (angle == 90.) return;
+
+    const coordf_t offset        = -float(scale_(std::tan(angle * M_PI / 180.) * m_config.layer_height.value));
+    const coordf_t max_hole_area = float(scale_(scale_(this->config().make_overhang_printable_hole_size.value)));
+
+    for (auto layer_it = m_layers.rbegin() + 1; layer_it != m_layers.rend(); ++layer_it) {
+        m_print->throw_if_canceled();
+        Layer *layer       = *layer_it;
+        Layer *upper_layer = layer->upper_layer;
+
+        if (upper_layer->empty() || std::all_of(layer->m_regions.begin(), layer->m_regions.end(),
+                                                [](const LayerRegion *region) { return region->slices.empty() || !region->region().config().make_overhang_printable.value; }))
+            continue;
+
+        ExPolygons upper   = union_ex(upper_layer->merged(float(SCALED_EPSILON)));
+        ExPolygons current = union_ex(layer->merged(float(SCALED_EPSILON)));
+
+        if (max_hole_area > 0.) {
+            for (const ExPolygon &polygon : current) {
+                for (const Polygon &hole : polygon.holes) {
+                    if (std::abs(hole.area()) >= max_hole_area) continue;
+
+                    ExPolygon  hole_polygon(hole);
+                    ExPolygons covered = intersection_ex(upper, hole_polygon);
+                    if (!covered.empty() && xor_ex(covered, hole_polygon).empty()) upper = diff_ex(upper, hole_polygon);
+                }
+            }
+        }
+
+        upper = offset_ex(upper, offset);
+        for (size_t region_id = 0; region_id < this->num_printing_regions(); ++region_id) {
+            if (!upper_layer->m_regions[region_id]->region().config().make_overhang_printable.value) continue;
+
+            ExPolygons additions = union_ex(intersection_ex(upper_layer->m_regions[region_id]->slices.surfaces, upper));
+            additions.erase(std::remove_if(additions.begin(), additions.end(), [&current](const ExPolygon &polygon) { return diff_ex(polygon, current).empty(); }),
+                            additions.end());
+
+            ExPolygons region = to_expolygons(layer->m_regions[region_id]->slices.surfaces);
+            layer->m_regions[region_id]->slices.set(union_ex(region, additions), stInternal);
+
+            for (size_t other_region = 0; other_region < this->num_printing_regions(); ++other_region) {
+                if (other_region == region_id) continue;
+                ExPolygons other = to_expolygons(layer->m_regions[other_region]->slices.surfaces);
+                layer->m_regions[other_region]->slices.set(diff_ex(other, additions, ApplySafetyOffset::Yes), stInternal);
+            }
+        }
+    }
 }
 
 //BBS: this function is used to offset contour and holes of expolygons seperately by different value

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -865,6 +865,10 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, in
     SeamPosition seam_pos = config->option<ConfigOptionEnum<SeamPosition>>("seam_position")->value;
     toggle_line("seam_placement_away_from_overhangs", seam_pos == SeamPosition::spAligned || seam_pos == SeamPosition::spRear);
 
+    const bool make_overhang_printable = config->opt_bool("make_overhang_printable");
+    toggle_line("make_overhang_printable_angle", make_overhang_printable);
+    toggle_line("make_overhang_printable_hole_size", make_overhang_printable);
+
     bool have_infill = config->option<ConfigOptionPercent>("sparse_infill_density")->value > 0;
     // sparse_infill_filament uses the same logic as in Print::extruders()
     for (auto el : {"sparse_infill_pattern", "sparse_infill_anchor_max", "infill_combination", "minimum_sparse_infill_area", "sparse_infill_filament", "infill_shift_step",

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -81,7 +81,8 @@ std::map<std::string, std::vector<SimpleSettingData>>  SettingsFactory::OBJECT_C
                     {"seam_position", "",3}, {"seam_gap", "",4}, {"wipe_speed", "",5},
                     {"slice_closing_radius", "",6}, {"resolution", "",7},
                     {"xy_hole_compensation", "",8}, {"xy_contour_compensation", "",9}, {"elefant_foot_compensation", "",10},
-                    {"precise_z_height", "",10}
+                    {"precise_z_height", "",10}, {"make_overhang_printable_angle", "",11},
+                    {"make_overhang_printable_hole_size", "",12}
 
                     }},
     { L("Support"), {{"brim_type", "",1},{"brim_width", "",2},{"brim_object_gap", "",3},
@@ -99,7 +100,8 @@ std::map<std::string, std::vector<SimpleSettingData>>  SettingsFactory::OBJECT_C
 
 // todo multi_extruders: Does the following need to be modified?
 std::map<std::string, std::vector<SimpleSettingData>>  SettingsFactory::PART_CATEGORY_SETTINGS=
-    {{L("Quality"), {{"ironing_type", "", 8}, {"ironing_flow", "", 9}, {"ironing_spacing", "", 10}, {"ironing_inset", "", 11}, {"ironing_speed", "", 12}, {"ironing_direction", "",13}
+    {{L("Quality"), {{"ironing_type", "", 8}, {"ironing_flow", "", 9}, {"ironing_spacing", "", 10}, {"ironing_inset", "", 11}, {"ironing_speed", "", 12}, {"ironing_direction", "",13},
+                    {"make_overhang_printable", "",14}
                     }},
     { L("Strength"), {{"wall_loops", "",1},{"top_shell_layers", "",1},{"top_shell_thickness", "",1},
                     {"bottom_shell_layers", "",1}, {"bottom_shell_thickness", "",1}, {"sparse_infill_density", "",1},

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1969,6 +1969,21 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
     if (opt_key == "single_extruder_multi_material" || opt_key == "extruders_count" )
         update_wiping_button_visibility();
 
+    if (opt_key == "make_overhang_printable" && m_config->opt_bool("make_overhang_printable")) {
+        wxString message = _L("Enabling this option will modify the model's shape. If your print requires precise dimensions or is part of an assembly, double-check that the "
+                              "geometry change does not affect its function.");
+        message += "\n\n" + _L("Are you sure you want to enable this option?");
+        MessageDialog dialog(wxGetApp().plater(), message, "", wxICON_WARNING | wxYES | wxNO);
+        dialog.SetButtonLabel(wxID_YES, _L("Enable"));
+        dialog.SetButtonLabel(wxID_NO, _L("Cancel"));
+        if (dialog.ShowModal() == wxID_NO) {
+            DynamicPrintConfig new_config = *m_config;
+            new_config.set_key_value("make_overhang_printable", new ConfigOptionBool(false));
+            m_config_manipulation.apply(m_config, &new_config);
+            wxGetApp().plater()->update();
+        }
+    }
+
     // BBS: 用户在 UI 上主动开启支撑时，联动开启识别悬空外墙（辅助体验，配合支撑可改善打印效果）。
     // preset 切换 / 3MF 加载走 Field::set_value(value, false) 不会进入本回调，已存值不会被覆盖。
     if (opt_key == "enable_support" && boost::any_cast<bool>(value)) {
@@ -3016,6 +3031,9 @@ void TabPrint::build()
         optgroup->append_single_option_line("top_area_threshold","parameter/quality-advance-settings");
         optgroup->append_single_option_line("only_one_wall_first_layer","parameter/quality-advance-settings");
         optgroup->append_single_option_line("detect_overhang_wall","parameter/quality-advance-settings");
+        optgroup->append_single_option_line("make_overhang_printable");
+        optgroup->append_single_option_line("make_overhang_printable_angle");
+        optgroup->append_single_option_line("make_overhang_printable_hole_size");
         optgroup->append_single_option_line("smooth_speed_discontinuity_area","parameter/quality-advance-settings");
         optgroup->append_single_option_line("smooth_coefficient","parameter/quality-advance-settings");
         optgroup->append_single_option_line("reduce_crossing_wall","parameter/quality-advance-settings");

--- a/tests/fff_print/test_printobject.cpp
+++ b/tests/fff_print/test_printobject.cpp
@@ -87,3 +87,32 @@ SCENARIO("PrintObject: object layer heights", "[PrintObject]") {
 #endif
     }
 }
+
+TEST_CASE("Make overhang printable expands lower slices after a config change", "[PrintObject][Overhang]")
+{
+    TriangleMesh stem = make_cube(4., 4., 2.);
+    stem.translate(4.f, 0.f, 0.f);
+    TriangleMesh top = make_cube(12., 4., 2.);
+    top.translate(0.f, 0.f, 2.f);
+    stem.merge(top);
+
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({{"first_layer_height", 1.},
+                                   {"layer_height", 1.},
+                                   {"nozzle_diameter", 2.},
+                                   {"elefant_foot_compensation", 0.},
+                                   {"make_overhang_printable", false},
+                                   {"make_overhang_printable_angle", 45.}});
+
+    Print print;
+    Model model;
+    init_print({stem}, print, model, config);
+    print.process();
+    const double original_area = area(print.objects().front()->get_layer(1)->lslices);
+
+    config.set_key_value("make_overhang_printable", new ConfigOptionBool(true));
+    print.apply(model, config);
+    print.process();
+
+    REQUIRE(area(print.objects().front()->get_layer(1)->lslices) > original_area);
+}


### PR DESCRIPTION
## Summary

- add `Make overhang printable`, maximum-angle, and hole-area settings
- apply conical slice geometry before color/fuzzy segmentation and size compensation
- support global, object, part, and modifier overrides with slice-cache invalidation
- warn before enabling geometry-changing behavior

## Why

This adds the long-requested supportless-overhang geometry transformation from OrcaSlicer. It is related to, but distinct from #11153: this implementation changes per-layer slice geometry, while #11153 generates wave-shaped extrusion paths while preserving the outer perimeter.

Closes #983.
Refs #6248 and #2916.

## Upstream attribution

Ported and adapted from OrcaSlicer [PR #1615](https://github.com/OrcaSlicer/OrcaSlicer/pull/1615) / [commit `b571318`](https://github.com/OrcaSlicer/OrcaSlicer/commit/b571318be8c0ba81ddcf73d4248d7b1901ddd72d), with its later multicolor ordering fix from [PR #6896](https://github.com/OrcaSlicer/OrcaSlicer/pull/6896) and overlapping-region fix from [PR #7630](https://github.com/OrcaSlicer/OrcaSlicer/pull/7630). The Orca implementation traces back to CuraEngine's conical-overhang work.

Original and follow-up authors are preserved in the commit trailers.

## Validation

- added a `fff_print` regression that toggles the setting on an already-processed print and verifies lower-layer expansion, covering geometry behavior and cache invalidation
- `git diff --check` passes
- local test execution is pending because this checkout does not have BambuStudio's generated CMake headers or prebuilt dependency bundle; CI should run the test target

## Known limitation

Like current OrcaSlicer, the offset uses the configured nominal layer height rather than each variable layer's actual height.
