### PR TITLE
Add quick inventory chips to Filament Manager

### DIFF
--- a/resources/web/fila_manager/index.css
+++ b/resources/web/fila_manager/index.css
@@ -215,6 +215,55 @@ body {
 .btn-delete:not(:disabled):hover { color: var(--danger); }
 .btn:disabled { opacity: 0.4; cursor: default; }
 
+/* Quick inventory chips */
+.quick-chip-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    flex-shrink: 0;
+}
+.quick-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 28px;
+    padding: 0 10px;
+    border-radius: var(--radius-lg);
+    border: 0.5px solid var(--border);
+    background: var(--bg-inner);
+    color: var(--text-secondary);
+    font-family: inherit;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background .15s, color .15s, border-color .15s;
+}
+.quick-chip:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+}
+.quick-chip.active {
+    color: var(--brand);
+    border-color: var(--brand);
+    background: var(--bg-input);
+}
+.quick-chip-count {
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border-radius: 999px;
+    background: var(--bg-sidebar);
+    color: var(--text-primary);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
+}
+.quick-chip.active .quick-chip-count {
+    color: #fff;
+    background: var(--brand);
+}
+
 /* Filter dropdown */
 .filter-dropdown {
     position: absolute;

--- a/resources/web/fila_manager/index.html
+++ b/resources/web/fila_manager/index.html
@@ -118,6 +118,9 @@
                 </div>
             </div>
 
+            <!-- Quick inventory chips -->
+            <div class="quick-chip-row" id="quick-chip-row"></div>
+
             <!-- Filter dropdown (shared, repositioned per button) -->
             <div class="filter-dropdown" id="filter-dropdown" style="display:none;">
                 <div class="filter-dropdown-list" id="filter-dropdown-list"></div>

--- a/resources/web/fila_manager/index.js
+++ b/resources/web/fila_manager/index.js
@@ -17,6 +17,7 @@ var g_grouped = false;
 var g_collapsed_groups = {};
 var g_page = 1;
 var g_page_size = 50;
+var g_quick_filter = "";
 
 var BAMBU_COLORS = [
     "#000000","#333333","#555555","#808080","#BBBBBB","#FFFFFF",
@@ -229,6 +230,113 @@ onPush("theme_changed", function(data) {
 });
 
 /* ===== Filtering & Sorting ===== */
+function isSpoolDryDue(s) {
+    if (!(s.dry_reminder_days > 0 && s.dry_date)) return false;
+
+    var dryDate = new Date(s.dry_date).getTime();
+    if (isNaN(dryDate)) return false;
+
+    var diff = (Date.now() - dryDate) / 86400000;
+    return diff >= s.dry_reminder_days;
+}
+
+function matchesQuickFilter(s) {
+    var remain = s.remain_percent || 0;
+
+    if (g_quick_filter === "low") return remain > 0 && remain < 20;
+    if (g_quick_filter === "dry") return isSpoolDryDue(s);
+    if (g_quick_filter === "empty") return remain === 0;
+    if (g_quick_filter === "ams") return s.entry_method === "ams_sync";
+
+    return true;
+}
+
+function getQuickChipCounts() {
+    var counts = { total: 0, low: 0, dry: 0, empty: 0, ams: 0, archived: 0 };
+
+    g_spools.forEach(function(s) {
+        if (s.status === "archived") {
+            counts.archived++;
+            return;
+        }
+
+        counts.total++;
+
+        var remain = s.remain_percent || 0;
+        if (remain === 0) counts.empty++;
+        else if (remain < 20) counts.low++;
+
+        if (isSpoolDryDue(s)) counts.dry++;
+        if (s.entry_method === "ams_sync") counts.ams++;
+    });
+
+    return counts;
+}
+
+function renderQuickChips() {
+    var el = document.getElementById("quick-chip-row");
+    if (!el) return;
+
+    var counts = getQuickChipCounts();
+    var chips = [
+        {key: "total", label: "全部", count: counts.total},
+        {key: "low", label: "低余量", count: counts.low},
+        {key: "dry", label: "需烘干", count: counts.dry},
+        {key: "empty", label: "已用尽", count: counts.empty},
+        {key: "ams", label: "AMS", count: counts.ams},
+        {key: "archived", label: "存档", count: counts.archived}
+    ];
+
+    el.innerHTML = chips.map(function(chip) {
+        var active = (chip.key === "archived")
+            ? g_view === "archived"
+            : (g_view !== "archived" && ((chip.key === "total" && !g_quick_filter) || g_quick_filter === chip.key));
+
+        return '<button class="quick-chip'+(active ? " active" : "")+'" data-chip="'+chip.key+'">' +
+            '<span>'+chip.label+'</span>' +
+            '<span class="quick-chip-count">'+chip.count+'</span>' +
+        '</button>';
+    }).join("");
+}
+
+function syncInventoryViewControls() {
+    document.querySelectorAll(".nav-item").forEach(function(el) {
+        el.classList.toggle("active", el.getAttribute("data-view") === g_view);
+    });
+    document.querySelectorAll(".tab-pill").forEach(function(el) {
+        el.classList.toggle("active", el.getAttribute("data-tab") === g_tab);
+    });
+
+    document.getElementById("stats-view").style.display = (g_view === "stats") ? "" : "none";
+    document.getElementById("list-view").style.display = (g_view === "stats") ? "none" : "";
+}
+
+function applyQuickChip(key) {
+    g_page = 1;
+    g_selected_ids = {};
+
+    if (key === "total") {
+        g_view = "my";
+        g_tab = "all";
+        g_quick_filter = "";
+    } else if (key === "archived") {
+        g_view = "archived";
+        g_tab = "all";
+        g_quick_filter = "";
+    } else if (key === "ams") {
+        g_view = "my";
+        g_tab = "ams";
+        g_quick_filter = "ams";
+    } else {
+        g_view = "my";
+        g_tab = "all";
+        g_quick_filter = key;
+    }
+
+    syncInventoryViewControls();
+    refresh();
+}
+
 function getFilteredSpools() {
     var keyword = (document.getElementById("search-input").value || "").toLowerCase();
     var list = g_spools.filter(function(s) {
@@ -236,6 +344,7 @@ function getFilteredSpools() {
         else { if (s.status === "archived") return false; }
         if (g_tab === "favorite" && !s.favorite) return false;
         if (g_tab === "ams" && s.entry_method !== "ams_sync") return false;
+        if (g_quick_filter && !matchesQuickFilter(s)) return false;
         if (keyword) {
             var hay = ((s.brand||"")+" "+(s.material_type||"")+" "+(s.series||"")+" "+(s.color_name||"")).toLowerCase();
             if (hay.indexOf(keyword) === -1) return false;
@@ -257,6 +366,7 @@ function getFilteredSpools() {
 }
 
 function refresh() {
+    renderQuickChips();
     var spools = getFilteredSpools();
     renderTable(spools);
     updateBatchUI();
@@ -973,6 +1083,7 @@ document.addEventListener("DOMContentLoaded", function() {
     document.querySelectorAll(".nav-item").forEach(function(el) {
         el.addEventListener("click", function() {
             g_view = this.getAttribute("data-view");
+            g_quick_filter = "";
             document.querySelectorAll(".nav-item").forEach(function(n) { n.classList.remove("active"); });
             this.classList.add("active");
             g_selected_ids = {};
@@ -986,6 +1097,7 @@ document.addEventListener("DOMContentLoaded", function() {
     document.querySelectorAll(".tab-pill").forEach(function(el) {
         el.addEventListener("click", function() {
             g_tab = this.getAttribute("data-tab");
+            g_quick_filter = "";
             document.querySelectorAll(".tab-pill").forEach(function(t) { t.classList.remove("active"); });
             this.classList.add("active");
             refresh();
@@ -1065,6 +1177,13 @@ document.addEventListener("DOMContentLoaded", function() {
     // Close dropdown on outside click
     document.addEventListener("click", function() {
         document.getElementById("filter-dropdown").style.display = "none";
+    });
+
+    // Quick inventory chips
+    document.getElementById("quick-chip-row").addEventListener("click", function(e) {
+        var chip = e.target.closest(".quick-chip");
+        if (!chip) return;
+        applyQuickChip(chip.getAttribute("data-chip"));
     });
 
     // Group toggle


### PR DESCRIPTION
## Summary

This PR adds clickable quick inventory chips to the Filament Manager list view.

## Why

Common inventory states such as low remaining spools, drying reminders, empty spools, AMS-synced spools, and archived spools are useful at a glance. Today users need to manually search, filter, or switch views to get to these subsets.

Related to #11488

## Implementation

- Add a quick chip row above the Filament Manager table.
- Show counts for:
  - Total
  - Low remaining
  - Needs drying
  - Empty
  - AMS
  - Archived
- Clicking a chip switches to the relevant subset.
- Use the existing Chinese UI labels for the chips.
- Keep the feature local to the WebView UI.
- Do not change spool data, cloud sync, AMS data, or the C++ backend.

## Test plan

- Build Bambu Studio.
- Open the Filament Manager.
- Confirm the quick chips show counts.
- Click Low and confirm low-remaining active spools are shown.
- Click Needs drying and confirm due-for-drying spools are shown.
- Click Empty and confirm empty active spools are shown.
- Click AMS and confirm AMS-synced spools are shown.
- Click Archived and confirm the archived view opens.
- Click Total and confirm the active list view is restored.
