### PR TITLE
Add Filament Manager inventory export

### DIFF
--- a/src/slic3r/GUI/DeviceWeb/ViewModels/FilamentManager/FilamentManagerVM.cpp
+++ b/src/slic3r/GUI/DeviceWeb/ViewModels/FilamentManager/FilamentManagerVM.cpp
@@ -3,8 +3,10 @@
 #include "slic3r/GUI/DeviceWeb/DeviceWebBridge.hpp"
 
 #include <algorithm>
+#include <stdexcept>
 #include <vector>
 #include <boost/log/trivial.hpp>
+#include <boost/nowide/fstream.hpp>
 
 #include "slic3r/GUI/GUI_App.hpp"
 #include "slic3r/GUI/DeviceCore/DevManager.h"
@@ -23,6 +25,7 @@
 
 #include <wx/app.h>
 #include <wx/colour.h>
+#include <wx/filedlg.h>
 #include <wx/string.h>
 #include <iomanip>
 #include <sstream>
@@ -220,6 +223,71 @@ nlohmann::json FilamentManagerVM::HandleSpool(const std::string& action, const n
     if (action == "list") {
         return MakeResp("spool", action, 0, "", build_spool_list());
     }
+    if (action == "export") {
+        wxFileDialog dialog(
+            wxGetApp().GetTopWindow(),
+            wxString::FromUTF8("Export filament inventory"),
+            wxEmptyString,
+            wxString::FromUTF8("filament_inventory_backup.json"),
+            wxString::FromUTF8("JSON files (*.json)|*.json"),
+            wxFD_SAVE | wxFD_OVERWRITE_PROMPT
+        );
+
+        if (dialog.ShowModal() == wxID_CANCEL) {
+            return MakeResp(
+                "spool",
+                action,
+                0,
+                "",
+                {{"cancelled", true}}
+            );
+        }
+
+        try {
+            const std::string path = dialog.GetPath().utf8_string();
+
+            boost::nowide::ofstream output(
+                path,
+                std::ios::out | std::ios::trunc
+            );
+
+            if (!output) {
+                throw std::runtime_error("failed to open export file");
+            }
+
+            const nlohmann::json inventory = {
+                {"spools", build_spool_list()}
+            };
+
+            output << inventory.dump(2) << '\n';
+
+            if (!output) {
+                throw std::runtime_error("failed to write export file");
+            }
+
+            output.close();
+
+            if (!output) {
+                throw std::runtime_error("failed to close export file");
+            }
+
+            return MakeResp(
+                "spool",
+                action,
+                0,
+                "",
+                {{"path", path}}
+            );
+        } catch (const std::exception& e) {
+            return MakeResp(
+                "spool",
+                action,
+                -1,
+                std::string("export failed: ") + e.what()
+            );
+        }
+    }
+
     if (is_spool_cloud_write_action(action) && (!store || !disp || !can_write_spool_to_cloud(agent))) {
         return MakeResp("spool", action, -2, "cloud sync requires sign-in and network");
     }

--- a/src/slic3r/GUI/DeviceWeb/device_page/locales/en.json
+++ b/src/slic3r/GUI/DeviceWeb/device_page/locales/en.json
@@ -34,6 +34,7 @@
   "Edit Filament Info": "Edit Filament Info",
   "Empty": "Empty",
   "Exhausted": "Exhausted",
+  "Export": "Export",
   "Fetching device info...": "Fetching device info...",
   "Fetching AMS data…": "Fetching AMS data…",
   "Filament": "Filament",

--- a/src/slic3r/GUI/DeviceWeb/device_page/locales/zh_CN.json
+++ b/src/slic3r/GUI/DeviceWeb/device_page/locales/zh_CN.json
@@ -34,6 +34,7 @@
   "Edit Filament Info": "编辑耗材信息",
   "Empty": "空",
   "Exhausted": "已耗尽",
+  "Export": "导出",
   "Fetching device info...": "正在获取设备信息…",
   "Fetching AMS data…": "正在获取",
   "Filament": "耗材",

--- a/src/slic3r/GUI/DeviceWeb/device_page/src/features/filament-manager/FilamentManagerPage.tsx
+++ b/src/slic3r/GUI/DeviceWeb/device_page/src/features/filament-manager/FilamentManagerPage.tsx
@@ -30,7 +30,7 @@ export function FilamentManagerPage() {
     init, addSpool, batchAddSpool, batchCreateSpools, updateSpool,
     removeSpool, batchRemoveSpool,
     fetchMachines, requestMachinePushall, fetchAmsData,
-    fetchPresets,
+    fetchPresets, exportSpoolInventory,
     fetchCloudSyncStatus, triggerCloudPull, pushAllNow, fetchCloudFilamentConfig,
   } = useFilamentManagerBridge();
 
@@ -304,6 +304,22 @@ export function FilamentManagerPage() {
     ]);
   }, [isLoggedIn, triggerCloudPull, fetchCloudFilamentConfig]);
 
+  // Keep file selection and writing native so the WebView does not need
+  // direct filesystem access.
+  const [exporting, setExporting] = useState(false);
+
+  const handleExportInventory = useCallback(async () => {
+    if (!isLoggedIn || exporting) return;
+
+    setExporting(true);
+
+    try {
+      await exportSpoolInventory();
+    } finally {
+      setExporting(false);
+    }
+  }, [isLoggedIn, exporting, exportSpoolInventory]);
+
   // STUDIO-18155：手动"推送本地到云端"按钮的加载态。pushAllNow 入队是同步
   // 操作（C++ 立即把所有 RFID + total>0 spool 入 dispatcher 队列），所以
   // loading 时间通常 < 100 ms，但 dispatcher 串行 PUT 会持续若干秒——这里
