### PR TITLE
Add realistic 3D editor view

### DIFF
--- a/resources/shaders/110/normal.fs
+++ b/resources/shaders/110/normal.fs
@@ -1,0 +1,20 @@
+#version 110
+
+// Encodes the world-space normal into [0, 1] for the SSAO pass.
+
+varying vec3 world_normal;
+varying vec3 clipping_planes_dots;
+
+void main()
+{
+    if (any(lessThan(
+            clipping_planes_dots,
+            vec3(0.0)))) {
+        discard;
+    }
+
+    vec3 normal = normalize(world_normal);
+
+    gl_FragColor =
+        vec4(normal * 0.5 + 0.5, 1.0);
+}

--- a/resources/shaders/110/normal.vs
+++ b/resources/shaders/110/normal.vs
@@ -1,0 +1,36 @@
+#version 110
+
+// Writes world-space normals into a G-buffer consumed by the SSAO pass.
+
+uniform mat4 view_model_matrix;
+uniform mat4 projection_matrix;
+uniform mat4 volume_world_matrix;
+uniform mat3 volume_world_normal_matrix;
+
+uniform vec2 z_range;
+uniform vec4 clipping_plane;
+
+attribute vec3 v_position;
+attribute vec3 v_normal;
+
+varying vec3 world_normal;
+varying vec3 clipping_planes_dots;
+
+void main()
+{
+    vec4 world_position =
+        volume_world_matrix * vec4(v_position, 1.0);
+
+    world_normal =
+        volume_world_normal_matrix * v_normal;
+
+    clipping_planes_dots = vec3(
+        dot(world_position, clipping_plane),
+        world_position.z - z_range.x,
+        z_range.y - world_position.z);
+
+    gl_Position =
+        projection_matrix *
+        view_model_matrix *
+        vec4(v_position, 1.0);
+}

--- a/resources/shaders/110/phong.fs
+++ b/resources/shaders/110/phong.fs
@@ -1,0 +1,247 @@
+#version 110
+
+const vec3 ZERO = vec3(0.0, 0.0, 0.0);
+const vec3 LightRed = vec3(0.78, 0.0, 0.0);
+const vec3 LightBlue = vec3(0.73, 1.0, 1.0);
+const float EPSILON = 0.0001;
+
+#define INTENSITY_CORRECTION 0.6
+#define PHONG_BRIGHTNESS     1.0
+
+// normalized values for (-0.6/1.31, 0.6/1.31, 1./1.31)
+const vec3 LIGHT_TOP_DIR = vec3(-0.4574957, 0.4574957, 0.7624929);
+#define LIGHT_TOP_DIFFUSE    (0.8 * INTENSITY_CORRECTION)
+#define LIGHT_TOP_SPECULAR   (0.8 * INTENSITY_CORRECTION)
+#define LIGHT_TOP_SHININESS  128.0
+
+// normalized values for (1./1.43, 0.2/1.43, 1./1.43)
+const vec3 LIGHT_FRONT_DIR = vec3(0.6985074, 0.1397015, 0.6985074);
+#define LIGHT_FRONT_DIFFUSE  (0.3 * INTENSITY_CORRECTION)
+#define LIGHT_FRONT_SPECULAR (0.28 * INTENSITY_CORRECTION)
+#define LIGHT_FRONT_SHININESS 64.0
+
+#define INTENSITY_AMBIENT    0.22
+#define WINDOW_REFLECTION_INTENSITY 0.55
+
+struct PrintVolumeDetection
+{
+    // 0 = rectangle, 1 = circle, 2 = custom, 3 = invalid
+    int type;
+    // type = 0 (rectangle):
+    // x = min.x, y = min.y, z = max.x, w = max.y
+    // type = 1 (circle):
+    // x = center.x, y = center.y, z = radius
+    vec4 xy_data;
+    // x = min z, y = max z
+    vec2 z_data;
+};
+
+struct SlopeDetection
+{
+    bool actived;
+    float normal_z;
+    mat3 volume_world_normal_matrix;
+};
+
+uniform vec4 uniform_color;
+uniform bool use_color_clip_plane;
+uniform vec4 uniform_color_clip_plane_1;
+uniform vec4 uniform_color_clip_plane_2;
+uniform SlopeDetection slope;
+
+//BBS: add outline_color
+uniform bool is_outline;
+uniform sampler2D depth_tex;
+uniform vec2 screen_size;
+
+#ifdef ENABLE_ENVIRONMENT_MAP
+    uniform sampler2D environment_tex;
+    uniform bool use_environment_tex;
+#endif // ENABLE_ENVIRONMENT_MAP
+
+uniform PrintVolumeDetection print_volume;
+
+uniform float z_far;
+uniform float z_near;
+uniform bool enable_ssao;
+
+varying vec3 clipping_planes_dots;
+varying float color_clip_plane_dot;
+
+varying vec4 world_pos;
+varying float world_normal_z;
+varying vec3 eye_normal;
+varying vec3 eye_position;
+
+vec3 getBackfaceColor(vec3 fill) {
+    float brightness = 0.2126 * fill.r + 0.7152 * fill.g + 0.0722 * fill.b;
+    return (brightness > 0.75) ? vec3(0.11, 0.165, 0.208) : vec3(0.988, 0.988, 0.988);
+}
+
+// Silhouette edge detection & rendering algorithm by leoneruggiero
+// https://www.shadertoy.com/view/DslXz2
+#define INFLATE 1
+
+float GetTolerance(float d, float k)
+{
+    float A = -(z_far+z_near)/(z_far-z_near);
+    float B = -2.0*z_far*z_near /(z_far-z_near);
+
+    d = d*2.0-1.0;
+
+    return -k*(d+A)*(d+A)/B;
+}
+
+float DetectSilho(vec2 fragCoord, vec2 dir)
+{
+    float x0 = abs(texture2D(depth_tex, (fragCoord + dir*-2.0) / screen_size).r);
+    float x1 = abs(texture2D(depth_tex, (fragCoord + dir*-1.0) / screen_size).r);
+    float x2 = abs(texture2D(depth_tex, (fragCoord + dir* 0.0) / screen_size).r);
+    float x3 = abs(texture2D(depth_tex, (fragCoord + dir* 1.0) / screen_size).r);
+
+    float d0 = (x1-x0);
+    float d1 = (x2-x3);
+
+    float r0 = x1 + d0 - x2;
+    float r1 = x2 + d1 - x1;
+
+    float tol = GetTolerance(x2, 0.04);
+
+    return smoothstep(0.0, tol*tol, max( - r0*r1, 0.0));
+}
+
+float DetectSilho(vec2 fragCoord)
+{
+    return max(
+        DetectSilho(fragCoord, vec2(1,0)),
+        DetectSilho(fragCoord, vec2(0,1))
+        );
+}
+
+float compute_ssao_factor(vec3 normal, vec3 view_dir, vec3 eye_pos)
+{
+    vec3 normal_dx = dFdx(normal);
+    vec3 normal_dy = dFdy(normal);
+    float normal_variation = clamp(length(normal_dx) + length(normal_dy), 0.0, 1.0);
+
+    float depth_gradient = clamp(length(vec2(dFdx(eye_pos.z), dFdy(eye_pos.z))) * 0.8, 0.0, 1.0);
+
+    float cavity = clamp(normal_variation * 0.70 + depth_gradient * 0.60, 0.0, 1.0);
+    float cavity_mask = smoothstep(0.25, 0.75, cavity);
+    float ao_strength = pow(cavity, 1.15) * cavity_mask;
+    return clamp(1.0 - ao_strength * 0.90, 0.25, 1.0);
+}
+
+float soft_circle(vec2 p, vec2 center, float radius, float blur)
+{
+    float dist = distance(p, center);
+    return 1.0 - smoothstep(radius - blur, radius, dist);
+}
+
+vec3 compute_window_reflection(vec3 normal, vec3 view_dir)
+{
+    const vec3 LIGHT_TOP_DIR = vec3(-0.4574957, 0.4574957, 0.7624929);
+
+    vec3 light_dir = normalize(LIGHT_TOP_DIR);
+    vec3 reflect_light = normalize(reflect(-light_dir, normal));
+
+    // UV coordinates for the reflection
+    vec2 uv = (reflect_light.xy / (1.0 + max(reflect_light.z, 0.3))) * 2.2;
+
+    vec2 grad = fwidth(uv) * 0.8;
+    float blur = 0.12 + grad.x * 1.5;
+
+    // === CIRCULAR WINDOW (porthole style) ===
+    // Single round window, no bars
+    vec2 window_center = vec2(0.0, 0.0);
+    float window_radius = 0.5;  // Radius of the circular window
+
+    float window_light = soft_circle(uv, window_center, window_radius, blur);
+
+    // No bars - just pure circular glass
+    float bars = 1.0;
+
+    // Fresnel effect for edge glow
+    float fresnel = pow(1.0 - max(dot(normal, view_dir), 0.0), 1.0);
+    float facing = smoothstep(-0.4, 0.6, reflect_light.z);
+
+    float intensity = window_light * bars * (0.25 + 0.25 * fresnel) * facing;
+    intensity = clamp(intensity, 0.0, 0.45);
+
+    return vec3(intensity);
+}
+
+void main()
+{
+    if (any(lessThan(clipping_planes_dots, ZERO)))
+        discard;
+
+    vec4 color;
+    if (use_color_clip_plane) {
+        color.rgb = (color_clip_plane_dot < 0.0) ? uniform_color_clip_plane_1.rgb : uniform_color_clip_plane_2.rgb;
+        color.a = uniform_color.a;
+    }
+    else
+        color = uniform_color;
+
+    if (slope.actived) {
+         if(world_pos.z<0.1 && world_pos.z>-0.1)
+         {
+                color.rgb = LightBlue;
+                color.a = 0.8;
+         }
+         else if( world_normal_z < slope.normal_z - EPSILON)
+         {
+                color.rgb = color.rgb * 0.5 + LightRed * 0.5;
+                color.a = 0.8;
+         }
+    }
+
+    vec3 pv_check_min = ZERO;
+    vec3 pv_check_max = ZERO;
+    if (print_volume.type == 0) {
+        pv_check_min = world_pos.xyz - vec3(print_volume.xy_data.x, print_volume.xy_data.y, print_volume.z_data.x);
+        pv_check_max = world_pos.xyz - vec3(print_volume.xy_data.z, print_volume.xy_data.w, print_volume.z_data.y);
+    }
+    else if (print_volume.type == 1) {
+        float delta_radius = print_volume.xy_data.z - distance(world_pos.xy, print_volume.xy_data.xy);
+        pv_check_min = vec3(delta_radius, 0.0, world_pos.z - print_volume.z_data.x);
+        pv_check_max = vec3(0.0, 0.0, world_pos.z - print_volume.z_data.y);
+    }
+    color.rgb = (any(lessThan(pv_check_min, ZERO)) || any(greaterThan(pv_check_max, ZERO))) ? mix(color.rgb, ZERO, 0.3333) : color.rgb;
+
+    vec3 normal = normalize(eye_normal);
+    vec3 view_dir = normalize(-eye_position);
+
+    float NdotL_top = max(dot(normal, LIGHT_TOP_DIR), 0.0);
+    float diffuse = INTENSITY_AMBIENT + NdotL_top * LIGHT_TOP_DIFFUSE;
+    vec3 half_top = normalize(LIGHT_TOP_DIR + view_dir);
+    float specular = LIGHT_TOP_SPECULAR * pow(max(dot(normal, half_top), 0.0), LIGHT_TOP_SHININESS);
+
+    float NdotL_front = max(dot(normal, LIGHT_FRONT_DIR), 0.0);
+    diffuse += NdotL_front * LIGHT_FRONT_DIFFUSE;
+    vec3 half_front = normalize(LIGHT_FRONT_DIR + view_dir);
+    specular += LIGHT_FRONT_SPECULAR * pow(max(dot(normal, half_front), 0.0), LIGHT_FRONT_SHININESS);
+    vec3 window_reflection = compute_window_reflection(normal, view_dir);
+
+    // SSAO is applied in post-process pass. Keep base lighting unchanged here.
+
+    if (is_outline) {
+        vec3 shaded_rgb = (vec3(specular) + window_reflection + color.rgb * diffuse) * PHONG_BRIGHTNESS;
+        vec4 shaded_color = vec4(clamp(shaded_rgb, vec3(0.0), vec3(1.0)), color.a);
+        vec2 fragCoord = gl_FragCoord.xy;
+        float s = DetectSilho(fragCoord);
+        for(int i=1;i<=INFLATE; i++)
+        {
+           s = max(s, DetectSilho(fragCoord.xy + vec2(i, 0)));
+           s = max(s, DetectSilho(fragCoord.xy + vec2(0, i)));
+        }
+        gl_FragColor = vec4(mix(shaded_color.rgb, getBackfaceColor(shaded_color.rgb), s), shaded_color.a);
+    }
+#ifdef ENABLE_ENVIRONMENT_MAP
+    else if (use_environment_tex)
+        gl_FragColor = vec4(clamp((0.45 * texture2D(environment_tex, normalize(eye_normal).xy * 0.5 + 0.5).xyz + window_reflection + 0.8 * color.rgb * diffuse) * PHONG_BRIGHTNESS, vec3(0.0), vec3(1.0)), color.a);
+#endif
+    else
+        gl_FragColor = vec4(clamp((vec3(specular) + window_reflection + color.rgb * diffuse) * PHONG_BRIGHTNESS, vec3(0.0), vec3(1.0)), color.a);
+}

--- a/resources/shaders/110/phong.vs
+++ b/resources/shaders/110/phong.vs
@@ -1,0 +1,54 @@
+#version 110
+
+const vec3 ZERO = vec3(0.0, 0.0, 0.0);
+
+struct SlopeDetection
+{
+    bool actived;
+    float normal_z;
+    mat3 volume_world_normal_matrix;
+};
+
+uniform mat4 view_model_matrix;
+uniform mat4 projection_matrix;
+uniform mat3 normal_matrix;
+uniform mat4 volume_world_matrix;
+uniform SlopeDetection slope;
+
+// Clipping plane, x = min z, y = max z. Used by the FFF and SLA previews to clip with a top / bottom plane.
+uniform vec2 z_range;
+// Clipping plane - general orientation. Used by the SLA gizmo.
+uniform vec4 clipping_plane;
+// Color clip plane - general orientation. Used by the cut gizmo.
+uniform vec4 color_clip_plane;
+
+attribute vec3 v_position;
+attribute vec3 v_normal;
+
+varying vec3 clipping_planes_dots;
+varying float color_clip_plane_dot;
+
+varying vec4 world_pos;
+varying float world_normal_z;
+varying vec3 eye_normal;
+varying vec3 eye_position;
+
+void main()
+{
+    // First transform the normal into camera space and normalize the result.
+    eye_normal = normalize(normal_matrix * v_normal);
+
+    vec4 position = view_model_matrix * vec4(v_position, 1.0);
+    eye_position = position.xyz;
+
+    // Point in homogenous coordinates.
+    world_pos = volume_world_matrix * vec4(v_position, 1.0);
+
+    // z component of normal vector in world coordinate used for slope shading
+    world_normal_z = slope.actived ? (normalize(slope.volume_world_normal_matrix * v_normal)).z : 0.0;
+
+    gl_Position = projection_matrix * position;
+    // Fill in the scalars for fragment shader clipping. Fragments with any of these components lower than zero are discarded.
+    clipping_planes_dots = vec3(dot(world_pos, clipping_plane), world_pos.z - z_range.x, z_range.y - world_pos.z);
+    color_clip_plane_dot = dot(world_pos, color_clip_plane);
+}

--- a/resources/shaders/110/plate_reflection.fs
+++ b/resources/shaders/110/plate_reflection.fs
@@ -1,0 +1,32 @@
+#version 110
+
+uniform vec4 uniform_color;
+uniform float reflection_strength;
+uniform float reflection_fade_distance;
+
+varying float reflection_height;
+
+void main()
+{
+    float normalized_height = clamp(
+        reflection_height / max(reflection_fade_distance, 1.0),
+        0.0,
+        1.0);
+
+    float fade = 1.0 - normalized_height;
+    fade *= fade;
+
+    float luminance = dot(
+        uniform_color.rgb,
+        vec3(0.2126, 0.7152, 0.0722));
+
+    vec3 reflected_color = mix(
+        vec3(luminance),
+        uniform_color.rgb,
+        0.65);
+
+    float alpha =
+        reflection_strength * fade * uniform_color.a;
+
+    gl_FragColor = vec4(reflected_color, alpha);
+}

