### PR TITLE
Add Standard 3MF color import preference

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -111,6 +111,9 @@ void AppConfig::set_defaults()
         if (get("drop_project_action").empty())
             set_bool("drop_project_action", true);
 
+        if (get("standard_3mf_color_import_mode").empty())
+            set("standard_3mf_color_import_mode", "ask");
+
 #ifdef _WIN32
         if (get("associate_3mf").empty())
             set_bool("associate_3mf", false);

--- a/src/slic3r/GUI/ObjColorDialog.cpp
+++ b/src/slic3r/GUI/ObjColorDialog.cpp
@@ -168,6 +168,16 @@ bool ObjColorDialog::Show(bool show) {
     }
 };
 
+bool ObjColorDialog::apply_default_mapping()
+{
+    if (!m_panel_ObjColor || !m_panel_ObjColor->is_ok())
+        return false;
+
+    m_panel_ObjColor->clear_instance_and_revert_offset();
+    m_panel_ObjColor->send_new_filament_to_ui();
+    return true;
+}
+
 ObjColorDialog::ObjColorDialog(wxWindow *parent, Slic3r::ObjDialogInOut &in_out, const std::vector<std::string> &extruder_colours)
     : DPIDialog(parent ? parent : static_cast<wxWindow *>(wxGetApp().mainframe),
                 wxID_ANY,
@@ -244,9 +254,8 @@ ObjColorDialog::ObjColorDialog(wxWindow *parent, Slic3r::ObjDialogInOut &in_out,
                   EndModal(wxCANCEL);
                   return;
               }
-              m_panel_ObjColor->clear_instance_and_revert_offset();
-              m_panel_ObjColor->send_new_filament_to_ui();
-              EndModal(wxID_OK);
+              if (apply_default_mapping())
+                  EndModal(wxID_OK);
             }, wxID_OK);
     }
     if (this->FindWindowById(wxID_CANCEL, this)) {

--- a/src/slic3r/GUI/ObjColorDialog.hpp
+++ b/src/slic3r/GUI/ObjColorDialog.hpp
@@ -131,6 +131,7 @@ public:
     void on_dpi_changed(const wxRect &suggested_rect) override;
     void update_layout();
     bool Show(bool show) override;
+    bool apply_default_mapping();
 
 private:
     ObjColorPanel*  m_panel_ObjColor  = nullptr;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8341,9 +8341,37 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                             color_dialog_in_out.model = &model;
                             color_dialog_in_out.input_type = ObjDialogInOut::FormatType::Standard3mf;
                             color_dialog_in_out.volume_colors = volume_color_data;
-                            ObjColorDialog color_dlg(nullptr, color_dialog_in_out, extruder_colours);
-                            if (color_dlg.ShowModal() == wxID_OK) {
-                                color_dialog_in_out.filament_ids.clear();
+
+                            const std::string color_import_mode =
+                                wxGetApp().app_config->get("standard_3mf_color_import_mode");
+
+                            if (color_import_mode != "geometry_only") {
+                                ObjColorDialog color_dlg(
+                                    nullptr,
+                                    color_dialog_in_out,
+                                    extruder_colours);
+
+                                bool colors_accepted = false;
+
+                                if (color_import_mode == "auto") {
+                                    colors_accepted =
+                                        color_dlg.apply_default_mapping();
+
+                                    if (!colors_accepted) {
+                                        BOOST_LOG_TRIVIAL(warning)
+                                            << "Standard 3MF automatic color mapping "
+                                               "was incomplete; showing the import dialog";
+                                    }
+                                }
+
+                                if (color_import_mode != "auto" ||
+                                    !colors_accepted) {
+                                    colors_accepted =
+                                        color_dlg.ShowModal() == wxID_OK;
+                                }
+
+                                if (colors_accepted)
+                                    color_dialog_in_out.filament_ids.clear();
                             }
                         }
                     }

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1366,6 +1366,28 @@ wxWindow* PreferencesDialog::create_general_page()
     auto  item_gamma_correct_in_import_obj = create_item_checkbox(_L("Enable gamma correction for the imported obj file"), page,
                                                                  _L("Perform gamma correction on color after importing the obj model."), 50,
                                                                  "gamma_correct_in_import_obj");
