### PR TITLE
Add user profile filter to AMS filament selection

### DIFF
--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -174,6 +174,19 @@ void AMSMaterialsSetting::create_panel_normal(wxWindow* parent)
     m_sizer_filament->Add(m_readonly_filament, 1, wxALIGN_CENTER, 0);
     m_readonly_filament->Hide();
 
+    m_show_only_user_presets = new wxCheckBox(
+        parent,
+        wxID_ANY,
+        _L("Show only my profiles"));
+    m_show_only_user_presets->SetFont(::Label::Body_13);
+    m_show_only_user_presets->SetValue(false);
+    m_show_only_user_presets->Hide();
+    m_show_only_user_presets->Bind(
+        wxEVT_CHECKBOX,
+        [this](wxCommandEvent&) {
+            apply_filament_profile_filter();
+        });
+
     wxBoxSizer* m_sizer_colour = new wxBoxSizer(wxHORIZONTAL);
 
     m_title_colour = new wxStaticText(parent, wxID_ANY, _L("Colour"), wxDefaultPosition, wxSize(AMS_MATERIALS_SETTING_LABEL_WIDTH, -1), 0);
@@ -291,6 +304,12 @@ void AMSMaterialsSetting::create_panel_normal(wxWindow* parent)
 
     sizer->Add(0, 0, 0, wxTOP, FromDIP(16));
     sizer->Add(m_sizer_filament, 0, wxLEFT | wxRIGHT, FromDIP(20));
+    sizer->Add(0, 0, 0, wxTOP, FromDIP(6));
+    sizer->Add(
+        m_show_only_user_presets,
+        0,
+        wxLEFT | wxRIGHT,
+        FromDIP(20));
     sizer->Add(0, 0, 0, wxTOP, FromDIP(16));
     sizer->Add(m_sizer_colour, 0, wxLEFT | wxRIGHT, FromDIP(20));
     sizer->Add(0, 0, 0, wxTOP, FromDIP(16));
@@ -996,6 +1015,7 @@ void AMSMaterialsSetting::get_filaments_info(const MachineObject*               
                 FilamentInfos filament_infos;
                 filament_infos.filament_id         = filament_it->filament_id;
                 filament_infos.setting_id          = filament_it->setting_id;
+                filament_infos.is_user_preset      = preset.is_user();
                 map_filament_items[fialment_alias] = filament_infos;
                 break;
             }
@@ -1008,6 +1028,42 @@ void AMSMaterialsSetting::get_filaments_info(const MachineObject*               
     if (obj->is_support_user_preset) {
         collect_pass(false);
     }
+}
+
+void AMSMaterialsSetting::apply_filament_profile_filter()
+{
+    if (!m_comboBox_filament)
+        return;
+
+    const wxString selected_item = m_comboBox_filament->GetValue();
+    const bool show_only_user =
+        m_show_only_user_presets &&
+        m_show_only_user_presets->IsChecked();
+
+    wxArrayString visible_items;
+
+    for (const wxString& item : m_all_filament_items) {
+        const auto filament_it =
+            map_filament_items.find(into_u8(item));
+
+        if (show_only_user &&
+            (filament_it == map_filament_items.end() ||
+             !filament_it->second.is_user_preset)) {
+            continue;
+        }
+
+        visible_items.Add(item);
+    }
+
+    const int selection_idx = visible_items.Index(selected_item);
+
+    m_comboBox_filament->Set(visible_items);
+    m_comboBox_filament->SetSelection(selection_idx);
+
+    if (selection_idx == wxNOT_FOUND)
+        m_comboBox_filament->SetValue(wxEmptyString);
+
+    post_select_event(selection_idx);
 }
 
 Preset* AMSMaterialsSetting::get_filament_by_id(const std::string& filament_id, bool is_system)
