### PR TITLE
Fix removing missing recent projects from history

### DIFF
--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -4390,20 +4390,12 @@ void MainFrame::open_recent_project(size_t file_id, wxString const & filename)
     }
     else
     {
-        MessageDialog msg(this, _L("The project is no longer available."), _L("Error"), wxOK | wxYES_DEFAULT);
+        MessageDialog msg(this,
+            _L("The project is no longer available. Do you want to remove it from the recent projects list?"),
+            _L("Error"),
+            wxYES_NO | wxYES_DEFAULT | wxICON_WARNING);
         if (msg.ShowModal() == wxID_YES)
-        {
-            m_recent_projects.RemoveFileFromHistory(file_id);
-            std::vector<std::string> recent_projects;
-            size_t count = m_recent_projects.GetCount();
-            for (size_t i = 0; i < count; ++i)
-            {
-                recent_projects.push_back(into_u8(m_recent_projects.GetHistoryFile(i)));
-            }
-            wxGetApp().app_config->set_recent_projects(recent_projects);
-            wxGetApp().app_config->save();
-            m_webview->SendRecentList(-1);
-        }
+            remove_recent_project(file_id, filename);
     }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes removal of missing recent projects from the recent projects history.

## Why

When a recent project file no longer exists, Bambu Studio already shows an error dialog and has code intended to remove the missing entry from the recent projects list.

However, the dialog was created with `wxOK`, while the code checked for `wxID_YES`. As a result, the removal branch could not be reached from that dialog, so missing files stayed in the MRU/recent projects list.

Related to #1729

Complementary to #11413, which adds a separate "Clear recent projects" action. This PR does not clear the full list. It only fixes the existing missing-file removal flow for a selected recent project.

## Implementation

- Change the missing recent project dialog from `wxOK` to `wxYES_NO`.
- Ask the user whether the missing project should be removed from recent projects.
- Reuse the existing `remove_recent_project(...)` helper instead of duplicating persistence/update logic.

## Scope

This PR does not:

- add a new menu item
- clear all recent projects
- change how recent projects are stored
- change thumbnail loading
- change project loading behavior for existing files

## Test plan

- Add or keep a project in the recent projects list.
- Delete or move the project file outside Bambu Studio.
- Click the missing entry from Recent projects.
- Confirm the dialog asks whether to remove it.
- Click Yes.
- Confirm the missing entry is removed from the recent projects list.
- Confirm existing recent project files still open normally.