+
+    std::vector<wxString> standard_3mf_color_import_labels = {
+        _L("Ask every time"),
+        _L("Apply automatic color mapping"),
+        _L("Import geometry only")
+    };
+    std::vector<std::string> standard_3mf_color_import_values = {
+        "ask",
+        "auto",
+        "geometry_only"
+    };
+    auto item_standard_3mf_color_import = create_item_combobox(
+        _L("Standard 3MF color import"),
+        page,
+        _L("Choose how color information from standard 3MF files is handled during import."),
+        "standard_3mf_color_import_mode",
+        standard_3mf_color_import_labels,
+        standard_3mf_color_import_values,
+        nullptr,
+        FromDIP(180),
+        FromDIP(190));
+
     auto  item_enable_record_gcodeviewer_option_item = create_item_checkbox(_L("Remember last used color scheme"), page,
                                                                  _L("When enabled, the last used color scheme (e.g., Line Type, Speed) will be automatically applied on next startup."), 50,
                                                                  "enable_record_gcodeviewer_option_item");
@@ -1525,6 +1547,7 @@ wxWindow* PreferencesDialog::create_general_page()
     sizer_page->Add(item_show_shells_in_preview_settings, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_import_single_svg_and_split, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_gamma_correct_in_import_obj, 0, wxTOP, FromDIP(3));
+    sizer_page->Add(item_standard_3mf_color_import, 0, wxTOP, FromDIP(3));
     sizer_page->Add(item_enable_record_gcodeviewer_option_item, 0, wxTOP, FromDIP(3));
     sizer_page->Add(enable_assemble_view_preview_settings, 0, wxTOP, FromDIP(3));
 #if !BBL_RELEASE_TO_PUBLIC


### PR DESCRIPTION
Closes #9734

## Summary

This PR adds a preference that controls how color information from standard 3MF files is handled during import.

## Available modes

- **Ask every time**: preserves the existing behavior and opens the color mapping dialog.
- **Apply automatic color mapping**: applies the dialog's existing default mapping without requiring confirmation.
- **Import geometry only**: skips color processing and imports only the model geometry.

## Why

Users who frequently import standard 3MF files currently need to dismiss or confirm the color mapping dialog for every import, even when they always choose the same action.

The new preference removes those repetitive steps while preserving the existing interactive workflow as the default.

## Implementation

- Adds `standard_3mf_color_import_mode` to the application configuration.
- Defaults the setting to `ask`, preserving existing behavior.
- Adds a new option under Preferences → 3D Settings.
- Reuses the existing default mapping logic for automatic imports.
- Falls back to the interactive dialog if automatic mapping is incomplete.
- Avoids constructing the color dialog in geometry-only mode so the model is not modified by the dialog initialization.
- Leaves OBJ color import behavior unchanged.

## Test plan

### Ask every time

- Set the preference to **Ask every time**.
- Import a standard 3MF file containing color information.
- Confirm the existing color mapping dialog appears.
- Confirm both OK and Cancel retain their previous behavior.

### Automatic mapping

- Set the preference to **Apply automatic color mapping**.
- Import a standard 3MF with a valid automatic mapping.
- Confirm the model imports without showing the dialog.
- Confirm mapped colors and newly required filament colors are applied.
- Import a file with an incomplete mapping and confirm the interactive dialog appears as a fallback.

### Geometry only

- Set the preference to **Import geometry only**.
- Import a colored standard 3MF.
- Confirm no color mapping dialog appears.
- Confirm the geometry imports without painted segmentation data.

### Regression checks

- Import an OBJ file with color information and confirm its dialog behavior is unchanged.
- Import a Bambu Studio project 3MF and confirm the new option does not affect project loading.
- Restart Bambu Studio and confirm the selected preference persists.