--- a/resources/shaders/110/plate_reflection.vs
+++ b/resources/shaders/110/plate_reflection.vs
@@ -1,0 +1,23 @@
+#version 110
+
+uniform mat4 projection_matrix;
+uniform mat4 view_matrix;
+uniform mat4 volume_world_matrix;
+
+attribute vec3 v_position;
+
+varying float reflection_height;
+
+void main()
+{
+    vec4 world_position =
+        volume_world_matrix * vec4(v_position, 1.0);
+
+    reflection_height = max(world_position.z, 0.0);
+
+    // Mirror around world z = 0 and place the image slightly below the plate.
+    world_position.z = -world_position.z - 0.10;
+
+    gl_Position =
+        projection_matrix * view_matrix * world_position;
+}

--- a/resources/shaders/110/plate_shadow.fs
+++ b/resources/shaders/110/plate_shadow.fs
@@ -1,0 +1,12 @@
+#version 110
+
+// Flat, semi-transparent shadow colour. Alpha comes from the uniform so the
+// darkness can be tuned without recompiling. A stencil pass ensures each pixel
+// is blended only once, so overlapping projected triangles stay uniform.
+
+uniform vec4 shadow_color;
+
+void main()
+{
+    gl_FragColor = shadow_color;
+}

--- a/resources/shaders/110/plate_shadow.vs
+++ b/resources/shaders/110/plate_shadow.vs
@@ -1,0 +1,16 @@
+#version 110
+
+// Planar projected shadow: the per-volume world matrix lifts the mesh into
+// world space, and shadow_matrix = projection * view * planar-projection then
+// flattens it onto the plate plane (world z = 0) along the light direction and
+// takes it to clip space.
+
+uniform mat4 shadow_matrix;
+uniform mat4 volume_world_matrix;
+
+attribute vec3 v_position;
+
+void main()
+{
+    gl_Position = shadow_matrix * volume_world_matrix * vec4(v_position, 1.0);
+}

--- a/resources/shaders/110/ssao.fs
+++ b/resources/shaders/110/ssao.fs
@@ -1,0 +1,85 @@
+#version 110
+
+/**
+ * SSAO Shader - GLSL 110 version with highlight protection
+ * Preserves brightness on upward-facing surfaces (top areas)
+ */
+
+uniform sampler2D color_texture;
+uniform sampler2D depth_texture;
+uniform sampler2D normal_texture;
+uniform vec2 inv_tex_size;
+uniform float z_near;
+uniform float z_far;
+
+varying vec2 tex_coord;
+
+float linearize_depth(float depth)
+{
+    float z = depth * 2.0 - 1.0;
+    return (2.0 * z_near * z_far) / (z_far + z_near - z * (z_far - z_near));
+}
+
+void main()
+{
+    vec3 base = texture2D(color_texture, tex_coord).rgb;
+    float depth_center = linearize_depth(texture2D(depth_texture, tex_coord).r);
+
+    // Sample normal at current fragment (range: -1 to 1)
+    vec3 normal_center = texture2D(normal_texture, tex_coord).rgb * 2.0 - 1.0;
+
+    // Calculate how much the surface faces upward
+    // up_factor = 1.0 for surfaces pointing straight up (0,0,1)
+    // up_factor = 0.0 for surfaces pointing down or sideways
+    float up_factor = max(0.0, normal_center.z);  // Assuming Z is up axis
+    // Alternative: if Y is up, use normal_center.y
+
+    // Adaptive sampling radius
+    float radius = mix(2.0, 4.0, depth_center / z_far);
+
+    vec2 offsets[8];
+    offsets[0] = vec2( 1.0,  0.0);
+    offsets[1] = vec2( 0.707, 0.707);
+    offsets[2] = vec2( 0.0,  1.0);
+    offsets[3] = vec2(-0.707, 0.707);
+    offsets[4] = vec2(-1.0,  0.0);
+    offsets[5] = vec2(-0.707,-0.707);
+    offsets[6] = vec2( 0.0, -1.0);
+    offsets[7] = vec2( 0.707,-0.707);
+
+    float occlusion = 0.0;
+    int valid_samples = 0;
+
+    for (int i = 0; i < 8; ++i) {
+        vec2 uv = tex_coord + offsets[i] * inv_tex_size * radius;
+        uv = clamp(uv, vec2(0.001), vec2(0.999));
+
+        float sample_depth = linearize_depth(texture2D(depth_texture, uv).r);
+        float depth_diff = max(0.0, depth_center - sample_depth);
+
+        float threshold = 0.015 * (0.5 + depth_center / z_far);
+        float contribution = smoothstep(0.001, threshold, depth_diff);
+
+        float diagonal_weight = 1.0 - abs(offsets[i].x * offsets[i].y) * 0.5;
+        occlusion += contribution * diagonal_weight;
+        valid_samples++;
+    }
+
+    if (valid_samples > 0)
+        occlusion /= float(valid_samples);
+
+    // flatter/top-like surfaces get less darkening
+    float ao_intensity = 0.55;
+    float ambient_occlusion = 1.0 - occlusion * ao_intensity;
+
+    // Different min values for top vs bottom surfaces
+    float ao_min = mix(0.45, 0.70, up_factor);  // Bottom: 0.45, Top: 0.70
+    ambient_occlusion = clamp(ambient_occlusion, ao_min, 1.0);
+
+    // Boost brightness on top surfaces (optional)
+    float brightness_boost = 1.0 + up_factor * 0.15;  // 15% extra brightness on top
+    ambient_occlusion = pow(ambient_occlusion, 2.2) * brightness_boost;
+    ambient_occlusion = clamp(ambient_occlusion, 0.45, 1.05);
+
+    gl_FragColor = vec4(base * ambient_occlusion, 1.0);
+}

--- a/resources/shaders/110/ssao.vs
+++ b/resources/shaders/110/ssao.vs
@@ -1,0 +1,12 @@
+#version 110
+
+attribute vec3 v_position;
+attribute vec2 v_tex_coord;
+
+varying vec2 tex_coord;
+
+void main()
+{
+    tex_coord = v_tex_coord;
+    gl_Position = vec4(v_position, 1.0);
+}

--- a/resources/shaders/140/normal.fs
+++ b/resources/shaders/140/normal.fs
@@ -1,0 +1,22 @@
+#version 140
+
+// Encodes the world-space normal into [0, 1] for the SSAO pass.
+
+in vec3 world_normal;
+in vec3 clipping_planes_dots;
+
+out vec4 out_color;
+
+void main()
+{
+    if (any(lessThan(
+            clipping_planes_dots,
+            vec3(0.0)))) {
+        discard;
+    }
+
+    vec3 normal = normalize(world_normal);
+
+    out_color =
+        vec4(normal * 0.5 + 0.5, 1.0);
+}

--- a/resources/shaders/140/normal.vs
+++ b/resources/shaders/140/normal.vs
@@ -1,0 +1,36 @@
+#version 140
+
+// Writes world-space normals into a G-buffer consumed by the SSAO pass.
+
+uniform mat4 view_model_matrix;
+uniform mat4 projection_matrix;
+uniform mat4 volume_world_matrix;
+uniform mat3 volume_world_normal_matrix;
+
+uniform vec2 z_range;
+uniform vec4 clipping_plane;
+
+in vec3 v_position;
+in vec3 v_normal;
+
+out vec3 world_normal;
+out vec3 clipping_planes_dots;
+
+void main()
+{
+    vec4 world_position =
+        volume_world_matrix * vec4(v_position, 1.0);
+
+    world_normal =
+        volume_world_normal_matrix * v_normal;
+
+    clipping_planes_dots = vec3(
+        dot(world_position, clipping_plane),
+        world_position.z - z_range.x,
+        z_range.y - world_position.z);
+
+    gl_Position =
+        projection_matrix *
+        view_model_matrix *
+        vec4(v_position, 1.0);
+}

--- a/resources/shaders/140/phong.fs
+++ b/resources/shaders/140/phong.fs
@@ -1,0 +1,259 @@
+#version 140
+
+const vec3 ZERO = vec3(0.0, 0.0, 0.0);
+const vec3 LightRed = vec3(0.78, 0.0, 0.0);
+const vec3 LightBlue = vec3(0.73, 1.0, 1.0);
+const float EPSILON = 0.0001;
+
+#define INTENSITY_CORRECTION 0.6
+#define PHONG_BRIGHTNESS     1.0
+
+// normalized values for (-0.6/1.31, 0.6/1.31, 1./1.31)
+const vec3 LIGHT_TOP_DIR = vec3(-0.4574957, 0.4574957, 0.7624929);
+#define LIGHT_TOP_DIFFUSE    (0.8 * INTENSITY_CORRECTION)
+#define LIGHT_TOP_SPECULAR   (0.8 * INTENSITY_CORRECTION)
+#define LIGHT_TOP_SHININESS  128.0
+
+// normalized values for (1./1.43, 0.2/1.43, 1./1.43)
+const vec3 LIGHT_FRONT_DIR = vec3(0.6985074, 0.1397015, 0.6985074);
+#define LIGHT_FRONT_DIFFUSE  (0.3 * INTENSITY_CORRECTION)
+#define LIGHT_FRONT_SPECULAR (0.28 * INTENSITY_CORRECTION)
+#define LIGHT_FRONT_SHININESS 64.0
+
+#define INTENSITY_AMBIENT    0.22
+#define WINDOW_REFLECTION_INTENSITY 0.55
+
+struct PrintVolumeDetection
+{
+    // 0 = rectangle, 1 = circle, 2 = custom, 3 = invalid
+    int type;
+    // type = 0 (rectangle):
+    // x = min.x, y = min.y, z = max.x, w = max.y
+    // type = 1 (circle):
+    // x = center.x, y = center.y, z = radius
+    vec4 xy_data;
+    // x = min z, y = max z
+    vec2 z_data;
+};
+
+struct SlopeDetection
+{
+    bool actived;
+    float normal_z;
+    mat3 volume_world_normal_matrix;
+};
+
+uniform vec4 uniform_color;
+uniform bool use_color_clip_plane;
+uniform vec4 uniform_color_clip_plane_1;
+uniform vec4 uniform_color_clip_plane_2;
+uniform SlopeDetection slope;
+
+//BBS: add outline_color
+uniform bool is_outline;
+uniform sampler2D depth_tex;
+uniform vec2 screen_size;
+
+#ifdef ENABLE_ENVIRONMENT_MAP
+    uniform sampler2D environment_tex;
+    uniform bool use_environment_tex;
+#endif // ENABLE_ENVIRONMENT_MAP
+
+uniform PrintVolumeDetection print_volume;
+
+uniform float z_far;
+uniform float z_near;
+uniform bool enable_ssao;
+
+in vec3 clipping_planes_dots;
+in float color_clip_plane_dot;
+
+in vec4 world_pos;
+in float world_normal_z;
+in vec3 eye_normal;
+in vec3 world_normal;
+in vec3 eye_position;
+
+out vec4 out_color;
+
+vec3 getBackfaceColor(vec3 fill) {
+    float brightness = 0.2126 * fill.r + 0.7152 * fill.g + 0.0722 * fill.b;
+    return (brightness > 0.75) ? vec3(0.11, 0.165, 0.208) : vec3(0.988, 0.988, 0.988);
+}
+
+// Silhouette edge detection & rendering algorithm by leoneruggiero
+// https://www.shadertoy.com/view/DslXz2
+#define INFLATE 1
+
+float GetTolerance(float d, float k)
+{
+    float A=-   (z_far+z_near)/(z_far-z_near);
+    float B=-2.0*z_far*z_near /(z_far-z_near);
+
+    d = d*2.0-1.0;
+
+    return -k*(d+A)*(d+A)/B;
+}
+
+float DetectSilho(vec2 fragCoord, vec2 dir)
+{
+    float x0 = abs(texture(depth_tex, (fragCoord + dir*-2.0) / screen_size).r);
+    float x1 = abs(texture(depth_tex, (fragCoord + dir*-1.0) / screen_size).r);
+    float x2 = abs(texture(depth_tex, (fragCoord + dir* 0.0) / screen_size).r);
+    float x3 = abs(texture(depth_tex, (fragCoord + dir* 1.0) / screen_size).r);
+
+    float d0 = (x1-x0);
+    float d1 = (x2-x3);
+
+    float r0 = x1 + d0 - x2;
+    float r1 = x2 + d1 - x1;
+
+    float tol = GetTolerance(x2, 0.04);
+
+    return smoothstep(0.0, tol*tol, max( - r0*r1, 0.0));
+
+}
+
+float DetectSilho(vec2 fragCoord)
+{
+    return max(
+        DetectSilho(fragCoord, vec2(1,0)),
+        DetectSilho(fragCoord, vec2(0,1))
+        );
+}
+
+float compute_ssao_factor(vec3 normal, vec3 view_dir, vec3 eye_pos)
+{
+    vec3 normal_dx = dFdx(normal);
+    vec3 normal_dy = dFdy(normal);
+    float normal_variation = clamp(length(normal_dx) + length(normal_dy), 0.0, 1.0);
+
+    float depth_gradient = clamp(length(vec2(dFdx(eye_pos.z), dFdy(eye_pos.z))) * 0.8, 0.0, 1.0);
+
+    float cavity = clamp(normal_variation * 0.70 + depth_gradient * 0.60, 0.0, 1.0);
+    float cavity_mask = smoothstep(0.25, 0.75, cavity);
+    float ao_strength = pow(cavity, 1.15) * cavity_mask;
+    return clamp(1.0 - ao_strength * 0.90, 0.25, 1.0);
+}
+
+float soft_circle(vec2 p, vec2 center, float radius, float blur)
+{
+    float dist = distance(p, center);
+    return 1.0 - smoothstep(radius - blur, radius, dist);
+}
+
+vec3 compute_window_reflection(vec3 normal, vec3 view_dir)
+{
+    const vec3 LIGHT_TOP_DIR = vec3(-0.4574957, 0.4574957, 0.7624929);
+
+    vec3 light_dir = normalize(LIGHT_TOP_DIR);
+    vec3 reflect_light = normalize(reflect(-light_dir, normal));
+
+    // UV coordinates for the reflection
+    vec2 uv = (reflect_light.xy / (1.0 + max(reflect_light.z, 0.3))) * 2.2;
+
+    vec2 grad = fwidth(uv) * 0.8;
+    float blur = 0.12 + grad.x * 1.5;
+
+    // === CIRCULAR WINDOW (porthole style) ===
+    // Single round window, no bars
+    vec2 window_center = vec2(0.0, 0.0);
+    float window_radius = 0.5;  // Radius of the circular window
+
+    float window_light = soft_circle(uv, window_center, window_radius, blur);
+
+    // No bars - just pure circular glass
+    float bars = 1.0;
+
+    // Fresnel effect for edge glow
+    float fresnel = pow(1.0 - max(dot(normal, view_dir), 0.0), 1.0);
+    float facing = smoothstep(-0.4, 0.6, reflect_light.z);
+
+    float intensity = window_light * bars * (0.25 + 0.25 * fresnel) * facing;
+    intensity = clamp(intensity, 0.0, 0.45);
+
+    return vec3(intensity);
+}
+
+void main()
+{
+    if (any(lessThan(clipping_planes_dots, ZERO)))
+        discard;
+
+    vec4 color;
+    if (use_color_clip_plane) {
+        color.rgb = (color_clip_plane_dot < 0.0) ? uniform_color_clip_plane_1.rgb : uniform_color_clip_plane_2.rgb;
+        color.a = uniform_color.a;
+    }
+    else
+        color = uniform_color;
+
+    if (slope.actived) {
+         if(world_pos.z<0.1&&world_pos.z>-0.1)
+         {
+                color.rgb = LightBlue;
+                color.a = 0.8;
+         }
+         else if( world_normal_z < slope.normal_z - EPSILON)
+         {
+                color.rgb = color.rgb * 0.5 + LightRed * 0.5;
+                color.a = 0.8;
+         }
+    }
+
+    vec3 pv_check_min = ZERO;
+    vec3 pv_check_max = ZERO;
+    if (print_volume.type == 0) {
+        pv_check_min = world_pos.xyz - vec3(print_volume.xy_data.x, print_volume.xy_data.y, print_volume.z_data.x);
+        pv_check_max = world_pos.xyz - vec3(print_volume.xy_data.z, print_volume.xy_data.w, print_volume.z_data.y);
+    }
+    else if (print_volume.type == 1) {
+        float delta_radius = print_volume.xy_data.z - distance(world_pos.xy, print_volume.xy_data.xy);
+        pv_check_min = vec3(delta_radius, 0.0, world_pos.z - print_volume.z_data.x);
+        pv_check_max = vec3(0.0, 0.0, world_pos.z - print_volume.z_data.y);
+    }
+    color.rgb = (any(lessThan(pv_check_min, ZERO)) || any(greaterThan(pv_check_max, ZERO))) ? mix(color.rgb, ZERO, 0.3333) : color.rgb;
+
+    vec3 normal = normalize(eye_normal);
+    vec3 view_dir = normalize(-eye_position);
+
+    // Diffuse key/fill lights are anchored to the world (Z-up), so the scene
+    // stays lit "from above" as the camera orbits instead of the light riding
+    // along with the camera. Specular/window highlights stay view-dependent,
+    // which is how real glossy highlights behave.
+    vec3 wnormal = normalize(world_normal);
+    const vec3 WORLD_LIGHT_TOP_DIR   = normalize(vec3(-0.35, -0.35, 0.87));
+    const vec3 WORLD_LIGHT_FRONT_DIR = normalize(vec3(0.0, -0.6, 0.8));
+
+    float NdotL_top = max(dot(wnormal, WORLD_LIGHT_TOP_DIR), 0.0);
+    float diffuse = INTENSITY_AMBIENT + NdotL_top * LIGHT_TOP_DIFFUSE;
+    vec3 half_top = normalize(LIGHT_TOP_DIR + view_dir);
+    float specular = LIGHT_TOP_SPECULAR * pow(max(dot(normal, half_top), 0.0), LIGHT_TOP_SHININESS);
+
+    float NdotL_front = max(dot(wnormal, WORLD_LIGHT_FRONT_DIR), 0.0);
+    diffuse += NdotL_front * LIGHT_FRONT_DIFFUSE;
+    vec3 half_front = normalize(LIGHT_FRONT_DIR + view_dir);
+    specular += LIGHT_FRONT_SPECULAR * pow(max(dot(normal, half_front), 0.0), LIGHT_FRONT_SHININESS);
+    vec3 window_reflection = compute_window_reflection(normal, view_dir);
+
+    // SSAO is applied in post-process pass. Keep base lighting unchanged here.
+
+    if (is_outline) {
+        vec3 shaded_rgb = (vec3(specular) + window_reflection + color.rgb * diffuse) * PHONG_BRIGHTNESS;
+        vec4 shaded_color = vec4(clamp(shaded_rgb, vec3(0.0), vec3(1.0)), color.a);
+        vec2 fragCoord = gl_FragCoord.xy;
+        float s = DetectSilho(fragCoord);
+        for(int i=1;i<=INFLATE; i++)
+        {
+           s = max(s, DetectSilho(fragCoord.xy + vec2(i, 0)));
+           s = max(s, DetectSilho(fragCoord.xy + vec2(0, i)));
+        }
+        out_color = vec4(mix(shaded_color.rgb, getBackfaceColor(shaded_color.rgb), s), shaded_color.a);
+    }
+#ifdef ENABLE_ENVIRONMENT_MAP
+    else if (use_environment_tex)
+        out_color = vec4(clamp((0.45 * texture(environment_tex, normalize(eye_normal).xy * 0.5 + 0.5).xyz + window_reflection + 0.8 * color.rgb * diffuse) * PHONG_BRIGHTNESS, vec3(0.0), vec3(1.0)), color.a);
+#endif
+    else
+        out_color = vec4(clamp((vec3(specular) + window_reflection + color.rgb * diffuse) * PHONG_BRIGHTNESS, vec3(0.0), vec3(1.0)), color.a);
+}

