### PR TITLE
Handle null windows in bitmap scaling

### DIFF
--- a/src/slic3r/GUI/wxExtensions.cpp
+++ b/src/slic3r/GUI/wxExtensions.cpp
@@ -455,7 +455,7 @@ wxBitmap create_scaled_bitmap(  const std::string& bmp_name_in,
         return create_scaled_bitmap2(bmp_name_in, cache, win, px_cnt, grayscale, resize, array_new_color);
     }
     unsigned int width = 0;
-    unsigned int height = (unsigned int) (win->FromDIP(px_cnt) + 0.5f);
+    unsigned int height = (unsigned int) (wxWindow::FromDIP(px_cnt, win) + 0.5f);
 
     std::string bmp_name = bmp_name_in;
     boost::replace_last(bmp_name, ".png", "");
@@ -469,7 +469,7 @@ wxBitmap create_scaled_bitmap(  const std::string& bmp_name_in,
     // Try loading an SVG first, then PNG if SVG is not found:
     wxBitmap *bmp = cache.load_svg(bmp_name, width, height, grayscale, dark_mode, new_color, resize ? em_unit(win) * 0.1f : 0.f);
     if (bmp == nullptr) {
-        bmp = cache.load_png(bmp_name, width, height, grayscale, resize ? win->FromDIP(10) * 0.1f : 0.f);
+        bmp = cache.load_png(bmp_name, width, height, grayscale, resize ? wxWindow::FromDIP(10, win) * 0.1f : 0.f);
     }
 
     if (bmp == nullptr) {
@@ -492,7 +492,7 @@ wxBitmap create_scaled_bitmap2(const std::string& bmp_name_in, Slic3r::GUI::Bitm
     const vector<std::string>& array_new_color/* = vector<std::string>()*/) // color witch will used instead of orange
 {
     unsigned int width = 0;
-    unsigned int height = (unsigned int)(win->FromDIP(px_cnt) + 0.5f);
+    unsigned int height = (unsigned int)(wxWindow::FromDIP(px_cnt, win) + 0.5f);
 
     std::string bmp_name = bmp_name_in;
     boost::replace_last(bmp_name, ".png", "");


### PR DESCRIPTION
## Summary

- use the null-safe static DPI conversion in scaled bitmap helpers
- apply the conversion consistently to SVG and PNG sizing
- preserve DPI-aware scaling when no owning window is available

## Problem

The scaled bitmap helpers explicitly allow a null window, and many GUI call sites use them that way. They nevertheless invoked `FromDIP` as an instance method through that pointer.

Calling a member function through a null pointer is undefined behavior and can crash optimized builds. The static overload accepts the optional window context directly.

## Testing

- syntax-checked `src/slic3r/GUI/wxExtensions.cpp` with the existing build configuration
- verified all three unsafe instance calls were replaced
- verified 118 existing GUI call sites pass a null window
