### PR TITLE
Add Windows ARM64 and ARM64EC build support

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -47,6 +47,10 @@ jobs:
           - os: ubuntu-24.04
           - os: ubuntu-26.04
           - os: windows-latest
+          - os: windows-11-arm
+            arch: arm64
+          - os: windows-11-arm
+            arch: arm64ec
           - os: macos-15-intel
             arch: x86_64
           - os: macos-15

--- a/.github/workflows/build_bambu.yml
+++ b/.github/workflows/build_bambu.yml
@@ -37,7 +37,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Get the version and date on Ubuntu and macOS
-        if: inputs.os != 'windows-latest'
+        if: ${{ !startsWith(inputs.os, 'windows') }}
         run: |
           ver_pure=$(grep 'set(SLIC3R_VERSION' version.inc | cut -d '"' -f2)
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
@@ -51,7 +51,7 @@ jobs:
         shell: bash
 
       - name: Get the version and date on Windows
-        if: inputs.os == 'windows-latest'
+        if: startsWith(inputs.os, 'windows')
         run: |
           $date = Get-Date -Format 'yyyyMMdd'
           $ref = "${{ github.ref }}"
@@ -114,11 +114,11 @@ jobs:
 
   # Windows
       - name: setup MSVC
-        if: inputs.os == 'windows-latest'
+        if: startsWith(inputs.os, 'windows')
         uses: microsoft/setup-msbuild@v2
 
       - name: Install nsis and pkgconfig
-        if: inputs.os == 'windows-latest'
+        if: startsWith(inputs.os, 'windows')
         run: |
           dir "C:/Program Files (x86)/Windows Kits/10/Include"
           choco install nsis
@@ -133,6 +133,25 @@ jobs:
           cmake .. -G "Visual Studio 18 2026" -A X64 -DBBL_RELEASE_TO_PUBLIC=1 -DBBL_INTERNAL_TESTING=0 -DCMAKE_PREFIX_PATH="${{ github.workspace }}\deps\build\BambuStudio_dep\usr\local" -DCMAKE_INSTALL_PREFIX="../install-dir" -DCMAKE_BUILD_TYPE=Release -DWIN10SDK_PATH="C:/Program Files (x86)/Windows Kits/10/Include/10.0.22000.0"
           cmake --build . --target install --config Release -- -m
 
+      # Windows on ARM64/ARM64EC: VS 2022 generator (the arm runner has no VS
+      # 2026), and the newest installed 10.* SDK is resolved at runtime rather
+      # than pinned, since the arm image may not ship the exact SDK the x64 job
+      # hard-codes. arm64ec produces the variant that can load the x64-only
+      # Bambu network plugin in-process at native speed.
+      - name: Build slicer Win ARM64/ARM64EC
+        if: inputs.os == 'windows-11-arm'
+        working-directory: ${{ github.workspace }}
+        shell: pwsh
+        run: |
+          $sdkRoot = "C:/Program Files (x86)/Windows Kits/10/Include"
+          $sdk = (Get-ChildItem $sdkRoot -Directory | Where-Object { $_.Name -match '^10\.' } | Sort-Object Name -Descending | Select-Object -First 1).FullName
+          Write-Output "Using Windows SDK: $sdk"
+          $platform = "${{ inputs.arch }}" -eq "arm64ec" ? "ARM64EC" : "ARM64"
+          mkdir build
+          cd build
+          cmake .. -G "Visual Studio 17 2022" -A $platform -DBBL_RELEASE_TO_PUBLIC=1 -DBBL_INTERNAL_TESTING=0 -DCMAKE_PREFIX_PATH="${{ github.workspace }}\deps\build\BambuStudio_dep\usr\local" -DCMAKE_INSTALL_PREFIX="../install-dir" -DCMAKE_BUILD_TYPE=Release -DWIN10SDK_PATH="$sdk"
+          cmake --build . --target install --config Release -- -m
+
       # - name: Create installer Win
       #   if: inputs.os == 'windows-latest'
       #   working-directory: ${{ github.workspace }}/build
@@ -144,6 +163,12 @@ jobs:
         working-directory: ${{ github.workspace }}
         shell: cmd
         run: '"C:/Program Files/7-Zip/7z.exe" a -tzip BambuStudio_Windows_${{ env.ver }}_portable.zip ${{ github.workspace }}/install-dir'
+
+      - name: Pack app ARM64
+        if: inputs.os == 'windows-11-arm'
+        working-directory: ${{ github.workspace }}
+        shell: cmd
+        run: '"C:/Program Files/7-Zip/7z.exe" a -tzip BambuStudio_Windows_${{ env.ver }}_${{ inputs.arch }}_portable.zip ${{ github.workspace }}/install-dir'
 
       # - name: Pack PDB
       #   if: inputs.os == 'windows-latest'
@@ -157,6 +182,13 @@ jobs:
         with:
           name: BambuStudio_Windows_${{ env.ver }}_portable
           path: ${{ github.workspace }}/BambuStudio_Windows_${{ env.ver }}_portable.zip
+
+      - name: Upload artifacts Win ARM64 zip
+        if: inputs.os == 'windows-11-arm'
+        uses: actions/upload-artifact@v6
+        with:
+          name: BambuStudio_Windows_${{ env.ver }}_${{ inputs.arch }}_portable
+          path: ${{ github.workspace }}/BambuStudio_Windows_${{ env.ver }}_${{ inputs.arch }}_portable.zip
 
 
   # Ubuntu

--- a/.github/workflows/build_check_cache.yml
+++ b/.github/workflows/build_check_cache.yml
@@ -30,10 +30,13 @@ jobs:
       - name: set outputs
         id: set_outputs
         env:
