### PR TITLE
Make filament manager notes searchable

### DIFF
--- a/src/slic3r/GUI/DeviceWeb/device_page/src/features/filament-manager/FilamentManagerPage.tsx
+++ b/src/slic3r/GUI/DeviceWeb/device_page/src/features/filament-manager/FilamentManagerPage.tsx
@@ -24,6 +24,19 @@ const FILTER_LABEL_KEYS: Record<FilterKey, string> = {
   brand: 'Brand', material_type: 'Filament Type', series: 'Material Type',
 };
 
+function spoolSearchText(spool: Spool): string {
+  return [
+    spool.brand,
+    spool.material_type,
+    spool.series,
+    spool.color_name,
+    spool.note,
+  ]
+    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+    .join(' ')
+    .toLowerCase();
+}
+
 export function FilamentManagerPage() {
   const { t } = useTranslation();
   const {
@@ -157,10 +170,8 @@ export function FilamentManagerPage() {
 
     // Search
     if (search.trim()) {
-      const kw = search.toLowerCase();
-      list = list.filter((s) =>
-        `${s.brand} ${s.material_type} ${s.series} ${s.color_name}`.toLowerCase().includes(kw)
-      );
+      const kw = search.trim().toLowerCase();
+      list = list.filter((s) => spoolSearchText(s).includes(kw));
     }
 
     // Filters


### PR DESCRIPTION
## Summary

This PR makes filament manager notes searchable.

## Why

The filament manager search currently matches brand, filament type, material series, and color name, but ignores the note field.

This makes it hard to find spools using user-provided labels such as storage location, project names, purchase notes, or custom descriptions.

## Implementation

- Adds a small `spoolSearchText()` helper.
- Includes `spool.note` in the searchable text.
- Trims the search keyword before matching.
- Keeps the existing brand/type/series/color-name search behavior.

## Test plan

- Add or edit a filament spool with a note.
- Search for a word that only appears in the note.
- Confirm the spool appears in the filtered list.
- Search for brand, filament type, material series, or color name and confirm existing behavior still works.
