### PR TITLE
Add first object name filename placeholder

### DIFF
--- a/src/libslic3r/PrintBase.cpp
+++ b/src/libslic3r/PrintBase.cpp
@@ -22,11 +22,12 @@ void PrintTryCancel::operator()()
 
 size_t PrintStateBase::g_last_timestamp = 0;
 
-// Update "scale", "input_filename", "input_filename_base" placeholders from the current m_objects.
+// Update "scale", "input_filename", "input_filename_base", "first_object_name" placeholders from the current m_objects.
 void PrintBase::update_object_placeholders(DynamicConfig &config, const std::string &default_ext) const
 {
     // get the first input file name
     std::string input_file;
+    std::string first_object_name;
     std::vector<std::string> v_scale;
     int num_objects = 0;
     int num_instances = 0;
@@ -39,6 +40,8 @@ void PrintBase::update_object_placeholders(DynamicConfig &config, const std::str
 			}
 		if (printable) {
             ++ num_objects;
+	        if (num_objects == 1)
+	            first_object_name = model_object->name;
 	        // CHECK_ME -> Is the following correct ?
 			v_scale.push_back("x:" + boost::lexical_cast<std::string>(printable->get_scaling_factor(X) * 100) +
 				"% y:" + boost::lexical_cast<std::string>(printable->get_scaling_factor(Y) * 100) +
@@ -52,6 +55,7 @@ void PrintBase::update_object_placeholders(DynamicConfig &config, const std::str
     config.set_key_value("num_instances", new ConfigOptionInt(num_instances));
 
     config.set_key_value("scale", new ConfigOptionStrings(v_scale));
+    config.set_key_value("first_object_name", new ConfigOptionString(first_object_name));
     if (! input_file.empty()) {
         // get basename with and without suffix
         const std::string input_filename = boost::filesystem::path(input_file).filename().string();

--- a/src/libslic3r/PrintBase.hpp
+++ b/src/libslic3r/PrintBase.hpp
@@ -550,7 +550,7 @@ protected:
 
     // To be called by this->output_filename() with the format string pulled from the configuration layer.
     std::string            output_filename(const std::string &format, const std::string &default_ext, const std::string &filename_base, const DynamicConfig *config_override = nullptr) const;
-    // Update "scale", "input_filename", "input_filename_base" placeholders from the current printable ModelObjects.
+    // Update "scale", "input_filename", "input_filename_base", "first_object_name" placeholders from printable ModelObjects.
     void                   update_object_placeholders(DynamicConfig &config, const std::string &default_ext) const;
 
 	Model                                   m_model;

--- a/tests/fff_print/CMakeLists.txt
+++ b/tests/fff_print/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(${_TEST_NAME}_tests
 	test_gcode.cpp
 	test_gcodewriter.cpp
 	test_model.cpp
+	test_output_filename.cpp
 	test_print.cpp
 	test_printgcode.cpp
 	test_printobject.cpp

--- a/tests/fff_print/test_output_filename.cpp
+++ b/tests/fff_print/test_output_filename.cpp
@@ -1,0 +1,54 @@
+#include <catch2/catch.hpp>
+
+#include "libslic3r/Print.hpp"
+
+using namespace Slic3r;
+
+namespace {
+
+ModelObject *add_filename_test_object(Model &model, const std::string &name, ModelInstanceEPrintVolumeState state)
+{
+    ModelObject *object = model.add_object();
+    object->name = name;
+    object->add_volume(make_cube(10.0, 10.0, 10.0));
+    object->add_instance()->print_volume_state = state;
+    object->ensure_on_bed();
+    return object;
+}
+
+void apply_filename_test_model(Print &print, Model &model, DynamicPrintConfig &config)
+{
+    for (ModelObject *object : model.objects)
+        print.auto_assign_extruders(object);
+    print.apply(model, config);
+}
+
+} // namespace
+
+TEST_CASE("Print filename exposes the first printable object name", "[Print][output_filename]")
+{
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set("filename_format", "[first_object_name]");
+
+    Print print;
+    Model model;
+    add_filename_test_object(model, "Outside", ModelInstancePVS_Fully_Outside);
+    add_filename_test_object(model, "Bracket", ModelInstancePVS_Inside);
+    add_filename_test_object(model, "Later", ModelInstancePVS_Inside);
+    apply_filename_test_model(print, model, config);
+
+    REQUIRE(print.output_filename("SavedProject") == "Bracket.gcode");
+}
+
+TEST_CASE("First object name filename placeholder is defined without a printable object", "[Print][output_filename]")
+{
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set("filename_format", "part_[first_object_name]");
+
+    Print print;
+    Model model;
+    add_filename_test_object(model, "Outside", ModelInstancePVS_Fully_Outside);
+    apply_filename_test_model(print, model, config);
+
+    REQUIRE(print.output_filename() == "part_.gcode");
+}


### PR DESCRIPTION
## Summary

- add `first_object_name` for output filename templates
- use the first printable object and skip objects without a printable instance
- keep the value independent from the saved project filename
- define an empty value when no printable object is available

For example, `[first_object_name].gcode` produces a filename based on the first printable object's name.

## Testing

- syntax-checked `PrintBase.cpp` with the existing Release build flags
- syntax-checked the isolated `test_output_filename.cpp`
- added focused tests for printable-object selection, saved project names, and models without a printable object
