### PR TITLE
Add saved views to Filament Manager

### DIFF
--- a/resources/web/fila_manager/index.css
+++ b/resources/web/fila_manager/index.css
@@ -215,6 +215,66 @@ body {
 .btn-delete:not(:disabled):hover { color: var(--danger); }
 .btn:disabled { opacity: 0.4; cursor: default; }
 
+.saved-view-menu {
+    position: relative;
+    display: inline-flex;
+}
+.saved-views-dropdown {
+    position: absolute;
+    right: 0;
+    top: 36px;
+    z-index: 120;
+    min-width: 220px;
+    max-width: 280px;
+    max-height: 280px;
+    overflow-y: auto;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 6px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+}
+.saved-view-empty {
+    padding: 10px 12px;
+    color: var(--text-detail);
+    font-size: 12px;
+}
+.saved-view-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    border-radius: var(--radius-md);
+}
+.saved-view-row:hover { background: var(--bg-hover); }
+.saved-view-apply {
+    flex: 1;
+    min-width: 0;
+    padding: 7px 8px;
+    border: 0;
+    background: transparent;
+    color: var(--text-primary);
+    font: inherit;
+    font-size: 12px;
+    text-align: left;
+    cursor: pointer;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.saved-view-delete {
+    width: 24px;
+    height: 24px;
+    border: 0;
+    background: transparent;
+    color: var(--text-detail);
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+}
+.saved-view-delete:hover {
+    color: var(--danger);
+    background: var(--bg-inner);
+}
+
 /* Filter dropdown */
 .filter-dropdown {
     position: absolute;

--- a/resources/web/fila_manager/index.html
+++ b/resources/web/fila_manager/index.html
@@ -111,6 +111,17 @@
                         <svg width="14" height="14" viewBox="0 0 14 14"><rect x="1" y="1" width="5" height="5" rx=".5" stroke="currentColor" fill="none"/><rect x="8" y="1" width="5" height="5" rx=".5" stroke="currentColor" fill="none"/><rect x="1" y="8" width="5" height="5" rx=".5" stroke="currentColor" fill="none"/><rect x="8" y="8" width="5" height="5" rx=".5" stroke="currentColor" fill="none"/></svg>
                         分组
                     </button>
+                    <button class="btn btn-outline" id="btn-save-view">
+                        <svg width="14" height="14" viewBox="0 0 14 14"><path d="M3 2.5h8v9H3z" stroke="currentColor" stroke-width="1.1" fill="none"/><path d="M4.5 2.5v3h5v-3M5 10h4" stroke="currentColor" stroke-width="1.1" fill="none"/></svg>
+                        保存视图
+                    </button>
+                    <div class="saved-view-menu">
+                        <button class="btn btn-outline" id="btn-saved-views">
+                            <svg width="14" height="14" viewBox="0 0 14 14"><path d="M3 3h8M3 7h8M3 11h8" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/></svg>
+                            视图
+                        </button>
+                        <div class="saved-views-dropdown" id="saved-views-dropdown" style="display:none;"></div>
+                    </div>
                     <button class="btn btn-primary" id="btn-add">
                         <svg width="14" height="14" viewBox="0 0 14 14"><line x1="7" y1="2" x2="7" y2="12" stroke="currentColor" stroke-width="1.5"/><line x1="2" y1="7" x2="12" y2="7" stroke="currentColor" stroke-width="1.5"/></svg>
                         添加耗材

--- a/resources/web/fila_manager/index.js
+++ b/resources/web/fila_manager/index.js
@@ -17,6 +17,7 @@ var g_grouped = false;
 var g_collapsed_groups = {};
 var g_page = 1;
 var g_page_size = 50;
+var FM_SAVED_VIEWS_KEY = "bambu_fila_manager_saved_views_v1";
 
 var BAMBU_COLORS = [
     "#000000","#333333","#555555","#808080","#BBBBBB","#FFFFFF",
@@ -261,6 +262,137 @@ function refresh() {
     renderTable(spools);
     updateBatchUI();
     if (g_view === "stats") renderStats();
+}
+
+function cloneSavedViewObject(obj) {
+    var out = {};
+    obj = obj || {};
+    for (var k in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, k)) out[k] = obj[k];
+    }
+    return out;
+}
+
+function loadSavedViews() {
+    try {
+        var raw = localStorage.getItem(FM_SAVED_VIEWS_KEY);
+        var views = raw ? JSON.parse(raw) : [];
+        return Array.isArray(views) ? views : [];
+    } catch (e) {
+        console.warn("[FM] failed to load saved views", e);
+        return [];
+    }
+}
+
+function saveSavedViews(views) {
+    try {
+        localStorage.setItem(FM_SAVED_VIEWS_KEY, JSON.stringify(views || []));
+        return true;
+    } catch (e) {
+        console.warn("[FM] failed to save views", e);
+        alert("保存视图失败");
+        return false;
+    }
+}
+
+function captureSavedViewState() {
+    var searchInput = document.getElementById("search-input");
+    return {
+        view: g_view,
+        tab: g_tab,
+        search: searchInput ? (searchInput.value || "") : "",
+        filters: cloneSavedViewObject(g_filters),
+        sort_key: g_sort_key,
+        sort_asc: g_sort_asc,
+        grouped: g_grouped,
+        page_size: g_page_size
+    };
+}
+
+function syncSavedViewControls() {
+    document.querySelectorAll(".nav-item").forEach(function(el) {
+        el.classList.toggle("active", el.getAttribute("data-view") === g_view);
+    });
+
+    document.getElementById("stats-view").style.display = (g_view === "stats") ? "" : "none";
+    document.getElementById("list-view").style.display = (g_view === "stats") ? "none" : "";
+    document.querySelectorAll(".tab-pill").forEach(function(el) {
+        el.classList.toggle("active", el.getAttribute("data-tab") === g_tab);
+    });
+    document.querySelectorAll(".filter-btn").forEach(function(el) {
+        var key = el.getAttribute("data-filter");
+        el.classList.toggle("active", !!g_filters[key]);
+    });
+    document.querySelectorAll("th.sortable").forEach(function(el) {
+        var active = el.getAttribute("data-sort") === g_sort_key;
+        el.classList.toggle("sort-asc", active && g_sort_asc);
+        el.classList.toggle("sort-desc", active && !g_sort_asc);
+    });
+    var groupBtn = document.getElementById("btn-group");
+    if (groupBtn) groupBtn.classList.toggle("btn-group-active", g_grouped);
+}
+
+function renderSavedViewsDropdown() {
+    var dd = document.getElementById("saved-views-dropdown");
+    if (!dd) return;
+
+    var views = loadSavedViews();
+    if (!views.length) {
+        dd.innerHTML = '<div class="saved-view-empty">暂无保存的视图</div>';
+        return;
+    }
+
+    dd.innerHTML = views.map(function(item, index) {
+        return '<div class="saved-view-row" data-index="'+index+'">' +
+            '<button class="saved-view-apply" title="'+esc(item.name || "")+'">'+esc(item.name || "—")+'</button>' +
+            '<button class="saved-view-delete" title="删除">×</button>' +
+        '</div>';
+    }).join("");
+}
+
+function applySavedView(item) {
+    var state = (item && item.state) || {};
+    var searchInput = document.getElementById("search-input");
+
+    g_view = state.view || "my";
+    g_tab = state.tab || "all";
+    g_filters = cloneSavedViewObject(state.filters);
+    g_sort_key = state.sort_key || "";
+    g_sort_asc = state.sort_asc !== false;
+    g_grouped = !!state.grouped;
+    g_collapsed_groups = {};
+    g_selected_ids = {};
+    g_page = 1;
+    if (state.page_size) g_page_size = state.page_size;
+    if (searchInput) searchInput.value = state.search || "";
+
+    syncSavedViewControls();
+
+    var dd = document.getElementById("saved-views-dropdown");
+    if (dd) dd.style.display = "none";
+
+    refresh();
+}
+
+function saveCurrentView() {
+    var name = prompt("保存当前视图为", "");
+    if (name === null) return;
+    name = name.replace(/^\s+|\s+$/g, "");
+    if (!name) return;
+
+    var views = loadSavedViews();
+    views = views.filter(function(item) { return item.name !== name; });
+    views.unshift({
+        name: name,
+        state: captureSavedViewState()
+    });
+    if (views.length > 20) views = views.slice(0, 20);
+
+    if (saveSavedViews(views)) {
+        renderSavedViewsDropdown();
+        var dd = document.getElementById("saved-views-dropdown");
+        if (dd) dd.style.display = "block";
+    }
 }
 
 /* ===== Status tags ===== */
@@ -1034,6 +1166,42 @@ document.addEventListener("DOMContentLoaded", function() {
         }
     });
 
