### PR TITLE
feat: add fill bed with object instances

### DIFF
--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -2461,8 +2461,26 @@ void MenuFactory::append_menu_item_locked(wxMenu* menu)
 void MenuFactory::append_menu_item_fill_bed(wxMenu *menu)
 {
     append_menu_item(
-        menu, wxID_ANY, _L("Fill bed with copies"), _L("Fill the remaining area of bed with copies of the selected object"),
-        [](wxCommandEvent &) { plater()->fill_bed_with_instances(); }, "", nullptr, []() { return plater()->can_increase_instances(); }, m_parent);
+        menu,
+        wxID_ANY,
+        _L("Fill bed with copies"),
+        _L("Fill the remaining area of bed with copies of the selected object"),
+        [](wxCommandEvent &) { plater()->fill_bed_with_copies(); },
+        "",
+        nullptr,
+        []() { return plater()->can_increase_instances(); },
+        m_parent);
+
+    append_menu_item(
+        menu,
+        wxID_ANY,
+        _L("Fill bed with instances"),
+        _L("Fill the remaining area of bed with instances of the selected object"),
+        [](wxCommandEvent &) { plater()->fill_bed_with_instances(); },
+        "",
+        nullptr,
+        []() { return plater()->can_increase_instances(); },
+        m_parent);
 }
 
 void MenuFactory::append_menu_item_plate_name(wxMenu *menu)

--- a/src/slic3r/GUI/Jobs/FillBedJob.cpp
+++ b/src/slic3r/GUI/Jobs/FillBedJob.cpp
@@ -167,15 +167,33 @@ void FillBedJob::prepare()
         ap.bed_idx = PartPlateList::MAX_PLATES_COUNT;
         ap.height = 1;
         ap.itemid = -1;
-        ap.setter = [this, mi_orig_trafo](const ArrangePolygon &p) {
+        ap.setter = [this, sel_id, mi_orig_trafo](const ArrangePolygon &p) {
             ModelObject *mo = m_plater->model().objects[m_object_idx];
-            ModelObject* newObj = m_plater->model().add_object(*mo);
-            newObj->name = mo->name +" "+ std::to_string(p.itemid);
-            for (ModelInstance *newInst : newObj->instances) {
-                newInst->set_transformation(mi_orig_trafo);
-                newInst->apply_arrange_result(p.translation.cast<double>(), p.rotation);
+
+            if (m_instances) {
+                ModelInstance *new_instance =
+                    mo->add_instance(*mo->instances[sel_id]);
+
+                new_instance->set_transformation(mi_orig_trafo);
+                new_instance->apply_arrange_result(
+                    p.translation.cast<double>(),
+                    p.rotation);
+            } else {
+                ModelObject *new_object =
+                    m_plater->model().add_object(*mo);
+
+                new_object->name =
+                    mo->name + " " + std::to_string(p.itemid);
+
+                for (ModelInstance *new_instance : new_object->instances) {
+                    new_instance->set_transformation(mi_orig_trafo);
+                    new_instance->apply_arrange_result(
+                        p.translation.cast<double>(),
+                        p.rotation);
+                }
+
+                m_plater->model().set_assembly_pos(new_object);
             }
-            m_plater->model().set_assembly_pos(newObj);
         };
         m_selected.emplace_back(ap);
     }
@@ -395,7 +413,7 @@ void FillBedJob::finalize()
         return s + int(ap.priority == 0 && ap.bed_idx == 0);
     });
 
-    int oldSize = m_plater->model().objects.size();
+    const size_t old_size = m_plater->model().objects.size();
 
     if (added_cnt > 0) {
         for (ArrangePolygon& ap : m_selected) {
@@ -417,14 +435,42 @@ void FillBedJob::finalize()
             BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << boost::format(":selected: bed_id %1%, trans {%2%,%3%}") % ap.bed_idx % unscale<double>(ap.translation(X)) % unscale<double>(ap.translation(Y));
         }
 
-        int   newSize = m_plater->model().objects.size();
-        auto obj_list = m_plater->sidebar().obj_list();
-        for (size_t i = oldSize; i < newSize; i++) {
-            obj_list->add_object_to_list(i, true, true, false);
-            obj_list->update_printable_state(i, 0);
-        }
+        auto *obj_list = m_plater->sidebar().obj_list();
 
-        BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << ": paste_objects_into_list";
+        if (m_instances) {
+            const size_t new_inst_cnt = model_object->instances.size();
+
+            if (new_inst_cnt > inst_cnt) {
+                // A single instance has no separate child node in the object
+                // list. When transitioning to multiple instances, add nodes
+                // for both the original instance and the newly created ones.
+                const size_t list_items_to_add =
+                    inst_cnt == 1
+                        ? new_inst_cnt
+                        : new_inst_cnt - inst_cnt;
+
+                obj_list->increase_object_instances(
+                    m_object_idx,
+                    list_items_to_add);
+            }
+
+            BOOST_LOG_TRIVIAL(debug)
+                << __FUNCTION__
+                << ": added "
+                << (new_inst_cnt - inst_cnt)
+                << " instances";
+        } else {
+            const size_t new_size = m_plater->model().objects.size();
+
+            for (size_t i = old_size; i < new_size; ++i) {
+                obj_list->add_object_to_list(i, true, true, false);
+                obj_list->update_printable_state(i, 0);
+            }
+
+            BOOST_LOG_TRIVIAL(debug)
+                << __FUNCTION__
+                << ": paste_objects_into_list";
+        }
 
         m_plater->update();
     }

