### PR TITLE
Add copy details button to device error dialog

### DIFF
--- a/src/slic3r/GUI/DeviceErrorDialog.cpp
+++ b/src/slic3r/GUI/DeviceErrorDialog.cpp
@@ -6,6 +6,9 @@
 #include "MainFrame.hpp"
 #include "ReleaseNote.hpp"
 
+#include <wx/clipbrd.h>
+#include <wx/dataobj.h>
+
 namespace Slic3r {
 namespace GUI
 {
@@ -214,6 +217,7 @@ void DeviceErrorDialog::init_button_list()
     init_button(DBL_CHECK_RETRY, _L("Retry"));
     init_button(DBL_CHECK_RESUME, _L("Resume"));
     init_button(DBL_CHECK_OK, _L("Confirm"));
+    init_button(COPY_ERROR_DETAILS, _L("Copy Error Details"));
 }
 
 void DeviceErrorDialog::on_dpi_changed(const wxRect& suggested_rect)
@@ -455,6 +459,14 @@ void DeviceErrorDialog::update_contents(const wxString& title, const wxString& t
             }
         }
 
+        auto copy_iter = m_button_list.find(COPY_ERROR_DETAILS);
+        if (copy_iter != m_button_list.end())
+        {
+            m_sizer_button->Add(copy_iter->second, 0, wxALL, FromDIP(5));
+            copy_iter->second->Show();
+            m_used_button.insert(copy_iter->second);
+        }
+
         // Special case, do not show close button
         if (need_remove_close_btn)
         {
@@ -495,6 +507,9 @@ void DeviceErrorDialog::update_contents(const wxString& title, const wxString& t
     /* error code*/
     const wxString& show_time = wxDateTime::Now().Format("%H%M%d");
     const wxString& error_code_msg = wxString::Format("[%S %S]", error_code, show_time);
+    m_error_title = title;
+    m_error_text = text;
+    m_error_code_text = error_code_msg;
     m_error_code_label->SetMaxSize(wxSize(FromDIP(300), -1));
     m_error_code_label->SetMinSize(wxSize(FromDIP(300), -1));
     m_error_code_label->SetLabelText(error_code_msg);
@@ -531,6 +546,34 @@ void DeviceErrorDialog::update_contents(const wxString& title, const wxString& t
         Fit();
     }
 };
+
+void DeviceErrorDialog::copy_error_details_to_clipboard() const
+{
+    wxString details;
+
+    if (!m_error_title.IsEmpty())
+        details += m_error_title;
+
+    if (!m_error_code_text.IsEmpty()) {
+        if (!details.IsEmpty())
+            details += "\n";
+        details += m_error_code_text;
+    }
+
+    if (!m_error_text.IsEmpty()) {
+        if (!details.IsEmpty())
+            details += "\n\n";
+        details += m_error_text;
+    }
+
+    if (details.IsEmpty())
+        return;
+
+    if (wxTheClipboard->Open()) {
+        wxTheClipboard->SetData(new wxTextDataObject(details));
+        wxTheClipboard->Close();
+    }
+}
 
 void DeviceErrorDialog::on_button_click(ActionButton btn_id)
 {
@@ -683,6 +726,11 @@ void DeviceErrorDialog::on_button_click(ActionButton btn_id)
         m_obj->command_clean_print_error(m_obj->subtask_id_, m_error_code);
         m_obj->command_clean_print_error_uiop(m_error_code);
         break;
+    }
+
+    case DeviceErrorDialog::COPY_ERROR_DETAILS: {
+        copy_error_details_to_clipboard();
+        return;
     }
 
     default: break;

--- a/src/slic3r/GUI/DeviceErrorDialog.hpp
+++ b/src/slic3r/GUI/DeviceErrorDialog.hpp
@@ -58,6 +58,7 @@ public:
         DBL_CHECK_RETRY = 10002,
         DBL_CHECK_RESUME = 10003,
         DBL_CHECK_OK = 10004,
+        COPY_ERROR_DETAILS = 10005,
     };
     /* action params json */
     nlohmann::json m_action_json;
@@ -86,6 +87,7 @@ protected:
     void update_contents(const wxString& title, const wxString& text, const wxString& error_code,const wxString& image_url, const std::vector<int>& btns);
 
     void on_button_click(ActionButton btn_id);
+    void copy_error_details_to_clipboard() const;
     void on_request_timeout(wxTimerEvent& event);
     void on_webrequest_state(wxWebRequestEvent& evt);
     void on_dpi_changed(const wxRect& suggested_rect);
@@ -99,6 +101,9 @@ private:
     MachineObject* m_obj;
 
     int m_error_code = 0;
+    wxString m_error_title;
+    wxString m_error_text;
+    wxString m_error_code_text;
     std::unordered_set<Button*> m_used_button;
 
     wxWebRequest web_request;


### PR DESCRIPTION
## Summary

This PR adds a `Copy Error Details` button to `DeviceErrorDialog`.

## Why

Printer/device error dialogs can contain useful troubleshooting details such as the error level, error code and message. Users often need to share those details in bug reports or support requests.

This PR makes that easier by adding a dedicated copy action for the currently displayed device error details.

Related to #11499

## Implementation

- Add a `COPY_ERROR_DETAILS` action button.
- Store the currently displayed error title, error code text and error message.
- Add `Copy Error Details` to the device error dialog button area.
- Copy the stored details to the clipboard.
- Return immediately after copying so the dialog stays open and no printer/device action is triggered.

## Scope

This PR only affects `DeviceErrorDialog`.

It does not:

- change printer error handling
- change HMS/error lookup logic
- change existing printer/device action buttons
- affect the generic `ErrorDialog`
- close the dialog after copying

## Note

This is separate from the generic `ErrorDialog` copy button. `DeviceErrorDialog` is a custom printer/device error dialog and does not use the generic error dialog implementation.

## Test plan

- Trigger or instantiate a `DeviceErrorDialog`.
- Confirm the dialog shows `Copy Error Details`.
- Click `Copy Error Details`.
- Confirm the visible error title/code/message are copied to the clipboard.
- Confirm the dialog stays open after copying.
- Confirm existing action buttons still work as before.
