### PR TITLE
Add copy button to generic error dialog

### DIFF
--- a/src/slic3r/GUI/MsgDialog.cpp
+++ b/src/slic3r/GUI/MsgDialog.cpp
@@ -134,7 +134,7 @@ void MsgDialog::SetButtonLabel(wxWindowID btn_id, const wxString& label, bool se
     }
 }
 
-Button* MsgDialog::add_button(wxWindowID btn_id, bool set_focus /*= false*/, const wxString& label/* = wxString()*/)
+Button* MsgDialog::add_button(wxWindowID btn_id, bool set_focus /*= false*/, const wxString& label/* = wxString()*/, bool end_modal /*= true*/)
 {
     Button* btn = new Button(this, label, "", 0, 0, btn_id);
     ButtonSizeType type;
@@ -192,7 +192,8 @@ Button* MsgDialog::add_button(wxWindowID btn_id, bool set_focus /*= false*/, con
     if (set_focus)
         btn->SetFocus();
     btn_sizer->Add(btn, 0, wxRIGHT | wxALIGN_CENTER_VERTICAL, BTN_SPACING);
-    btn->Bind(wxEVT_BUTTON, [this, btn_id](wxCommandEvent&) { EndModal(btn_id); });
+    if (end_modal)
+        btn->Bind(wxEVT_BUTTON, [this, btn_id](wxCommandEvent&) { EndModal(btn_id); });
 
     MsgButton *mb = new MsgButton;
     ButtonData *bd = new ButtonData;
@@ -379,6 +380,14 @@ ErrorDialog::ErrorDialog(wxWindow *parent, const wxString &temp_msg, bool monosp
 
     // Use a small bitmap with monospaced font, as the error text will not be wrapped.
     logo->SetBitmap(create_scaled_bitmap("BambuStudio_192px_grayscale.png", this, monospaced_font ? 48 : /*1*/84));
+
+    Button* copy_btn = add_button(wxID_COPY, false, _L("Copy"), false);
+    copy_btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+        if (wxTheClipboard->Open()) {
+            wxTheClipboard->SetData(new wxTextDataObject(msg));
+            wxTheClipboard->Close();
+        }
+    });
 
     SetMaxSize(MSG_DLG_MAX_SIZE);
 

--- a/src/slic3r/GUI/MsgDialog.hpp
+++ b/src/slic3r/GUI/MsgDialog.hpp
@@ -81,7 +81,7 @@ protected:
 
 	MsgDialog(wxWindow *parent, const wxString &title, const wxString &headline, long style = wxOK, wxBitmap bitmap = wxNullBitmap, const wxString &forward_str = "");
 	// returns pointer to created button
-	Button* add_button(wxWindowID btn_id, bool set_focus = false, const wxString& label = wxString());
+	Button* add_button(wxWindowID btn_id, bool set_focus = false, const wxString& label = wxString(), bool end_modal = true);
 	// returns pointer to found button or NULL
 	Button* get_button(wxWindowID btn_id);
 	void apply_style(long style);


### PR DESCRIPTION
## Summary

This PR adds a non-closing `Copy` button to the generic `ErrorDialog`.

## Why

Error dialogs often contain details that are useful for bug reports or support requests. A dedicated copy button makes it easier for users to copy the exact error text instead of taking screenshots or manually retyping it.

Related to #11497

## Implementation

- Extend `MsgDialog::add_button(...)` with an optional `end_modal` argument.
- Keep the default behavior unchanged for existing callers.
- Add a `Copy` button to `ErrorDialog`.
- The copy button writes the stored error message to the clipboard and keeps the dialog open.

## Scope

This PR only affects the generic `ErrorDialog`.

It does not:

- add copy buttons to all message dialogs
- change warning, confirmation, or question dialogs
- change error handling behavior
- change the existing `OK` button behavior

## Test plan

- Trigger or instantiate an `ErrorDialog`.
- Confirm the dialog shows both `OK` and `Copy`.
- Click `Copy`.
- Confirm the error text is copied to the clipboard.
- Confirm the dialog stays open after clicking `Copy`.
- Click `OK`.
- Confirm the dialog closes normally.