### PR TITLE
fix: show Bambu splash screen on Linux instead of black window

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3286,10 +3286,18 @@ bool GUI_App::on_init_inner()
         BOOST_LOG_TRIVIAL(info) << "begin to show the splash screen...";
         //BBS use BBL splashScreen
         scrn = new BBLSplashScreen(bmp, wxSPLASH_CENTRE_ON_SCREEN, 0, splashscreen_pos);
-#ifndef __linux__
+        // Process pending paint events so the splash is drawn immediately on all
+        // platforms. Without this, GTK never paints the window before the heavy
+        // loading work begins, leaving a black window until the app is ready.
         wxYield();
-#endif
+        scrn->Raise();
+        scrn->Update();
         scrn->SetText(_L("Loading configuration")+ dots);
+        // BBLSplashScreen::SetText() does not force a repaint on non-macOS.
+        // Refresh() + Update() ensure the first status line is visible before
+        // the heavy startup work begins.
+        scrn->Refresh();
+        scrn->Update();
     }
 
     BOOST_LOG_TRIVIAL(info) << "loading systen presets...";


### PR DESCRIPTION
Fixes #11532

On Linux the startup splash is currently a plain black window, because wxYield() is explicitly skipped on this platform right after the BBLSplashScreen is created. On wxGTK that call is what flushes the pending paint events — without it GTK never draws the splash before the long blocking startup work begins.

This change enables wxYield() on Linux too (it is harmless on the other platforms, which already ran it), raises the window and adds a Refresh()/Update() pair after the first SetText() so the status line actually becomes visible.

Before and after on Debian 13 / KDE Plasma:

![before: black window](https://raw.githubusercontent.com/BenJule/BambuStudio/assets/linux-splash/splash-before-black.png)

![after: splash renders](https://raw.githubusercontent.com/BenJule/BambuStudio/assets/linux-splash/splash-after-fixed.png)

I have been running this in my fork since May 2026 (Debian and Ubuntu builds, X11 and Wayland) with no regressions on Windows either. 