-          dep-folder-name: ${{ inputs.os == 'windows-latest' && '/BambuStudio_dep' || ((inputs.os == 'macos-15-intel' || inputs.os == 'macos-15' || inputs.os == 'macos-26') && '') || (inputs.os != 'macos-15-intel' && inputs.os != 'macos-15' && inputs.os != 'macos-26') && '/destdir' || '' }}
-          output-cmd: ${{ inputs.os == 'windows-latest' && '$env:GITHUB_OUTPUT' || '"$GITHUB_OUTPUT"'}}
+          dep-folder-name: ${{ startsWith(inputs.os, 'windows') && '/BambuStudio_dep' || ((inputs.os == 'macos-15-intel' || inputs.os == 'macos-15' || inputs.os == 'macos-26') && '') || (inputs.os != 'macos-15-intel' && inputs.os != 'macos-15' && inputs.os != 'macos-26') && '/destdir' || '' }}
+          output-cmd: ${{ startsWith(inputs.os, 'windows') && '$env:GITHUB_OUTPUT' || '"$GITHUB_OUTPUT"'}}
+          # Windows runs two variants (arm64/arm64ec) on the same runner label,
+          # so the arch must be part of the key or their caches collide.
+          arch-suffix: ${{ (startsWith(inputs.os, 'windows') && inputs.arch != '') && format('-{0}', inputs.arch) || '' }}
         run: |
-          echo cache-key=${{ inputs.os }}-cache-bambustudio_deps-build-${{ hashFiles('deps/**') }} >> ${{ env.output-cmd }}
+          echo cache-key=${{ inputs.os }}${{ env.arch-suffix }}-cache-bambustudio_deps-build-${{ hashFiles('deps/**') }} >> ${{ env.output-cmd }}
           echo cache-path=${{ github.workspace }}/deps/build${{ env.dep-folder-name }} >> ${{ env.output-cmd }}
             
       - name: load cache

--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -42,16 +42,16 @@ jobs:
           key: ${{ inputs.cache-key }}
 
       - name: setup dev on Windows
-        if: inputs.os == 'windows-latest'
+        if: startsWith(inputs.os, 'windows')
         uses: microsoft/setup-msbuild@v2
 
       - name: Get the date on Ubuntu and macOS
-        if: inputs.os != 'windows-latest'
+        if: ${{ !startsWith(inputs.os, 'windows') }}
         run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_ENV
         shell: bash
 
       - name: Get the date on Windows
-        if: inputs.os == 'windows-latest'
+        if: startsWith(inputs.os, 'windows')
         run: echo "date=$(Get-Date -Format 'yyyyMMdd')" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
         shell: pwsh
 
@@ -73,6 +73,32 @@ jobs:
         if: inputs.os == 'windows-latest'
         working-directory: ${{ github.workspace }}
         run: Compress-Archive -Path "${{ github.workspace }}\deps\build\BambuStudio_dep\*" -DestinationPath "${{ github.workspace }}\deps\build\BambuStudio_dep_win64_${{ env.date }}_vs2022.zip"
+        shell: pwsh
+
+      # Windows on ARM64/ARM64EC. The windows-11-arm runner ships Visual
+      # Studio 2022 (v17), not 2026, so the generator differs from the x64 job
+      # above. All per-dep arch handling lives in deps/*.cmake and is selected
+      # automatically from the -A platform (arm64ec = native ARM64 code with
+      # the x64-compatible ABI, which is what lets the app load the x64-only
+      # Bambu network plugin in-process).
+      - name: Build on Windows ARM64/ARM64EC
+        if: inputs.os == 'windows-11-arm'
+        working-directory: ${{ github.workspace }}
+        run: |
+            choco install strawberryperl
+            choco install pkgconfiglite
+            mkdir ${{ github.workspace }}\deps\build
+            mkdir ${{ github.workspace }}\deps\build\BambuStudio_dep
+            cd "${{ github.workspace }}\deps\build"
+            $platform = "${{ inputs.arch }}" -eq "arm64ec" ? "ARM64EC" : "ARM64"
+            cmake ../ -G "Visual Studio 17 2022" -A $platform -DDESTDIR="./BambuStudio_dep" -DCMAKE_BUILD_TYPE=Release -DDEP_DEBUG=OFF
+            msbuild /m ALL_BUILD.vcxproj
+        shell: pwsh
+
+      - name: pack deps on Windows ARM64/ARM64EC
+        if: inputs.os == 'windows-11-arm'
+        working-directory: ${{ github.workspace }}
+        run: Compress-Archive -Path "${{ github.workspace }}\deps\build\BambuStudio_dep\*" -DestinationPath "${{ github.workspace }}\deps\build\BambuStudio_dep_win-${{ inputs.arch }}_${{ env.date }}_vs2022.zip"
         shell: pwsh
           
       - name: Fix python install error on mac
@@ -165,6 +191,13 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: BambuStudio_dep_win64_${{ env.date }}
+          path: ${{ github.workspace }}/deps/build/BambuStudio_dep*.zip
+
+      - name: Upload Windows ARM64/ARM64EC artifacts
+        if: inputs.os == 'windows-11-arm'
+        uses: actions/upload-artifact@v6
+        with:
+          name: BambuStudio_dep_win-${{ inputs.arch }}_${{ env.date }}
           path: ${{ github.workspace }}/deps/build/BambuStudio_dep*.zip
 
       - name: Upload Ubuntu artifacts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,19 @@ elseif (MSVC)
             message(STATUS " is cross compile set to true.............")
             set(IS_CROSS_COMPILE TRUE)
         endif ()
