### PR TITLE
Add axis locks to support painting

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoFdmSupports.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoFdmSupports.cpp
@@ -367,6 +367,17 @@ void GLGizmoFdmSupports::on_render_input_window(float x, float y, float bottom_l
         ImGui::SameLine(drag_left_width);
         ImGui::PushItemWidth(1.5 * slider_icon_width);
         ImGui::BBLDragFloat("##cursor_radius_input", &m_cursor_radius, 0.05f, 0.0f, 0.0f, "%.2f");
+
+        if (m_imgui->bbl_checkbox(_L("Vertical"), m_vertical_only)) {
+            if (m_vertical_only) {
+                m_horizontal_only = false;
+            }
+        }
+        if (m_imgui->bbl_checkbox(_L("Horizontal"), m_horizontal_only)) {
+            if (m_horizontal_only) {
+                m_vertical_only = false;
+            }
+        }
     } else if (m_current_tool == ImGui::SphereButtonIcon) {
         m_cursor_type = TriangleSelector::CursorType::SPHERE;
         m_tool_type = ToolType::BRUSH;
@@ -379,6 +390,17 @@ void GLGizmoFdmSupports::on_render_input_window(float x, float y, float bottom_l
         ImGui::SameLine(drag_left_width);
         ImGui::PushItemWidth(1.5 * slider_icon_width);
         ImGui::BBLDragFloat("##cursor_radius_input", &m_cursor_radius, 0.05f, 0.0f, 0.0f, "%.2f");
+
+        if (m_imgui->bbl_checkbox(_L("Vertical"), m_vertical_only)) {
+            if (m_vertical_only) {
+                m_horizontal_only = false;
+            }
+        }
+        if (m_imgui->bbl_checkbox(_L("Horizontal"), m_horizontal_only)) {
+            if (m_horizontal_only) {
+                m_vertical_only = false;
+            }
+        }
     } else if (m_current_tool == ImGui::FillButtonIcon) {
         m_cursor_type = TriangleSelector::CursorType::POINTER;
         m_tool_type = ToolType::SMART_FILL;


### PR DESCRIPTION
## Summary

- add **Vertical** and **Horizontal** axis-lock controls to Support Painting
- expose the controls for both Circle and Sphere brushes
- keep both constraints mutually exclusive

## Details

The shared painter base already implements vertical and horizontal stroke constraints for brush actions. Seam Painting and MMU Painting expose these controls, but Support Painting does not.

This change adds the missing controls without changing the existing painting logic. Both options remain disabled by default.

## Compatibility

- no project or 3MF format changes
- no printer, filament, or process profile changes
- no new constraint logic
- existing freehand painting remains unchanged by default

## Validation

- compiled `GLGizmoFdmSupports.cpp` successfully using the existing Release GUI compiler configuration
- verified the committed diff and GPG signature
- no full GUI/runtime test was performed

## Attribution

Ported from OrcaSlicer/OrcaSlicer#14262.

Original commit: OrcaSlicer/OrcaSlicer@1d61962ea720b9b45caa3887057d2e6ec7821e64