--- a/resources/shaders/140/phong.vs
+++ b/resources/shaders/140/phong.vs
@@ -1,0 +1,59 @@
+#version 140
+
+const vec3 ZERO = vec3(0.0, 0.0, 0.0);
+
+struct SlopeDetection
+{
+    bool actived;
+    float normal_z;
+    mat3 volume_world_normal_matrix;
+};
+
+uniform mat4 view_model_matrix;
+uniform mat4 projection_matrix;
+uniform mat3 normal_matrix;
+uniform mat4 volume_world_matrix;
+uniform SlopeDetection slope;
+
+// Clipping plane, x = min z, y = max z. Used by the FFF and SLA previews to clip with a top / bottom plane.
+uniform vec2 z_range;
+// Clipping plane - general orientation. Used by the SLA gizmo.
+uniform vec4 clipping_plane;
+// Color clip plane - general orientation. Used by the cut gizmo.
+uniform vec4 color_clip_plane;
+
+in vec3 v_position;
+in vec3 v_normal;
+
+out vec3 clipping_planes_dots;
+out float color_clip_plane_dot;
+
+out vec4 world_pos;
+out float world_normal_z;
+out vec3 eye_normal;
+out vec3 world_normal;
+out vec3 eye_position;
+
+void main()
+{
+    // First transform the normal into camera space and normalize the result.
+    eye_normal = normalize(normal_matrix * v_normal);
+
+    // World-space normal, used to anchor the diffuse key light to the scene
+    // (light "from above") instead of following the camera.
+    world_normal = mat3(volume_world_matrix) * v_normal;
+
+    vec4 position = view_model_matrix * vec4(v_position, 1.0);
+    eye_position = position.xyz;
+
+    // Point in homogenous coordinates.
+    world_pos = volume_world_matrix * vec4(v_position, 1.0);
+
+    // z component of normal vector in world coordinate used for slope shading
+    world_normal_z = slope.actived ? (normalize(slope.volume_world_normal_matrix * v_normal)).z : 0.0;
+
+    gl_Position = projection_matrix * position;
+    // Fill in the scalars for fragment shader clipping. Fragments with any of these components lower than zero are discarded.
+    clipping_planes_dots = vec3(dot(world_pos, clipping_plane), world_pos.z - z_range.x, z_range.y - world_pos.z);
+    color_clip_plane_dot = dot(world_pos, color_clip_plane);
+}

--- a/resources/shaders/140/plate_reflection.fs
+++ b/resources/shaders/140/plate_reflection.fs
@@ -1,0 +1,34 @@
+#version 140
+
+uniform vec4 uniform_color;
+uniform float reflection_strength;
+uniform float reflection_fade_distance;
+
+in float reflection_height;
+
+out vec4 out_color;
+
+void main()
+{
+    float normalized_height = clamp(
+        reflection_height / max(reflection_fade_distance, 1.0),
+        0.0,
+        1.0);
+
+    float fade = 1.0 - normalized_height;
+    fade *= fade;
+
+    float luminance = dot(
+        uniform_color.rgb,
+        vec3(0.2126, 0.7152, 0.0722));
+
+    vec3 reflected_color = mix(
+        vec3(luminance),
+        uniform_color.rgb,
+        0.65);
+
+    float alpha =
+        reflection_strength * fade * uniform_color.a;
+
+    out_color = vec4(reflected_color, alpha);
+}

--- a/resources/shaders/140/plate_reflection.vs
+++ b/resources/shaders/140/plate_reflection.vs
@@ -1,0 +1,23 @@
+#version 140
+
+uniform mat4 projection_matrix;
+uniform mat4 view_matrix;
+uniform mat4 volume_world_matrix;
+
+in vec3 v_position;
+
+out float reflection_height;
+
+void main()
+{
+    vec4 world_position =
+        volume_world_matrix * vec4(v_position, 1.0);
+
+    reflection_height = max(world_position.z, 0.0);
+
+    // Mirror around world z = 0 and place the image slightly below the plate.
+    world_position.z = -world_position.z - 0.10;
+
+    gl_Position =
+        projection_matrix * view_matrix * world_position;
+}

--- a/resources/shaders/140/plate_shadow.fs
+++ b/resources/shaders/140/plate_shadow.fs
@@ -1,0 +1,14 @@
+#version 140
+
+// Flat, semi-transparent shadow colour. Alpha comes from the uniform so the
+// darkness can be tuned without recompiling. A stencil pass ensures each pixel
+// is blended only once, so overlapping projected triangles stay uniform.
+
+uniform vec4 shadow_color;
+
+out vec4 out_color;
+
+void main()
+{
+    out_color = shadow_color;
+}

--- a/resources/shaders/140/plate_shadow.vs
+++ b/resources/shaders/140/plate_shadow.vs
@@ -1,0 +1,16 @@
+#version 140
+
+// Planar projected shadow: the per-volume world matrix lifts the mesh into
+// world space, and shadow_matrix = projection * view * planar-projection then
+// flattens it onto the plate plane (world z = 0) along the light direction and
+// takes it to clip space.
+
+uniform mat4 shadow_matrix;
+uniform mat4 volume_world_matrix;
+
+in vec3 v_position;
+
+void main()
+{
+    gl_Position = shadow_matrix * volume_world_matrix * vec4(v_position, 1.0);
+}

--- a/resources/shaders/140/ssao.fs
+++ b/resources/shaders/140/ssao.fs
@@ -1,0 +1,106 @@
+#version 140
+
+/**
+ * SSAO Shader - GLSL 140 version with sharp depth threshold
+ * Only darkens valleys/concave areas, ignores smooth variations
+ */
+
+uniform sampler2D color_texture;
+uniform sampler2D depth_texture;
+uniform sampler2D normal_texture;
+uniform float z_near;
+uniform float z_far;
+
+in vec2 tex_coord;
+out vec4 frag_color;
+
+float linearize_depth(float depth)
+{
+    float z = depth * 2.0 - 1.0;
+    return (2.0 * z_near * z_far) / (z_far + z_near - z * (z_far - z_near));
+}
+
+void main()
+{
+    ivec2 pixel = ivec2(gl_FragCoord.xy);
+    float center_depth = linearize_depth(texelFetch(depth_texture, pixel, 0).r);
+
+    // Sample normal buffer (stored as RGB in 0-1 range, convert to -1 to 1)
+    vec3 normal_center = texelFetch(normal_texture, pixel, 0).rgb * 2.0 - 1.0;
+    normal_center = normalize(normal_center);
+
+    // Calculate upward-facing factor (Z-up coordinate system)
+    float up_factor = clamp(normal_center.z * 1.5, 0.0, 1.0);
+
+    // Adaptive radius in pixel space
+    int radius = int(mix(4.0, 7.0, center_depth / z_far));
+
+    // Optimized sampling pattern
+    const ivec2 offsets[12] = ivec2[](
+        ivec2(1, 0),  ivec2(-1, 0),  ivec2(0, 1),  ivec2(0, -1),
+        ivec2(1, 1),  ivec2(-1, 1),  ivec2(1, -1), ivec2(-1, -1),
+        ivec2(2, 0),  ivec2(-2, 0),  ivec2(0, 2),  ivec2(0, -2)
+    );
+
+    float occlusion = 0.0;
+    int valid_samples = 0;
+
+    for (int i = 0; i < 12; i++) {
+        ivec2 sample_pixel = pixel + offsets[i] * radius;
+
+        if (sample_pixel.x < 0 || sample_pixel.y < 0)
+            continue;
+
+        float sample_depth = linearize_depth(texelFetch(depth_texture, sample_pixel, 0).r);
+
+        // Sample normal at neighbor
+        vec3 normal_sample = texelFetch(normal_texture, sample_pixel, 0).rgb * 2.0 - 1.0;
+
+        // Depth difference (positive if neighbor is closer to camera)
+        float depth_diff = center_depth - sample_depth;
+
+        // Sharp depth threshold ===
+        // Minimum depth difference to consider occlusion (ignores small variations)
+        float threshold_min = 0.008;  // Higher = only deep valleys get darkened
+        float threshold_max = 0.04;   // Transition range for full occlusion
+
+        float contribution = 0.0;
+        if (depth_diff > threshold_min) {
+            // Abrupt mapping with power curve
+            contribution = (depth_diff - threshold_min) / (threshold_max - threshold_min);
+            contribution = clamp(contribution, 0.0, 1.0);
+            contribution = pow(contribution, 2.0);  // Steeper curve for sharper transition
+        }
+
+        // Reject occlusion on smooth/convex surfaces: if the neighbour normal is
+        // similar, the depth difference comes from surface curvature, not a real
+        // concave feature. Only keep occlusion where normals diverge (crevices,
+        // inside corners, contact with the plate).
+        float normal_similarity = dot(normal_center, normal_sample);
+        float planar_factor = smoothstep(0.55, 0.85, normal_similarity);
+        contribution *= (1.0 - planar_factor);
+
+        occlusion += contribution;
+        valid_samples++;
+    }
+
+    if (valid_samples > 0) {
+        // Calculate ambient occlusion factor with higher base intensity
+        float ao_factor = 1.0 - (occlusion / float(valid_samples)) * 0.6;
+
+        // Keep bright areas clean (higher minimum for upward-facing surfaces)
+        float ao_min = mix(0.55, 0.85, up_factor);
+        ao_factor = clamp(ao_factor, ao_min, 1.0);
+
+        // Slight brightness boost for upward-facing surfaces
+        float brightness_boost = 1.0 + up_factor * 0.15;
+        ao_factor = ao_factor * brightness_boost;
+
+        occlusion = ao_factor;
+    } else {
+        occlusion = 1.0;
+    }
+
+    vec3 color = texture(color_texture, tex_coord).rgb;
+    frag_color = vec4(color * occlusion, 1.0);
+}

--- a/resources/shaders/140/ssao.vs
+++ b/resources/shaders/140/ssao.vs
@@ -1,0 +1,12 @@
+#version 140
+
+in vec3 v_position;
+in vec2 v_tex_coord;
+
+out vec2 tex_coord;
+
+void main()
+{
+    tex_coord = v_tex_coord;
+    gl_Position = vec4(v_position, 1.0);
+}

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -193,6 +193,20 @@ void AppConfig::set_defaults()
         set_bool("use_last_fold_state_gcodeview_option_panel", true);
     if (get("enable_lod").empty())
         set_bool("enable_lod", true);
+    if (get(SETTING_OPENGL_REALISTIC_MODE).empty())
+        set_bool(SETTING_OPENGL_REALISTIC_MODE, false);
+    if (get(SETTING_OPENGL_REALISTIC_PHONG).empty())
+        set_bool(SETTING_OPENGL_REALISTIC_PHONG, true);
+    if (get(SETTING_OPENGL_SHADING_MODEL).empty())
+        set(SETTING_OPENGL_SHADING_MODEL, "gouraud");
+    if (get(SETTING_OPENGL_PHONG_BASIC_PLATE_SHADOWS).empty())
+        set_bool(SETTING_OPENGL_PHONG_BASIC_PLATE_SHADOWS, false);
+    if (get(SETTING_OPENGL_PHONG_BUILD_PLATE_REFLECTIONS).empty())
+        set_bool(SETTING_OPENGL_PHONG_BUILD_PLATE_REFLECTIONS, false);
+    if (get(SETTING_OPENGL_PHONG_SSAO).empty())
+        set_bool(SETTING_OPENGL_PHONG_SSAO, false);
+    if (get(SETTING_OPENGL_PHONG_SMOOTH_NORMALS).empty())
+        set_bool(SETTING_OPENGL_PHONG_SMOOTH_NORMALS, false);
     if (get("enable_assemble_view_preview").empty())
         set("enable_assemble_view_preview", "Auto");
     if (get("enable_bvh").empty())
@@ -241,11 +255,15 @@ void AppConfig::set_defaults()
     if (get("prefer_to_use_dgpu").empty())
         set_bool("prefer_to_use_dgpu", false);
 
-    if (get("msaa_type").empty())
-        set("msaa_type", "X4");
+    if (get(SETTING_OPENGL_MSAA_TYPE).empty())
+        set(SETTING_OPENGL_MSAA_TYPE, "X4");
 
-    if (get("enable_advanced_antialiasing").empty())
-        set_bool("enable_advanced_antialiasing", false);
+    if (get(SETTING_OPENGL_FXAA_ENABLED).empty())
+        set_bool(SETTING_OPENGL_FXAA_ENABLED, false);
+    if (get(SETTING_OPENGL_FRAME_RATE_LIMIT).empty())
+        set(SETTING_OPENGL_FRAME_RATE_LIMIT, "0");
+    if (get(SETTING_OPENGL_SHOW_FPS).empty())
+        set_bool(SETTING_OPENGL_SHOW_FPS, false);
 
     if (get("enable_advanced_gcode_viewer_").empty())
         set_bool("enable_advanced_gcode_viewer_", true);

--- a/src/libslic3r/AppConfig.hpp
+++ b/src/libslic3r/AppConfig.hpp
@@ -18,6 +18,18 @@ using namespace nlohmann;
 #define ENV_PRE_HOST		"2"
 #define ENV_PRODUCT_HOST	"3"
 