+        if (CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64EC")
+            # On ARM64EC the x86 SIMD headers (immintrin.h etc.) refuse direct
+            # inclusion - they must come via <intrin.h> so the softintrin
+            # emulation layer is set up first. Several bundled libraries
+            # (eigen, imgui, clipper2, tinybvh, libigl, minih264) include them
+            # directly, so force-include intrin.h globally instead of patching
+            # each one.
+            add_compile_options(/FIintrin.h)
+            # Software implementations of x86 intrinsics that have no native
+            # ARM64EC lowering (e.g. _mm_cvtsd_si64). MSBuild does not add this
+            # automatically for CMake-generated projects.
+            add_link_options(softintrin.lib)
+        endif ()
 endif ()
 
 # Proposal for C++ unit tests and sandboxes
@@ -132,7 +145,19 @@ if (MSVC)
     # /bigobj (Increase Number of Sections in .Obj file)
     # error C3859: virtual memory range for PCH exceeded; please recompile with a command line option of '-Zm90' or greater
     # Generate symbols at every build target, even for the release.
-    add_compile_options(-bigobj -Zm520 /Zi)
+    if (CMAKE_GENERATOR MATCHES "Ninja")
+        # /Z7 embeds debug info in the objects instead of writing per-target
+        # .pdb files during compilation: /Zi's shared-PDB writes fail with
+        # C1041 under Ninja's parallelism (the VS generator serializes them
+        # via /FS+mspdbsrv) and defeat compiler-launcher caches like sccache.
+        # Only debug-carrying configs get it - embedding into every object of
+        # a Release build pushes libslic3r_gui.lib past the 4 GB .lib format
+        # limit (LNK1248), and plain Release omits debug info in standard
+        # CMake semantics anyway.
+        add_compile_options(-bigobj -Zm520 "$<$<OR:$<CONFIG:RelWithDebInfo>,$<CONFIG:Debug>>:/Z7>")
+    else ()
+        add_compile_options(-bigobj -Zm520 /Zi)
+    endif ()
     # Disable STL4007: Many result_type typedefs and all argument_type, first_argument_type, and second_argument_type typedefs are deprecated in C++17.
     #FIXME Remove this line after eigen library adapts to the new C++17 adaptor rules.
     add_compile_options(-D_SILENCE_CXX17_ADAPTOR_TYPEDEFS_DEPRECATION_WARNING)
@@ -636,7 +661,15 @@ function(bambustudio_copy_dlls target config postfix output_dlls)
         set(_bits 32)
     endif ()
 
-    if ((CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|aarch64)$") OR (CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64"))
+    # Generator platform takes precedence over the host processor so an ARM64
+    # host can build x64 or ARM64EC targets (both consume the x64 runtime DLLs;
+    # ARM64EC processes load x64 DLLs via emulation).
+    set(_copydll_plat "${CMAKE_GENERATOR_PLATFORM}")
+    if (NOT _copydll_plat)
+        set(_copydll_plat "${CMAKE_SYSTEM_PROCESSOR}")
+    endif ()
+    string(TOUPPER "${_copydll_plat}" _copydll_plat)
+    if (_copydll_plat MATCHES "^(ARM64|AARCH64)$")
         set(_gmpdll win_arm64/gmp-10.dll)
         set(_mpfrdll win_arm64/mpfr-6.dll)
         set(output_gmpdll gmp-10.dll)

--- a/cmake/modules/FindGLEW.cmake
+++ b/cmake/modules/FindGLEW.cmake
@@ -134,6 +134,12 @@ endif()
 
 if("${CMAKE_GENERATOR_PLATFORM}" MATCHES "x64" OR "${CMAKE_GENERATOR}" MATCHES "Win64")
   set(_arch "x64")
+elseif("${CMAKE_GENERATOR_PLATFORM}" MATCHES "ARM64|arm64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|aarch64)$")
+  # GLEW's binary distribution ships one 64-bit import-library layout; ARM64
+  # reuses the x64 lib/Release path. (Bambu builds GLEW from source into the
+  # dep prefix, so this only affects the GLEW_ROOT binary-dist fallback.)
+  # Matched case-insensitively since build_win.bat passes -A arm64 (lowercase).
+  set(_arch "x64")
 else()
   set(_arch "Win32")
 endif()

--- a/deps/Boost/Boost.cmake
+++ b/deps/Boost/Boost.cmake
@@ -29,6 +29,22 @@ if (MSVC)
         set(_context_arch_line "-DBOOST_CONTEXT_ARCHITECTURE:STRING=arm64")
         set(_context_impl_line "-DBOOST_CONTEXT_IMPLEMENTATION:STRING=winfib")
         message(STATUS "BOOST param: ${_context_abi_line} ${_context_arch_line} ${_context_impl_line}")
+    elseif (_msvc_target_arch STREQUAL "ARM64EC")
+        # ARM64EC uses the x64-compatible ABI; the Windows Fiber implementation
+        # needs no assembler, sidestepping fcontext arch detection entirely.
+        set(_context_impl_line "-DBOOST_CONTEXT_IMPLEMENTATION:STRING=winfib")
+        # Boost.JSON's ryu needs __shiftright128, which ARM64EC lacks (no
+        # native lowering, no softintrin fallback); cobalt is in the same
+        # C++20-era boat. Neither is used by BambuStudio.
+        set(_boost_ec_extra_excludes "|json|cobalt")
+        message(STATUS "BOOST param: ${_context_impl_line}")
+    elseif (_msvc_target_arch STREQUAL "X64")
+        # Pin arch AND abi: Boost.Context otherwise sniffs the HOST processor,
+        # so building x64 deps on an ARM64 host selects armasm/aapcs and fails
+        # (x86_64 + aapcs has no asm source; the x64 Windows ABI is 'ms').
+        set(_context_abi_line "-DBOOST_CONTEXT_ABI:STRING=ms")
+        set(_context_arch_line "-DBOOST_CONTEXT_ARCHITECTURE:STRING=x86_64")
+        message(STATUS "BOOST param: ${_context_abi_line} ${_context_arch_line}")
     endif ()
 endif ()
 
