### PR TITLE
Search Filament Manager notes

### DIFF
--- a/resources/web/fila_manager/index.js
+++ b/resources/web/fila_manager/index.js
@@ -237,7 +237,15 @@ function getFilteredSpools() {
         if (g_tab === "favorite" && !s.favorite) return false;
         if (g_tab === "ams" && s.entry_method !== "ams_sync") return false;
         if (keyword) {
-            var hay = ((s.brand||"")+" "+(s.material_type||"")+" "+(s.series||"")+" "+(s.color_name||"")).toLowerCase();
+            var hay = [
+                s.brand,
+                s.material_type,
+                s.series,
+                s.color_name,
+                s.note,
+                s.notes,
+                s.spool_id
+            ].map(function(v) { return v || ""; }).join(" ").toLowerCase();
             if (hay.indexOf(keyword) === -1) return false;
         }
         for (var k in g_filters) {


### PR DESCRIPTION
## Summary

This PR extends the Filament Manager search to include spool notes and spool IDs.

## Why

The current search only checks brand, material type, series, and color name. This makes it difficult to find spools when users store identifying information in the note field.

Related to #10754

## Implementation

- Extend the existing Filament Manager search haystack.
- Include `note`, `notes`, and `spool_id` in the client-side search.
- Do not change the UI layout.
- Do not add new columns.
- Do not change the spool data schema.

## Test plan

- Build Bambu Studio.
- Open the Filament Manager.
- Add or edit a spool with a unique note.
- Search for text that only appears in the note.
- Confirm the matching spool is shown.
- Search for existing brand, material, series, and color values and confirm those still work.
