### PR TITLE
Fix User Customized Offset tooltip direction

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -5856,7 +5856,7 @@ void PrintConfigDef::init_fff_params()
     def          = this->add("circle_compensation_manual_offset", coFloat);
     def->label   = L("User Customized Offset");
     def->sidetext = L("mm");
-    def->tooltip = L("If you want to have tighter or looser assemble, you can set this value. When it is positive, it indicates tightening, otherwise, it indicates loosening");
+    def->tooltip = L("Adjust this value to change the fit between mating parts. Positive values make the assembly looser, while negative values make it tighter.");
     def->mode    = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0.0));
 


### PR DESCRIPTION
## Summary

- correct the tooltip for **User Customized Offset**
- clarify that positive values make the assembly looser
- clarify that negative values make the assembly tighter
- improve the tooltip wording for readability

## Testing

- ran `git diff --check`
- verified the corrected tooltip in `src/libslic3r/PrintConfig.cpp`
- no functional code changes

Fixes #8873
