### PR TITLE
Preserve text volume center when updating text

### DIFF
--- a/src/slic3r/GUI/Jobs/EmbossJob.cpp
+++ b/src/slic3r/GUI/Jobs/EmbossJob.cpp
@@ -147,7 +147,7 @@ void _update_volume(TriangleMesh &&mesh, const DataUpdate &data, const Transform
         if (emboss_shape.has_value() && emboss_shape->fix_3mf_tr.has_value()) volume->set_transformation(volume->get_matrix() * emboss_shape->fix_3mf_tr->inverse());
     }
 
-    UpdateJob::update_volume(volume, std::move(mesh), *data.base);
+    UpdateJob::update_volume(volume, std::move(mesh), *data.base, tr == nullptr);
 }
 
 std::vector<BoundingBoxes> create_line_bounds(const ExPolygonsWithIds &shapes, size_t count_lines = 0)
@@ -374,17 +374,29 @@ void UpdateJob::finalize(bool canceled, std::exception_ptr &eptr)
     _update_volume(std::move(m_result), m_input);
 }
 
-void UpdateJob::update_volume(ModelVolume *volume, TriangleMesh &&mesh, const DataBase &base)
+void UpdateJob::update_volume(ModelVolume *volume, TriangleMesh &&mesh, const DataBase &base, bool preserve_center)
 { // check inputs
     bool is_valid_input = volume != nullptr && !mesh.empty() && !base.volume_name.empty();
     assert(is_valid_input);
     if (!is_valid_input) return;
+
+    const bool keep_center = preserve_center && !volume->mesh().empty();
+    const Vec3d old_center = keep_center ?
+        volume->get_matrix() * volume->mesh().bounding_box().center() :
+        Vec3d::Zero();
 
     // update volume
     volume->set_mesh(std::move(mesh));
     volume->calculate_convex_hull();
     volume->set_new_unique_id();
     volume->calculate_convex_hull();
+
+    if (keep_center) {
+        const Vec3d new_center = volume->get_matrix() * volume->mesh().bounding_box().center();
+        Transform3d transform = volume->get_matrix();
+        transform.pretranslate(old_center - new_center);
+        volume->set_transformation(transform);
+    }
 
     // write data from base into volume
     base.write(*volume);

--- a/src/slic3r/GUI/Jobs/EmbossJob.hpp
+++ b/src/slic3r/GUI/Jobs/EmbossJob.hpp
@@ -242,7 +242,7 @@ public:
     /// <param name="volume">Volume to be updated</param>
     /// <param name="mesh">New Triangle mesh for volume</param>
     /// <param name="base">Data to write into volume</param>
-    static void update_volume(ModelVolume *volume, TriangleMesh &&mesh, const DataBase &base);
+    static void update_volume(ModelVolume *volume, TriangleMesh &&mesh, const DataBase &base, bool preserve_center = false);
 };
 
 /// <summary>


### PR DESCRIPTION
## Summary

This PR preserves the transformed center of an existing text volume when its text mesh is regenerated after editing.

Fixes #11423.

## Why

When editing an existing text object, changing the text length can change the local mesh bounding box center. The previous transformation is kept, so the visible text object may shift position after the mesh is replaced.

## Implementation

- Preserve the transformed center for normal text volume updates.
- Capture the old transformed mesh center before replacing the mesh.
- Capture the new transformed mesh center after regeneration.
- Apply a translation correction so the text volume stays centered at the same position.
- Skip this correction for surface text updates, where the update path provides an explicit surface-based transformation.

## Scope

This does not add new justification UI. It implements the minimal behavior requested in the issue: keep the text object's center stable when the text changes.

## Test plan

- Create a text object.
- Edit the text and change its length.
- Confirm the text volume keeps its center position instead of shifting.
- Change font/style values that regenerate the text mesh and confirm the center is preserved.
- Confirm surface text updates still use their explicit surface transformation path.