### PR TITLE
Fix: LAN-only printer unreachable when Studio stays on cloud MQTT

### DIFF
--- a/src/slic3r/GUI/DeviceCore/DevManager.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevManager.cpp
@@ -631,8 +631,14 @@ namespace Slic3r
     {
         if (selected_machine.empty()) return nullptr;
 
-        MachineObject* obj = get_user_machine(selected_machine);
-        if (obj)
+        // Prefer the canonical object from get_my_machine_list().
+        // When the same device exists in both userMachineList and localMachineList
+        // (logged-in account + LAN discovery), LAN MQTT / publish_json use the local
+        // object while the old path returned the user object — leaving UI state empty.
+        if (MachineObject* obj = get_my_machine(selected_machine))
+            return obj;
+
+        if (MachineObject* obj = get_user_machine(selected_machine))
             return obj;
 
         // return local machine has access code
@@ -704,22 +710,25 @@ namespace Slic3r
     {
         std::map<std::string, MachineObject*> result;
 
-        for (auto it = userMachineList.begin(); it != userMachineList.end(); it++)
-        {
-            if (it->second && !it->second->is_lan_mode_printer())
-            {
-                result.insert(std::make_pair(it->first, it->second));
-            }
-        }
-
+        // Prefer LAN machines with a direct connection path. When the same device also
+        // appears in userMachineList (account login), the printer may have no Internet
+        // access, so cloud MQTT is unreachable while local MQTT still works.
         for (auto it = localMachineList.begin(); it != localMachineList.end(); it++)
         {
             if (it->second && it->second->has_access_right() && it->second->is_avaliable() && it->second->is_lan_mode_printer())
             {
-                // remove redundant in userMachineList
+                result.emplace(std::make_pair(it->first, it->second));
+            }
+        }
+
+        for (auto it = userMachineList.begin(); it != userMachineList.end(); it++)
+        {
+            if (it->second && !it->second->is_lan_mode_printer())
+            {
+                // Do not override an active LAN entry for the same device
                 if (result.find(it->first) == result.end())
                 {
-                    result.emplace(std::make_pair(it->first, it->second));
+                    result.insert(std::make_pair(it->first, it->second));
                 }
             }
         }

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2252,6 +2252,16 @@ void GUI_App::init_networking_callbacks()
                     return;
                 }
 
+                // Direct LAN connection owns this device — ignore cloud MQTT so state
+                // is not applied to a different MachineObject than local MQTT updates.
+                if (MachineObject* my = this->m_device_manager->get_my_machine(dev_id)) {
+                    if (my->is_lan_mode_printer()) {
+                        if (GUI::wxGetApp().plater())
+                            GUI::wxGetApp().plater()->update_machine_sync_status();
+                        return;
+                    }
+                }
+
                 if (MachineObject* obj = this->m_device_manager->get_user_machine(dev_id)) {
                     auto sel = this->m_device_manager->get_selected_machine();
                     if (sel && sel->get_dev_id() == dev_id) {
@@ -2311,7 +2321,8 @@ void GUI_App::init_networking_callbacks()
 
                 if (MachineObject* obj = m_device_manager->get_my_machine(dev_id)) {
                     obj->parse_json("lan", msg);
-                    if (this->m_device_manager->get_selected_machine() == obj) {
+                    auto sel = this->m_device_manager->get_selected_machine();
+                    if (sel && sel->get_dev_id() == dev_id) {
                         GUI::wxGetApp().sidebar().load_ams_list(obj);
                         // STUDIO-18155: AMS 状态变化驱动耗材同步（本地 store + 节流后云端）
                         // 仅在在位字段实际变化时才推 spool list，避免每条 MQTT 都整体重渲。


### PR DESCRIPTION
# Fix: LAN-only printer unreachable when Studio stays on cloud MQTT

## Summary

This happens when the printer is in **LAN-only** mode (real LAN-only: no
path to Bambu cloud MQTT) while the user is **logged into a Bambu account**.
Studio can still put the device on the **cloud MQTT** path; the printer cannot
answer there, so a usable connection cannot be established at all — Studio
waits for cloud replies that the printer can never send.

Even with a working local path (SSDP + access code) — and even though Studio
largely knows the printer is local — it still waits for replies on **cloud
MQTT** and effectively ignores the matching LAN replies for UI readiness.
Local MQTT delivers `get_version` / `push_status`, but the UI never becomes
ready.

Symptom: replies are parsed in logs, but `is_info_ready()` reports
`failed to check version` because it checks a **different** `MachineObject`
whose `module_vers` is still empty. Logging out of the account removes the
cloud object and the problem disappears.

This PR prefers the LAN path whenever a direct LAN machine entry exists for
the same `dev_id`, and routes selected-machine / MQTT handling through that
same object so Studio no longer depends on cloud MQTT that a LAN-only printer
cannot reach.

## Root cause

Studio keeps two maps of printers:

- `userMachineList` — devices from the logged-in account (cloud)
- `localMachineList` — devices discovered on the LAN (SSDP), with access code

For the same serial/`dev_id`, both maps can hold **separate** `MachineObject`
instances.

Previously:

1. `get_my_machine_list()` preferred the **cloud** entry when both existed, and
   only added the LAN entry if the cloud key was absent.
2. `get_selected_machine()` always looked up `userMachineList` first.
3. LAN MQTT (`set_on_local_message_fn`) parsed into `get_my_machine()` (often the
   local object after SSDP marked connection type as `lan`).
4. Outgoing `publish_json()` also followed `is_lan_mode_printer()` on the object
   used by the send dialog — so commands went out on **local** MQTT.
5. UI readiness (`is_info_ready()`, sidebar sync) used `get_selected_machine()` —
   the **cloud** object — whose `module_vers` / push counters never updated.

Timeline matching the bug logs:

```
publish_json(get_version)          → local MQTT (LAN object)
get_version :product_name=...      → parse_json on LAN object (module_vers filled)
is_info_ready: failed to check version
                                   → check on cloud object (module_vers empty)
```

When the printer is LAN-only (no Internet / no cloud MQTT), cloud state never
arrives, so the cloud object stays empty indefinitely. Logging out removes
`userMachineList`, so only the LAN object remains and everything works.

## Change

### 1. Prefer LAN in `get_my_machine_list()`

Build the list from `localMachineList` first (LAN + access code + available).
Only then add cloud entries from `userMachineList`, and **do not** override an
existing LAN entry for the same `dev_id`.

### 2. Align `get_selected_machine()` with that list

Return `get_my_machine(selected_machine)` first so the selected printer is the
same `MachineObject` used for LAN publish/parse and for UI readiness checks.

### 3. Ignore cloud MQTT while the device is on the LAN path

In `GUI_App::init_networking_callbacks()` cloud message handler: if
`get_my_machine(dev_id)` is a LAN-mode printer, skip applying cloud payloads to
`userMachineList`. Direct LAN connection owns device state.

### 4. Match LAN UI updates by `dev_id`, not pointer equality

LAN message handler previously required `get_selected_machine() == obj`. After
the dual-object split that comparison failed even for the correct device.
Compare `sel->get_dev_id() == dev_id` instead.

## Files changed

- `src/slic3r/GUI/DeviceCore/DevManager.cpp` — prefer LAN in machine list;
  `get_selected_machine()` uses the canonical `get_my_machine()` object.
- `src/slic3r/GUI/GUI_App.cpp` — skip cloud MQTT for LAN-owned devices; fix LAN
  sidebar update matching by `dev_id`.

## Test plan

- [ ] Log in to a Bambu account. Use a **LAN-only** printer (no cloud access /
      no Internet to Bambu MQTT) on the same LAN with a valid access code.
- [ ] Select the printer and open Send / Device flows that wait on
      `is_info_ready()`. Confirm it becomes ready (no stuck "Reading…" /
      timeout) after `get_version` + `push_status`.
- [ ] Confirm logs show local `publish_json` and matching `get_version` parse,
      and that `is_info_ready` no longer reports `failed to check version`
      immediately after a successful parse.
- [ ] Log out of the account and repeat — still works (regression check).
- [ ] With a normal cloud-online printer (Internet OK, no conflicting LAN-only
      path), confirm Device tab / send still update via cloud MQTT as before.
- [ ] Switch between LAN and cloud printers; confirm no cross-talk of AMS /
      sync badges between devices.
