### PR TITLE
Fix Filament Manager filament column sorting

### DIFF
--- a/resources/web/fila_manager/index.html
+++ b/resources/web/fila_manager/index.html
@@ -129,7 +129,7 @@
                     <thead>
                         <tr>
                             <th class="col-check"><input type="checkbox" id="check-all"></th>
-                            <th class="col-filament sortable" data-sort="brand">耗材<span class="sort-icon"></span></th>
+                            <th class="col-filament sortable" data-sort="filament">耗材<span class="sort-icon"></span></th>
                             <th class="col-remain sortable" data-sort="remain_percent">余量<span class="sort-icon"></span></th>
                             <th class="col-status sortable" data-sort="status">状态<span class="sort-icon"></span></th>
                             <th class="col-price sortable" data-sort="unit_price">单价 (/kg)<span class="sort-icon"></span></th>

--- a/resources/web/fila_manager/index.js
+++ b/resources/web/fila_manager/index.js
@@ -229,6 +229,19 @@ onPush("theme_changed", function(data) {
 });
 
 /* ===== Filtering & Sorting ===== */
+function getSpoolSortValue(s, key) {
+    if (key === "filament") {
+        return [
+            s.brand,
+            s.material_type,
+            s.series,
+            s.color_name,
+            s.color_code
+        ].map(function(v) { return v || ""; }).join(" ");
+    }
+    return s[key];
+}
+
 function getFilteredSpools() {
     var keyword = (document.getElementById("search-input").value || "").toLowerCase();
     var list = g_spools.filter(function(s) {
@@ -247,7 +260,7 @@ function getFilteredSpools() {
     });
     if (g_sort_key) {
         list.sort(function(a, b) {
-            var va = a[g_sort_key], vb = b[g_sort_key];
+            var va = getSpoolSortValue(a, g_sort_key), vb = getSpoolSortValue(b, g_sort_key);
             if (typeof va === "number" && typeof vb === "number") return g_sort_asc ? va - vb : vb - va;
             va = String(va || ""); vb = String(vb || "");
             return g_sort_asc ? va.localeCompare(vb) : vb.localeCompare(va);


### PR DESCRIPTION
## Summary

This PR fixes sorting for the Filament column in the Filament Manager table.

## Why

The Filament column displays a combined filament identity, but the table header currently sorts only by `brand`. When multiple spools have the same or empty brand, clicking the Filament header can change the sort arrow without visibly reordering the list.

Fixes #11042

## Implementation

- Change the Filament table header to use a semantic `filament` sort key.
- Add a small sort-value resolver for synthetic sort keys.
- Sort the Filament column by brand, material type, series, color name, and color code.
- Keep the existing numeric and string sorting behavior for the other columns.

## Test plan

- Build Bambu Studio.
- Open the Filament Manager.
- Add or use spools with different material types, series, colors, and brands.
- Click the Filament column header.
- Confirm the list is sorted by visible filament identity.
- Click again and confirm descending order works.
- Confirm sorting by remaining amount, status, and price still works.
