### PR TITLE
Avoid crash when transforming the prime tower

### DIFF
--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -2037,6 +2037,9 @@ void Selection::rotate(unsigned int object_idx, unsigned int instance_idx, unsig
 //BBS: add partplate related logic
 void Selection::notify_instance_update(int object_idx, int instance_idx)
 {
+    if (object_idx >= 1000)
+        return;
+
     //BBS: notify instance updates to part plater list
     PartPlateList& plate_list = wxGetApp().plater()->get_partplate_list();
 
@@ -2047,6 +2050,9 @@ void Selection::notify_instance_update(int object_idx, int instance_idx)
         for (unsigned int i : list)
         {
             int obj_index = (*m_volumes)[i]->object_idx();
+            if (obj_index >= 1000)
+                continue;
+
             //-1 means all the instance in this object
             if (instance_idx == -1)
             {


### PR DESCRIPTION
## Summary

- ignore synthetic prime tower object IDs during instance update notifications
- cover both direct and selection-wide notification paths
- prevent prime tower transforms from indexing the model object list out of bounds

Prime towers use synthetic object IDs starting at 1000. Transform operations share the normal instance-update path, which previously treated those IDs as indices into `Model::objects`. Rotating, scaling, or mirroring a selected prime tower could therefore access invalid memory.

## Testing

- syntax-checked `Selection.cpp` using the existing Release GUI build flags
- verified guards for both direct and selection-wide update notifications