### PR TITLE
Show AMS filament compatibility hints

### DIFF
--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -174,6 +174,20 @@ void AMSMaterialsSetting::create_panel_normal(wxWindow* parent)
     m_sizer_filament->Add(m_readonly_filament, 1, wxALIGN_CENTER, 0);
     m_readonly_filament->Hide();
 
+    m_filament_compatibility_hint = new wxStaticText(
+        parent,
+        wxID_ANY,
+        wxEmptyString,
+        wxDefaultPosition,
+        wxDefaultSize,
+        0);
+    m_filament_compatibility_hint->SetFont(::Label::Body_13);
+    m_filament_compatibility_hint->SetMinSize(
+        wxSize(AMS_MATERIALS_SETTING_BODY_WIDTH, -1));
+    m_filament_compatibility_hint->Wrap(
+        AMS_MATERIALS_SETTING_BODY_WIDTH);
+    m_filament_compatibility_hint->Hide();
+
     wxBoxSizer* m_sizer_colour = new wxBoxSizer(wxHORIZONTAL);
 
     m_title_colour = new wxStaticText(parent, wxID_ANY, _L("Colour"), wxDefaultPosition, wxSize(AMS_MATERIALS_SETTING_LABEL_WIDTH, -1), 0);
@@ -291,6 +305,12 @@ void AMSMaterialsSetting::create_panel_normal(wxWindow* parent)
 
     sizer->Add(0, 0, 0, wxTOP, FromDIP(16));
     sizer->Add(m_sizer_filament, 0, wxLEFT | wxRIGHT, FromDIP(20));
+    sizer->Add(0, 0, 0, wxTOP, FromDIP(4));
+    sizer->Add(
+        m_filament_compatibility_hint,
+        0,
+        wxLEFT | wxRIGHT,
+        FromDIP(20));
     sizer->Add(0, 0, 0, wxTOP, FromDIP(16));
     sizer->Add(m_sizer_colour, 0, wxLEFT | wxRIGHT, FromDIP(20));
     sizer->Add(0, 0, 0, wxTOP, FromDIP(16));
@@ -630,6 +650,105 @@ sCheckFilamentInfo(PresetBundle* preset_bundle,
     ams_filament_id = it->filament_id;
     ams_setting_id = it->setting_id;
     return result;
+}
+
+void AMSMaterialsSetting::update_filament_compatibility_hint()
+{
+    if (!m_filament_compatibility_hint)
+        return;
+
+    auto hide_hint = [this]() {
+        m_filament_compatibility_hint->SetLabel(wxEmptyString);
+        m_filament_compatibility_hint->Hide();
+        m_panel_normal->Layout();
+        Layout();
+        Fit();
+    };
+
+    if (!obj ||
+        !m_is_third ||
+        m_filament_selection < 0 ||
+        m_comboBox_filament->GetValue().IsEmpty() ||
+        !wxGetApp().preset_bundle ||
+        wxGetApp().app_config->get("skip_ams_blacklist_check") == "true") {
+        hide_hint();
+        return;
+    }
+
+    const auto filament_it =
+        map_filament_items.find(into_u8(m_comboBox_filament->GetValue()));
+
+    if (filament_it == map_filament_items.end() ||
+        filament_it->second.filament_id.empty()) {
+        hide_hint();
+        return;
+    }
+
+    std::string checked_filament_id;
+    std::string checked_setting_id;
+
+    const auto check_result = sCheckFilamentInfo(
+        wxGetApp().preset_bundle,
+        obj,
+        ams_id,
+        slot_id,
+        filament_it->second.filament_id,
+        checked_filament_id,
+        checked_setting_id);
+
+    const auto prohibition_items =
+        check_result.get_items_by_action("prohibition");
+
+    const auto warning_items =
+        check_result.get_items_by_action("warning");
+
+    wxString message;
+
+    if (!prohibition_items.empty()) {
+        for (const auto& item : prohibition_items) {
+            if (!message.empty())
+                message += "\n";
+
+            message += item.info_msg;
+        }
+
+        if (message.empty()) {
+            message = _L(
+                "This filament is not supported by the selected slot.");
+        }
+
+        m_filament_compatibility_hint->SetForegroundColour(
+            wxColour(196, 43, 28));
+    }
+    else if (!warning_items.empty()) {
+        for (const auto& item : warning_items) {
+            if (!message.empty())
+                message += "\n";
+
+            message += item.info_msg;
+        }
+
+        if (message.empty()) {
+            message = _L(
+                "This filament may require special handling in the selected slot.");
+        }
+
+        m_filament_compatibility_hint->SetForegroundColour(
+            wxColour(255, 111, 0));
+    }
+    else {
+        hide_hint();
+        return;
+    }
+
+    m_filament_compatibility_hint->SetLabel(message);
+    m_filament_compatibility_hint->Wrap(
+        AMS_MATERIALS_SETTING_BODY_WIDTH);
+    m_filament_compatibility_hint->Show();
+
+    m_panel_normal->Layout();
+    Layout();
+    Fit();
 }
 
 void AMSMaterialsSetting::on_select_ok(wxCommandEvent& event)