@@ -38,7 +54,7 @@ bambustudio_add_cmake_project(Boost
     LIST_SEPARATOR |
     PATCH_COMMAND git apply --verbose --ignore-space-change --whitespace=fix ${CMAKE_CURRENT_LIST_DIR}/0001-FIX-OBS-cannot-start-streaming-on-MAC.patch
     CMAKE_ARGS
-        -DBOOST_EXCLUDE_LIBRARIES:STRING=contract|fiber|numpy|wave|test
+        -DBOOST_EXCLUDE_LIBRARIES:STRING=contract|fiber|numpy|wave|test${_boost_ec_extra_excludes}
         -DBOOST_LOCALE_ENABLE_ICU:BOOL=OFF # do not link to libicu, breaks compatibility between distros
         -DBUILD_TESTING:BOOL=OFF
         "${_context_abi_line}"

--- a/deps/FFMPEG/FFMPEG.cmake
+++ b/deps/FFMPEG/FFMPEG.cmake
@@ -1,11 +1,29 @@
 set(_conf_cmd ./configure)
 
 if (MSVC)
+    # bambulab's ffmpeg_prebuilts are x64-only; linking them on ARM64 leaves
+    # every av*/sws* symbol unresolved. For Windows ARM64 use BtbN's winarm64
+    # shared build (pinned autobuild tag). FFmpeg 7.0/7.1 share the same
+    # library majors (avcodec-61, avutil-59, swscale-8), so the layout and DLL
+    # names match what the x64 package ships and what the code links against.
+    set(_ffmpeg_msvc_url "https://github.com/bambulab/ffmpeg_prebuilts/releases/download/7.0.2/7.0.2_msvc.zip")
+    set(_ffmpeg_msvc_hash "SHA256=DF44AE6B97CE84C720695AE7F151B4A9654915D1841C68F10D62A1189E0E7181")
+    # Generator platform takes precedence over the host processor so an ARM64
+    # host can still build x64 deps (and ARM64EC targets get the x64 package).
+    set(_ffmpeg_gen_platform "${CMAKE_GENERATOR_PLATFORM}")
+    if (NOT _ffmpeg_gen_platform)
+        set(_ffmpeg_gen_platform "${CMAKE_SYSTEM_PROCESSOR}")
+    endif ()
+    string(TOUPPER "${_ffmpeg_gen_platform}" _ffmpeg_gen_platform)
+    if (_ffmpeg_gen_platform MATCHES "^(ARM64|AARCH64)$")
+        set(_ffmpeg_msvc_url "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-17-13-22/ffmpeg-n7.1.5-2-g998de74adf-winarm64-gpl-shared-7.1.zip")
+        set(_ffmpeg_msvc_hash "SHA256=37e39b6f9115ec01a0ac6d7728e629e6be988d42495c850da4514930ad857f97")
+    endif ()
     set(_dstdir ${DESTDIR}/usr/local)
     set(_source_dir "${CMAKE_BINARY_DIR}/dep_FFMPEG-prefix/src/dep_FFMPEG")
     ExternalProject_Add(dep_FFMPEG
-        URL https://github.com/bambulab/ffmpeg_prebuilts/releases/download/7.0.2/7.0.2_msvc.zip
-        URL_HASH SHA256=DF44AE6B97CE84C720695AE7F151B4A9654915D1841C68F10D62A1189E0E7181
+        URL ${_ffmpeg_msvc_url}
+        URL_HASH ${_ffmpeg_msvc_hash}
         DOWNLOAD_DIR ${DEP_DOWNLOAD_DIR}/FFMPEG
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/deps/GMP/GMP.cmake
+++ b/deps/GMP/GMP.cmake
@@ -7,7 +7,14 @@ if (IN_GIT_REPO)
 endif ()
 
 if (MSVC)
-    if ((CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|aarch64)$") OR (CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64"))
+    # Prefer the generator platform (-A ...) over the host processor so that an
+    # ARM64 host building an x64 (or ARM64EC) target stages the right blobs.
+    set(_gmp_plat "${CMAKE_GENERATOR_PLATFORM}")
+    if (NOT _gmp_plat)
+        set(_gmp_plat "${CMAKE_SYSTEM_PROCESSOR}")
+    endif ()
+    string(TOUPPER "${_gmp_plat}" _gmp_plat)
+    if (_gmp_plat MATCHES "^(ARM64|AARCH64)$")
         set(_gmpheader win_arm64/gmp.h)
         set(_gmplib win_arm64/libgmp-10.lib)
         set(_gmpdll win_arm64/gmp-10.dll)

--- a/deps/JPEG/JPEG.cmake
+++ b/deps/JPEG/JPEG.cmake
@@ -12,7 +12,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif()
 
 if (MSVC)
-    if ((CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|aarch64)$") OR (CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64"))
+    # Generator platform takes precedence over the host processor; SIMD is off
+    # for ARM64 (no x86 asm) and ARM64EC (deterministic pure-C build).
+    set(_jpeg_plat "${CMAKE_GENERATOR_PLATFORM}")
+    if (NOT _jpeg_plat)
+        set(_jpeg_plat "${CMAKE_SYSTEM_PROCESSOR}")
+    endif ()
+    string(TOUPPER "${_jpeg_plat}" _jpeg_plat)
+    if (_jpeg_plat MATCHES "^(ARM64|AARCH64|ARM64EC)$")
         set(_use_SIMD "-DWITH_SIMD=OFF")
     endif ()
 endif ()

--- a/deps/MPFR/MPFR.cmake
+++ b/deps/MPFR/MPFR.cmake
@@ -2,14 +2,28 @@ set(_srcdir ${CMAKE_CURRENT_LIST_DIR}/mpfr)
 set(_dstdir ${DESTDIR}/usr/local)
 
 if (MSVC)
-    if ((CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|aarch64)$") OR (CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64"))
+    # Prefer the generator platform (-A ...) over the host processor so that an
+    # ARM64 host building an x64 (or ARM64EC) target stages the right blobs.
+    set(_mpfr_plat "${CMAKE_GENERATOR_PLATFORM}")
+    if (NOT _mpfr_plat)
+        set(_mpfr_plat "${CMAKE_SYSTEM_PROCESSOR}")
+    endif ()
+    string(TOUPPER "${_mpfr_plat}" _mpfr_plat)
+    if (_mpfr_plat MATCHES "^(ARM64|AARCH64)$")
         set(_output  ${_dstdir}/include/mpfr.h
                  ${_dstdir}/include/mpf2mpfr.h
-                 ${_dstdir}/lib/libmpfr-6.lib 
+                 ${_dstdir}/lib/libmpfr-6.lib
+                 ${_dstdir}/lib/libmpfr-4.lib
                  ${_dstdir}/bin/mpfr-6.dll)
         set(_mpfrheader win_arm64)
         set(_mpfrlib win_arm64/libmpfr-6.lib)
         set(_mpfrdll win_arm64/mpfr-6.dll)
