### PR TITLE
Update macOS copyright year to 2026

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -263,7 +263,7 @@ else ()
         set(MACOSX_BUNDLE_ICON_FILE Icon.icns)
         set(MACOSX_BUNDLE_BUNDLE_NAME "Bambu Studio")
         set(MACOSX_BUNDLE_SHORT_VERSION_STRING ${SLIC3R_VERSION})
-        set(MACOSX_BUNDLE_COPYRIGHT "Copyright(C) 2021-2025 Lunkuo All Rights Reserved")
+        set(MACOSX_BUNDLE_COPYRIGHT "Copyright(C) 2021-2026 Lunkuo All Rights Reserved")
     endif()
     add_custom_command(TARGET BambuStudio POST_BUILD
         COMMAND ln -sfn "${SLIC3R_RESOURCES_DIR}" "${BIN_RESOURCES_DIR}"


### PR DESCRIPTION
## Summary

Update the macOS application bundle copyright year from 2025 to 2026.

The value is written to `NSHumanReadableCopyright` in the generated macOS `Info.plist`.

## Testing

- verified the CMake copyright value
- verified that `MacOSXBundleInfo.plist.in` uses `MACOSX_BUNDLE_COPYRIGHT`
- ran `git diff --check`
- no local full build was performed because this only changes macOS bundle metadata

Fixes #8849