+    // Saved views
+    renderSavedViewsDropdown();
+
+    document.getElementById("btn-save-view").addEventListener("click", function(e) {
+        e.stopPropagation();
+        saveCurrentView();
+    });
+
+    document.getElementById("btn-saved-views").addEventListener("click", function(e) {
+        e.stopPropagation();
+        renderSavedViewsDropdown();
+        var dd = document.getElementById("saved-views-dropdown");
+        dd.style.display = dd.style.display === "block" ? "none" : "block";
+    });
+
+    document.getElementById("saved-views-dropdown").addEventListener("click", function(e) {
+        e.stopPropagation();
+        var row = e.target.closest(".saved-view-row");
+        if (!row) return;
+
+        var views = loadSavedViews();
+        var index = parseInt(row.getAttribute("data-index"), 10);
+        if (isNaN(index) || !views[index]) return;
+
+        if (e.target.closest(".saved-view-delete")) {
+            if (confirm("删除保存的视图？")) {
+                views.splice(index, 1);
+                saveSavedViews(views);
+                renderSavedViewsDropdown();
+            }
+            return;
+        }
+
+        applySavedView(views[index]);
+    });
+
     // Search
     document.getElementById("search-input").addEventListener("input", function() { refresh(); });
 
@@ -1062,9 +1230,11 @@ document.addEventListener("DOMContentLoaded", function() {
         refresh();
     });
 