@@ -1581,6 +1700,7 @@ void AMSMaterialsSetting::on_select_filament(wxCommandEvent &evt)
         m_comboBox_nozzle_type->SetValue(wxEmptyString);
         m_input_k_val->GetTextCtrl()->SetValue(wxEmptyString);
         m_input_n_val->GetTextCtrl()->SetValue(wxEmptyString);
+        update_filament_compatibility_hint();
         m_comboBox_filament->SetClientData(new int(0));
         return;
     }
@@ -1683,6 +1803,7 @@ void AMSMaterialsSetting::on_select_filament(wxCommandEvent &evt)
         m_input_k_val->Enable(!ams_filament_id.empty());
     }
 
+    update_filament_compatibility_hint();
     m_comboBox_filament->SetClientData(new int(0));
 }
 

--- a/src/slic3r/GUI/AMSMaterialsSetting.hpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.hpp
@@ -150,6 +150,7 @@ protected:
     void on_dpi_changed(const wxRect &suggested_rect) override;
     void on_select_nozzle_id(wxCommandEvent &evt);
     void on_select_filament(wxCommandEvent& evt);
+    void update_filament_compatibility_hint();
     void on_select_cali_result(wxCommandEvent &evt);
     void on_select_nozzle_pos_id(wxCommandEvent &evt);
     void on_select_ok(wxCommandEvent &event);
@@ -182,6 +183,7 @@ protected:
     wxPanel *           m_panel_SN;
     wxStaticText *      m_sn_number;
     wxStaticText *      warning_text;
+    wxStaticText *      m_filament_compatibility_hint { nullptr };
     //wxPanel *           m_panel_body;
     wxStaticText *      m_title_filament;
     wxStaticText *      m_title_nozzle_type;
@@ -206,7 +208,7 @@ protected:
     TextInput*          m_input_k_val;
     wxStaticText*       m_n_param;
     TextInput*          m_input_n_val;
-    int                 m_filament_selection;
+    int                 m_filament_selection { -1 };
 
     int m_pa_cali_select_id = 0;
     bool m_pa_data_pending{false};


### PR DESCRIPTION
## Summary

This PR shows filament compatibility warnings directly in the AMS material settings dialog when a filament preset is selected.

## Why

Compatibility checks currently happen only after the user confirms the selection. This means users may complete the entire selection flow before learning that a filament is unsupported or requires special handling.

Showing the existing compatibility result immediately makes the selection process clearer while preserving the existing confirmation dialogs.

## Implementation

- Reuses the existing `sCheckFilamentInfo()` blacklist and compatibility check.
- Shows prohibition messages in red.
- Shows warning messages in orange.
- Hides the hint when no compatibility rule applies.
- Keeps the existing confirmation-time warnings and blocking behavior unchanged.
- Uses a separate label from the existing nozzle-temperature validation warning.
- Does not modify printer, cloud, or firmware behavior.

## Test plan

- Open the AMS material settings dialog for an editable third-party spool.
- Select a filament with a prohibition rule and confirm a red message appears.
- Select a filament with a warning rule and confirm an orange message appears.
- Select a filament without a matching compatibility rule and confirm no hint is shown.
- Clear the filament selection and confirm the hint disappears.
- Confirm existing warning and prohibition dialogs still appear after pressing Confirm.
- Confirm readonly Bambu/RFID slots do not show the new hint.