+#define SETTING_OPENGL_REALISTIC_MODE "opengl_realistic_mode"
+#define SETTING_OPENGL_REALISTIC_PHONG "opengl_realistic_phong"
+#define SETTING_OPENGL_SHADING_MODEL "opengl_shading_model"
+#define SETTING_OPENGL_PHONG_BASIC_PLATE_SHADOWS "opengl_phong_basic_plate_shadows"
+#define SETTING_OPENGL_PHONG_BUILD_PLATE_REFLECTIONS "opengl_phong_build_plate_reflections"
+#define SETTING_OPENGL_PHONG_SSAO "opengl_phong_ssao"
+#define SETTING_OPENGL_PHONG_SMOOTH_NORMALS "opengl_phong_smooth_normals"
+#define SETTING_OPENGL_MSAA_TYPE "msaa_type"
+#define SETTING_OPENGL_FXAA_ENABLED "enable_advanced_antialiasing"
+#define SETTING_OPENGL_FRAME_RATE_LIMIT "opengl_frame_rate_limit"
+#define SETTING_OPENGL_SHOW_FPS "opengl_show_fps"
+
 #define SUPPORT_DARK_MODE
 //#define _MSW_DARK_MODE
 

--- a/src/libslic3r/Technologies.hpp
+++ b/src/libslic3r/Technologies.hpp
@@ -30,8 +30,6 @@
 
 // Enable rendering of objects using environment map
 #define ENABLE_ENVIRONMENT_MAP 0
-// Enable smoothing of objects normals
-#define ENABLE_SMOOTH_NORMALS 0
 // Enable rendering markers for options in preview as fixed screen size points
 #define ENABLE_FIXED_SCREEN_SIZE_POINT_MARKERS 1
 

--- a/src/slic3r/GUI/3DScene.cpp
+++ b/src/slic3r/GUI/3DScene.cpp
@@ -1,10 +1,9 @@
 #include <GL/glew.h>
 
-#if ENABLE_SMOOTH_NORMALS
-#include <igl/per_face_normals.h>
+#ifdef L
+#undef L
+#endif
 #include <igl/per_corner_normals.h>
-#include <igl/per_vertex_normals.h>
-#endif // ENABLE_SMOOTH_NORMALS
 
 #include "3DScene.hpp"
 #include "GLShader.hpp"