--- a/src/slic3r/GUI/Jobs/FillBedJob.hpp
+++ b/src/slic3r/GUI/Jobs/FillBedJob.hpp
@@ -23,7 +23,8 @@ class FillBedJob : public PlaterJob
 
     arrangement::ArrangeParams params;
 
-    int m_status_range = 0;
+    int  m_status_range = 0;
+    bool m_instances    = false;
 
 protected:
 
@@ -31,8 +32,12 @@ protected:
     void process() override;
 
 public:
-    FillBedJob(std::shared_ptr<ProgressIndicator> pri, Plater *plater)
+    FillBedJob(
+        std::shared_ptr<ProgressIndicator> pri,
+        Plater                            *plater,
+        bool                               instances = false)
         : PlaterJob{std::move(pri), plater}
+        , m_instances{instances}
     {}
 
     int status_range() const override

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -6349,7 +6349,12 @@ public:
     class Jobs: public ExclusiveJobGroup
     {
         priv *m;
-        size_t m_arrange_id, m_fill_bed_id, m_rotoptimize_id, m_sla_import_id, m_orient_id;
+        size_t m_arrange_id;
+        size_t m_fill_bed_id;
+        size_t m_fill_bed_instances_id;
+        size_t m_rotoptimize_id;
+        size_t m_sla_import_id;
+        size_t m_orient_id;
         std::shared_ptr<NotificationProgressIndicator> m_pri;
         //BBS
         size_t m_print_id;
@@ -6363,7 +6368,11 @@ public:
         {
             m_arrange_id = add_job(std::make_unique<ArrangeJob>(m_pri, m->q));
             m_orient_id = add_job(std::make_unique<OrientJob>(m_pri, m->q));
-            m_fill_bed_id = add_job(std::make_unique<FillBedJob>(m_pri, m->q));
+            m_fill_bed_id =
+                add_job(std::make_unique<FillBedJob>(m_pri, m->q));
+
+            m_fill_bed_instances_id =
+                add_job(std::make_unique<FillBedJob>(m_pri, m->q, true));
             m_rotoptimize_id = add_job(std::make_unique<RotoptimizeJob>(m_pri, m->q));
             m_sla_import_id = add_job(std::make_unique<SLAImportJob>(m_pri, m->q));
             //BBS add print id
@@ -6386,6 +6395,12 @@ public:
         {
             m->take_snapshot("Fill bed");
             start(m_fill_bed_id);
+        }
+
+        void fill_bed_with_instances()
+        {
+            m->take_snapshot("Fill bed with instances");
+            start(m_fill_bed_instances_id);
         }
 
         void optimize_rotation()
@@ -20280,10 +20295,16 @@ void Plater::set_number_of_copies(/*size_t num*/)
         decrease_instances(-diff);
 }
 
-void Plater::fill_bed_with_instances()
+void Plater::fill_bed_with_copies()
 {
     if (!p->m_ui_jobs.is_any_running())
         p->m_ui_jobs.fill_bed();
+}
+
+void Plater::fill_bed_with_instances()
+{
+    if (!p->m_ui_jobs.is_any_running())
+        p->m_ui_jobs.fill_bed_with_instances();
 }
 
 bool Plater::is_selection_empty() const

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -482,6 +482,7 @@ public:
     void increase_instances(size_t num = 1);
     void decrease_instances(size_t num = 1);
     void set_number_of_copies(/*size_t num*/);
+    void fill_bed_with_copies();
     void fill_bed_with_instances();
     bool is_selection_empty() const;
     void scale_selection_to_fit_print_volume();


### PR DESCRIPTION
## Summary

Adds a separate **Fill bed with instances** action alongside the existing **Fill bed with copies** action.

The existing action continues to create independent object copies. The new action fills the remaining plate area with linked `ModelInstance` entries belonging to the selected object.

## Changes

- Add separate menu entries for:
  - Fill bed with copies
  - Fill bed with instances
- Add a dedicated persistent `FillBedJob` for instance creation
- Reuse the selected instance as the transformation template
- Add generated instances to the existing `ModelObject`
- Update the object tree correctly when transitioning from one instance to multiple instances
- Preserve the existing copy-based behavior unchanged

## Implementation notes

Bambu Studio already contained the `fill_bed_with_instances()` entry point, but it invoked the same copy-based fill-bed job.

This change gives the fill-bed job an explicit copies/instances mode and registers separate persistent jobs for both operations.

## Testing

- Targeted compilation of `FillBedJob.cpp`
- Targeted compilation of `GUI_Factories.cpp`
- Targeted compilation of `Plater.cpp`
- `git diff --check`

Not tested:

- Full application build
- Runtime UI behavior

Related to #496
