### PR TITLE
Handle skirt flow on empty plates

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1769,7 +1769,7 @@ Flow Print::skirt_flow() const
 {
     ConfigOptionFloat width = m_config.initial_layer_line_width;
     if (width.value == 0)
-        width = m_objects.front()->config().line_width;
+        width = m_objects.empty() ? m_config.initial_layer_line_width : m_objects.front()->config().line_width;
 
     /* We currently use a random object's support material extruder.
        While this works for most cases, we should probably consider all of the support material
@@ -1779,7 +1779,7 @@ Flow Print::skirt_flow() const
     return Flow::new_from_config_width(
         frPerimeter,
 		width,
-		(float)m_config.nozzle_diameter.get_at(m_objects.front()->config().support_filament-1),
+		(float)m_config.nozzle_diameter.get_at(m_objects.empty() ? 0 : m_objects.front()->config().support_filament-1),
 		(float)this->skirt_first_layer_height());
 }
 

--- a/tests/fff_print/CMakeLists.txt
+++ b/tests/fff_print/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(${_TEST_NAME}_tests
 	test_printgcode.cpp
 	test_printobject.cpp
 	test_skirt_brim.cpp
+	test_skirt_flow.cpp
 	test_support_material.cpp
 	test_trianglemesh.cpp
 	)

--- a/tests/fff_print/test_skirt_flow.cpp
+++ b/tests/fff_print/test_skirt_flow.cpp
@@ -1,0 +1,25 @@
+#include <catch2/catch.hpp>
+
+#include "libslic3r/Print.hpp"
+
+using namespace Slic3r;
+
+TEST_CASE("Skirt flow is available for an empty plate", "[Print][Skirt][Regression]")
+{
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        {"skirt_per_object", "1"},
+        {"skirt_loops", "1"},
+        {"initial_layer_line_width", "0"},
+    });
+
+    Print print;
+    Model model;
+    print.apply(model, config);
+
+    REQUIRE(print.empty());
+
+    Flow flow;
+    REQUIRE_NOTHROW(flow = print.skirt_flow());
+    REQUIRE(flow.width() > 0.);
+}


### PR DESCRIPTION
## Summary

- avoid dereferencing the first print object when calculating skirt flow for an empty plate
- use the global automatic line width and first nozzle as safe fallbacks
- add regression coverage for skirt-flow calculation without model objects

## Problem

With per-object skirts enabled, arranging can request skirt flow before an object exists on the plate. The calculation previously accessed the first print object unconditionally, causing a crash on an empty plate.

## Testing

- syntax-checked `src/libslic3r/Print.cpp`
- syntax-checked `tests/fff_print/test_skirt_flow.cpp`
- verified the empty-plate fallback paths and test registration
