### PR TITLE
Fix Dutch travel speed translation

### DIFF
--- a/bbl/i18n/nl/BambuStudio_nl.po
+++ b/bbl/i18n/nl/BambuStudio_nl.po
@@ -10191,7 +10191,7 @@ msgid "This is the speed for various overhang degrees. Overhang degrees are expr
 msgstr "Dit is de snelheid voor diverse overhanggraden. Overhanggraden worden uitgedrukt als een percentage van de laag breedte. 0 betekend dat er niet afgeremd wordt voor overhanggraden en dat dezelfde snelheid als voor wanden gebruikt wordt."
 
 msgid "Travel speed"
-msgstr "Verplaatsing-sneleheid"
+msgstr "Verplaatsing-snelheid"
 
 msgid "Acceleration"
 msgstr "Versnelling"


### PR DESCRIPTION
## Summary

Correct the Dutch translation of `Travel speed` from `Verplaatsing-sneleheid` to `Verplaatsing-snelheid`.

Closes #11319.

## Validation

- `msgfmt --check -o /dev/null bbl/i18n/nl/BambuStudio_nl.po`
- verified the corrected translation occurs once and the misspelling no longer occurs
- `git diff --check`
