### PR TITLE
Copy extended system information to clipboard

### DIFF
--- a/src/slic3r/GUI/SysInfoDialog.cpp
+++ b/src/slic3r/GUI/SysInfoDialog.cpp
@@ -215,7 +215,12 @@ void SysInfoDialog::on_dpi_changed(const wxRect &suggested_rect)
 void SysInfoDialog::onCopyToClipboard(wxEvent &)
 {
     wxTheClipboard->Open();
-    const auto text = get_main_info(false) + "\n" + wxGetApp().get_gl_info(true);
+
+    const auto text = get_main_info(false) + "\n\n" +
+        get_mem_info(false) +
+        wxGetApp().get_gl_info(true) + "\n\n" +
+        std::string("SIMD is supported: ") + Eigen::SimdInstructionSetsInUse();
+
     wxTheClipboard->SetData(new wxTextDataObject(text));
     wxTheClipboard->Close();
 }


### PR DESCRIPTION
## Summary

This PR extends the existing System Information dialog "Copy to Clipboard" output.

## Why

The dialog already displays useful diagnostic details, but the clipboard output only copied the main application/system information plus OpenGL information. Memory details and SIMD instruction set information were visible in the dialog but missing from the copied text.

Related to #11490

## Implementation

- Keep the existing "Copy to Clipboard" button.
- Add memory information to the copied diagnostic text.
- Add SIMD instruction set information to the copied diagnostic text.
- Keep the change limited to `SysInfoDialog.cpp`.
- Do not add telemetry or automatic data sending.

## Test plan

- Build Bambu Studio.
- Open the System Information dialog.
- Click "Copy to Clipboard".
- Paste the clipboard text into a text editor.
- Confirm the copied text includes:
  - main application/system information
  - memory information
  - OpenGL information
  - SIMD instruction set information