+        # CGAL's FindMPFR searches a fixed name list (mpfr, libmpfr-4, libmpfr-1)
+        # that predates the MPFR 4.x "-6" ABI naming, so it misses libmpfr-6.lib
+        # and the app configure fails with "Could NOT find MPFR". Install an
+        # aliased copy under the legacy name; the import library's filename does
+        # not affect runtime binding (it still references mpfr-6.dll internally).
+        set(_mpfrlib_alias ${_dstdir}/lib/libmpfr-4.lib)
     else ()
         set(_output  ${_dstdir}/include/mpfr.h
                  ${_dstdir}/include/mpf2mpfr.h
@@ -20,12 +34,18 @@ if (MSVC)
         set(_mpfrdll win${DEPS_BITS}/libmpfr-4.dll)
     endif ()
 
+    set(_mpfr_alias_cmd "")
+    if (DEFINED _mpfrlib_alias)
+        set(_mpfr_alias_cmd COMMAND ${CMAKE_COMMAND} -E copy ${_srcdir}/lib/${_mpfrlib} ${_mpfrlib_alias})
+    endif ()
+
     add_custom_command(
         OUTPUT  ${_output}
         COMMAND ${CMAKE_COMMAND} -E copy ${_srcdir}/include/${_mpfrheader}/mpfr.h ${_dstdir}/include/
         COMMAND ${CMAKE_COMMAND} -E copy ${_srcdir}/include/${_mpfrheader}/mpf2mpfr.h ${_dstdir}/include/
         COMMAND ${CMAKE_COMMAND} -E copy ${_srcdir}/lib/${_mpfrlib} ${_dstdir}/lib/
         COMMAND ${CMAKE_COMMAND} -E copy ${_srcdir}/lib/${_mpfrdll} ${_dstdir}/bin/
+        ${_mpfr_alias_cmd}
     )
 
     add_custom_target(dep_MPFR SOURCES ${_output})

--- a/deps/OpenCV/OpenCV.cmake
+++ b/deps/OpenCV/OpenCV.cmake
@@ -15,6 +15,12 @@ if (MSVC)
     if (_msvc_target_arch STREQUAL "ARM64" OR _msvc_target_arch STREQUAL "AARCH64")
         set(_is_arm64 TRUE)
     endif ()
+    if (_msvc_target_arch STREQUAL "ARM64EC")
+        # Intel IPP has no ARM64EC-linkable distribution (prebuilt x64 IPP
+        # members fail to resolve in an EC link), and softintrin'd SSE dispatch
+        # would be slower than plain C++ compiled native - treat like arm64.
+        set(_is_arm64 TRUE)
+    endif ()
 else ()
     if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|aarch64)$")
         set(_is_arm64 TRUE)

--- a/deps/OpenSSL/OpenSSL.cmake
+++ b/deps/OpenSSL/OpenSSL.cmake
@@ -6,7 +6,19 @@ if(DEFINED OPENSSL_ARCH)
     set(_cross_arch ${OPENSSL_ARCH})
 else()
     if(WIN32)
-        set(_cross_arch "VC-WIN64A")
+        # Detect ARM64 whether the platform arrived as -A ARM64 (CI) or -A arm64
+        # (build_win.bat lowercases it). The generator platform takes precedence
+        # over the host processor so an ARM64 host can still build x64 deps.
+        set(_win_target_plat "${CMAKE_GENERATOR_PLATFORM}")
+        if(NOT _win_target_plat)
+            set(_win_target_plat "${CMAKE_SYSTEM_PROCESSOR}")
+        endif()
+        string(TOUPPER "${_win_target_plat}" _win_target_plat)
+        if(_win_target_plat MATCHES "^(ARM64|AARCH64)$")
+            set(_cross_arch "VC-WIN64-ARM")
+        else()
+            set(_cross_arch "VC-WIN64A")
+        endif()
     elseif(APPLE)
         set(_cross_arch "darwin64-arm64-cc")
 	endif()
@@ -17,6 +29,29 @@ if(WIN32)
     set(_cross_comp_prefix_line "")
     set(_make_cmd nmake)
     set(_install_cmd nmake install_sw )
+    if(_win_target_plat STREQUAL "ARM64EC")
+        # ARM64EC links the x64 OpenSSL static libs (EC and x64 objects mix),
+        # but VC-WIN64A requires an x64-targeting cl. The deps environment
+        # targets arm64, so run the OpenSSL steps under the x64 cross tools
+        # via a generated wrapper batch file.
+        set(_vsdevcmd "$ENV{VSINSTALLDIR}Common7\\Tools\\vsdevcmd.bat")
+        if(NOT EXISTS "${_vsdevcmd}")
+            execute_process(
+                COMMAND "$ENV{ProgramFiles\(x86\)}\\Microsoft Visual Studio\\Installer\\vswhere.exe"
+                        -latest -products * -property installationPath
+                OUTPUT_VARIABLE _vs_root OUTPUT_STRIP_TRAILING_WHITESPACE)
+            set(_vsdevcmd "${_vs_root}\\Common7\\Tools\\vsdevcmd.bat")
+        endif()
+        if(NOT EXISTS "${_vsdevcmd}")
+            message(FATAL_ERROR "OpenSSL ARM64EC: cannot locate vsdevcmd.bat for the x64 cross environment")
+        endif()
+        set(_x64env_bat "${CMAKE_CURRENT_BINARY_DIR}/openssl_x64env.bat")
+        file(WRITE "${_x64env_bat}" "@echo off\r\ncall \"${_vsdevcmd}\" -arch=x64 -host_arch=arm64 -no_logo\r\n%*\r\n")
+        set(_cross_arch "VC-WIN64A")
+        set(_conf_cmd "${_x64env_bat}" perl Configure )
+        set(_make_cmd "${_x64env_bat}" nmake)
+        set(_install_cmd "${_x64env_bat}" nmake install_sw )
+    endif()
 else()
     if(APPLE)
         set(_conf_cmd export MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET} && ./Configure -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET} )