@@ -1029,6 +1085,10 @@ Preset* AMSMaterialsSetting::get_filament_by_id(const std::string& filament_id, 
 void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_min, wxString temp_max, wxString k, wxString n)
 {
     if (!obj) return;
+
+    m_all_filament_items.Clear();
+    map_filament_items.clear();
+
     update_widgets();
     // set default value
     if (k.IsEmpty())
@@ -1058,6 +1118,25 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
     std::string nozzle_diameter_str = stream.str();
 
     get_filaments_info(obj, nozzle_diameter_str, filament_items, map_filament_items, query_filament_vendors, query_filament_types);
+
+    const bool has_user_presets = std::any_of(
+        filament_items.begin(),
+        filament_items.end(),
+        [this](const wxString& item) {
+            const auto filament_it =
+                map_filament_items.find(into_u8(item));
+
+            return filament_it != map_filament_items.end() &&
+                   filament_it->second.is_user_preset;
+        });
+
+    const bool show_user_filter =
+        m_is_third &&
+        obj->is_support_user_preset &&
+        has_user_presets;
+
+    m_show_only_user_presets->SetValue(false);
+    m_show_only_user_presets->Show(show_user_filter);
 
     if (Preset* ams_fila_it = get_filament_by_id(ams_filament_id, !m_is_third)) {
         auto fialment_alias = preset_bundle->filaments.get_preset_alias(*ams_fila_it, true);
@@ -1163,6 +1242,8 @@ void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_mi
 
         std::sort(filament_items.begin(), filament_items.end(), _filament_sorter);
     }
+
+    m_all_filament_items = filament_items;
 
     // traverse the hint selection idx
     int selection_idx = -1;

--- a/src/slic3r/GUI/AMSMaterialsSetting.hpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.hpp
@@ -13,6 +13,7 @@
 #include "Widgets/Label.hpp"
 #include "Widgets/CheckBox.hpp"
 #include "Widgets/ComboBox.hpp"
+#include <wx/checkbox.h>
 #include "Widgets/TextInput.hpp"
 #include "../slic3r/Utils/CalibUtils.hpp"
 #include "DeviceCore/DevNozzleRack.h"
@@ -142,6 +143,7 @@ public:
     struct FilamentInfos {
         std::string filament_id;
         std::string setting_id;
+        bool        is_user_preset { false };
     };
 
 protected:
@@ -150,6 +152,7 @@ protected:
     void on_dpi_changed(const wxRect &suggested_rect) override;
     void on_select_nozzle_id(wxCommandEvent &evt);
     void on_select_filament(wxCommandEvent& evt);
+    void apply_filament_profile_filter();
     void on_select_cali_result(wxCommandEvent &evt);
     void on_select_nozzle_pos_id(wxCommandEvent &evt);
     void on_select_ok(wxCommandEvent &event);
@@ -182,6 +185,7 @@ protected:
     wxPanel *           m_panel_SN;
     wxStaticText *      m_sn_number;
     wxStaticText *      warning_text;
+    wxCheckBox *         m_show_only_user_presets { nullptr };
     //wxPanel *           m_panel_body;
     wxStaticText *      m_title_filament;
     wxStaticText *      m_title_nozzle_type;
@@ -220,6 +224,7 @@ protected:
     ComboBox * m_comboBox_cali_result;
     TextInput*       m_readonly_filament;
 
+    wxArrayString                         m_all_filament_items;
     std::map<std::string, FilamentInfos> map_filament_items;
 };
 


### PR DESCRIPTION
## Summary

This PR adds a "Show only my profiles" filter to the AMS filament selection dialog.

## Why

Users with many installed system filament presets may need to scroll through a long list to find their own custom or duplicated profiles.

The new filter lets users temporarily display only their own compatible filament profiles.

## Implementation

- Marks collected filament entries as system or user presets.
- Keeps the complete sorted filament list in the dialog.
- Adds a "Show only my profiles" checkbox for editable AMS slots.
- Filters the existing dropdown locally without reloading printer or cloud data.
- Shows the checkbox only when user presets are supported and available.
- Clears an incompatible current selection when it is hidden by the filter.
- Leaves existing sorting and filament-selection behavior unchanged.

## Test plan

- Open an editable third-party AMS slot with system and user filament profiles.
- Confirm the checkbox is visible.
- Enable the checkbox and confirm only user-created profiles remain.
- Disable it and confirm the complete sorted list returns.
- Select a user profile and confirm the selection remains when filtering.
- Select a system profile, enable the filter, and confirm the hidden selection is cleared.
- Open a readonly Bambu/RFID slot and confirm the checkbox is hidden.
- Test a printer without user-preset support and confirm the checkbox is hidden.
