### PR TITLE
Format remaining drying time as HH:MM

### DIFF
--- a/src/slic3r/GUI/AMSDryControl.cpp
+++ b/src/slic3r/GUI/AMSDryControl.cpp
@@ -1478,7 +1478,7 @@ int AMSDryCtrWin::update_dryness_status(DevAms* dev_ams)
         if (m_ams_info.m_left_dry_time != dev_ams->GetLeftDryTime()) {
             updated += 1;
             m_ams_info.m_left_dry_time = dev_ams->GetLeftDryTime();
-            m_time_data_label->SetLabel(wxString::Format("%02d : %02d",
+            m_time_data_label->SetLabel(wxString::Format("%02d:%02d",
                 m_ams_info.m_left_dry_time / 60, m_ams_info.m_left_dry_time % 60));
         }
     }

--- a/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.cpp
+++ b/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.cpp
@@ -151,24 +151,7 @@ void uiAmsPercentHumidityDryPopup::UpdateContents()
 
     if (m_left_dry_time > 0)
     {
-        wxString display_hour_str;
-        int left_hours = m_left_dry_time / 60;
-        if (left_hours < 10) {
-            display_hour_str = wxString::Format("0%d", left_hours);
-        } else {
-            display_hour_str = wxString::Format("%d", left_hours);
-        }
-
-        wxString display_min_str;
-        int left_minutes = m_left_dry_time % 60;
-        if (left_minutes < 10) {
-            display_min_str = wxString::Format("0%d", left_minutes);
-        } else {
-            display_min_str = wxString::Format("%d", left_minutes);
-        }
-
-        const wxString& time_str = wxString::Format("%s : %s", display_hour_str, display_min_str);
-        left_dry_time_label->SetLabel(time_str);
+        left_dry_time_label->SetLabel(wxString::Format("%02d:%02d", m_left_dry_time / 60, m_left_dry_time % 60));
     }
     else
     {


### PR DESCRIPTION
## Summary

- display remaining filament-drying time as zero-padded `HH:MM`
- remove the duplicate manual hour/minute padding in the humidity popup
- use the same format in both drying-time UI paths

This changes confusing output such as `04 : 05` to the conventional `04:05` format.

Closes #11171.

## Validation

- verified both remaining-time display paths use `%02d:%02d`
- verified the old spaced formats and manual padding variables are gone
- `git diff --check`

The checkout has no configured BambuStudio dependency build, so full GUI compilation was not run locally.
