### PR TITLE
Add menu item to show current project in folder

### DIFF
--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2931,6 +2931,21 @@ void MainFrame::init_menubar_as_editor()
             [this](){return m_plater != nullptr && can_save_as(); }, this);
 #endif
 
+        append_menu_item(fileMenu, wxID_ANY, _L("Show Project in Folder"), _L("Show current project in folder"),
+            [this](wxCommandEvent&) {
+                if (m_plater) {
+                    const wxString filename = m_plater->get_project_filename(".3mf");
+                    if (!filename.IsEmpty() && wxFileExists(filename))
+                        Slic3r::GUI::desktop_open_any_folder(into_u8(filename));
+                }
+            }, "", nullptr,
+            [this]() {
+                if (m_plater == nullptr)
+                    return false;
+                const wxString filename = m_plater->get_project_filename(".3mf");
+                return !filename.IsEmpty() && wxFileExists(filename);
+            }, this);
+
 
         fileMenu->AppendSeparator();
 


### PR DESCRIPTION
## Summary

This PR adds a File menu item to reveal the currently saved project in the system file manager.

New menu item:

`File > Show Project in Folder`

## Why

After opening or saving a project, users may want to quickly locate the active `.3mf` file on disk, for example to copy it, attach it to a bug report, or verify where it was saved.

Bambu Studio already has a cross-platform helper for opening folders, so this PR reuses that instead of adding platform-specific logic.

Related to #11495

## Implementation

- Add `File > Show Project in Folder` after `Save Project as`.
- Use `m_plater->get_project_filename(".3mf")` to resolve the current project path.
- Enable the menu item only when the project path is not empty and the file exists.
- Reuse `Slic3r::GUI::desktop_open_any_folder(...)` to reveal/open the containing folder.

## Scope

This PR does not:

- change project saving
- change project loading
- change recent projects
- change exported G-code behavior
- prompt users to save unsaved projects

## Test plan

- Open or save a `.3mf` project.
- Open the File menu.
- Confirm `Show Project in Folder` is enabled.
- Click it.
- Confirm the system file manager opens the project location.
- Start a new unsaved project.
- Confirm `Show Project in Folder` is disabled.
- Delete or move the saved project file externally.
- Confirm `Show Project in Folder` becomes disabled.
