### PR TITLE
Fix macOS 26+ dock icon losing system theming (#8816)

### DIFF
--- a/src/libslic3r/MacUtils.hpp
+++ b/src/libslic3r/MacUtils.hpp
@@ -5,6 +5,9 @@ namespace Slic3r {
 
 bool is_macos_support_boost_add_file_log();
 int  is_mac_version_15();
+
+// Returns true when running on macOS `major` or any later version.
+bool is_mac_os_at_least(int major);
 }
 
 #endif

--- a/src/libslic3r/MacUtils.mm
+++ b/src/libslic3r/MacUtils.mm
@@ -20,4 +20,12 @@ int is_mac_version_15()
         return false;
     }
 }
+
+// Runtime check that works regardless of the SDK used to build, and is
+// inherently true for the given major version and all later ones.
+bool is_mac_os_at_least(int major)
+{
+    NSOperatingSystemVersion version = { major, 0, 0 };
+    return [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:version];
+}
 }; // namespace Slic3r

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -47,6 +47,9 @@
 #include "Widgets/ProgressDialog.hpp"
 #include "BindDialog.hpp"
 #include "../Utils/MacDarkMode.hpp"
+#ifdef __APPLE__
+#include "libslic3r/MacUtils.hpp"
+#endif
 
 #include <fstream>
 #include <string_view>
@@ -303,14 +306,20 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
 
 #ifdef __APPLE__
     // Initialize the docker task bar icon.
-    switch (wxGetApp().get_app_mode()) {
-    default:
-    case GUI_App::EAppMode::Editor:
-        m_taskbar_icon = std::make_unique<BambuStudioTaskBarIcon>(wxTBI_DOCK);
-        m_taskbar_icon->SetIcon(wxIcon(Slic3r::var("BambuStudio-mac_256px.ico"), wxBITMAP_TYPE_ICO), "BambuStudio");
-        break;
-    case GUI_App::EAppMode::GCodeViewer:
-        break;
+    // On macOS 26+ (Tahoe) setting a custom dock icon at runtime overrides the
+    // system's Liquid Glass / tinted icon theming for the app bundle icon. Skip
+    // it there so the themed bundle icon (Icon.icns) is shown instead. The check
+    // is a lower bound, so future macOS releases (27+) are covered as well.
+    if (!is_mac_os_at_least(26)) {
+        switch (wxGetApp().get_app_mode()) {
+        default:
+        case GUI_App::EAppMode::Editor:
+            m_taskbar_icon = std::make_unique<BambuStudioTaskBarIcon>(wxTBI_DOCK);
+            m_taskbar_icon->SetIcon(wxIcon(Slic3r::var("BambuStudio-mac_256px.ico"), wxBITMAP_TYPE_ICO), "BambuStudio");
+            break;
+        case GUI_App::EAppMode::GCodeViewer:
+            break;
+        }
     }
 #endif // __APPLE__
 


### PR DESCRIPTION
### Problem

On macOS 26 (Tahoe) the Bambu Studio dock icon does not respect the system's
new icon theming (Liquid Glass / Tinted / Clear / Dark). When the app launches
it loses the themed appearance and shows a plain raster icon instead.

Root cause: on startup `MainFrame` sets a custom dock icon at runtime via a
`wxTBI_DOCK` taskbar icon (`BambuStudio-mac_256px.ico`). This calls
`-[NSApp setApplicationIconImage:]` under the hood, which overrides the system
theming that macOS applies to the app bundle icon (`Icon.icns`).

Fixes #8816

### Change

Skip the runtime dock-icon override on macOS 26 and later, so the system-themed
bundle icon is used instead. Behaviour on macOS < 26 is unchanged.

- Add `Slic3r::is_mac_os_at_least(int major)` in `MacUtils.mm`, implemented with
  `-[NSProcessInfo isOperatingSystemAtLeastVersion:]`. This is a lower-bound
  check, so future releases (27+) are covered automatically, and it works
  regardless of the SDK the project is built with.
- Guard the `#ifdef __APPLE__` dock-icon initialization in `MainFrame` with
  `if (!is_mac_os_at_least(26))`.

### Testing

- Built and ran locally on macOS 26.5 (Apple Silicon, arm64).
- With the fix, the dock icon now follows the system Icon & Widget Style
  (verified with the "Tinted" style — the running app's dock icon stays tinted
  instead of reverting to the raster icon).
- Change is fully contained in `#ifdef __APPLE__`, so non-Apple builds are
  unaffected.
