### PR TITLE
Initialize print plate origin

### DIFF
--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -1204,7 +1204,7 @@ private:
     std::vector<unsigned int> m_slice_used_filaments_first_layer;
 
     //BBS: plate's origin
-    Vec3d   m_origin;
+    Vec3d   m_origin {0., 0., 0.};
     //BBS: modified_count
     int     m_modified_count {0};
     //BBS

--- a/tests/fff_print/test_print.cpp
+++ b/tests/fff_print/test_print.cpp
@@ -9,6 +9,13 @@
 using namespace Slic3r;
 using namespace Slic3r::Test;
 
+TEST_CASE("Print plate origin starts at zero", "[Print][Regression]")
+{
+    Print print;
+
+    REQUIRE(print.get_plate_origin().isApprox(Vec3d::Zero()));
+}
+
 SCENARIO("PrintObject: Perimeter generation", "[PrintObject]") {
     GIVEN("20mm cube and default config") {
         WHEN("make_perimeters() is called")  {


### PR DESCRIPTION
## Summary

- initialize the plate origin of a new `Print` instance to zero
- prevent coordinate calculations from using indeterminate values
- add focused regression coverage to the existing Print test suite

## Problem

`Print::m_origin` had no initializer, while the default constructor did not assign it. Code that reads the origin before `set_plate_origin()` could therefore receive indeterminate coordinates.

The origin is used by wipe tower placement and coordinate conversion, so invalid values can propagate into geometry calculations and range checks.

## Testing

- syntax-checked `src/libslic3r/Print.cpp` with the changed header
- syntax-checked the focused plate-origin regression case against the current `Print` interface
- verified the regression case is included in `tests/fff_print/test_print.cpp`