### PR TITLE
Confirm before clearing recent projects

### DIFF
--- a/resources/web/homepage3/js/home.js
+++ b/resources/web/homepage3/js/home.js
@@ -482,22 +482,11 @@ function OnDeleteRecentFile( )
 
 function OnDeleteAllRecentFiles()
 {
-	showConfirmDialog({
-		title: GetCurrentTextByKey("t39"),
-		message: GetCurrentTextByKey("t149"),
-		okText: GetCurrentTextByKey("t21"),
-		cancelText: GetCurrentTextByKey("t22"),
-		onOk: function() {
-			$('#FileList').html('');
-			UpdateRecentClearBtnDisplay();
-			
-			var tSend={};
-			tSend['sequence_id']=Math.round(new Date() / 1000);
-			tSend['command']="homepage_delete_all_recentfile";
-			
-			SendWXMessage( JSON.stringify(tSend) );
-		}
-	});
+	var tSend={};
+	tSend['sequence_id']=Math.round(new Date() / 1000);
+	tSend['command']="homepage_delete_all_recentfile";
+
+	SendWXMessage( JSON.stringify(tSend) );
 }
 
 function UpdateRecentClearBtnDisplay()

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -4425,9 +4425,19 @@ void MainFrame::open_recent_project(size_t file_id, wxString const & filename)
 void MainFrame::remove_recent_project(size_t file_id, wxString const &filename)
 {
     if (file_id == size_t(-1)) {
-        if (filename.IsEmpty())
+        if (filename.IsEmpty()) {
+            wxMessageDialog confirmation(
+                this,
+                _L("Are you sure you want to clear all recent projects?"),
+                _L("Clear recent projects"),
+                wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION);
+
+            if (confirmation.ShowModal() != wxID_YES)
+                return;
+
             while (m_recent_projects.GetCount() > 0)
                 m_recent_projects.RemoveFileFromHistory(0);
+        }
         else
             file_id = m_recent_projects.FindFileInHistory(filename);
     }


### PR DESCRIPTION
## Summary

- add a confirmation dialog before clearing all recent projects
- make **No** the default choice to prevent accidental deletion
- leave removal of individual recent projects unchanged

## Testing

- ran `git diff --check`
- verified the Clear All confirmation control flow
- verified that the dialog only appears for the empty-filename Clear All action
- no local full build; the change is limited to the existing recent-project handler

Fixes #8351
