### PR TITLE
Add object instance controls

### DIFF
--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -1246,11 +1246,53 @@ void MenuFactory::create_default_menu()
         []() { return plater()->is_view3D_shown(); }, [this]() { return plater()->are_view3D_object_labels_shown(); }, m_parent);
 }
 
+void MenuFactory::append_menu_items_instance_manipulation(wxMenu* menu)
+{
+    const MenuType type = menu == &m_object_menu ? mtObjectFFF : mtObjectSLA;
+
+    items_increase[type] = append_menu_item(
+        menu,
+        wxID_ANY,
+        _L("Add instance"),
+        _L("Add one more instance of the selected object"),
+        [](wxCommandEvent&) { plater()->increase_instances(); },
+        "",
+        nullptr,
+        []() { return plater()->can_increase_instances(); },
+        m_parent);
+
+    items_decrease[type] = append_menu_item(
+        menu,
+        wxID_ANY,
+        _L("Remove instance"),
+        _L("Remove one instance of the selected object"),
+        [](wxCommandEvent&) { plater()->decrease_instances(); },
+        "",
+        nullptr,
+        []() { return plater()->can_decrease_instances(); },
+        m_parent);
+
+    items_set_number_of_copies[type] = append_menu_item(
+        menu,
+        wxID_ANY,
+        _L("Set number of instances") + dots,
+        _L("Change the number of instances of the selected object"),
+        [](wxCommandEvent&) { plater()->set_number_of_copies(); },
+        "",
+        nullptr,
+        []() {
+            return plater()->can_increase_instances() ||
+                   plater()->can_decrease_instances();
+        },
+        m_parent);
+
+    menu->AppendSeparator();
+}
+
 void MenuFactory::create_common_object_menu(wxMenu* menu)
 {
     append_menu_item_rename(menu);
-    // BBS
-    //append_menu_items_instance_manipulation(menu);
+    append_menu_items_instance_manipulation(menu);
     // Delete menu was moved to be after +/- instace to make it more difficult to be selected by mistake.
     append_menu_item_delete(menu);
     //append_menu_item_instance_to_object(menu);
@@ -1292,6 +1334,7 @@ void MenuFactory::create_object_menu()
 
 void MenuFactory::create_bbl_object_menu()
 {
+    append_menu_items_instance_manipulation(&m_object_menu);
     append_menu_item_fill_bed(&m_object_menu);
     // Object Clone
     append_menu_item_clone(&m_object_menu);

--- a/src/slic3r/GUI/GUI_Factories.hpp
+++ b/src/slic3r/GUI/GUI_Factories.hpp
@@ -166,7 +166,7 @@ private:
     void        append_menu_item_edit_text(wxMenu *menu);
     void        append_menu_item_edit_svg(wxMenu *menu);
 
-    //void        append_menu_items_instance_manipulation(wxMenu *menu);
+    void        append_menu_items_instance_manipulation(wxMenu *menu);
     //void        update_menu_items_instance_manipulation(MenuType type);
     //BBS add bbl menu item
     void        append_menu_item_clone(wxMenu* menu);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -20171,8 +20171,6 @@ void Plater::remove_selected()
 
 void Plater::increase_instances(size_t num)
 {
-    // BBS
-#if 0
     if (! can_increase_instances()) { return; }
 
     Plater::TakeSnapshot snapshot(this, "Increase Instances");
@@ -20205,13 +20203,10 @@ void Plater::increase_instances(size_t num)
 
     p->selection_changed();
     this->p->schedule_background_process();
-#endif
 }
 
 void Plater::decrease_instances(size_t num)
 {
-    // BBS
-#if 0
     if (! can_decrease_instances()) { return; }
 
     Plater::TakeSnapshot snapshot(this, "Decrease Instances");
@@ -20228,6 +20223,7 @@ void Plater::decrease_instances(size_t num)
     }
     else {
         remove(obj_idx);
+        return;
     }
 
     if (!model_object->instances.empty())
@@ -20235,7 +20231,6 @@ void Plater::decrease_instances(size_t num)
 
     p->selection_changed();
     this->p->schedule_background_process();
-#endif
 }
 
 static long GetNumberFromUser(  const wxString& msg,
@@ -20266,12 +20261,10 @@ void Plater::set_number_of_copies(/*size_t num*/)
 
     ModelObject* model_object = p->model.objects[obj_idx];
 
-    const int num = GetNumberFromUser( " ", _L("Number of copies:"),
-                                    _L("Copies of the selected object"), model_object->instances.size(), 0, 1000, this );
+    const int num = GetNumberFromUser( " ", _L("Number of instances:"),
+                                    _L("Instances of the selected object"), model_object->instances.size(), 1, 1000, this );
     if (num < 0)
         return;
-
-    Plater::TakeSnapshot snapshot(this, (boost::format("Set numbers of copies to %1%")%num).str());
 
     int diff = num - (int)model_object->instances.size();
     if (diff > 0)


### PR DESCRIPTION
## Summary

Add object instance controls to the object context menu by restoring Bambu Studio’s existing but disabled instance-management implementation.

## Changes

- Add **Add instance** to object context menus
- Add **Remove instance** to object context menus
- Add **Set number of instances** with a numeric input dialog
- Enable the existing `increase_instances()` and `decrease_instances()` implementations
- Support both FFF and SLA object menus
- Reuse the existing object-list and selection update logic
- Require objects to retain at least one instance
- Avoid accessing the model object after it has been removed
- Avoid creating duplicate undo snapshots when setting the instance count
- Use consistent instance terminology in the dialog

## Scope

This PR intentionally does not add:

- Fill bed with instances
- Toolbar buttons
- Keyboard shortcuts

Those can be handled separately to keep this change focused and easier to review.

## Testing

- `git diff --check`
- Successfully compiled the affected translation units:

```text
ninja -C build \
  src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/GUI_Factories.cpp.o \
  src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/Plater.cpp.o \
  -j6
```

- Re-running the targeted build reports `ninja: no work to do`
- No compiler errors were introduced
- Runtime UI testing has not yet been performed

Related to #496