@@ -98,90 +97,114 @@ namespace Slic3r {
 
 static std::map<const TriangleMesh*, std::set<GLVolume*>> g_mesh_volumes_map;
 
-#if ENABLE_SMOOTH_NORMALS
-static void smooth_normals_corner(TriangleMesh& mesh, std::vector<stl_normal>& normals)
+void GLIndexedVertexArray::load_mesh_full_shading(
+    const TriangleMesh& mesh,
+    bool smooth_normals)
 {
-    using MapMatrixXfUnaligned = Eigen::Map<const Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor | Eigen::DontAlign>>;
-    using MapMatrixXiUnaligned = Eigen::Map<const Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor | Eigen::DontAlign>>;
+    assert(
+        triangle_indices.empty() &&
+        vertices_and_normals_interleaved_size == 0);
 
-    std::vector<Vec3f> face_normals = its_face_normals(mesh.its);
+    assert(
+        quad_indices.empty() &&
+        triangle_indices_size == 0);
 
-    Eigen::MatrixXd vertices = MapMatrixXfUnaligned(mesh.its.vertices.front().data(),
-        Eigen::Index(mesh.its.vertices.size()), 3).cast<double>();
-    Eigen::MatrixXi indices = MapMatrixXiUnaligned(mesh.its.indices.front().data(),
-        Eigen::Index(mesh.its.indices.size()), 3);
-    Eigen::MatrixXd in_normals = MapMatrixXfUnaligned(face_normals.front().data(),
-        Eigen::Index(face_normals.size()), 3).cast<double>();
-    Eigen::MatrixXd out_normals;
+    assert(
+        vertices_and_normals_interleaved.size() % 6 == 0 &&
+        quad_indices_size ==
+            vertices_and_normals_interleaved.size());
 
-    igl::per_corner_normals(vertices, indices, in_normals, 1.0, out_normals);
+    const indexed_triangle_set& its = mesh.its;
 
-    normals = std::vector<stl_normal>(mesh.its.vertices.size());
-    for (size_t i = 0; i < mesh.its.indices.size(); ++i) {
-        for (size_t j = 0; j < 3; ++j) {
-            normals[mesh.its.indices[i][j]] = out_normals.row(i * 3 + j).cast<float>();
-        }
-    }
-}
+    if (
+        smooth_normals &&
+        !its.vertices.empty() &&
+        !its.indices.empty())
+    {
+        using MapVertices = Eigen::Map<
+            const Eigen::Matrix<
+                float,
+                Eigen::Dynamic,
+                Eigen::Dynamic,
+                Eigen::RowMajor | Eigen::DontAlign>>;
 
-static void smooth_normals_vertex(TriangleMesh& mesh, std::vector<stl_normal>& normals)
-{
-    using MapMatrixXfUnaligned = Eigen::Map<const Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor | Eigen::DontAlign>>;
-    using MapMatrixXiUnaligned = Eigen::Map<const Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor | Eigen::DontAlign>>;
+        using MapIndices = Eigen::Map<
+            const Eigen::Matrix<
+                int,
+                Eigen::Dynamic,
+                Eigen::Dynamic,
+                Eigen::RowMajor | Eigen::DontAlign>>;
 
-    Eigen::MatrixXd vertices = MapMatrixXfUnaligned(mesh.its.vertices.front().data(),
-        Eigen::Index(mesh.its.vertices.size()), 3).cast<double>();
-    Eigen::MatrixXi indices = MapMatrixXiUnaligned(mesh.its.indices.front().data(),
-        Eigen::Index(mesh.its.indices.size()), 3);
-    Eigen::MatrixXd out_normals;
+        const Eigen::MatrixXd vertices =
+            MapVertices(
+                its.vertices.front().data(),
+                Eigen::Index(its.vertices.size()),
+                3)
+            .cast<double>();
 
-//    igl::per_vertex_normals(vertices, indices, igl::PER_VERTEX_NORMALS_WEIGHTING_TYPE_UNIFORM, out_normals);
-//    igl::per_vertex_normals(vertices, indices, igl::PER_VERTEX_NORMALS_WEIGHTING_TYPE_AREA, out_normals);
-    igl::per_vertex_normals(vertices, indices, igl::PER_VERTEX_NORMALS_WEIGHTING_TYPE_ANGLE, out_normals);
-//    igl::per_vertex_normals(vertices, indices, igl::PER_VERTEX_NORMALS_WEIGHTING_TYPE_DEFAULT, out_normals);
+        const Eigen::MatrixXi indices =
+            MapIndices(
+                its.indices.front().data(),
+                Eigen::Index(its.indices.size()),
+                3);
 
-    normals = std::vector<stl_normal>(mesh.its.vertices.size());
-    for (size_t i = 0; i < static_cast<size_t>(out_normals.rows()); ++i) {
-        normals[i] = out_normals.row(i).cast<float>();
-    }
-}
-#endif // ENABLE_SMOOTH_NORMALS
+        Eigen::MatrixXd corner_normals;
 
-#if ENABLE_SMOOTH_NORMALS
-void GLIndexedVertexArray::load_mesh_full_shading(const TriangleMesh& mesh, bool smooth_normals)
-#else
-void GLIndexedVertexArray::load_mesh_full_shading(const TriangleMesh& mesh)
-#endif // ENABLE_SMOOTH_NORMALS
-{
-    assert(triangle_indices.empty() && vertices_and_normals_interleaved_size == 0);
-    assert(quad_indices.empty() && triangle_indices_size == 0);
-    assert(vertices_and_normals_interleaved.size() % 6 == 0 && quad_indices_size == vertices_and_normals_interleaved.size());
+        // Match OrcaSlicer's five-degree smoothing threshold.
+        igl::per_corner_normals(
+            vertices,
+            indices,
+            5.0,
+            corner_normals);
 
-#if ENABLE_SMOOTH_NORMALS
-    if (smooth_normals) {
-        TriangleMesh new_mesh(mesh);
-        std::vector<stl_normal> normals;
-        smooth_normals_corner(new_mesh, normals);
-//        smooth_normals_vertex(new_mesh, normals);
+        this->vertices_and_normals_interleaved.reserve(
+            this->vertices_and_normals_interleaved.size() +
+            3 * 3 * 2 * its.indices.size());
 
-        this->vertices_and_normals_interleaved.reserve(this->vertices_and_normals_interleaved.size() + 3 * 2 * new_mesh.its.vertices.size());
-        for (size_t i = 0; i < new_mesh.its.vertices.size(); ++i) {
-            const stl_vertex& v = new_mesh.its.vertices[i];
-            const stl_normal& n = normals[i];
-            this->push_geometry(v(0), v(1), v(2), n(0), n(1), n(2));
-        }
+        this->triangle_indices.reserve(
+            this->triangle_indices.size() +
+            3 * its.indices.size());
 
-        for (size_t i = 0; i < new_mesh.its.indices.size(); ++i) {
-            const stl_triangle_vertex_indices& idx = new_mesh.its.indices[i];
-            this->push_triangle(idx(0), idx(1), idx(2));
+        unsigned int vertex_index = 0;
+
+        for (
+            size_t face_index = 0;
+            face_index < its.indices.size();
+            ++face_index)
+        {
+            const stl_triangle_vertex_indices& face =
+                its.indices[face_index];
+
+            for (size_t corner = 0; corner < 3; ++corner) {
+                const Vec3f normal =
+                    corner_normals
+                        .row(Eigen::Index(
+                            face_index * 3 + corner))
+                        .cast<float>();
+
+                const stl_vertex& vertex =
+                    its.vertices[face[corner]];
+
+                this->push_geometry(
+                    vertex.x(),
+                    vertex.y(),
+                    vertex.z(),
+                    normal.x(),
+                    normal.y(),
+                    normal.z());
+            }
+
+            this->push_triangle(
+                vertex_index,
+                vertex_index + 1,
+                vertex_index + 2);
+
+            vertex_index += 3;
         }
     }
     else {
-#endif // ENABLE_SMOOTH_NORMALS
-        this->load_its_flat_shading(mesh.its);
-#if ENABLE_SMOOTH_NORMALS
+        this->load_its_flat_shading(its);
     }
-#endif // ENABLE_SMOOTH_NORMALS
 }
 
 void GLIndexedVertexArray::load_its_flat_shading(const indexed_triangle_set &its)
@@ -1364,27 +1387,41 @@ int GLVolumeCollection::load_object_volume(
         g_mesh_volumes_map.emplace(mesh_ptr, std::move(volume_set));
     }
     if (need_create_mesh) {
-#if ENABLE_SMOOTH_NORMALS
-        v.indexed_vertex_array->load_mesh(mesh, true);
-#else
         if (lod_enabled) {
-            if (v.indexed_vertex_array_middle == nullptr)
-            {
-                v.indexed_vertex_array_middle = std::make_shared<GLIndexedVertexArray>();
+            if (v.indexed_vertex_array_middle == nullptr) {
+                v.indexed_vertex_array_middle =
+                    std::make_shared<GLIndexedVertexArray>();
             }
 
-            v.simplify_mesh(mesh, v.indexed_vertex_array_middle, LOD_LEVEL::MIDDLE); // include finalize_geometry
+            v.simplify_mesh(
+                mesh,
+                v.indexed_vertex_array_middle,
+                LOD_LEVEL::MIDDLE);
 
-            if (v.indexed_vertex_array_small == nullptr)
-            {
-                v.indexed_vertex_array_small = std::make_shared<GLIndexedVertexArray>();
+            if (v.indexed_vertex_array_small == nullptr) {
+                v.indexed_vertex_array_small =
+                    std::make_shared<GLIndexedVertexArray>();
             }
-            v.simplify_mesh(mesh, v.indexed_vertex_array_small, LOD_LEVEL::SMALL);
+
+            v.simplify_mesh(
+                mesh,
+                v.indexed_vertex_array_small,
+                LOD_LEVEL::SMALL);
         }
 
-        v.indexed_vertex_array->load_mesh(mesh);
-#endif // ENABLE_SMOOTH_NORMALS
-        v.indexed_vertex_array->finalize_geometry(opengl_initialized);
+        const bool smooth_normals =
+            GUI::wxGetApp().app_config != nullptr &&
+            GUI::wxGetApp().app_config->get_bool(
+                SETTING_OPENGL_REALISTIC_MODE) &&
+            GUI::wxGetApp().app_config->get_bool(
+                SETTING_OPENGL_PHONG_SMOOTH_NORMALS);
+
+        v.indexed_vertex_array->load_mesh(
+            mesh,
+            smooth_normals);
+
+        v.indexed_vertex_array->finalize_geometry(
+            opengl_initialized);
     }
     v.composite_id = GLVolume::CompositeID(obj_idx, volume_idx, instance_idx);
     if (model_volume->is_model_part())
@@ -1474,11 +1511,7 @@ void GLVolumeCollection::load_object_auxiliary(
         const ModelInstance& model_instance = *print_object->model_object()->instances[instance_idx.first];
         this->volumes.emplace_back(new GLVolume((milestone == slaposPad) ? GLVolume::SLA_PAD_COLOR : GLVolume::SLA_SUPPORT_COLOR));
         GLVolume& v = *this->volumes.back();
-#if ENABLE_SMOOTH_NORMALS
-        v.indexed_vertex_array->load_mesh(mesh, true);
-#else
         v.indexed_vertex_array->load_mesh(mesh);
-#endif // ENABLE_SMOOTH_NORMALS
         v.indexed_vertex_array->finalize_geometry(opengl_initialized);
         v.composite_id = GLVolume::CompositeID(obj_idx, -int(milestone), (int)instance_idx.first);
         v.geometry_id = std::pair<size_t, size_t>(timestamp, model_instance.id().id);
@@ -1800,9 +1833,28 @@ void GLVolumeCollection::render(GUI::ERenderPipelineStage             render_pip
 
             float normal_z = -::cos(Geometry::deg2rad((float)support_threshold_angle));
 
-            shader->set_uniform("volume_world_matrix", volume.first->world_matrix());
+            const Transform3d volume_world_matrix =
+                volume.first->world_matrix();
+
+            const Matrix3f volume_world_normal_matrix =
+                volume_world_matrix.matrix()
+                    .block(0, 0, 3, 3)
+                    .inverse()
+                    .transpose()
+                    .cast<float>();
+
+            shader->set_uniform(
+                "volume_world_matrix",
+                volume_world_matrix);
+
+            shader->set_uniform(
+                "volume_world_normal_matrix",
+                volume_world_normal_matrix);
+
             shader->set_uniform("slope.actived", m_slope.isGlobalActive && !volume.first->is_modifier && !volume.first->is_wipe_tower);
-            shader->set_uniform("slope.volume_world_normal_matrix", static_cast<Matrix3f>(volume.first->world_matrix().matrix().block(0, 0, 3, 3).inverse().transpose().cast<float>()));
+            shader->set_uniform(
+                "slope.volume_world_normal_matrix",
+                volume_world_normal_matrix);
             shader->set_uniform("slope.normal_z", normal_z);
 
 #if ENABLE_ENVIRONMENT_MAP
@@ -1814,7 +1866,7 @@ void GLVolumeCollection::render(GUI::ERenderPipelineStage             render_pip
 #endif // ENABLE_ENVIRONMENT_MAP
             glcheck();
 
-            const Transform3d matrix = view_matrix * volume.first->world_matrix();
+            const Transform3d matrix = view_matrix * volume_world_matrix;
             shader->set_uniform("view_model_matrix", matrix);
             shader->set_uniform("projection_matrix", projection_matrix);
             shader->set_uniform("normal_matrix", (Matrix3d)matrix.matrix().block(0, 0, 3, 3).inverse().transpose());

--- a/src/slic3r/GUI/3DScene.hpp
+++ b/src/slic3r/GUI/3DScene.hpp
@@ -153,13 +153,16 @@ public:
     unsigned int       triangle_indices_VBO_id{ 0 };
     unsigned int       quad_indices_VBO_id{ 0 };
 
-#if ENABLE_SMOOTH_NORMALS
-    void load_mesh_full_shading(const TriangleMesh& mesh, bool smooth_normals = false);
-    void load_mesh(const TriangleMesh& mesh, bool smooth_normals = false) { this->load_mesh_full_shading(mesh, smooth_normals); }
-#else
-    void load_mesh_full_shading(const TriangleMesh& mesh);
-    void load_mesh(const TriangleMesh& mesh) { this->load_mesh_full_shading(mesh); }
-#endif // ENABLE_SMOOTH_NORMALS
+    void load_mesh_full_shading(
+        const TriangleMesh& mesh,
+        bool smooth_normals = false);
+
+    void load_mesh(
+        const TriangleMesh& mesh,
+        bool smooth_normals = false)
+    {
+        this->load_mesh_full_shading(mesh, smooth_normals);
+    }
 
     void load_its_flat_shading(const indexed_triangle_set &its);
 

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -2759,6 +2759,52 @@ void GLCanvas3D::render(bool only_init)
     if (only_init)
         return;
 
+    // Limit only interactive 3D and Preview canvases. The Assembly
+    // canvas owns frame-sensitive video and PDF capture workflows.
+    if (
+        m_canvas_type != ECanvasType::CanvasAssembleView &&
+        wxGetApp().app_config != nullptr)
+    {
+        const int frame_rate_limit = std::clamp(
+            std::atoi(
+                wxGetApp().app_config
+                    ->get(SETTING_OPENGL_FRAME_RATE_LIMIT)
+                    .c_str()),
+            0,
+            240);
+
+        if (
+            frame_rate_limit > 0 &&
+            m_last_present_time !=
+                std::chrono::steady_clock::time_point{})
+        {
+            const auto minimum_frame_duration =
+                std::chrono::microseconds(
+                    1000000 / frame_rate_limit);
+
+            const auto elapsed =
+                std::chrono::steady_clock::now() -
+                m_last_present_time;
+
+            if (elapsed < minimum_frame_duration) {
+                const auto remaining_us =
+                    std::chrono::duration_cast<
+                        std::chrono::microseconds>(
+                            minimum_frame_duration - elapsed)
+                        .count();
+
+                const int remaining_ms = std::max(
+                    1,
+                    static_cast<int>(
+                        (remaining_us + 999) / 1000));
+
+                m_dirty = true;
+                schedule_extra_frame(remaining_ms);
+                return;
+            }
+        }
+    }
+
 #if ENABLE_ENVIRONMENT_MAP
     if (wxGetApp().is_editor())
         wxGetApp().plater()->init_environment_texture();
@@ -2840,20 +2886,82 @@ void GLCanvas3D::render(bool only_init)
         }
     }
 
-    const bool off_screen_rendering_enabled = ogl_manager.is_fxaa_enabled();
+    const bool realistic_ssao_enabled =
+        m_canvas_type == ECanvasType::CanvasView3D &&
+        _get_current_render_stage() ==
+            GUI::ERenderPipelineStage::Normal &&
+        !m_gizmos.is_paint_gizmo() &&
+        OpenGLManager::get_gl_info()
+            .is_version_greater_or_equal_to(3, 1) &&
+        wxGetApp().app_config != nullptr &&
+        wxGetApp().app_config->get_bool(
+            SETTING_OPENGL_REALISTIC_MODE) &&
+        wxGetApp().app_config->get_bool(
+            SETTING_OPENGL_REALISTIC_PHONG) &&
+        wxGetApp().app_config->get_bool(
+            SETTING_OPENGL_PHONG_SSAO) &&
+        wxGetApp().get_shader("phong") != nullptr &&
+        wxGetApp().get_shader("ssao") != nullptr;
 
-    if (m_picking_enabled && EPickingEffect::Silhouette == picking_effect) {
+    const bool cast_shadows_enabled =
+        m_canvas_type == ECanvasType::CanvasView3D &&
+        _get_current_render_stage() ==
+            GUI::ERenderPipelineStage::Normal &&
+        camera.is_looking_downward() &&
+        !m_gizmos.is_paint_gizmo() &&
+        wxGetApp().app_config != nullptr &&
+        wxGetApp().app_config->get_bool(
+            SETTING_OPENGL_REALISTIC_MODE) &&
+        wxGetApp().app_config->get_bool(
+            SETTING_OPENGL_REALISTIC_PHONG) &&
+        wxGetApp().app_config->get_bool(
+            SETTING_OPENGL_PHONG_BASIC_PLATE_SHADOWS) &&
+        wxGetApp().get_shader("plate_shadow") != nullptr;
+
+    const bool build_plate_reflections_enabled =
+        m_canvas_type == ECanvasType::CanvasView3D &&
+        _get_current_render_stage() ==
+            GUI::ERenderPipelineStage::Normal &&
+        camera.is_looking_downward() &&
+        !m_gizmos.is_paint_gizmo() &&
+        wxGetApp().app_config != nullptr &&
+        wxGetApp().app_config->get_bool(
+            SETTING_OPENGL_REALISTIC_MODE) &&
+        wxGetApp().app_config->get_bool(
+            SETTING_OPENGL_REALISTIC_PHONG) &&
+        wxGetApp().app_config->get_bool(
+            SETTING_OPENGL_PHONG_BUILD_PLATE_REFLECTIONS) &&
+        wxGetApp().get_shader("plate_reflection") != nullptr;
+
+    const bool off_screen_rendering_enabled =
+        ogl_manager.is_fxaa_enabled() ||
+        realistic_ssao_enabled;
+
+    if (m_picking_enabled &&
+        EPickingEffect::Silhouette == picking_effect) {
         _render_silhouette_effect();
     }
 
     std::string write_to_framebuffer_name{};
+
     if (off_screen_rendering_enabled) {
         write_to_framebuffer_name = "mainframe";
-        OpenGLManager::FrameBufferModifier main_frame(ogl_manager, write_to_framebuffer_name, ogl_manager.get_msaa_type());
+
+        OpenGLManager::FrameBufferModifier main_frame(
+            ogl_manager,
+            write_to_framebuffer_name,
+            ogl_manager.get_msaa_type());
+
+        main_frame.set_depth_texture(
+            realistic_ssao_enabled);
     }
     else {
-        write_to_framebuffer_name = OpenGLManager::s_back_frame;
-        OpenGLManager::FrameBufferModifier main_frame(ogl_manager, write_to_framebuffer_name);
+        write_to_framebuffer_name =
+            OpenGLManager::s_back_frame;
+
+        OpenGLManager::FrameBufferModifier main_frame(
+            ogl_manager,
+            write_to_framebuffer_name);
     }
 
 #if ENABLE_RENDER_PICKING_PASS
@@ -2890,17 +2998,28 @@ void GLCanvas3D::render(bool only_init)
     int hover_id = (m_hover_plate_idxs.size() > 0) ? m_hover_plate_idxs.front() : -1;
     bool b_with_stencil_outline = !m_gizmos.is_running() && (EPickingEffect::StencilOutline == picking_effect);
     if (m_canvas_type == ECanvasType::CanvasView3D) {
-        //BBS: add outline logic
-        _render_objects(m_volumes,GLVolumeCollection::ERenderType::Opaque, b_with_stencil_outline);
-        if (!m_paint_outline_volumes.empty()) {
-            _render_objects(m_paint_outline_volumes, GLVolumeCollection::ERenderType::Opaque, b_with_stencil_outline,true);
-        }
-        _render_sla_slices();
-        _render_selection();
+        // Render the plate first so the depth buffer can mask the realistic
+        // reflection and cast-shadow passes.
         if (!no_partplate)
             _render_bed(!camera.is_looking_downward(), show_axes);
         if (!no_partplate) //BBS: add outline logic
             _render_platelist(!camera.is_looking_downward(), only_current, only_body, hover_id, true, show_grid);
+
+        if (!no_partplate && build_plate_reflections_enabled)
+            _render_build_plate_reflections(camera);
+        if (!no_partplate && cast_shadows_enabled)
+            _render_cast_shadows_on_plate(camera);
+
+        // Draw opaque geometry after the plate effects so real objects always
+        // occlude their own reflections and shadows.
+        _render_objects(m_volumes, GLVolumeCollection::ERenderType::Opaque, b_with_stencil_outline);
+        if (!m_paint_outline_volumes.empty()) {
+            _render_objects(m_paint_outline_volumes, GLVolumeCollection::ERenderType::Opaque, b_with_stencil_outline, true);
+        }
+
+        _render_sla_slices();
+        _render_selection();
+
         _render_objects(m_volumes, GLVolumeCollection::ERenderType::Transparent, b_with_stencil_outline);
         _render_objects(m_paint_outline_volumes, GLVolumeCollection::ERenderType::Transparent, b_with_stencil_outline, true);
     }
@@ -2944,7 +3063,19 @@ void GLCanvas3D::render(bool only_init)
     _render_selection_sidebar_hints();
     _render_current_gizmo();
 
-    _rebuild_postprocessing_pipeline(p_ogl_manager, write_to_framebuffer_name, OpenGLManager::s_back_frame, viewport[2], viewport[3]);
+    if (realistic_ssao_enabled) {
+        _render_normal_buffer(ogl_manager, viewport[2], viewport[3]);
+    }
+
+    _rebuild_postprocessing_pipeline(
+        p_ogl_manager,
+        write_to_framebuffer_name,
+        OpenGLManager::s_back_frame,
+        viewport[2],
+        viewport[3],
+        realistic_ssao_enabled,
+        static_cast<float>(camera.get_near_z()),
+        static_cast<float>(camera.get_far_z()));
 
 #if ENABLE_RENDER_PICKING_PASS
     }
@@ -2958,6 +3089,60 @@ void GLCanvas3D::render(bool only_init)
 
     // draw overlays
     _render_overlays();
+
+    if (
+        m_canvas_type != ECanvasType::CanvasAssembleView &&
+        wxGetApp().app_config != nullptr &&
+        wxGetApp().app_config->get_bool(
+            SETTING_OPENGL_SHOW_FPS))
+    {
+        const Size canvas_size = get_canvas_size();
+        ImGuiWrapper& imgui = *wxGetApp().imgui();
+
+        ImGui::PushStyleVar(
+            ImGuiStyleVar_WindowRounding,
+            4.0f);
+        ImGui::PushStyleVar(
+            ImGuiStyleVar_WindowBorderSize,
+            0.0f);
+        ImGui::PushStyleVar(
+            ImGuiStyleVar_WindowPadding,
+            ImVec2(8.0f, 5.0f));
+        ImGui::PushStyleColor(
+            ImGuiCol_WindowBg,
+            ImVec4(0.13f, 0.13f, 0.13f, 0.86f));
+        ImGui::PushStyleColor(
+            ImGuiCol_Text,
+            ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
+
+        imgui.set_next_window_pos(
+            static_cast<float>(canvas_size.get_width()) - 10.0f,
+            10.0f,
+            ImGuiCond_Always,
+            1.0f,
+            0.0f);
+
+        imgui.begin(
+            std::string("FPS overlay"),
+            ImGuiWindowFlags_AlwaysAutoResize |
+                ImGuiWindowFlags_NoMouseInputs |
+                ImGuiWindowFlags_NoMove |
+                ImGuiWindowFlags_NoDecoration |
+                ImGuiWindowFlags_NoSavedSettings |
+                ImGuiWindowFlags_NoFocusOnAppearing |
+                ImGuiWindowFlags_NoNav);
+
+        imgui.text(
+            std::string("FPS: ") +
+            std::to_string(std::max(
+                0,
+                m_render_stats.get_fps_and_reset_if_needed())));
+
+        imgui.end();
+
+        ImGui::PopStyleColor(2);
+        ImGui::PopStyleVar(3);
+    }
 
     if (wxGetApp().plater()->is_render_statistic_dialog_visible()) {
         // Match the canvas tooltip styling: dark window background with white text,
@@ -3070,6 +3255,7 @@ void GLCanvas3D::render(bool only_init)
     ogl_manager.unbind_vao();
     ogl_manager.clear_dirty();
     m_canvas->SwapBuffers();
+    m_last_present_time = std::chrono::steady_clock::now();
 
     for (const auto& cb : m_frame_callback_list) {
         cb();
@@ -3752,18 +3938,10 @@ void GLCanvas3D::reload_scene(bool refresh_immediately, bool force_full_scene_re
                                 TriangleMesh mesh = print_object->get_mesh(slaposDrillHoles);
 	                            assert(! mesh.empty());
                                 mesh.transform(sla_print->sla_trafo(*m_model->objects[volume.object_idx()]).inverse());
-#if ENABLE_SMOOTH_NORMALS
-                                volume.indexed_vertex_array->load_mesh(mesh, true);
-#else
                                 volume.indexed_vertex_array->load_mesh(mesh);
-#endif // ENABLE_SMOOTH_NORMALS
                             } else {
 	                        	// Reload the original volume.
-#if ENABLE_SMOOTH_NORMALS
-                                volume.indexed_vertex_array->load_mesh(m_model->objects[volume.object_idx()]->volumes[volume.volume_idx()]->mesh(), true);
-#else
                                 volume.indexed_vertex_array->load_mesh(m_model->objects[volume.object_idx()]->volumes[volume.volume_idx()]->mesh());
-#endif // ENABLE_SMOOTH_NORMALS
                             }
                             volume.finalize_geometry(true);
 	                    }
@@ -7541,7 +7719,15 @@ void GLCanvas3D::render_thumbnail_framebuffer(const std::shared_ptr<OpenGLManage
     if (thumbnail_params.post_processing_enabled) {
          // fxaa pass
         write_to_framebuffer_name = "thumbnail_fb_aa";
-        _rebuild_postprocessing_pipeline(p_ogl_manager, thumbnail_fb_name, write_to_framebuffer_name, w, h);
+        _rebuild_postprocessing_pipeline(
+            p_ogl_manager,
+            thumbnail_fb_name,
+            write_to_framebuffer_name,
+            w,
+            h,
+            false,
+            0.0f,
+            0.0f);
          // end fxaa pass
     }
 
@@ -8722,13 +8908,48 @@ void GLCanvas3D::_render_objects(GLVolumeCollection &cur_volumes, GLVolumeCollec
     else
         cur_volumes.set_show_sinking_contours(!m_gizmos.is_hiding_instances());
 
-    const auto& shader = wxGetApp().get_shader("gouraud");
+    const GUI::ERenderPipelineStage render_pipeline_stage = _get_current_render_stage();
+
+    const bool realistic_view_supported =
+        OpenGLManager::get_gl_info()
+            .is_version_greater_or_equal_to(3, 1);
+
+    const bool realistic_view_allowed =
+        realistic_view_supported &&
+        m_canvas_type == ECanvasType::CanvasView3D &&
+        render_pipeline_stage == GUI::ERenderPipelineStage::Normal &&
+        !in_paint_gizmo &&
+        !m_gizmos.is_paint_gizmo();
+
+    const bool realistic_view_requested =
+        wxGetApp().app_config != nullptr &&
+        wxGetApp().app_config->get_bool(
+            SETTING_OPENGL_REALISTIC_MODE);
+
+    const bool phong_requested =
+        wxGetApp().app_config != nullptr &&
+        wxGetApp().app_config->get_bool(
+            SETTING_OPENGL_REALISTIC_PHONG);
+
+    auto shader = wxGetApp().get_shader("gouraud");
+    bool using_phong_shader = false;
+
+    if (realistic_view_allowed &&
+        realistic_view_requested &&
+        phong_requested) {
+        const auto& phong_shader =
+            wxGetApp().get_shader("phong");
+
+        if (phong_shader) {
+            shader = phong_shader;
+            using_phong_shader = true;
+        }
+    }
     ECanvasType canvas_type = this->m_canvas_type;
     std::array<float, 4> body_color  = canvas_type == ECanvasType::CanvasAssembleView ? std::array<float, 4>({1.0f, 1.0f, 0.0f, 1.0f}) ://yellow
                                                                                         std::array<float, 4>({1.0f, 1.0f, 1.0f, 1.0f});//white
     bool                 partly_inside_enable = canvas_type == ECanvasType::CanvasAssembleView ? false : true;
     auto printable_height_option = GUI::wxGetApp().preset_bundle->printers.get_edited_preset().config.option<ConfigOptionFloatsNullable>("extruder_printable_height");
-    const GUI::ERenderPipelineStage render_pipeline_stage = _get_current_render_stage();
 
     const auto& camera = get_active_camera();
     std::vector<std::array<float, 4>> colors = get_active_colors();
@@ -8736,6 +8957,9 @@ void GLCanvas3D::_render_objects(GLVolumeCollection &cur_volumes, GLVolumeCollec
         if (GUI::ERenderPipelineStage::Silhouette != render_pipeline_stage)
         {
             wxGetApp().bind_shader(shader);
+
+            if (using_phong_shader)
+                shader->set_uniform("enable_ssao", false);
         }
         switch (type)
         {
@@ -11523,11 +11747,7 @@ void GLCanvas3D::_load_sla_shells()
         const TriangleMesh& mesh, const std::array<float, 4>& color, bool outside_printer_detection_enabled) {
         m_volumes.volumes.emplace_back(new GLVolume(color));
         GLVolume& v = *m_volumes.volumes.back();
-#if ENABLE_SMOOTH_NORMALS
-        v.indexed_vertex_array->load_mesh(mesh, true);
-#else
         v.indexed_vertex_array->load_mesh(mesh);
-#endif // ENABLE_SMOOTH_NORMALS
         v.indexed_vertex_array->finalize_geometry(m_initialized);
         v.shader_outside_printer_detection_enabled = outside_printer_detection_enabled;
         v.composite_id.volume_id = volume_id;
@@ -11867,7 +12087,211 @@ void GLCanvas3D::_init_fullscreen_mesh()
     s_full_screen_mesh.init_from(std::move(geo));
 }
 
-void GLCanvas3D::_rebuild_postprocessing_pipeline(const std::shared_ptr<OpenGLManager>& p_ogl_manager, const std::string& input_framebuffer_name, std::string& output_framebuffer_name, uint32_t width, uint32_t height)
+void GLCanvas3D::_render_normal_buffer(OpenGLManager& ogl_manager, uint32_t width, uint32_t height)
+{
+    if (0 == width || 0 == height)
+        return;
+
+    const auto& shader = wxGetApp().get_shader("normal");
+    if (!shader)
+        return;
+
+    // Bind (creating if needed) a non-MSAA G-buffer of the same size as the
+    // main frame. Binding it also resolves the previously bound MSAA main frame.
+    {
+        OpenGLManager::FrameBufferModifier normal_frame(ogl_manager, "normalframe", EMSAAType::Disabled);
+        normal_frame.set_width(width)
+            .set_height(height);
+    }
+
+    GLfloat prev_clear_color[4];
+    glsafe(::glGetFloatv(GL_COLOR_CLEAR_VALUE, prev_clear_color));
+
+    // Clear to the encoded world-up normal (0, 0, 1) so that background pixels
+    // do not introduce spurious occlusion.
+    glsafe(::glClearColor(0.5f, 0.5f, 1.0f, 1.0f));
+    glsafe(::glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+    glsafe(::glEnable(GL_DEPTH_TEST));
+    glsafe(::glDisable(GL_BLEND));
+
+    wxGetApp().bind_shader(shader);
+
+    const auto& camera = get_active_camera();
+    const std::vector<std::array<float, 4>> colors = get_active_colors();
+
+    // Same opaque volume selection as the phong pass, so the normal G-buffer
+    // lines up per-pixel with the shaded color and depth buffers.
+    m_volumes.render(
+        GUI::ERenderPipelineStage::Normal,
+        GLVolumeCollection::ERenderType::Opaque,
+        false,
+        camera,
+        colors,
+        *m_model,
+        [this](const GLVolume& volume) {
+            return m_render_sla_auxiliaries || volume.composite_id.volume_id >= 0;
+        },
+        false,
+        { 1.0f, 1.0f, 1.0f, 1.0f },
+        false,
+        nullptr);
+
+    wxGetApp().unbind_shader();
+
+    glsafe(::glClearColor(prev_clear_color[0], prev_clear_color[1], prev_clear_color[2], prev_clear_color[3]));
+}
+
+void GLCanvas3D::_render_cast_shadows_on_plate(const Camera& camera)
+{
+    if (m_volumes.empty())
+        return;
+
+    const auto& shader = wxGetApp().get_shader("plate_shadow");
+    if (!shader)
+        return;
+
+    // Planar projection onto the plate plane (world z = 0) along the same world
+    // light direction the phong shader uses ("from above", slightly tilted).
+    const Vec3d to_light = Vec3d(-0.35, -0.35, 0.87).normalized();
+    const Vec3d l = -to_light; // direction the light travels (downwards)
+    Matrix4d flatten = Matrix4d::Identity();
+    flatten(0, 2) = -l.x() / l.z();
+    flatten(1, 2) = -l.y() / l.z();
+    // Place the projected geometry slightly below the visible plate.
+    // GL_GREATER then uses the existing plate depth as an exact screen-space
+    // mask, while background pixels remain untouched.
+    constexpr double shadow_plane_z = -0.10;
+    flatten(2, 0) = 0.0;
+    flatten(2, 1) = 0.0;
+    flatten(2, 2) = 0.0;
+    flatten(2, 3) = shadow_plane_z;
+
+    const Matrix4d shadow_matrix =
+        camera.get_projection_matrix().matrix() *
+        camera.get_view_matrix().matrix() *
+        flatten;
+
+    wxGetApp().bind_shader(shader);
+    shader->set_uniform("shadow_matrix", shadow_matrix);
+    shader->set_uniform("shadow_color", std::array<float, 4>{ 0.0f, 0.0f, 0.0f, 0.30f });
+
+    // The plate has already populated the depth buffer. Projecting the
+    // shadow slightly below it and using GL_GREATER clips the shadow to visible
+    // plate pixels. The stencil prevents overlapping triangles from repeatedly
+    // darkening the same pixel.
+    glsafe(::glEnable(GL_BLEND));
+    glsafe(::glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
+    glsafe(::glEnable(GL_DEPTH_TEST));
+    glsafe(::glDepthFunc(GL_GREATER));
+    glsafe(::glDepthMask(GL_FALSE));
+    glsafe(::glClearStencil(0));
+    glsafe(::glStencilMask(0xFF));
+    glsafe(::glClear(GL_STENCIL_BUFFER_BIT));
+    glsafe(::glEnable(GL_STENCIL_TEST));
+    glsafe(::glStencilFunc(GL_EQUAL, 0, 0xFF));
+    glsafe(::glStencilOp(GL_KEEP, GL_KEEP, GL_INCR));
+
+    const std::vector<std::array<float, 4>> colors = get_active_colors();
+    m_volumes.render(
+        GUI::ERenderPipelineStage::Normal,
+        GLVolumeCollection::ERenderType::Opaque,
+        true, // disable cull face: project all faces, the stencil keeps one layer
+        camera,
+        colors,
+        *m_model,
+        [](const GLVolume& volume) {
+            return !volume.is_modifier && !volume.is_wipe_tower && volume.composite_id.volume_id >= 0;
+        },
+        false,
+        { 0.0f, 0.0f, 0.0f, 0.0f },
+        false,
+        nullptr);
+
+    glsafe(::glDisable(GL_STENCIL_TEST));
+    glsafe(::glDepthFunc(GL_LESS));
+    glsafe(::glDepthMask(GL_TRUE));
+    glsafe(::glDisable(GL_BLEND));
+    glsafe(::glEnable(GL_CULL_FACE));
+    wxGetApp().unbind_shader();
+}
+
+void GLCanvas3D::_render_build_plate_reflections(const Camera& camera)
+{
+    if (m_volumes.empty())
+        return;
+
+    const auto& shader = wxGetApp().get_shader("plate_reflection");
+    if (!shader)
+        return;
+
+    wxGetApp().bind_shader(shader);
+
+    shader->set_uniform(
+        "view_matrix",
+        camera.get_view_matrix().matrix());
+
+    // A low value keeps the result closer to a textured PEI plate than a
+    // mirror. Vertices higher than 80 mm fade almost completely.
+    shader->set_uniform("reflection_strength", 0.10f);
+    shader->set_uniform("reflection_fade_distance", 80.0f);
+
+    // Reflected geometry is placed below the build plate. GL_GREATER makes it
+    // visible only where the plate has written depth. Opaque objects are drawn
+    // afterwards and therefore cover their own reflection correctly.
+    glsafe(::glEnable(GL_BLEND));
+    glsafe(::glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
+    glsafe(::glEnable(GL_DEPTH_TEST));
+    glsafe(::glDepthFunc(GL_GREATER));
+    glsafe(::glDepthMask(GL_FALSE));
+
+    // Draw at most one translucent layer per pixel. This avoids excessive
+    // darkening from closed meshes and overlapping triangles.
+    glsafe(::glClearStencil(0));
+    glsafe(::glStencilMask(0xFF));
+    glsafe(::glClear(GL_STENCIL_BUFFER_BIT));
+    glsafe(::glEnable(GL_STENCIL_TEST));
+    glsafe(::glStencilFunc(GL_EQUAL, 0, 0xFF));
+    glsafe(::glStencilOp(GL_KEEP, GL_KEEP, GL_INCR));
+
+    const std::vector<std::array<float, 4>> colors =
+        get_active_colors();
+
+    m_volumes.render(
+        GUI::ERenderPipelineStage::Normal,
+        GLVolumeCollection::ERenderType::Opaque,
+        true,
+        camera,
+        colors,
+        *m_model,
+        [](const GLVolume& volume) {
+            return !volume.is_modifier &&
+                   !volume.is_wipe_tower &&
+                   !volume.is_below_printbed() &&
+                   volume.composite_id.volume_id >= 0;
+        },
+        false,
+        { 1.0f, 1.0f, 1.0f, 1.0f },
+        false,
+        nullptr);
+
+    glsafe(::glDisable(GL_STENCIL_TEST));
+    glsafe(::glDepthFunc(GL_LESS));
+    glsafe(::glDepthMask(GL_TRUE));
+    glsafe(::glDisable(GL_BLEND));
+    glsafe(::glEnable(GL_CULL_FACE));
+
+    wxGetApp().unbind_shader();
+}
+
+void GLCanvas3D::_rebuild_postprocessing_pipeline(
+    const std::shared_ptr<OpenGLManager>& p_ogl_manager,
+    const std::string& input_framebuffer_name,
+    std::string& output_framebuffer_name,
+    uint32_t width,
+    uint32_t height,
+    bool enable_ssao,
+    float z_near,
+    float z_far)
 {
     if (!p_ogl_manager) {
         return;
@@ -11882,6 +12306,153 @@ void GLCanvas3D::_rebuild_postprocessing_pipeline(const std::shared_ptr<OpenGLMa
     _init_fullscreen_mesh();
 
     uint32_t output_texture_id = UINT32_MAX;
+
+    if (enable_ssao) {
+        {
+            OpenGLManager::FrameBufferModifier ssao_frame(
+                ogl_manager,
+                "ssaoframe",
+                EMSAAType::Disabled);
+
+            ssao_frame.set_width(width)
+                .set_height(height);
+        }
+
+        glsafe(::glDisable(GL_DEPTH_TEST));
+        glsafe(::glDisable(GL_BLEND));
+
+        const auto& input_frame_buffer =
+            ogl_manager.get_frame_buffer(
+                input_framebuffer_name);
+
+        if (input_frame_buffer) {
+            const uint32_t color_texture_id =
+                input_frame_buffer->get_color_texture();
+
+            const uint32_t depth_texture_id =
+                input_frame_buffer->get_depth_texture();
+
+            if (color_texture_id != UINT32_MAX &&
+                depth_texture_id != UINT32_MAX) {
+                const auto& ssao_shader =
+                    p_ogl_manager->get_shader("ssao");
+
+                if (ssao_shader) {
+                    p_ogl_manager->bind_shader(
+                        ssao_shader);
+
+                    constexpr int color_stage = 0;
+                    constexpr int depth_stage = 1;
+
+                    ssao_shader->set_uniform(
+                        "color_texture",
+                        color_stage);
+
+                    glsafe(::glActiveTexture(
+                        GL_TEXTURE0 + color_stage));
+
+                    glsafe(::glBindTexture(
+                        GL_TEXTURE_2D,
+                        color_texture_id));
+
+                    ssao_shader->set_uniform(
+                        "depth_texture",
+                        depth_stage);
+
+                    glsafe(::glActiveTexture(
+                        GL_TEXTURE0 + depth_stage));
+
+                    glsafe(::glBindTexture(
+                        GL_TEXTURE_2D,
+                        depth_texture_id));
+
+                    constexpr int normal_stage = 2;
+
+                    const auto& normal_frame_buffer =
+                        ogl_manager.get_frame_buffer(
+                            "normalframe");
+
+                    if (normal_frame_buffer) {
+                        const uint32_t normal_texture_id =
+                            normal_frame_buffer
+                                ->get_color_texture();
+
+                        if (normal_texture_id != UINT32_MAX) {
+                            ssao_shader->set_uniform(
+                                "normal_texture",
+                                normal_stage);
+
+                            glsafe(::glActiveTexture(
+                                GL_TEXTURE0 + normal_stage));
+
+                            glsafe(::glBindTexture(
+                                GL_TEXTURE_2D,
+                                normal_texture_id));
+                        }
+                    }
+
+                    const std::array<float, 2>
+                        inverse_texture_size{
+                            1.0f /
+                                static_cast<float>(width),
+                            1.0f /
+                                static_cast<float>(height)
+                        };
+
+                    ssao_shader->set_uniform(
+                        "inv_tex_size",
+                        inverse_texture_size);
+
+                    ssao_shader->set_uniform(
+                        "z_near",
+                        z_near);
+
+                    ssao_shader->set_uniform(
+                        "z_far",
+                        z_far);
+
+                    s_full_screen_mesh.render_geometry();
+
+                    p_ogl_manager->unbind_shader();
+
+                    glsafe(::glActiveTexture(
+                        GL_TEXTURE0));
+
+                    const auto& ssao_frame_buffer =
+                        ogl_manager.get_frame_buffer(
+                            "ssaoframe");
+
+                    if (ssao_frame_buffer) {
+                        output_texture_id =
+                            ssao_frame_buffer
+                                ->get_color_texture();
+
+                        if (output_texture_id ==
+                            UINT32_MAX) {
+                            BOOST_LOG_TRIVIAL(error)
+                                << "Invalid SSAO output texture.";
+                        }
+                    }
+                    else {
+                        BOOST_LOG_TRIVIAL(error)
+                            << "Invalid SSAO framebuffer.";
+                    }
+                }
+                else {
+                    BOOST_LOG_TRIVIAL(error)
+                        << "Invalid SSAO shader.";
+                }
+            }
+            else {
+                BOOST_LOG_TRIVIAL(error)
+                    << "Invalid SSAO input textures.";
+            }
+        }
+        else {
+            BOOST_LOG_TRIVIAL(error)
+                << "Invalid SSAO input framebuffer.";
+        }
+    }
     if (ogl_manager.is_fxaa_enabled()) {
         if (!offscreen_rendering) {
             {
@@ -11903,47 +12474,92 @@ void GLCanvas3D::_rebuild_postprocessing_pipeline(const std::shared_ptr<OpenGLMa
         glsafe(::glDisable(GL_DEPTH_TEST));
         glsafe(::glDisable(GL_BLEND));
 
-        const auto& p_main_frame_buffer = ogl_manager.get_frame_buffer(offscreen_rendering ? input_framebuffer_name : "fxaaframe_temp");
-        if (p_main_frame_buffer) {
-            output_texture_id = p_main_frame_buffer->get_color_texture();
-            if (p_main_frame_buffer->is_texture_valid(output_texture_id)) {
-                const auto& p_fxaa_shader = p_ogl_manager->get_shader("fxaa");
-                if (p_fxaa_shader) {
-                    p_ogl_manager->bind_shader(p_fxaa_shader);
+        if (output_texture_id == UINT32_MAX) {
+            const auto& p_main_frame_buffer =
+                ogl_manager.get_frame_buffer(
+                    offscreen_rendering
+                        ? input_framebuffer_name
+                        : "fxaaframe_temp");
 
-                    const int stage = 0;
-                    p_fxaa_shader->set_uniform("u_sampler", stage);
-                    glsafe(::glActiveTexture(GL_TEXTURE0 + stage));
-                    glsafe(::glBindTexture(GL_TEXTURE_2D, output_texture_id));
+            if (p_main_frame_buffer) {
+                output_texture_id =
+                    p_main_frame_buffer
+                        ->get_color_texture();
+            }
+        }
 
-                    const std::array<float, 4> viewport_size{ static_cast<float>(width), static_cast<float>(height), 1.0f / width, 1.0f / height };
-                    p_fxaa_shader->set_uniform("u_viewport_size", viewport_size);
+        if (output_texture_id != UINT32_MAX) {
+            const auto& p_fxaa_shader =
+                p_ogl_manager->get_shader("fxaa");
 
-                    s_full_screen_mesh.render_geometry();
+            if (p_fxaa_shader) {
+                p_ogl_manager->bind_shader(
+                    p_fxaa_shader);
 
-                    p_ogl_manager->unbind_shader();
+                const int stage = 0;
 
-                    const auto& p_fxaa_frame_buffer = p_ogl_manager->get_frame_buffer("fxaaframe");
-                    if (p_fxaa_frame_buffer) {
-                        output_texture_id = p_fxaa_frame_buffer->get_color_texture();
-                        if (!p_fxaa_frame_buffer->is_texture_valid(output_texture_id)) {
-                            BOOST_LOG_TRIVIAL(error) << "Invalid fxaa texture.";
-                        }
-                    }
-                    else {
-                        BOOST_LOG_TRIVIAL(error) << "Invalid fxaa framebuffer.";
+                p_fxaa_shader->set_uniform(
+                    "u_sampler",
+                    stage);
+
+                glsafe(::glActiveTexture(
+                    GL_TEXTURE0 + stage));
+
+                glsafe(::glBindTexture(
+                    GL_TEXTURE_2D,
+                    output_texture_id));
+
+                const std::array<float, 4>
+                    viewport_size{
+                        static_cast<float>(width),
+                        static_cast<float>(height),
+                        1.0f /
+                            static_cast<float>(width),
+                        1.0f /
+                            static_cast<float>(height)
+                    };
+
+                p_fxaa_shader->set_uniform(
+                    "u_viewport_size",
+                    viewport_size);
+
+                s_full_screen_mesh.render_geometry();
+
+                p_ogl_manager->unbind_shader();
+
+                const auto& p_fxaa_frame_buffer =
+                    p_ogl_manager->get_frame_buffer(
+                        "fxaaframe");
+
+                if (p_fxaa_frame_buffer) {
+                    output_texture_id =
+                        p_fxaa_frame_buffer
+                            ->get_color_texture();
+
+                    if (output_texture_id ==
+                        UINT32_MAX) {
+                        BOOST_LOG_TRIVIAL(error)
+                            << "Invalid fxaa texture.";
                     }
                 }
                 else {
-                    BOOST_LOG_TRIVIAL(error) << "Invalid fxaa shader.";
+                    BOOST_LOG_TRIVIAL(error)
+                        << "Invalid fxaa framebuffer.";
                 }
             }
             else {
-                BOOST_LOG_TRIVIAL(error) << "Invalid main frame texture. Failed to composite main frame.";
+                BOOST_LOG_TRIVIAL(error)
+                    << "Invalid fxaa shader.";
             }
         }
+        else {
+            BOOST_LOG_TRIVIAL(error)
+                << "Invalid main frame texture. "
+                   "Failed to composite main frame.";
+        }
     }
-    else if (offscreen_rendering) {
+    else if (offscreen_rendering &&
+             output_texture_id == UINT32_MAX) {
         const auto& p_main_frame_buffer = ogl_manager.get_frame_buffer(input_framebuffer_name);
         if (p_main_frame_buffer) {
             output_texture_id = p_main_frame_buffer->get_color_texture();

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -706,6 +706,7 @@ private:
 #endif // ENABLE_RENDER_PICKING_PASS
 
     RenderStats m_render_stats;
+    std::chrono::steady_clock::time_point m_last_present_time{};
 
     int m_imgui_undo_redo_hovered_pos{ -1 };
     int m_mouse_wheel{ 0 };
@@ -1467,7 +1468,26 @@ private:
     static bool is_volume_in_plate_boundingbox(const GLVolume &v, int plate_idx, const BoundingBoxf3 &plate_build_volume);
     static void _init_fullscreen_mesh();
 
-    static void _rebuild_postprocessing_pipeline(const std::shared_ptr<OpenGLManager>& p_ogl_manager, const std::string& input_framebuffer_name, std::string& output_framebuffer_name, uint32_t width, uint32_t height);
+    static void _rebuild_postprocessing_pipeline(
+        const std::shared_ptr<OpenGLManager>& p_ogl_manager,
+        const std::string& input_framebuffer_name,
+        std::string& output_framebuffer_name,
+        uint32_t width,
+        uint32_t height,
+        bool enable_ssao,
+        float z_near,
+        float z_far);
+
+    // Renders world-space normals of the opaque scene into a dedicated
+    // "normalframe" G-buffer that the SSAO post-processing pass samples.
+    void _render_normal_buffer(OpenGLManager& ogl_manager, uint32_t width, uint32_t height);
+
+    // Renders a planar projected shadow slightly below the plate surface
+    // along the realistic-view world light direction.
+    void _render_cast_shadows_on_plate(const Camera& camera);
+
+    // Renders a subtle mirrored image of opaque model volumes below the plate.
+    void _render_build_plate_reflections(const Camera& camera);
 
     static void _render_thumbnail_internal(ThumbnailData& thumbnail_data, const ThumbnailsParams& thumbnail_params, PartPlateList& partplate_list, ModelObjectPtrs& model_objects,
         const GLVolumeCollection& volumes, std::vector<std::array<float, 4>>& extruder_colors,

--- a/src/slic3r/GUI/GLShadersManager.cpp
+++ b/src/slic3r/GUI/GLShadersManager.cpp
@@ -60,6 +60,13 @@ std::pair<bool, std::string> GLShadersManager::init()
         , { "ENABLE_ENVIRONMENT_MAP"sv }
 #endif // ENABLE_ENVIRONMENT_MAP
         );
+
+    // used to render objects in 3D editor with Phong shading
+    valid &= append_shader("phong", { glsl_version_prefix + "phong.vs", glsl_version_prefix + "phong.fs" }
+#if ENABLE_ENVIRONMENT_MAP
+        , { "ENABLE_ENVIRONMENT_MAP"sv }
+#endif // ENABLE_ENVIRONMENT_MAP
+    );
     // used to render variable layers heights in 3d editor
     valid &= append_shader("variable_layer_height", { glsl_version_prefix + "variable_layer_height.vs", glsl_version_prefix + "variable_layer_height.fs" });
     // used to render highlight contour around selected triangles inside the multi-material gizmo
@@ -96,6 +103,18 @@ std::pair<bool, std::string> GLShadersManager::init()
     valid &= append_shader("mainframe_composite", { glsl_version_prefix + "mainframe_composite.vs", glsl_version_prefix + "mainframe_composite.fs" });
 
     valid &= append_shader("fxaa", { glsl_version_prefix + "fxaa.vs", glsl_version_prefix + "fxaa.fs" });
+
+    // renders world-space normals into a G-buffer consumed by the SSAO pass
+    valid &= append_shader("normal", { glsl_version_prefix + "normal.vs", glsl_version_prefix + "normal.fs" });
+
+    // projects objects onto the plate for the cast-shadow pass
+    valid &= append_shader("plate_shadow", { glsl_version_prefix + "plate_shadow.vs", glsl_version_prefix + "plate_shadow.fs" });
+
+    // renders a subtle mirrored image of opaque objects below the plate
+    valid &= append_shader("plate_reflection", { glsl_version_prefix + "plate_reflection.vs", glsl_version_prefix + "plate_reflection.fs" });
+
+    // used to apply screen-space ambient occlusion
+    valid &= append_shader("ssao", { glsl_version_prefix + "ssao.vs", glsl_version_prefix + "ssao.fs" });
 
     valid &= append_shader("gaussian_blur33", { glsl_version_prefix + "gaussian_blur33.vs", glsl_version_prefix + "gaussian_blur33.fs" });
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3179,9 +3179,9 @@ bool GUI_App::on_init_inner()
 
     const auto& p_ogl_manager = get_opengl_manager();
     if (p_ogl_manager) {
-        const auto& msaa_type = app_config->get("msaa_type");
+        const auto& msaa_type = app_config->get(SETTING_OPENGL_MSAA_TYPE);
         p_ogl_manager->set_msaa_type(msaa_type);
-        const bool is_fxaa_enabled = app_config->get_bool("enable_advanced_antialiasing");
+        const bool is_fxaa_enabled = app_config->get_bool(SETTING_OPENGL_FXAA_ENABLED);
         p_ogl_manager->set_fxaa_enabled(is_fxaa_enabled);
 
         const bool gizmo_keep_screen_size = app_config->get_bool("gizmo_keep_screen_size");

--- a/src/slic3r/GUI/Gizmos/GLGizmoPainterBase.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoPainterBase.cpp
@@ -137,11 +137,7 @@ void GLGizmoPainterBase::init_selected_glvolume(GLVolume &v,const TriangleMesh &
     v.force_native_color = true;
     v.selected           = true;
     v.set_render_color();
-#if ENABLE_SMOOTH_NORMALS
-    v.indexed_vertex_array->load_mesh(mesh, true);
-#else
     v.indexed_vertex_array->load_mesh(mesh);
-#endif // ENABLE_SMOOTH_NORMALS
     v.indexed_vertex_array->finalize_geometry(true);
     v.set_instance_transformation(world_transformation);
     v.set_convex_hull(mesh.convex_hull_3d());

--- a/src/slic3r/GUI/OpenGLManager.cpp
+++ b/src/slic3r/GUI/OpenGLManager.cpp
@@ -515,7 +515,7 @@ void OpenGLManager::get_viewport_size(uint32_t& width, uint32_t& height) const
     height = m_viewport_height;
 }
 
-void OpenGLManager::_bind_frame_buffer(const std::string& name, EMSAAType msaa_type, uint32_t t_width, uint32_t t_height)
+void OpenGLManager::_bind_frame_buffer(const std::string& name, EMSAAType msaa_type, uint32_t t_width, uint32_t t_height, bool depth_texture)
 {
     if (OpenGLManager::s_back_frame == name) {
         const auto current_framebuffer = m_current_binded_framebuffer.lock();
@@ -540,7 +540,7 @@ void OpenGLManager::_bind_frame_buffer(const std::string& name, EMSAAType msaa_t
     t_fb_params.m_width = width;
     t_fb_params.m_height = height;
     t_fb_params.m_msaa = num_samples;
-
+    t_fb_params.m_depth_texture = depth_texture;
     const auto& iter = m_name_to_framebuffer.find(name);
     bool needs_to_recreate = false;
     if (iter == m_name_to_framebuffer.end()) {
@@ -1053,7 +1053,10 @@ FrameBuffer::FrameBuffer(const FrameBufferParams& params)
     : m_width(params.m_width)
     , m_height(params.m_height)
     , m_msaa(params.m_msaa)
+    , m_depth_texture(params.m_depth_texture)
 {
+    if (m_depth_texture)
+        m_blit_option_type = EBlitOptionType::All;
 }
 
 FrameBuffer::~FrameBuffer()
@@ -1068,6 +1071,12 @@ FrameBuffer::~FrameBuffer()
     {
         glDeleteTextures(1, &m_color_texture_id);
         m_color_texture_id = UINT32_MAX;
+    }
+
+    if (UINT32_MAX != m_depth_texture_id)
+    {
+        glsafe(::glDeleteTextures(1, &m_depth_texture_id));
+        m_depth_texture_id = UINT32_MAX;
     }
 
     if (UINT32_MAX != m_depth_rbo_id)
@@ -1144,6 +1153,11 @@ uint32_t FrameBuffer::get_color_texture() const noexcept
     return m_color_texture_id;
 }
 
+uint32_t FrameBuffer::get_depth_texture() const noexcept
+{
+    return m_depth_texture_id;
+}
+
 bool FrameBuffer::is_texture_valid(uint32_t texture_id) const noexcept
 {
     return m_color_texture_id != UINT32_MAX;
@@ -1192,7 +1206,8 @@ bool FrameBuffer::is_format_equal(const FrameBufferParams& params) const
 {
     const bool rt = m_width == params.m_width
         && m_height == params.m_height
-        && m_msaa == params.m_msaa;
+        && m_msaa == params.m_msaa
+        && m_depth_texture == params.m_depth_texture;
     return rt;
 }
 
@@ -1215,21 +1230,98 @@ void FrameBuffer::create_no_msaa_fbo(bool with_depth)
 
     if (with_depth)
     {
-        glsafe(BBS_GL_EXTENSION_FUNC(::glGenRenderbuffers)(1, &m_depth_rbo_id));
-        glsafe(BBS_GL_EXTENSION_FUNC(::glBindRenderbuffer)(BBS_GL_EXTENSION_PARAMETER(GL_RENDERBUFFER), m_depth_rbo_id));
-
-        glsafe(BBS_GL_EXTENSION_FUNC(::glRenderbufferStorage)(BBS_GL_EXTENSION_PARAMETER(GL_RENDERBUFFER), GL_DEPTH24_STENCIL8, m_width, m_height));
-
         const auto& gl_info = OpenGLManager::get_gl_info();
-        uint32_t formated_gl_version = gl_info.get_formated_gl_version();
-        if (formated_gl_version < 30)
+        const uint32_t formated_gl_version =
+            gl_info.get_formated_gl_version();
+
+        if (m_depth_texture &&
+            gl_info.is_version_greater_or_equal_to(3, 0))
         {
-            glsafe(::glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_DEPTH_ATTACHMENT_EXT, GL_RENDERBUFFER_EXT, m_depth_rbo_id));
-            glsafe(::glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_STENCIL_ATTACHMENT_EXT, GL_RENDERBUFFER_EXT, m_depth_rbo_id));
+            glsafe(::glGenTextures(1, &m_depth_texture_id));
+            glsafe(::glBindTexture(
+                GL_TEXTURE_2D,
+                m_depth_texture_id));
+
+            glsafe(::glTexImage2D(
+                GL_TEXTURE_2D,
+                0,
+                GL_DEPTH24_STENCIL8,
+                m_width,
+                m_height,
+                0,
+                GL_DEPTH_STENCIL,
+                GL_UNSIGNED_INT_24_8,
+                nullptr));
+
+            glsafe(::glTexParameteri(
+                GL_TEXTURE_2D,
+                GL_TEXTURE_MIN_FILTER,
+                GL_NEAREST));
+            glsafe(::glTexParameteri(
+                GL_TEXTURE_2D,
+                GL_TEXTURE_MAG_FILTER,
+                GL_NEAREST));
+            glsafe(::glTexParameteri(
+                GL_TEXTURE_2D,
+                GL_TEXTURE_WRAP_S,
+                GL_CLAMP_TO_EDGE));
+            glsafe(::glTexParameteri(
+                GL_TEXTURE_2D,
+                GL_TEXTURE_WRAP_T,
+                GL_CLAMP_TO_EDGE));
+            glsafe(::glTexParameteri(
+                GL_TEXTURE_2D,
+                GL_TEXTURE_COMPARE_MODE,
+                GL_NONE));
+
+            glsafe(::glFramebufferTexture2D(
+                GL_FRAMEBUFFER,
+                GL_DEPTH_STENCIL_ATTACHMENT,
+                GL_TEXTURE_2D,
+                m_depth_texture_id,
+                0));
         }
         else
         {
-            glsafe(::glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, m_depth_rbo_id));
+            glsafe(BBS_GL_EXTENSION_FUNC(
+                ::glGenRenderbuffers)(
+                    1,
+                    &m_depth_rbo_id));
+
+            glsafe(BBS_GL_EXTENSION_FUNC(
+                ::glBindRenderbuffer)(
+                    BBS_GL_EXTENSION_PARAMETER(GL_RENDERBUFFER),
+                    m_depth_rbo_id));
+
+            glsafe(BBS_GL_EXTENSION_FUNC(
+                ::glRenderbufferStorage)(
+                    BBS_GL_EXTENSION_PARAMETER(GL_RENDERBUFFER),
+                    GL_DEPTH24_STENCIL8,
+                    m_width,
+                    m_height));
+
+            if (formated_gl_version < 30)
+            {
+                glsafe(::glFramebufferRenderbufferEXT(
+                    GL_FRAMEBUFFER_EXT,
+                    GL_DEPTH_ATTACHMENT_EXT,
+                    GL_RENDERBUFFER_EXT,
+                    m_depth_rbo_id));
+
+                glsafe(::glFramebufferRenderbufferEXT(
+                    GL_FRAMEBUFFER_EXT,
+                    GL_STENCIL_ATTACHMENT_EXT,
+                    GL_RENDERBUFFER_EXT,
+                    m_depth_rbo_id));
+            }
+            else
+            {
+                glsafe(::glFramebufferRenderbuffer(
+                    GL_FRAMEBUFFER,
+                    GL_DEPTH_STENCIL_ATTACHMENT,
+                    GL_RENDERBUFFER,
+                    m_depth_rbo_id));
+            }
         }
     }
 }
@@ -1348,7 +1440,12 @@ OpenGLManager::FrameBufferModifier::FrameBufferModifier(OpenGLManager& ogl_manag
 
 OpenGLManager::FrameBufferModifier::~FrameBufferModifier()
 {
-    m_ogl_manager._bind_frame_buffer(m_frame_buffer_name, m_msaa_type, m_width, m_height);
+    m_ogl_manager._bind_frame_buffer(
+        m_frame_buffer_name,
+        m_msaa_type,
+        m_width,
+        m_height,
+        m_depth_texture);
 }
 
 OpenGLManager::FrameBufferModifier& OpenGLManager::FrameBufferModifier::set_width(uint32_t t_width)
@@ -1360,6 +1457,12 @@ OpenGLManager::FrameBufferModifier& OpenGLManager::FrameBufferModifier::set_widt
 OpenGLManager::FrameBufferModifier& OpenGLManager::FrameBufferModifier::set_height(uint32_t t_height)
 {
     m_height = t_height;
+    return *this;
+}
+
+OpenGLManager::FrameBufferModifier& OpenGLManager::FrameBufferModifier::set_depth_texture(bool enabled)
+{
+    m_depth_texture = enabled;
     return *this;
 }
 

--- a/src/slic3r/GUI/OpenGLManager.hpp
+++ b/src/slic3r/GUI/OpenGLManager.hpp
@@ -56,6 +56,7 @@ struct FrameBufferParams
     uint32_t m_width{ 0 };
     uint32_t m_height{ 0 };
     uint32_t m_msaa{ 0 };
+    bool m_depth_texture{ false };
 };
 
 struct FrameBuffer
@@ -67,6 +68,7 @@ struct FrameBuffer
     void unbind();
 
     uint32_t get_color_texture() const noexcept;
+    uint32_t get_depth_texture() const noexcept;
 
     bool is_texture_valid(uint32_t texture_id) const noexcept;
 
@@ -99,10 +101,12 @@ private:
     uint32_t m_width{ 0 };
     uint32_t m_height{ 0 };
     uint8_t m_msaa{ 0 };
+    bool m_depth_texture{ false };
     uint32_t m_msaa_back_buffer_rbos[2]{ UINT32_MAX, UINT32_MAX };
     uint32_t m_gl_id_for_back_fbo{ UINT32_MAX };
     uint32_t m_gl_id{ UINT32_MAX };
     uint32_t m_color_texture_id{ UINT32_MAX };
+    uint32_t m_depth_texture_id{ UINT32_MAX };
     uint32_t m_depth_rbo_id{ UINT32_MAX };
     bool m_needs_to_solve{ false };
     EBlitOptionType m_blit_option_type{ EBlitOptionType::Color };
@@ -176,6 +180,7 @@ public:
         ~FrameBufferModifier();
         FrameBufferModifier& set_width(uint32_t t_width);
         FrameBufferModifier& set_height(uint32_t t_height);
+        FrameBufferModifier& set_depth_texture(bool enabled);
 
     private:
         // no copy
@@ -192,6 +197,7 @@ public:
         EMSAAType m_msaa_type{ EMSAAType::Disabled };
         uint32_t m_width{ 0u };
         uint32_t m_height{ 0u };
+        bool m_depth_texture{ false };
     };
 
 #ifdef __APPLE__
@@ -309,7 +315,7 @@ public:
 
 private:
     static void detect_multisample(int* attribList);
-    void _bind_frame_buffer(const std::string& name, EMSAAType msaa_type, uint32_t t_width = 0, uint32_t t_height = 0);
+    void _bind_frame_buffer(const std::string& name, EMSAAType msaa_type, uint32_t t_width = 0, uint32_t t_height = 0, bool depth_texture = false);
     void _unbind_frame_buffer(const std::string& name);
 };
 

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -800,7 +800,13 @@ void PreferencesDialog::set_dark_mode()
 #endif
 }
 
-wxBoxSizer *PreferencesDialog::create_item_checkbox(wxString title, wxWindow *parent, wxString tooltip, int padding_left, std::string param)
+wxBoxSizer *PreferencesDialog::create_item_checkbox(
+    wxString title,
+    wxWindow *parent,
+    wxString tooltip,
+    int padding_left,
+    std::string param,
+    std::function<void(bool)> callback)
 {
     wxBoxSizer *m_sizer_checkbox  = new wxBoxSizer(wxHORIZONTAL);
     m_sizer_checkbox->SetMinSize(wxSize(-1, FromDIP(ITEM_MIN_HEIGHT)));
@@ -828,7 +834,7 @@ wxBoxSizer *PreferencesDialog::create_item_checkbox(wxString title, wxWindow *pa
     m_sizer_checkbox->Add(checkbox, wxSizerFlags().CenterVertical().Border(wxRIGHT, FromDIP(ITEM_RIGHT_PADDING)));
 
     //// save config
-    checkbox->Bind(wxEVT_TOGGLEBUTTON, [this, checkbox, param](wxCommandEvent &e) {
+    checkbox->Bind(wxEVT_TOGGLEBUTTON, [this, checkbox, param, callback](wxCommandEvent &e) {
         if (param == "privacyuse") {
             app_config->set("firstguide", param, checkbox->GetValue());
             NetworkAgent* agent = GUI::wxGetApp().getAgent();
@@ -987,6 +993,9 @@ wxBoxSizer *PreferencesDialog::create_item_checkbox(wxString title, wxWindow *pa
                 }
             }
         }
+        if (callback)
+            callback(checkbox->GetValue());
+
         e.Skip();
     });
 
@@ -1506,8 +1515,156 @@ wxWindow *PreferencesDialog::create_3d_tab()
 
     auto title_3d = create_item_title(_L("3D Settings"), scrolled, _L("3D Settings"));
 
+    auto title_realistic_rendering = create_item_title(
+        _L("Realistic Rendering"),
+        scrolled,
+        _L("Realistic Rendering"));
+
+    auto title_antialiasing = create_item_title(
+        _L("Anti-aliasing"),
+        scrolled,
+        _L("Anti-aliasing"));
+
+    auto title_rendering_performance = create_item_title(
+        _L("Rendering performance"),
+        scrolled,
+        _L("Rendering performance"));
+
+    auto refresh_current_canvas = []() {
+        if (wxGetApp().plater() != nullptr)
+            wxGetApp().plater()->set_current_canvas_as_dirty();
+    };
+
     auto item_zoom_to_mouse = create_item_checkbox(_L("Zoom to mouse position"), scrolled,
                                                    _L("Zoom in towards the mouse pointer's position in the 3D view, rather than the 2D window center."), 50, "zoom_to_mouse");
+
+    auto item_realistic_view = create_item_checkbox(
+        _L("Realistic view"),
+        scrolled,
+        _L("Use per-pixel Phong lighting in the 3D editor. Requires OpenGL 3.1 or newer. Preview, thumbnails, picking and painting tools remain unchanged."),
+        50,
+        SETTING_OPENGL_REALISTIC_MODE);
+
+    auto item_realistic_ssao = create_item_checkbox(
+        _L("Ambient occlusion (SSAO)"),
+        scrolled,
+        _L("Add subtle contact shadows to the realistic 3D editor view. Requires Realistic view and OpenGL 3.1 or newer."),
+        50,
+        SETTING_OPENGL_PHONG_SSAO);
+
+    auto item_cast_shadows = create_item_checkbox(
+        _L("Cast shadows"),
+        scrolled,
+        _L("Cast shadows from objects onto the build plate in the realistic 3D editor view. Requires Realistic view."),
+        50,
+        SETTING_OPENGL_PHONG_BASIC_PLATE_SHADOWS);
+
+    auto item_build_plate_reflections = create_item_checkbox(
+        _L("Build plate reflections"),
+        scrolled,
+        _L("Show subtle reflections of opaque model parts on the build plate. Requires Realistic view."),
+        50,
+        SETTING_OPENGL_PHONG_BUILD_PLATE_REFLECTIONS);
+
+    auto item_realistic_smooth_normals = create_item_checkbox(
+        _L("Smooth normals"),
+        scrolled,
+        _L("Applies smooth normals to the realistic view.\n\nRequires a manual scene reload to take effect (right-click the 3D view and select \"Reload All\")."),
+        50,
+        SETTING_OPENGL_PHONG_SMOOTH_NORMALS);
+
+    const std::vector<wxString> msaa_labels = {
+        _L("Off"),
+        _L("2x"),
+        _L("4x"),
+        _L("8x"),
+        _L("16x")
+    };
+
+    const std::vector<std::string> msaa_values = {
+        "Disabled",
+        "X2",
+        "X4",
+        "X8",
+        "X16"
+    };
+
+    auto item_msaa = create_item_combobox(
+        _L("MSAA"),
+        scrolled,
+        _L("Sets the multisample anti-aliasing level. Higher values produce smoother edges but increase GPU load."),
+        SETTING_OPENGL_MSAA_TYPE,
+        msaa_labels,
+        msaa_values,
+        [refresh_current_canvas](int) {
+            const auto& ogl_manager =
+                wxGetApp().get_opengl_manager();
+
+            if (ogl_manager != nullptr) {
+                ogl_manager->set_msaa_type(
+                    wxGetApp().app_config->get(
+                        SETTING_OPENGL_MSAA_TYPE));
+            }
+
+            refresh_current_canvas();
+        });
+
+    auto item_fxaa = create_item_checkbox(
+        _L("FXAA post-processing"),
+        scrolled,
+        _L("Applies Fast Approximate Anti-Aliasing as a screen-space post-processing pass."),
+        50,
+        SETTING_OPENGL_FXAA_ENABLED,
+        [refresh_current_canvas](bool enabled) {
+            const auto& ogl_manager =
+                wxGetApp().get_opengl_manager();
+
+            if (ogl_manager != nullptr)
+                ogl_manager->set_fxaa_enabled(enabled);
+
+            refresh_current_canvas();
+        });
+
+    const std::vector<wxString> frame_rate_labels = {
+        _L("Unlimited"),
+        _L("30 FPS"),
+        _L("60 FPS"),
+        _L("90 FPS"),
+        _L("120 FPS"),
+        _L("144 FPS"),
+        _L("240 FPS")
+    };
+
+    const std::vector<std::string> frame_rate_values = {
+        "0",
+        "30",
+        "60",
+        "90",
+        "120",
+        "144",
+        "240"
+    };
+
+    auto item_frame_rate_limit = create_item_combobox(
+        _L("Frame rate limit"),
+        scrolled,
+        _L("Limits the frame rate of the interactive 3D and Preview canvases without blocking the user interface. Assembly exports are not limited."),
+        SETTING_OPENGL_FRAME_RATE_LIMIT,
+        frame_rate_labels,
+        frame_rate_values,
+        [refresh_current_canvas](int) {
+            refresh_current_canvas();
+        });
+
+    auto item_show_fps = create_item_checkbox(
+        _L("Show FPS overlay"),
+        scrolled,
+        _L("Shows the measured number of displayed frames per second in the top-right corner of the interactive canvas."),
+        50,
+        SETTING_OPENGL_SHOW_FPS,
+        [refresh_current_canvas](bool) {
+            refresh_current_canvas();
+        });
 
     std::vector<wxString> assemble_view_preview_options = {_L("Auto"), _L("Open"), _L("Close")};
     auto                  enable_assemble_view_preview  = create_item_combobox(
@@ -1575,6 +1732,31 @@ wxWindow *PreferencesDialog::create_3d_tab()
     sizer->Add(item_tooltip_offset, flags);
     sizer->Add(item_toolbar_style, flags);
     sizer->Add(item_zoom_to_mouse, flags);
+
+    sizer->Add(
+        title_realistic_rendering,
+        wxSizerFlags().Expand().Border(wxTOP, FromDIP(16)));
+    sizer->AddSpacer(FromDIP(8));
+    sizer->Add(item_realistic_view, flags);
+    sizer->Add(item_realistic_ssao, flags);
+    sizer->Add(item_cast_shadows, flags);
+    sizer->Add(item_build_plate_reflections, flags);
+    sizer->Add(item_realistic_smooth_normals, flags);
+
+    sizer->Add(
+        title_antialiasing,
+        wxSizerFlags().Expand().Border(wxTOP, FromDIP(16)));
+    sizer->AddSpacer(FromDIP(8));
+    sizer->Add(item_msaa, flags);
+    sizer->Add(item_fxaa, flags);
+
+    sizer->Add(
+        title_rendering_performance,
+        wxSizerFlags().Expand().Border(wxTOP, FromDIP(16)));
+    sizer->AddSpacer(FromDIP(8));
+    sizer->Add(item_frame_rate_limit, flags);
+    sizer->Add(item_show_fps, flags);
+
     sizer->Add(item_show_shells, flags);
 #if !BBL_RELEASE_TO_PUBLIC
     auto item_show_bvh_bounds = create_item_checkbox(_L("Show assembly BVH primary bounds"), scrolled, _L("Display the BVH primary bounding box wireframe in assembly view."), 50,
@@ -2014,6 +2196,17 @@ void PreferencesDialog::on_reset_preferences()
         "import_single_svg_and_split",
         "gamma_correct_in_import_obj",
         "enable_lod",
+        SETTING_OPENGL_REALISTIC_MODE,
+        SETTING_OPENGL_REALISTIC_PHONG,
+        SETTING_OPENGL_SHADING_MODEL,
+        SETTING_OPENGL_PHONG_BASIC_PLATE_SHADOWS,
+        SETTING_OPENGL_PHONG_BUILD_PLATE_REFLECTIONS,
+        SETTING_OPENGL_PHONG_SSAO,
+        SETTING_OPENGL_PHONG_SMOOTH_NORMALS,
+        SETTING_OPENGL_MSAA_TYPE,
+        SETTING_OPENGL_FXAA_ENABLED,
+        SETTING_OPENGL_FRAME_RATE_LIMIT,
+        SETTING_OPENGL_SHOW_FPS,
         "enable_advanced_gcode_viewer_",
         "camera_fullscreen_active_monitor_only",
         "max_recent_count",

--- a/src/slic3r/GUI/Preferences.hpp
+++ b/src/slic3r/GUI/Preferences.hpp
@@ -95,7 +95,13 @@ public:
     wxBoxSizer *create_item_region_combobox(wxString title, wxWindow *parent, wxString tooltip, std::vector<wxString> vlist);
     wxBoxSizer *create_item_language_combobox(wxString title, wxWindow *parent, wxString tooltip, int padding_left, std::string param, std::vector<const wxLanguageInfo *> vlist);
     wxBoxSizer *create_item_loglevel_combobox(wxString title, wxWindow *parent, wxString tooltip, std::vector<wxString> vlist);
-    wxBoxSizer *create_item_checkbox(wxString title, wxWindow *parent, wxString tooltip, int padding_left, std::string param);
+    wxBoxSizer *create_item_checkbox(
+        wxString title,
+        wxWindow *parent,
+        wxString tooltip,
+        int padding_left,
+        std::string param,
+        std::function<void(bool)> callback = nullptr);
     wxBoxSizer *create_item_darkmode_checkbox(wxString title, wxWindow *parent, wxString tooltip, int padding_left, std::string param);
     void        set_dark_mode();
     wxWindow* create_item_downloads(wxWindow* parent, int padding_left, std::string param);


### PR DESCRIPTION
## Summary

Adds an optional realistic rendering mode to the normal 3D editor view.

The new mode uses Phong shading and can optionally apply screen-space ambient occlusion (SSAO) before the existing FXAA pass.

This work is based on the corresponding OrcaSlicer implementation from commit `cf8bb38dc6af95d27fc85f37329ee542d2e76ac3`, adapted to Bambu Studio's current rendering pipeline.

## Screenshot

Realistic view with ambient occlusion enabled (Preferences → 3D), rendered on a graphical system:

![Realistic 3D editor view with SSAO](https://raw.githubusercontent.com/BenJule/BambuStudio/pr-assets/realistic-view-ssao.png)

## Behavior

- disabled by default
- available only in the normal 3D editor view
- requires OpenGL 3.1 or newer
- falls back to the existing Gouraud shader when Phong is unavailable
- SSAO is enabled only when both the Phong and SSAO shaders are available
- disabled for painting, picking, assembly rendering and thumbnails
- preserves the existing FXAA post-processing path

## Implementation

- adds GLSL 1.10 and 1.40 Phong shaders
- adds GLSL 1.10 and 1.40 SSAO shaders
- adds optional depth textures to the framebuffer implementation
- integrates SSAO before FXAA
- adds preferences for Realistic view and Ambient occlusion (SSAO)

## Validation

- `git diff --check` passes
- targeted compilation of the modified C++ translation units passes
- a Linux CI build successfully compiled and linked `src/bambu-studio`
- the packaging stage subsequently failed because the generated `BuildLinuxImage.sh` lacked executable permission; this occurred after the application had linked

The final commit additionally contains null checks that prevent SSAO from being enabled when the Phong or SSAO shader is unavailable.

## Pending validation

- runtime GLSL compilation on a graphical system
- visual comparison of Gouraud, Phong and Phong with SSAO
- interaction checks for selection, painting and other editor tools
