### PR TITLE
Handle automatic line widths in PA pattern calibration

### DIFF
--- a/src/libslic3r/Calib.cpp
+++ b/src/libslic3r/Calib.cpp
@@ -663,6 +663,24 @@ void CalibPressureAdvancePattern::set_start_offset(const Vec3d &offset)
 
 Vec3d CalibPressureAdvancePattern::get_start_offset() { return m_starting_point; }
 
+double CalibPressureAdvancePattern::line_width_first_layer() const
+{
+    const double width = m_config.get_abs_value("initial_layer_line_width");
+    // Zero selects the default line width, matching normal slicing.
+    return width > 0. ? width : line_width();
+}
+
+double CalibPressureAdvancePattern::line_width() const
+{
+    const double width = m_config.get_abs_value("line_width");
+    if (width > 0.)
+        return width;
+
+    // Zero also enables automatic width for the default itself.
+    const double nozzle_diameter = m_config.option<ConfigOptionFloatsNullable>("nozzle_diameter")->get_at(m_params.extruder_id);
+    return Flow::auto_extrusion_width(frExternalPerimeter, float(nozzle_diameter));
+}
+
 void CalibPressureAdvancePattern::refresh_setup(const DynamicPrintConfig &config, bool is_bbl_machine, const Model &model, const Vec3d &origin)
 {
     m_config = config;

--- a/src/libslic3r/Calib.hpp
+++ b/src/libslic3r/Calib.hpp
@@ -319,8 +319,8 @@ public:
 protected:
     double speed_first_layer() const { return m_config.option<ConfigOptionFloatsNullable>("initial_layer_speed")->get_at(m_params.extruder_id); };
     double speed_perimeter() const { return m_config.option<ConfigOptionFloatsNullable>("outer_wall_speed")->get_at(m_params.extruder_id); };
-    double line_width_first_layer() const { return m_config.get_abs_value("initial_layer_line_width"); };
-    double line_width() const { return m_config.get_abs_value("line_width"); };
+    double line_width_first_layer() const;
+    double line_width() const;
     int    wall_count() const { return m_config.option<ConfigOptionInt>("wall_loops")->value; };
 
 private:

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(${_TEST_NAME}_tests
 	${_TEST_NAME}_tests.cpp
 	test_3mf.cpp
 	test_aabbindirect.cpp
+	test_calib_pa_width.cpp
 	test_clipper_offset.cpp
 	test_clipper_utils.cpp
 	test_config.cpp

--- a/tests/libslic3r/test_calib_pa_width.cpp
+++ b/tests/libslic3r/test_calib_pa_width.cpp
@@ -1,0 +1,32 @@
+#include <catch2/catch.hpp>
+
+#include "libslic3r/Calib.hpp"
+#include "libslic3r/Model.hpp"
+#include "libslic3r/TriangleMesh.hpp"
+
+using namespace Slic3r;
+
+TEST_CASE("PA pattern resolves automatic line widths", "[Calib][Regression]")
+{
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        {"initial_layer_line_width", "0"},
+        {"line_width", "0"},
+    });
+
+    Model model;
+    model.add_object("cube", "", make_cube(20., 20., 20.))->add_instance();
+
+    Calib_Params params;
+    params.mode  = CalibMode::Calib_PA_Pattern;
+    params.start = 0.;
+    params.end   = 0.08;
+    params.step  = 0.002;
+
+    CalibPressureAdvancePattern pattern(params, config, false, model, Vec3d::Zero());
+    REQUIRE_NOTHROW(pattern.generate_custom_gcodes(config, false, model, Vec3d::Zero()));
+
+    const auto &gcodes = model.plates_custom_gcodes.at(model.curr_plate_index).gcodes;
+    REQUIRE_FALSE(gcodes.empty());
+    REQUIRE_FALSE(gcodes.front().extra.empty());
+}


### PR DESCRIPTION
## Summary

- resolve a zero initial-layer line width through the default line width
- derive a safe automatic width from the active nozzle when the default is also zero
- add regression coverage for generating a PA pattern with both width settings set to automatic

## Problem

The PA pattern calibration reads the configured line widths directly. A value of zero means automatic sizing during normal slicing, but the calibration treated it as a literal zero. This could feed an invalid width into the flow calculation and abort PA pattern generation.

## Solution

The calibration now follows the normal fallback chain:

1. use the configured initial-layer width when it is positive
2. otherwise use the default line width
3. if that is also automatic, derive the width from the active nozzle diameter

## Testing

- targeted C++ syntax check for `Calib.cpp`
- targeted C++ syntax check for the new regression test
- `git diff --check`