-    // Close dropdown on outside click
+    // Close dropdowns on outside click
     document.addEventListener("click", function() {
         document.getElementById("filter-dropdown").style.display = "none";
+        var savedViewsDropdown = document.getElementById("saved-views-dropdown");
+        if (savedViewsDropdown) savedViewsDropdown.style.display = "none";
     });
 
     // Group toggle


### PR DESCRIPTION
## Summary

This PR adds local saved views to the Filament Manager.

## Why

Users with larger filament inventories often recreate the same search, filter, grouping, and sorting combinations repeatedly. Saved views make those common workflows available with one click.

Related to #11486

## Implementation

- Add a "Save view" button to the Filament Manager toolbar.
- Add a "Views" dropdown to apply or delete saved views.
- Store saved views locally in WebView `localStorage`.
- Saved views capture:
  - current inventory view
  - selected tab
  - search text
  - active filters
  - sort key and direction
  - grouped mode
  - page size
- Applying a saved view restores the captured UI state and refreshes the table.

## Scope

- Local UI state only.
- No spool data schema changes.
- No cloud sync changes.
- No AMS data changes.
- No C++ backend changes.

## Test plan

- Build Bambu Studio.
- Open the Filament Manager.
- Apply search text, filters, sorting, and grouped mode.
- Click "Save view" and give it a name.
- Open the "Views" dropdown and apply the saved view.
- Confirm the saved search/filter/sort/group state is restored.
- Delete a saved view and confirm it disappears from the dropdown.
- Restart/reopen the Filament Manager and confirm saved views remain available.