### PR TITLE
Avoid travel crash before initial tool selection

### DIFF
--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -33,6 +33,7 @@ void GCodeWriter::set_extruders(std::vector<unsigned int> extruder_ids)
 {
     std::sort(extruder_ids.begin(), extruder_ids.end());
     m_curr_extruder_id = -1;
+    m_current_process_config_idx = 0;
     std::fill(m_curr_filament_extruder.begin(), m_curr_filament_extruder.end(), nullptr);
     m_filament_extruders.clear();
     m_filament_extruders.reserve(extruder_ids.size());
@@ -367,6 +368,7 @@ std::string GCodeWriter::toolchange(unsigned int filament_id, unsigned int nozzl
     assert(filament_extruder_iter != m_filament_extruders.end() && filament_extruder_iter->id() == filament_id);
     m_curr_extruder_id = filament_extruder_iter->extruder_id();
     m_curr_filament_extruder[m_curr_extruder_id] = &*filament_extruder_iter;
+    m_current_process_config_idx = get_process_config_idx(this->config, filament_id);
 
     // return the toolchange command
     // if we are running a single-extruder setup, just set the extruder and return nothing
@@ -415,7 +417,7 @@ std::string GCodeWriter::travel_to_xy(const Vec2d &point, const std::string &com
 
     GCodeG1Formatter w;
     w.emit_xy(point_on_plate);
-    w.emit_f(this->config.travel_speed.get_at(get_process_config_idx(this->config, filament()->id())) * 60.0);
+    w.emit_f(this->config.travel_speed.get_at(m_current_process_config_idx) * 60.0);
     //BBS
     w.emit_comment(GCodeWriter::full_gcode_comment, comment);
     return set_travel_acceleration(use_short_travel_acceleration) + w.string();
@@ -554,7 +556,7 @@ std::string GCodeWriter::travel_to_xyz(const Vec3d &point, const std::string &co
                 Vec3d slope_top_point = Vec3d(temp(0), temp(1), delta(2)) + source;
                 GCodeG1Formatter w0;
                 w0.emit_xyz(slope_top_point);
-                w0.emit_f(this->config.travel_speed.get_at(get_process_config_idx(this->config, filament()->id())) * 60.0);
+                w0.emit_f(this->config.travel_speed.get_at(m_current_process_config_idx) * 60.0);
                 //BBS
                 w0.emit_comment(GCodeWriter::full_gcode_comment, "slope lift Z");
                 slop_move = w0.string();
@@ -569,13 +571,13 @@ std::string GCodeWriter::travel_to_xyz(const Vec3d &point, const std::string &co
             GCodeG1Formatter w0;
             if (this->is_current_position_clear()) {
                 w0.emit_xyz(target);
-                w0.emit_f(this->config.travel_speed.get_at(get_process_config_idx(this->config, filament()->id())) * 60.0);
+                w0.emit_f(this->config.travel_speed.get_at(m_current_process_config_idx) * 60.0);
                 w0.emit_comment(GCodeWriter::full_gcode_comment, comment);
                 xy_z_move = w0.string();
             }
             else {
                 w0.emit_xy(Vec2d(target.x(), target.y()));
-                w0.emit_f(this->config.travel_speed.get_at(get_process_config_idx(this->config, filament()->id())) * 60.0);
+                w0.emit_f(this->config.travel_speed.get_at(m_current_process_config_idx) * 60.0);
                 w0.emit_comment(GCodeWriter::full_gcode_comment, comment);
                 xy_z_move = w0.string() + _travel_to_z(target.z(), comment);
             }
@@ -609,13 +611,13 @@ std::string GCodeWriter::travel_to_xyz(const Vec3d &point, const std::string &co
     {
         //force to move xy first then z after filament change
         w.emit_xy(Vec2d(point_on_plate.x(), point_on_plate.y()));
-        w.emit_f(this->config.travel_speed.get_at(get_process_config_idx(this->config, filament()->id())) * 60.0);
+        w.emit_f(this->config.travel_speed.get_at(m_current_process_config_idx) * 60.0);
         w.emit_comment(GCodeWriter::full_gcode_comment, comment);
         out_string = w.string() + _travel_to_z(point_on_plate.z(), comment);
     } else {
         GCodeG1Formatter w;
         w.emit_xyz(point_on_plate);
-        w.emit_f(this->config.travel_speed.get_at(get_process_config_idx(this->config, filament()->id())) * 60.0);
+        w.emit_f(this->config.travel_speed.get_at(m_current_process_config_idx) * 60.0);
         w.emit_comment(GCodeWriter::full_gcode_comment, comment);
         out_string = w.string();
     }
@@ -648,9 +650,9 @@ std::string GCodeWriter::_travel_to_z(double z, const std::string &comment, bool
 {
     m_pos(2) = z;
 
-    double speed = this->config.travel_speed_z.get_at(get_process_config_idx(this->config, filament()->id()));
+    double speed = this->config.travel_speed_z.get_at(m_current_process_config_idx);
     if (speed == 0.)
-        speed = this->config.travel_speed.get_at(get_process_config_idx(this->config, filament()->id()));
+        speed = this->config.travel_speed.get_at(m_current_process_config_idx);
     if (tool_change && this->config.prime_tower_lift_speed.value>0) {
         speed = this->config.prime_tower_lift_speed.value; // lift speed
     }
@@ -666,9 +668,9 @@ std::string GCodeWriter::_spiral_travel_to_z(double z, const Vec2d &ij_offset, c
 {
     m_pos(2) = z;
 
-    double speed = this->config.travel_speed_z.get_at(get_process_config_idx(this->config, filament()->id()));
+    double speed = this->config.travel_speed_z.get_at(m_current_process_config_idx);
     if (speed == 0.)
-        speed = this->config.travel_speed.get_at(get_process_config_idx(this->config, filament()->id()));
+        speed = this->config.travel_speed.get_at(m_current_process_config_idx);
     if (tool_change && this->config.prime_tower_lift_speed.value>0) {
         speed = this->config.prime_tower_lift_speed.value; // lift speed
     }
@@ -965,6 +967,7 @@ void GCodeWriter::init_extruder(unsigned int filament_id,unsigned int nozzle_id)
         assert(filament_extruder_iter != m_filament_extruders.end() && filament_extruder_iter->id() == filament_id);
         m_curr_extruder_id = nozzle_id>0;
         m_curr_filament_extruder[m_curr_extruder_id] = &*filament_extruder_iter;
+        m_current_process_config_idx = get_process_config_idx(this->config, filament_id);
     }
 }
 

--- a/src/libslic3r/GCodeWriter.hpp
+++ b/src/libslic3r/GCodeWriter.hpp
@@ -26,6 +26,7 @@ public:
     GCodeWriter() :
         multiple_extruders(false), m_curr_filament_extruder{ nullptr,nullptr },
         m_curr_extruder_id (-1),
+        m_current_process_config_idx(0),
         m_single_extruder_multi_material(false),
         m_last_acceleration(0), m_max_acceleration(0),
         m_last_jerk(0), m_max_jerk(0),
@@ -142,6 +143,7 @@ private:
     bool            m_single_extruder_multi_material;
     std::vector<Extruder*> m_curr_filament_extruder;
     int        m_curr_extruder_id;
+    size_t     m_current_process_config_idx;
     unsigned int    m_last_acceleration;
     // Limit for setting the acceleration, to respect the machine limits set for the Marlin firmware.
     // If set to zero, the limit is not in action.

--- a/tests/fff_print/CMakeLists.txt
+++ b/tests/fff_print/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(${_TEST_NAME}_tests
 	test_flow.cpp
 	test_gcode.cpp
 	test_gcodewriter.cpp
+	test_gcodewriter_travel.cpp
 	test_model.cpp
 	test_print.cpp
 	test_printgcode.cpp

--- a/tests/fff_print/test_gcodewriter_travel.cpp
+++ b/tests/fff_print/test_gcodewriter_travel.cpp
@@ -1,0 +1,17 @@
+#include <catch2/catch.hpp>
+
+#include "libslic3r/GCodeWriter.hpp"
+
+using namespace Slic3r;
+
+TEST_CASE("Travel before initial tool selection uses the default process configuration", "[GCodeWriter]")
+{
+    GCodeWriter writer;
+    writer.config.travel_speed.values   = {150.0};
+    writer.config.travel_speed_z.values = {0.0};
+    writer.set_extruders({0, 1});
+
+    REQUIRE(writer.filament() == nullptr);
+    REQUIRE_THAT(writer.travel_to_xy(Vec2d(10.0, 20.0)), Catch::Contains("F9000"));
+    REQUIRE_THAT(writer.travel_to_z(0.2), Catch::Contains("F9000"));
+}


### PR DESCRIPTION
## Summary

- keep a safe process configuration index for travel moves before the first filament is selected
- refresh the cached index when an extruder is initialized or changed
- use the cached configuration for XY, XYZ, Z, and spiral-Z travel speeds
- add a regression test covering XY and Z travel without an active filament

## Problem

Some multi-extruder configurations may generate a travel move before initial tool selection. Travel speed lookup currently dereferences the active filament even though no filament has been selected yet, causing a null-pointer crash.

Until the first tool is selected, travel moves now use the base process configuration at index 0. Normal per-extruder configuration lookup resumes as soon as a filament becomes active.

## Testing

- `GCodeWriter.cpp` syntax-checked using the existing generated compiler command
- isolated regression test syntax-checked with the same compiler configuration
- verified that all affected travel-speed lookups use the cached process configuration index