--- a/deps/TBB/TBB.cmake
+++ b/deps/TBB/TBB.cmake
@@ -1,10 +1,29 @@
+# The ARM64EC fixes (drop the hard-coded /GL that blocks EC links, guard/stub
+# the TSX intrinsics) are MSVC-only. Keep them off non-MSVC toolchains so
+# macOS/Linux build TBB exactly as before: in particular TBB_STRICT=OFF makes
+# oneTBB rewrite the compile flags, which mangles the macOS -Werror=<availability>
+# flags into bare '=<availability>' tokens (LNK/compile failure).
+set(_tbb_patch "")
+set(_tbb_strict "")
+if (MSVC)
+    # Removes the hard-coded /GL (blocks ARM64EC links) and guards TSX
+    # intrinsics against ARM64EC. On x64 this only drops LTCG (same code).
+    set(_tbb_patch PATCH_COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_LIST_DIR}/patch_tbb.cmake)
+    # ARM64EC: /FIintrin.h makes cl warn C4163 for x86-only intrinsics
+    # (__rdtsc, _mm_mfence) that softintrin handles at link time; TBB's default
+    # warnings-as-errors turns those fatal.
+    set(_tbb_strict -DTBB_STRICT=OFF)
+endif ()
+
 bambustudio_add_cmake_project(
     TBB
     URL "https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.5.0.zip"
     URL_HASH SHA256=83ea786c964a384dd72534f9854b419716f412f9d43c0be88d41874763e7bb47
     #PATCH_COMMAND ${PATCH_CMD} ${CMAKE_CURRENT_LIST_DIR}/0001-TBB-GCC13.patch
-    CMAKE_ARGS          
+    ${_tbb_patch}
+    CMAKE_ARGS
         -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        ${_tbb_strict}
         -DTBB_BUILD_SHARED=OFF
         -DTBB_BUILD_TESTS=OFF
         -DTBB_TEST=OFF

--- a/deps/TBB/patch_tbb.cmake
+++ b/deps/TBB/patch_tbb.cmake
@@ -1,0 +1,86 @@
+# Applied as PATCH_COMMAND for oneTBB. Two fixes, both idempotent:
+#
+# 1. Remove the hard-coded /GL (LTCG) from the MSVC release flags. oneTBB
+#    2021.5 has no option for this (TBB_ENABLE_IPO came later). x64 LTCG
+#    objects cannot participate in an ARM64EC link (C1905 front end/back end
+#    mismatch), and this static lib is consumed by the ARM64EC BambuStudio
+#    build.
+#
+# 2. Guard the TSX (hardware transactional memory) intrinsics against
+#    ARM64EC. ARM64EC defines _M_X64, so TBB assumes _xbegin/_xend/_xabort
+#    exist, but softintrin cannot emulate hardware transactions and the
+#    symbols fail to link.
+
+set(_msvc_cmake "cmake/compilers/MSVC.cmake")
+if(EXISTS "${_msvc_cmake}")
+    file(READ "${_msvc_cmake}" _content)
+    set(_old "set(TBB_IPO_COMPILE_FLAGS $<$<NOT:$<CONFIG:Debug>>:/GL>)")
+    if(_content MATCHES "TBB_IPO_COMPILE_FLAGS \"\"")
+        message(STATUS "[TBB patch] /GL already removed")
+    else()
+        string(REPLACE "${_old}" "set(TBB_IPO_COMPILE_FLAGS \"\")" _patched "${_content}")
+        if(_patched STREQUAL _content)
+            message(FATAL_ERROR "[TBB patch] failed to match /GL line in ${_msvc_cmake}")
+        endif()
+        file(WRITE "${_msvc_cmake}" "${_patched}")
+        message(STATUS "[TBB patch] removed /GL from MSVC release flags")
+    endif()
+else()
+    message(FATAL_ERROR "[TBB patch] not found: ${_msvc_cmake}")
+endif()
+
+# 3. Provide link-time definitions of the TSX intrinsics for ARM64EC builds.
+#    rtm_mutex.cpp/rtm_rw_mutex.cpp call _xbegin/_xend/_xabort unconditionally;
+#    on ARM64EC those lower to extern calls with no softintrin implementation.
+#    The code paths are unreachable at runtime (the governor only enables RTM
+#    when CPUID reports TSX, which the x64 emulator never does), but the
+#    symbols must resolve. A separate stub TU avoids touching the RTM sources.
+set(_stub "src/tbb/arm64ec_tsx_stub.cpp")
+set(_tbb_cml "src/tbb/CMakeLists.txt")
+if(NOT EXISTS "${_stub}")
+    file(WRITE "${_stub}" [=[
+// Link-time stubs for Intel TSX intrinsics on ARM64EC (no hardware TSX, no
+// softintrin fallback). Unreachable at runtime: TBB only takes RTM paths when
+// CPUID reports TSX support, which the x64/EC emulator never does.
+#if defined(_M_ARM64EC)
+extern "C" unsigned int _xbegin(void) { return 0u; /* abort, no retry */ }
+extern "C" void _xend(void) {}
+extern "C" void _xabort(unsigned int) {}
+#endif
+]=])
+    message(STATUS "[TBB patch] wrote ${_stub}")
+endif()
+if(EXISTS "${_tbb_cml}")
+    file(READ "${_tbb_cml}" _content)
+    if(_content MATCHES "arm64ec_tsx_stub")
+        message(STATUS "[TBB patch] stub already registered")
+    else()
+        string(REPLACE "rtm_mutex.cpp" "rtm_mutex.cpp\n    arm64ec_tsx_stub.cpp" _patched "${_content}")
+        if(_patched STREQUAL _content)
+            message(FATAL_ERROR "[TBB patch] failed to register stub in ${_tbb_cml}")
+        endif()
+        file(WRITE "${_tbb_cml}" "${_patched}")
+        message(STATUS "[TBB patch] registered arm64ec_tsx_stub.cpp")
+    endif()
+else()
+    message(FATAL_ERROR "[TBB patch] not found: ${_tbb_cml}")
+endif()
+
+set(_config_h "include/oneapi/tbb/detail/_config.h")
+if(EXISTS "${_config_h}")
+    file(READ "${_config_h}" _content)
+    set(_old "#define __TBB_TSX_INTRINSICS_PRESENT (__RTM__ || __INTEL_COMPILER || (_MSC_VER>=1700 && (__TBB_x86_64 || __TBB_x86_32)))")
+    set(_new "#define __TBB_TSX_INTRINSICS_PRESENT ((__RTM__ || __INTEL_COMPILER || (_MSC_VER>=1700 && (__TBB_x86_64 || __TBB_x86_32))) && !defined(_M_ARM64EC))")
+    if(_content MATCHES "_M_ARM64EC")
+        message(STATUS "[TBB patch] TSX guard already applied")
+    else()
+        string(REPLACE "${_old}" "${_new}" _patched "${_content}")
+        if(_patched STREQUAL _content)
+            message(FATAL_ERROR "[TBB patch] failed to match TSX guard in ${_config_h}")
+        endif()
+        file(WRITE "${_config_h}" "${_patched}")
+        message(STATUS "[TBB patch] guarded TSX intrinsics against ARM64EC")
+    endif()
+else()
+    message(FATAL_ERROR "[TBB patch] not found: ${_config_h}")
+endif()

--- a/deps/deps-windows.cmake
+++ b/deps/deps-windows.cmake
@@ -52,6 +52,11 @@ else ()
 
     if (DEP_ARCH STREQUAL "ARM64")
         set(DEP_PLATFORM "ARM64")
+    elseif (DEP_ARCH STREQUAL "ARM64EC")
+        # ARM64EC: native ARM64 code with an x64-compatible ABI, so an ARM64EC
+        # app can link these deps AND load x64-only DLLs (e.g. the Bambu
+        # network plugin) in-process. CMake-based deps build with -A ARM64EC.
+        set(DEP_PLATFORM "ARM64EC")
     else ()
         set(DEP_PLATFORM "x64")
     endif ()
@@ -60,6 +65,20 @@ endif ()
 set(DEP_CMAKE_OPTS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 if (DEP_PLATFORM STREQUAL "ARM64")
     list(APPEND DEP_CMAKE_OPTS "-DCMAKE_SYSTEM_PROCESSOR=ARM64")
+endif ()
+if (DEP_PLATFORM STREQUAL "ARM64EC")
+    # ARM64EC defines _M_X64, and the x86 SIMD headers (emmintrin.h etc.)
+    # refuse direct inclusion there - they must arrive via <intrin.h> so the
+    # softintrin emulation layer is set up first; /FIintrin.h forces that for
+    # third-party code that includes them directly. /FI in turn breaks the
+    # common "#define _CRT_SECURE_NO_WARNINGS before includes" idiom (the CRT
+    # headers are already in), so silence C4996/C4005 which several deps
+    # (boost.nowide among them) promote to errors. The flag strings must
+    # restate CMake's default MSVC flags: CMAKE_ARGS replaces, not appends,
+    # and losing /EHsc breaks any dep that requires exception handling.
+    list(APPEND DEP_CMAKE_OPTS
+        "-DCMAKE_C_FLAGS=/DWIN32 /D_WINDOWS /W3 /wd4996 /wd4005 /FIintrin.h"
+        "-DCMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /W3 /GR /EHsc /wd4996 /wd4005 /FIintrin.h")
 endif ()
 
 if (${DEP_DEBUG})

--- a/src/BaseException.cpp
+++ b/src/BaseException.cpp
@@ -326,6 +326,13 @@ void CBaseException::ShowRegistorInformation(PCONTEXT pCtx)
 	OutputString( _T("DS:%04X  ES:%04X  FS:%04X  GS:%04X\r\n"), pCtx->SegDs, pCtx->SegEs, pCtx->SegFs, pCtx->SegGs );
 	OutputString( _T("Flags:%08X\r\n"), pCtx->EFlags );
 
+#elif defined(_M_ARM64)  // Windows on ARM64
+	OutputString(_T("\nRegisters:\r\n"));
+	OutputString(_T("PC:%016llX  SP:%016llX  FP:%016llX  LR:%016llX\r\n"),
+		(unsigned long long)pCtx->Pc, (unsigned long long)pCtx->Sp,
+		(unsigned long long)pCtx->Fp, (unsigned long long)pCtx->Lr);
+	OutputString(_T("Cpsr:%08X\r\n"), pCtx->Cpsr);
+
 #endif
 
 	OutputString( _T("\r\n") );
@@ -349,7 +356,12 @@ void CBaseException::ShowExceptionInformation()
 		OutputString(_T("Param %d :0x%x \n"), i, m_pEp->ExceptionRecord->ExceptionInformation[i]);
 	}
 	OutputString(_T("Context :%p \n"), m_pEp->ContextRecord);
+#if defined(_M_ARM64)
+    // The ARM64 CONTEXT has no EFlags member; the status register is Cpsr.
+    OutputString(_T("ContextFlag : 0x%x, Cpsr: 0x%x \n"), m_pEp->ContextRecord->ContextFlags, m_pEp->ContextRecord->Cpsr);
+#else
     OutputString(_T("ContextFlag : 0x%x, EFlags: 0x%x \n"), m_pEp->ContextRecord->ContextFlags, m_pEp->ContextRecord->EFlags);
+#endif
 
 	TCHAR szFaultingModule[MAX_PATH];
 	DWORD section, offset;

--- a/src/StackWalker.cpp
+++ b/src/StackWalker.cpp
@@ -457,6 +457,15 @@ LPSTACKINFO CStackWalker::StackWalker(HANDLE hThread, const CONTEXT* context)
 	sf.AddrBStore.Mode = AddrModeFlat;
 	sf.AddrStack.Offset = c.IntSp;
 	sf.AddrStack.Mode = AddrModeFlat;
+	// ARM64
+#elif defined(_M_ARM64)
+	imageType = IMAGE_FILE_MACHINE_ARM64;
+	sf.AddrPC.Offset = c.Pc;
+	sf.AddrPC.Mode = AddrModeFlat;
+	sf.AddrFrame.Offset = c.Fp;
+	sf.AddrFrame.Mode = AddrModeFlat;
+	sf.AddrStack.Offset = c.Sp;
+	sf.AddrStack.Mode = AddrModeFlat;
 #else
 #error "Platform not supported!"
 #endif

--- a/src/clipper2/Clipper2Lib/src/clipper.engine.cpp
+++ b/src/clipper2/Clipper2Lib/src/clipper.engine.cpp
@@ -13,7 +13,10 @@
 
 // https://github.com/AngusJohnson/Clipper2/discussions/334
 // #discussioncomment-4248602
-#if defined(_MSC_VER) && ( defined(_M_AMD64) || defined(_M_X64) )
+// ARM64EC defines _M_X64 but _mm_cvtsd_si64 has neither a native EC lowering
+// nor a softintrin fallback; the standard C functions compile to native ARM64
+// rounding/min/max instructions there anyway.
+#if defined(_MSC_VER) && ( defined(_M_AMD64) || defined(_M_X64) ) && !defined(_M_ARM64EC)
 #include <xmmintrin.h>
 #include <emmintrin.h>
 #define fmin(a,b) _mm_cvtsd_f64(_mm_min_sd(_mm_set_sd(a),_mm_set_sd(b)))

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -526,6 +526,43 @@ if(MSVC AND MSVC_VERSION GREATER_EQUAL 1950 AND NOT DEFINED OpenCV_RUNTIME)
     # explicitly here to match what find_package looks for.
     set(OpenCV_RUNTIME vc17)
 endif()
+if(MSVC AND NOT DEFINED OpenCV_ARCH)
+    # OpenCVConfig.cmake's arch dispatcher matches CMAKE_GENERATOR_PLATFORM against
+    # "ARM64" case-sensitively, but build_win.bat passes -A arm64 (lowercase), so it
+    # falls back to x64 and misses the ARM64/<runtime>/staticlib install layout.
+    # Select the arch explicitly for any spelling of an ARM64 target. The dispatcher
+    # only honours pre-set values when BOTH OpenCV_ARCH and OpenCV_RUNTIME are
+    # defined, so pin the runtime too (our deps build installs the vc17 layout).
+    set(_slic3r_gen_platform "${CMAKE_GENERATOR_PLATFORM}")
+    if(NOT _slic3r_gen_platform)
+        set(_slic3r_gen_platform "${CMAKE_SYSTEM_PROCESSOR}")
+    endif()
+    string(TOUPPER "${_slic3r_gen_platform}" _slic3r_gen_platform)
+    if(_slic3r_gen_platform MATCHES "^(ARM64|AARCH64)$")
+        set(OpenCV_ARCH ARM64)
+        if(NOT DEFINED OpenCV_RUNTIME)
+            set(OpenCV_RUNTIME vc17)
+        endif()
+    elseif(_slic3r_gen_platform STREQUAL "ARM64EC")
+        # ARM64EC consumes either dependency flavor (EC and x64 code
+        # interoperate): the in-repo ARM64EC deps bundle installs OpenCV under
+        # ARM64/vc17 (its recipe treats EC like arm64), while an x64 deps
+        # prefix uses x64/vc17. Pick whichever layout the prefix provides.
+        # MSVC 19.4x also falls in a gap in OpenCV 4.6's runtime table, so the
+        # runtime must be pinned here too.
+        set(OpenCV_ARCH x64)
+        foreach(_slic3r_prefix ${CMAKE_PREFIX_PATH})
+            if(EXISTS "${_slic3r_prefix}/ARM64/vc17")
+                set(OpenCV_ARCH ARM64)
+            endif()
+        endforeach()
+        unset(_slic3r_prefix)
+        if(NOT DEFINED OpenCV_RUNTIME)
+            set(OpenCV_RUNTIME vc17)
+        endif()
+    endif()
+    unset(_slic3r_gen_platform)
+endif()
 find_package(OpenCV REQUIRED core)
 find_package(assimp REQUIRED)
 cmake_policy(POP)

--- a/src/libslic3r/Int128.hpp
+++ b/src/libslic3r/Int128.hpp
@@ -59,7 +59,10 @@
 
 #if defined(_MSC_VER) && defined(_WIN64)
 	#include <intrin.h>
+	// _mul128 exists only on x64; ARM64 MSVC uses __umulh (also from <intrin.h>).
+	#ifdef _M_X64
 	#pragma intrinsic(_mul128)
+	#endif
 #endif
 
 //------------------------------------------------------------------------------

--- a/src/minimp4/minih264e.h
+++ b/src/minimp4/minih264e.h
@@ -337,7 +337,11 @@ void H264E_set_vbv_state(
 #define MAX_LONG_TERM_FRAMES 8 // Max long-term frames count
 #endif
 
-#if !defined(MINIH264_ONLY_SIMD) && (defined(_M_X64) || defined(_M_ARM64) || defined(__x86_64__) || defined(__aarch64__))
+/* Note: _M_ARM64 (MSVC on Windows ARM64) is deliberately NOT listed. The NEON
+ * implementation below is only enabled for __ARM_NEON/__aarch64__ (GCC/Clang
+ * macros that MSVC does not define), so MSVC ARM64 must keep the generic C
+ * path available or the MINIH264_ONLY_SIMD check below hits #error. */
+#if !defined(MINIH264_ONLY_SIMD) && (defined(_M_X64) || defined(__x86_64__) || defined(__aarch64__))
 /* x64 always have SSE2, arm64 always have neon, no need for generic code */
 #define MINIH264_ONLY_SIMD
 #endif /* SIMD checks... */


### PR DESCRIPTION
## What this does

Adds native Windows on ARM support to BambuStudio in two variants:

- **arm64**: a fully native ARM64 build. Everything compiles and links for
  ARM64, including OCCT/OpenCASCADE, so STEP import, SVG to 3D and text emboss
  all work. The one limitation is the network plugin (see below).
- **arm64ec**: native ARM64 code built with the x64-compatible ABI. An ARM64EC
  process runs the application at native speed and can still load x64-only DLLs
  in process, which is what allows the closed-source Bambu network plugin
  (cloud login, device management, camera) to work. Bambu currently ships that
  plugin as x64 only, so this is the variant most users on ARM would want.

Both are folded into the existing Windows build matrix on the `windows-11-arm`
runner. All ARM-specific logic is gated, so the x64, x86, macOS and Linux
paths are unchanged.

## Why

Windows on ARM machines (Snapdragon X and similar) currently run BambuStudio
under x64 emulation. A native build removes the emulation overhead from
slicing, and the ARM64EC variant keeps full networking/device support while
doing so.

## Notes for reviewers

- The `windows-11-arm` GitHub runner ships Visual Studio 2022, not 2026, so the
  ARM jobs use the `Visual Studio 17 2022` generator and resolve the Windows
  SDK at runtime rather than pinning it.
- GMP and MPFR have no upstream win-arm64 prebuilt binaries; the ARM64 blobs
  were already present in the tree. MPFR 4.x ships as `libmpfr-6.lib`, so an
  aliased `libmpfr-4.lib` is installed for CGAL's `FindMPFR`.
- FFMPEG uses BtbN's winarm64 shared build for the ARM targets because the
  bundled prebuilt package is x64 only. The tag and hash are pinned.
- For ARM64EC, oneTBB is patched at configure time (drop the hard-coded `/GL`
  that blocks EC links, and stub the Intel TSX intrinsics, which are unreachable
  under emulation but must resolve at link). The patch is a no-op on non-MSVC
  toolchains.
- OpenSSL for ARM64EC is built as its x64 flavor under the x64 cross
  environment, since ARM64EC links the x64 static libraries.

## Testing

- CI builds, links and uploads native arm64 and arm64ec portable artifacts on
  `windows-11-arm`; the x64, macOS and Linux jobs remain green.
- The arm64ec build was validated on a Snapdragon X machine: it launches,
  slices, imports STEP, and loads the x64 network plugin in process (verified
  by module list and by signing in to a Bambu account and driving a printer).

## Not included

Signed installer and release-pipeline wiring for the ARM artifacts are left as
a maintainer follow-up. This is a build-and-CI change.
