### PR TITLE
Add Help menu item to show log folder

### DIFF
--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -566,6 +566,16 @@ void desktop_open_datadir_folder()
 #endif
 }
 
+void desktop_open_log_folder()
+{
+    const auto log_folder = (boost::filesystem::path(data_dir()) / "log").make_preferred();
+
+    if (!boost::filesystem::exists(log_folder))
+        boost::filesystem::create_directories(log_folder);
+
+    desktop_open_any_folder(log_folder.string());
+}
+
 void desktop_open_any_folder( const std::string& path )
 {
     // Execute command to open a file explorer, platform dependent.

--- a/src/slic3r/GUI/GUI.hpp
+++ b/src/slic3r/GUI/GUI.hpp
@@ -82,6 +82,8 @@ extern void about();
 extern void login();
 // Ask the destop to open the datadir using the default file explorer.
 extern void desktop_open_datadir_folder();
+// Ask the desktop to open the application log folder using the default file explorer.
+extern void desktop_open_log_folder();
 // Ask the destop to open one folder
 extern void desktop_open_any_folder(const std::string& path);
 } // namespace GUI

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2741,6 +2741,9 @@ static wxMenu* generate_help_menu()
     append_menu_item(helpMenu, wxID_ANY, _L("Show Configuration Folder"), _L("Show Configuration Folder"),
         [](wxCommandEvent&) { Slic3r::GUI::desktop_open_datadir_folder(); });
 
+    append_menu_item(helpMenu, wxID_ANY, _L("Show Log Folder"), _L("Show Log Folder"),
+        [](wxCommandEvent&) { Slic3r::GUI::desktop_open_log_folder(); });
+
     append_menu_item(helpMenu, wxID_ANY, _L("Show Tip of the Day"), _L("Show Tip of the Day"), [](wxCommandEvent&) {
         wxGetApp().plater()->get_dailytips()->open();
         wxGetApp().plater()->get_current_canvas3D()->set_as_dirty();


### PR DESCRIPTION
## Summary

This PR adds a Help menu item to open the application log folder.

New menu item:

`Help > Show Log Folder`

## Why

Bambu Studio already has a Help menu item for opening the configuration folder, but users still need to manually locate the log folder when reporting bugs or inspecting large log files.

This makes the existing application log folder easier to find from the UI.

Related to #11492

Related context: #9845

## Implementation

- Add `desktop_open_log_folder()`.
- Resolve the log folder as `data_dir()/log`.
- Create the log folder if it does not exist yet.
- Reuse the existing cross-platform folder-opening helper.
- Add `Help > Show Log Folder` next to `Show Configuration Folder`.

## Scope

This PR does not:

- change log generation
- change log retention
- delete logs
- upload logs
- add telemetry

## Test plan

- Build Bambu Studio.
- Open the Help menu.
- Click `Show Log Folder`.
- Confirm the application log folder opens in the system file manager.
- Confirm `Show Configuration Folder` still works as before.
