### PR TITLE
Keep tool ordering layer height lookup in bounds

### DIFF
--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -196,7 +196,8 @@ static double calc_max_layer_height(const PrintConfig &config, double max_object
 {
     double max_layer_height = std::numeric_limits<double>::max();
     for (size_t i = 0; i < config.nozzle_diameter.values.size(); ++ i) {
-        double mlh = config.max_layer_height.values[i];
+        // The option may contain fewer entries than the nozzle list; get_at() falls back to the first value.
+        double mlh = config.max_layer_height.get_at(i);
         if (mlh == 0.)
             mlh = 0.75 * config.nozzle_diameter.values[i];
         max_layer_height = std::min(max_layer_height, mlh);

--- a/tests/fff_print/CMakeLists.txt
+++ b/tests/fff_print/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(${_TEST_NAME}_tests
 	test_printobject.cpp
 	test_skirt_brim.cpp
 	test_support_material.cpp
+	test_tool_ordering.cpp
 	test_trianglemesh.cpp
 	)
 target_link_libraries(${_TEST_NAME}_tests test_common libslic3r)

--- a/tests/fff_print/test_tool_ordering.cpp
+++ b/tests/fff_print/test_tool_ordering.cpp
@@ -1,0 +1,27 @@
+#include <catch2/catch.hpp>
+
+#include "libslic3r/Print.hpp"
+
+#include "test_data.hpp"
+
+using namespace Slic3r;
+using namespace Slic3r::Test;
+
+TEST_CASE("Tool ordering accepts fewer maximum layer heights than nozzles", "[ToolOrdering]")
+{
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_num_filaments(2);
+    // Keep max_layer_height deliberately shorter than the nozzle list.
+    config.set_deserialize_strict({
+        { "nozzle_diameter", "0.4,0.4" },
+        { "max_layer_height", "0.3" }
+    });
+
+    REQUIRE(config.option<ConfigOptionFloatsNullable>("nozzle_diameter")->values.size() == 2);
+    REQUIRE(config.option<ConfigOptionFloatsNullable>("max_layer_height")->values.size() == 1);
+
+    Print print;
+    init_and_process_print({TestMesh::cube_20x20x20}, print, config);
+
+    REQUIRE_FALSE(print.objects().front()->layers().empty());
+}


### PR DESCRIPTION
## Summary
- use the configuration fallback accessor when matching maximum layer heights to nozzles
- prevent an out-of-bounds read when `max_layer_height` is shorter than `nozzle_diameter`
- add a focused regression test for two nozzles with one maximum-layer-height entry

## Testing
- syntax-checked `ToolOrdering.cpp` with the existing Release compiler flags
- syntax-checked the isolated `test_tool_ordering.cpp` regression test
- verified the patch with `git diff --check`