@@ -422,6 +438,63 @@ export function FilamentManagerPage() {
                   disabled={!isLoggedIn}
                 >
                   {t('Group')}
+                </button>
+                <button
+                  type="button"
+                  data-testid="filament-export"
+                  data-exporting={exporting ? 'true' : 'false'}
+                  className={`inline-flex items-center gap-1 h-[30px] px-3 rounded-lg border border-fm-border-focus/50 bg-fm-inner text-fm-text-primary text-xs whitespace-nowrap transition-colors duration-150 ${
+                    (!isLoggedIn || exporting)
+                      ? 'opacity-40 cursor-not-allowed'
+                      : 'cursor-pointer hover:bg-fm-hover'
+                  }`}
+                  title={t('Export')}
+                  aria-label={t('Export')}
+                  onClick={handleExportInventory}
+                  disabled={!isLoggedIn || exporting}
+                >
+                  {exporting ? (
+                    <svg
+                      className="animate-spin"
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      aria-hidden="true"
+                    >
+                      <circle
+                        cx="12"
+                        cy="12"
+                        r="9"
+                        stroke="currentColor"
+                        strokeOpacity="0.3"
+                        strokeWidth="2"
+                      />
+                      <path
+                        d="M21 12a9 9 0 0 1-9 9"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                      />
+                    </svg>
+                  ) : (
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 14 14"
+                      fill="none"
+                      aria-hidden="true"
+                    >
+                      <path
+                        d="M7 2v7M4.5 6.5L7 9l2.5-2.5M3 11.5h8"
+                        stroke="currentColor"
+                        strokeWidth="1.2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  )}
+                  {t('Export')}
                 </button>
                 <CloudBadge
                   state={cloudSync}

--- a/src/slic3r/GUI/DeviceWeb/device_page/src/features/filament-manager/useFilamentManagerBridge.ts
+++ b/src/slic3r/GUI/DeviceWeb/device_page/src/features/filament-manager/useFilamentManagerBridge.ts
@@ -19,6 +19,8 @@ function makeBody(submod: string, action: string, payload?: Record<string, unkno
   return { module: 'filament', submod, action, payload: payload ?? {} };
 }
 
+const NATIVE_FILE_DIALOG_TIMEOUT_MS = 30 * 60 * 1000;
+
 function isFilamentManagerVisible() {
   const hashPath = window.location.hash.replace(/^#/, '').split('?')[0] || '';
   const route = hashPath.startsWith('/') ? hashPath : `/${hashPath}`;
@@ -436,6 +438,39 @@ export function useFilamentManagerBridge() {
     });
   }, [pushToast, t]);
 
+  const exportSpoolInventory = useCallback(async () => {
+    const res = await request<ReturnType<typeof makeBody>, BridgeResponseBody>(
+      makeBody('spool', 'export'),
+      NATIVE_FILE_DIALOG_TIMEOUT_MS
+    );
+
+    if (!res.ok) {
+      pushToast({
+        level: 'error',
+        text: `${t('Failed')}: ${String(res.error)}`,
+      });
+      return false;
+    }
+
+    const responsePayload = res.value.payload as
+      | { cancelled?: boolean }
+      | undefined;
+
+    if (responsePayload?.cancelled) {
+      return false;
+    }
+
+    if (res.value.error_code !== 0) {
+      pushToast({
+        level: 'error',
+        text: `${t('Failed')}: ${res.value.message || t('unknown error')}`,
+      });
+      return false;
+    }
+
+    return true;
+  }, [request, pushToast, t]);
+
   const addSpool = useCallback(async (spool: Partial<Spool>) => {
     const res = await request<ReturnType<typeof makeBody>, BridgeResponseBody>(
       makeBody('spool', 'add', spool as Record<string, unknown>)
@@ -691,6 +726,7 @@ export function useFilamentManagerBridge() {
   return {
     init,
     fetchSpools,
+    exportSpoolInventory,
     addSpool,
     batchAddSpool,
     batchCreateSpools,


### PR DESCRIPTION
## Summary

This PR adds a local JSON export action for the Filament Manager inventory.

## Why

The Filament Manager stores user-maintained spool inventory data such as brand, material type, color, weight, status, notes, and AMS/cloud-related metadata.

Without a simple export action, users have no obvious UI path to back up or migrate this inventory.

Related to #11478

## Implementation

- Add an Export button to the Filament Manager toolbar.
- Add a WebView bridge command: `export_spool_inventory`.
- Open a native save-file dialog from C++.
- Write the current spool list as JSON using the existing spool representation.
- Keep the stored data unchanged.
- Do not add import functionality.
- Do not change cloud sync behavior.
- Do not change the spool schema.

## Test plan

- Build Bambu Studio.
- Open the Filament Manager.
- Click Export.
- Choose a JSON file path.
- Confirm the file is written and contains a top-level `spools` array.
- Cancel the save dialog and confirm no error is shown.
- Confirm add/edit/delete/sync actions still work as before.
