### PR TITLE
Fix filament colors in Hotends Info

### DIFF
--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRack.cpp
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRack.cpp
@@ -45,7 +45,7 @@ wxDEFINE_EVENT(EVT_NOZZLE_RACK_NOZZLE_ITEM_SELECTED, wxCommandEvent);
 namespace Slic3r::GUI
 {
 
-static wxBitmap SetNozzleBmpColor(const wxBitmap& bmp, const std::string& color_str) {
+wxBitmap SetNozzleBmpColor(const wxBitmap& bmp, const std::string& color_str) {
     if(color_str.empty()) return bmp;
 
     wxImage img = bmp.ConvertToImage();

--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRack.h
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRack.h
@@ -14,9 +14,11 @@
 #include "slic3r/GUI/Widgets/StaticBox.hpp"
 #include "slic3r/GUI/Widgets/AnimaController.hpp"
 
+#include <wx/bitmap.h>
 #include <wx/panel.h>
 #include <wx/simplebook.h>
 #include <memory>
+#include <string>
 
 // Previous definitions
 class Button;
@@ -43,6 +45,8 @@ wxDECLARE_EVENT(EVT_NOZZLE_RACK_NOZZLE_ITEM_SELECTED, wxCommandEvent);
 
 namespace Slic3r::GUI
 {
+wxBitmap SetNozzleBmpColor(const wxBitmap& bmp, const std::string& color_str);
+
 class wgtDeviceNozzleRack : public wxPanel
 {
 public:

--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRackUpdate.cpp
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRackUpdate.cpp
@@ -6,6 +6,7 @@
 //**********************************************************/
 
 #include "wgtDeviceNozzleRackUpdate.h"
+#include "wgtDeviceNozzleRack.h"
 
 #include "slic3r/GUI/DeviceCore/DevNozzleSystem.h"
 #include "slic3r/GUI/DeviceCore/DevUpgrade.h"
@@ -383,7 +384,14 @@ void wgtDeviceNozzleRackHotendUpdate::OnBitmapHoverEnter(wxMouseEvent& event)
     wxBoxSizer* frameSizer = new wxBoxSizer(wxVERTICAL);
     m_hoverFrame->SetSizer(frameSizer);
 
-    wxStaticBitmap* hoverBmp = new wxStaticBitmap(m_hoverFrame, wxID_ANY, scaledBmp->bmp());
+    wxBitmap hover_bitmap = scaledBmp->bmp();
+    if (m_nozzle_status == NOZZLE_STATUS_NORMAL ||
+        m_nozzle_status == NOZZLE_STATUS_ABNORMAL)
+        hover_bitmap =
+            SetNozzleBmpColor(hover_bitmap, m_filament_color);
+
+    wxStaticBitmap* hoverBmp =
+        new wxStaticBitmap(m_hoverFrame, wxID_ANY, hover_bitmap);
     frameSizer->Add(hoverBmp, 0, wxALIGN_CENTER_HORIZONTAL | wxTOP | wxBOTTOM, FromDIP(12));
 
     wxPoint mousePos = wxGetMousePosition();
@@ -428,14 +436,20 @@ void wgtDeviceNozzleRackHotendUpdate::updateNozzleImage(const DevNozzle& nozzle)
         if (nozzle.GetNozzleFlowType() == H_FLOW && index >= 1)
         {
             m_nozzle_image = nozzle_hh[index - 1][0];
-            m_icon_bitmap->SetBitmap(m_nozzle_image->bmp());
+            m_icon_bitmap->SetBitmap(
+                SetNozzleBmpColor(
+                    m_nozzle_image->bmp(),
+                    nozzle.GetFilamentColor()));
             m_scaled_nozzle_image = nozzle_hh[index - 1][1];
             findNozzleImage = true;
         }
         else if (nozzle.GetNozzleFlowType() == S_FLOW && index >= 0)
         {
             m_nozzle_image = nozzle_hs[index][0];
-            m_icon_bitmap->SetBitmap(m_nozzle_image->bmp());
+            m_icon_bitmap->SetBitmap(
+                SetNozzleBmpColor(
+                    m_nozzle_image->bmp(),
+                    nozzle.GetFilamentColor()));
             m_scaled_nozzle_image = nozzle_hs[index][1];
             findNozzleImage = true;
         }
@@ -521,6 +535,10 @@ void wgtDeviceNozzleRackHotendUpdate::UpdateInfo(const DevNozzle& nozzle)
         }
     }
 
+    const std::string filament_color = nozzle.GetFilamentColor();
+    const bool filament_color_changed = m_filament_color != filament_color;
+    m_filament_color = filament_color;
+
     if (nozzle.IsEmpty() && m_nozzle_status != NOZZLE_STATUS_EMPTY)
     {
         m_nozzle_status = NOZZLE_STATUS_EMPTY;
@@ -544,7 +562,8 @@ void wgtDeviceNozzleRackHotendUpdate::UpdateInfo(const DevNozzle& nozzle)
         m_status_bitmap->Show(false);
 
     }
-    else if (nozzle.IsNormal() && m_nozzle_status != NOZZLE_STATUS_NORMAL)
+    else if (nozzle.IsNormal() &&
+             (m_nozzle_status != NOZZLE_STATUS_NORMAL || filament_color_changed))
     {
         m_nozzle_status = NOZZLE_STATUS_NORMAL;
 
@@ -570,7 +589,8 @@ void wgtDeviceNozzleRackHotendUpdate::UpdateInfo(const DevNozzle& nozzle)
         m_status_label->Show(false);
         m_status_bitmap->Show(false);
     }
-    else if (nozzle.IsAbnormal() && m_nozzle_status != NOZZLE_STATUS_ABNORMAL)
+    else if (nozzle.IsAbnormal() &&
+             (m_nozzle_status != NOZZLE_STATUS_ABNORMAL || filament_color_changed))
     {
         m_nozzle_status = NOZZLE_STATUS_ABNORMAL;
 
@@ -693,7 +713,10 @@ void wgtDeviceNozzleRackHotendUpdate::Rescale()
     }
     else if (m_nozzle_image != nullptr)
     {
-        m_icon_bitmap->SetBitmap(m_nozzle_image->bmp());
+        m_icon_bitmap->SetBitmap(
+            SetNozzleBmpColor(
+                m_nozzle_image->bmp(),
+                m_filament_color));
     }
     m_icon_bitmap->Refresh();
 }

--- a/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRackUpdate.h
+++ b/src/slic3r/GUI/DeviceTab/wgtDeviceNozzleRackUpdate.h
@@ -126,6 +126,7 @@ private:
     bool findNozzleImage = false;
 
     NozzleStatus m_nozzle_status = NOZZLE_STATUS_DC;
+    std::string m_filament_color;
     std::weak_ptr<DevNozzleRack> m_nozzle_rack;
 
     std::vector<std::vector<ScalableBitmap*>> nozzle_hs;


### PR DESCRIPTION
## Summary

- color the hotend images in the Hotends Info view using each hotend's filament color
- color the enlarged hover preview as well
- preserve the filament color after DPI rescaling
- refresh the displayed color when it changes without a nozzle status change
- reuse the existing nozzle bitmap coloring helper

## Testing

- ran `git diff --check`
- ran targeted C++ syntax checks for:
  - `wgtDeviceNozzleRack.cpp`
  - `wgtDeviceNozzleRackUpdate.cpp`
- both targeted syntax checks completed successfully
- no local full build was performed

Fixes #9576
