### PR TITLE
Keep Arachne beading interpolation in bounds

### DIFF
--- a/src/libslic3r/Arachne/SkeletalTrapezoidation.cpp
+++ b/src/libslic3r/Arachne/SkeletalTrapezoidation.cpp
@@ -1706,7 +1706,7 @@ void SkeletalTrapezoidation::propagateBeadingsDownward(edge_t* edge_to_peak, ptr
 }
 
 
-SkeletalTrapezoidation::Beading SkeletalTrapezoidation::interpolate(const Beading& left, double ratio_left_to_whole, const Beading& right, coord_t switching_radius) const
+SkeletalTrapezoidation::Beading SkeletalTrapezoidation::interpolate(const Beading& left, double ratio_left_to_whole, const Beading& right, coord_t switching_radius)
 {
     assert(ratio_left_to_whole >= 0.0 && ratio_left_to_whole <= 1.0);
     Beading ret = interpolate(left, ratio_left_to_whole, right);
@@ -1730,6 +1730,12 @@ SkeletalTrapezoidation::Beading SkeletalTrapezoidation::interpolate(const Beadin
     { // We cant adjust to fit the next edge because there is no previous one?!
         return ret;
     }
+    // The merged beading follows the thicker side, which may contain fewer
+    // insets than the left side used to calculate next_inset_idx.
+    if (next_inset_idx >= coord_t(ret.toolpath_locations.size()))
+    {
+        return ret;
+    }
     assert(next_inset_idx < coord_t(left.toolpath_locations.size()));
     assert(left.toolpath_locations[next_inset_idx] <= switching_radius);
     assert(left.toolpath_locations[next_inset_idx + 1] >= switching_radius);
@@ -1749,7 +1755,7 @@ SkeletalTrapezoidation::Beading SkeletalTrapezoidation::interpolate(const Beadin
 }
 
 
-SkeletalTrapezoidation::Beading SkeletalTrapezoidation::interpolate(const Beading& left, double ratio_left_to_whole, const Beading& right) const
+SkeletalTrapezoidation::Beading SkeletalTrapezoidation::interpolate(const Beading& left, double ratio_left_to_whole, const Beading& right)
 {
     assert(ratio_left_to_whole >= 0.0 && ratio_left_to_whole <= 1.0);
     float ratio_right_to_whole = 1.0 - ratio_left_to_whole;

--- a/src/libslic3r/Arachne/SkeletalTrapezoidation.hpp
+++ b/src/libslic3r/Arachne/SkeletalTrapezoidation.hpp
@@ -515,7 +515,7 @@ protected:
      * beads.
      * \return The beading at the interpolated location.
      */
-    Beading interpolate(const Beading& left, double ratio_left_to_whole, const Beading& right, coord_t switching_radius) const;
+    static Beading interpolate(const Beading& left, double ratio_left_to_whole, const Beading& right, coord_t switching_radius);
 
     /*!
      * Subroutine of \ref interpolate(const Beading&, Ratio, const Beading&, coord_t)
@@ -528,7 +528,7 @@ protected:
      * \param right One of the beadings to interpolate between.
      * \return The beading at the interpolated location.
      */
-    Beading interpolate(const Beading& left, double ratio_left_to_whole, const Beading& right) const;
+    static Beading interpolate(const Beading& left, double ratio_left_to_whole, const Beading& right);
 
     /*!
      * Get the beading at a certain node of the skeletal graph, or create one if

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(${_TEST_NAME}_tests
 	${_TEST_NAME}_tests.cpp
 	test_3mf.cpp
 	test_aabbindirect.cpp
+	test_arachne_beading.cpp
 	test_clipper_offset.cpp
 	test_clipper_utils.cpp
 	test_config.cpp

--- a/tests/libslic3r/test_arachne_beading.cpp
+++ b/tests/libslic3r/test_arachne_beading.cpp
@@ -1,0 +1,42 @@
+#include <catch2/catch.hpp>
+
+#include "libslic3r/Arachne/SkeletalTrapezoidation.hpp"
+
+using namespace Slic3r;
+using namespace Slic3r::Arachne;
+
+namespace {
+
+struct InterpolationProbe : SkeletalTrapezoidation {
+    using SkeletalTrapezoidation::interpolate;
+};
+
+} // namespace
+
+TEST_CASE("Arachne beading interpolation handles fewer insets on the thicker side", "[Arachne][Regression]")
+{
+    using Beading = BeadingStrategy::Beading;
+
+    const coord_t width = scaled<coord_t>(0.42);
+
+    Beading left;
+    left.total_thickness    = scaled<coord_t>(1.0);
+    left.bead_widths        = {width, width, width, width};
+    left.toolpath_locations = {scaled<coord_t>(0.1), scaled<coord_t>(0.3), scaled<coord_t>(0.5), scaled<coord_t>(0.7)};
+    left.left_over          = 0;
+
+    Beading right;
+    right.total_thickness    = scaled<coord_t>(2.0);
+    right.bead_widths        = {width, width};
+    right.toolpath_locations = {scaled<coord_t>(0.1), scaled<coord_t>(0.3)};
+    right.left_over          = 0;
+
+    const coord_t switching_radius = scaled<coord_t>(0.6);
+
+    Beading result;
+    REQUIRE_NOTHROW(result = InterpolationProbe::interpolate(left, 0.5, right, switching_radius));
+
+    const Beading expected = InterpolationProbe::interpolate(left, 0.5, right);
+    REQUIRE(result.toolpath_locations == expected.toolpath_locations);
+    REQUIRE(result.bead_widths == expected.bead_widths);
+}


### PR DESCRIPTION
## Summary

- prevent an out-of-bounds access during Arachne beading interpolation
- skip the transition adjustment when the merged beading has no corresponding inset
- add focused regression coverage for mismatched inset counts

The interpolation index is derived from the left-side beading, while the merged result follows the thicker side. If that side contains fewer insets, the previous code could index past the end of the merged toolpath locations while generating walls.

## Testing

- syntax-checked `SkeletalTrapezoidation.cpp` using the existing Release build flags
- syntax-checked `test_arachne_beading.cpp` using the same build configuration