### PR TITLE
Reset extrusion after PA pattern calibration

### DIFF
--- a/src/libslic3r/Calib.cpp
+++ b/src/libslic3r/Calib.cpp
@@ -639,6 +639,7 @@ void CalibPressureAdvancePattern::generate_custom_gcodes(const DynamicPrintConfi
         }
     }
 
+    gcode << m_writer.reset_e();
     gcode << m_writer.set_pressure_advance(m_is_bbl_bowden ? 0.4 : m_params.start, m_is_bbl_bowden);
     gcode << "; end pressure advance pattern for layer\n";
 

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(${_TEST_NAME}_tests
 	${_TEST_NAME}_tests.cpp
 	test_3mf.cpp
 	test_aabbindirect.cpp
+	test_calib_pa_pattern.cpp
 	test_clipper_offset.cpp
 	test_clipper_utils.cpp
 	test_config.cpp

--- a/tests/libslic3r/test_calib_pa_pattern.cpp
+++ b/tests/libslic3r/test_calib_pa_pattern.cpp
@@ -1,0 +1,82 @@
+#include <catch2/catch.hpp>
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+
+#include "libslic3r/Calib.hpp"
+#include "libslic3r/Model.hpp"
+#include "libslic3r/TriangleMesh.hpp"
+
+using namespace Slic3r;
+
+namespace {
+
+struct ExtrusionState {
+    double final_e;
+    double max_e;
+};
+
+ExtrusionState simulate_absolute_e(const std::string &gcode)
+{
+    double final_e = 0.;
+    double max_e   = 0.;
+
+    std::istringstream lines(gcode);
+    std::string line;
+    while (std::getline(lines, line)) {
+        std::istringstream words(line);
+        std::string command;
+        if (!(words >> command) ||
+            (command != "G0" && command != "G1" && command != "G92"))
+            continue;
+
+        std::string word;
+        while (words >> word) {
+            if (word.size() >= 2 && word.front() == 'E') {
+                final_e = std::stod(word.substr(1));
+                max_e   = std::max(max_e, final_e);
+                break;
+            }
+        }
+    }
+
+    return {final_e, max_e};
+}
+
+} // namespace
+
+TEST_CASE("PA pattern resets extrusion after its final layer in absolute E mode", "[Calib][Regression]")
+{
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        {"use_relative_e_distances", "0"},
+        {"line_width", "0.45"},
+        {"initial_layer_line_width", "0.45"},
+    });
+
+    Model model;
+    model.add_object("cube", "", make_cube(20., 20., 20.))->add_instance();
+
+    Calib_Params params;
+    params.mode  = CalibMode::Calib_PA_Pattern;
+    params.start = 0.;
+    params.end   = 0.08;
+    params.step  = 0.002;
+
+    CalibPressureAdvancePattern pattern(
+        params, config, false, model, Vec3d::Zero());
+    pattern.generate_custom_gcodes(
+        config, false, model, Vec3d::Zero());
+
+    std::string gcode;
+    for (const CustomGCode::Item &item :
+         model.plates_custom_gcodes.at(model.curr_plate_index).gcodes)
+        gcode += item.extra;
+
+    const ExtrusionState state = simulate_absolute_e(gcode);
+    REQUIRE(state.max_e > 1.);
+    REQUIRE_THAT(
+        state.final_e,
+        Catch::Matchers::WithinAbs(0., 1e-9));
+}


### PR DESCRIPTION
## Summary

- reset the extruder position after the final pressure advance pattern layer
- preserve existing behavior for relative-E configurations, where the reset is a no-op
- add a focused regression test for the generated absolute-E sequence

## Problem

The pressure advance pattern resets the extruder between layers but not after its final layer. With absolute E coordinates, the pattern therefore hands the following object a large accumulated extrusion position.

The next retraction may then attempt to retract that entire value in one move, which can disrupt extrusion or clog the hotend.

The pattern now emits the same `G92 E0` reset after its final layer before handing control back to the normal print.

## Testing

- `Calib.cpp` syntax-checked using the existing generated compiler command
- isolated calibration regression test syntax-checked with the same compiler configuration
- regression test verifies that the pattern performs real extrusion and finishes with absolute E at zero