### PR TITLE
feat: add option to exclude timelapse time from the print time estimate

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -667,22 +667,36 @@ void GCodeProcessor::TimeProcessor::post_process(const std::string& filename, st
                 }
             }
             else if (line == reserved_tag(ETags::Estimated_Printing_Time_Placeholder)) {
+                // BBS: optionally drop the timelapse block time from the reported estimate.
+                // timelapse_part_time is accumulated over all enabled modes, so spread it evenly.
+                float timelapse_time_per_mode = 0.0f;
+                if (context.exclude_timelapse_time && context.timelapse_part_time > 0.0f) {
+                    size_t enabled_modes = 0;
+                    for (const auto& m : machines)
+                        if (m.enabled)
+                            ++enabled_modes;
+                    if (enabled_modes == 0)
+                        enabled_modes = 1;
+                    timelapse_time_per_mode = context.timelapse_part_time / static_cast<float>(enabled_modes);
+                }
                 for (size_t i = 0; i < static_cast<size_t>(PrintEstimatedStatistics::ETimeMode::Count); ++i) {
                     const TimeMachine& machine = machines[i];
                     PrintEstimatedStatistics::ETimeMode mode = static_cast<PrintEstimatedStatistics::ETimeMode>(i);
                     if (mode == PrintEstimatedStatistics::ETimeMode::Normal || machine.enabled) {
                         char buf[128];
+                        const float total_time = std::max(0.0f, machine.time - timelapse_time_per_mode);
+                        const float model_time = std::max(0.0f, total_time - machine.prepare_time);
                         if (!s_IsBBLPrinter) {
                             // Klipper estimator
                             sprintf(buf, "; estimated printing time (normal mode) = %s\n",
-                                get_time_dhms(machine.time).c_str());
+                                get_time_dhms(total_time).c_str());
                             ret += buf;
                         }
                         else {
                             // BBS estimator
                             sprintf(buf, "; model printing time: %s; total estimated time: %s\n",
-                                get_time_dhms(machine.time - machine.prepare_time).c_str(),
-                                get_time_dhms(machine.time).c_str());
+                                get_time_dhms(model_time).c_str(),
+                                get_time_dhms(total_time).c_str());
                             ret += buf;
                         }
                     }
@@ -1500,6 +1514,7 @@ void GCodeProcessorResult::reset() {
     label_object_enabled = false;
     timelapse_warning_code = 0;
     support_traditional_timelapse = true;
+    exclude_timelapse_time_from_estimate = false;
     printable_height = 0.0f;
     settings_ids.reset();
     extruders_count = 0;
@@ -1533,6 +1548,7 @@ void GCodeProcessorResult::reset() {
     long_retraction_when_cut = false;
     timelapse_warning_code = 0;
     support_traditional_timelapse = true;
+    exclude_timelapse_time_from_estimate = false;
     printable_height = 0.0f;
     settings_ids.reset();
     filaments_count = 0;
@@ -1933,6 +1949,7 @@ void GCodeProcessor::apply_config(const PrintConfig& config)
     m_filament_pre_cooling_temp = config.filament_pre_cooling_temperature.values;
     m_filament_preheat_temperature_delta = config.filament_preheat_temperature_delta.values;
     m_enable_pre_heating = config.enable_pre_heating;
+    m_exclude_timelapse_time = config.exclude_timelapse_from_estimate;
     m_has_filament_switcher = config.has_filament_switcher;
     m_physical_extruder_map = config.physical_extruder_map.values;
     m_extruder_max_nozzle_count = config.extruder_max_nozzle_count.values;
@@ -2729,7 +2746,12 @@ void GCodeProcessor::finalize(bool post_process)
             m_extruder_max_nozzle_count,
             m_filament_preheat_temperature_delta,
             m_result.extruder_types,
-            m_nozzle_diameter
+            m_nozzle_diameter,
+            m_exclude_timelapse_time,
+            [this]() {
+                auto it = m_result.skippable_part_time.find(SkipType::stTimelapse);
+                return (it != m_result.skippable_part_time.end()) ? it->second : 0.0f;
+            }()
         );
         m_time_processor.post_process(m_result.filename, m_result.moves, m_result.lines_ends, context);
     }
@@ -6246,9 +6268,30 @@ void GCodeProcessor::simulate_st_synchronize(float additional_time, ExtrusionRol
 
 void GCodeProcessor::update_estimated_times_stats()
 {
-    auto update_mode = [this](PrintEstimatedStatistics::ETimeMode mode) {
+    // BBS: when the user opts out of counting timelapse time, subtract the duration of the
+    // timelapse blocks (tagged "; SKIPTYPE: timelapse" in the printer's time-lapse G-code) from
+    // the reported estimate. skippable_part_time is accumulated across all enabled time modes, so
+    // spread it evenly to avoid over-subtracting when more than one mode is enabled.
+    m_result.exclude_timelapse_time_from_estimate = m_exclude_timelapse_time;
+    float timelapse_time_per_mode = 0.0f;
+    if (m_exclude_timelapse_time) {
+        auto it = m_result.skippable_part_time.find(SkipType::stTimelapse);
+        if (it != m_result.skippable_part_time.end() && it->second > 0.0f) {
+            size_t enabled_modes = 0;
+            for (const auto& machine : m_time_processor.machines)
+                if (machine.enabled)
+                    ++enabled_modes;
+            if (enabled_modes == 0)
+                enabled_modes = 1;
+            timelapse_time_per_mode = it->second / static_cast<float>(enabled_modes);
+        }
+    }
+
+    auto update_mode = [this, timelapse_time_per_mode](PrintEstimatedStatistics::ETimeMode mode) {
         PrintEstimatedStatistics::Mode& data = m_result.print_statistics.modes[static_cast<size_t>(mode)];
         data.time = get_time(mode);
+        if (timelapse_time_per_mode > 0.0f)
+            data.time = std::max(0.0f, data.time - timelapse_time_per_mode);
         data.prepare_time = get_prepare_time(mode);
         data.custom_gcode_times = get_custom_gcode_times(mode, true);
         data.moves_times = get_moves_time(mode);

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -267,6 +267,9 @@ namespace Slic3r {
         bool long_retraction_when_cut {0};
         int timelapse_warning_code {0};
         bool support_traditional_timelapse{true};
+        // BBS: when true, timelapse time is excluded from the reported estimate; the preview legend
+        // uses this to avoid showing / double-counting the timelapse portion.
+        bool exclude_timelapse_time_from_estimate{false};
         bool update_imgui_flag{false};
         bool is_helio_gcode{false};
         float printable_height;
@@ -325,6 +328,7 @@ namespace Slic3r {
             long_retraction_when_cut = other.long_retraction_when_cut;
             timelapse_warning_code = other.timelapse_warning_code;
             support_traditional_timelapse = other.support_traditional_timelapse;
+            exclude_timelapse_time_from_estimate = other.exclude_timelapse_time_from_estimate;
             printable_height = other.printable_height;
             settings_ids = other.settings_ids;
             filaments_count = other.filaments_count;
@@ -767,6 +771,9 @@ namespace Slic3r {
             std::vector<int> extruder_max_nozzle_count { 1 };
             std::vector<ExtruderType> extruder_types;
             std::vector<double> nozzle_diameter;
+            // BBS: when true, subtract timelapse_part_time from the estimate written into the G-code header.
+            bool exclude_timelapse_time{ false };
+            float timelapse_part_time{ 0.0f };
 
             TimeProcessContext(
                 const UsedFilaments& used_filaments_,
@@ -786,7 +793,9 @@ namespace Slic3r {
                 const std::vector<int>& extruder_max_nozzle_count_,
                 const std::vector<double>& filament_preheat_temperature_delta_,
                 const std::vector<ExtruderType>& extruder_types_,
-                const std::vector<double>& nozzle_diameter_
+                const std::vector<double>& nozzle_diameter_,
+                const bool exclude_timelapse_time_,
+                const float timelapse_part_time_
             ) :
                 used_filaments(used_filaments_),
                 filament_lists(filament_lists_),
@@ -805,7 +814,9 @@ namespace Slic3r {
                 extruder_max_nozzle_count(extruder_max_nozzle_count_),
                 filament_preheat_temperature_delta(filament_preheat_temperature_delta_),
                 extruder_types(extruder_types_),
-                nozzle_diameter(nozzle_diameter_)
+                nozzle_diameter(nozzle_diameter_),
+                exclude_timelapse_time(exclude_timelapse_time_),
+                timelapse_part_time(timelapse_part_time_)
             {
             }
 
@@ -1137,6 +1148,8 @@ namespace Slic3r {
         std::vector<int> m_filament_pre_cooling_temp{ 0 };
         std::vector<double> m_filament_preheat_temperature_delta;
         bool m_enable_pre_heating{ false };
+        // When true, the timelapse block time is subtracted from the reported print-time estimate.
+        bool m_exclude_timelapse_time{ false };
         bool m_handle_hotend_as_extruder { false };
         bool m_has_filament_switcher{ false };
         std::vector<int> m_physical_extruder_map;

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1067,7 +1067,7 @@ static std::vector<std::string> s_Preset_print_options {
      "support_bottom_interface_spacing", "enable_overhang_speed", "overhang_1_4_speed", "overhang_2_4_speed", "overhang_3_4_speed", "overhang_4_4_speed", "overhang_totally_speed",
     "enable_height_slowdown","slowdown_start_height", "slowdown_start_speed", "slowdown_start_acc", "slowdown_end_height", "slowdown_end_speed", "slowdown_end_acc",
      "initial_layer_infill_speed", "top_one_wall_type", "top_area_threshold", "only_one_wall_first_layer",
-     "timelapse_type", "internal_bridge_support_thickness",
+     "timelapse_type", "exclude_timelapse_from_estimate", "internal_bridge_support_thickness",
      "wall_generator", "wall_transition_length", "wall_transition_filter_deviation", "wall_transition_angle",
      "wall_distribution_count", "min_feature_size", "min_bead_width", "post_process",
     "seam_gap", "wipe_speed", "top_solid_infill_flow_ratio", "initial_layer_flow_ratio",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -5111,6 +5111,15 @@ void PrintConfigDef::init_fff_params()
     def->mode = comSimple;
     def->set_default_value(new ConfigOptionBool(false));
 
+    def = this->add("exclude_timelapse_from_estimate", coBool);
+    def->label = L("Exclude timelapse time from estimate");
+    def->tooltip = L("When enabled, the extra time spent on timelapse moves is not counted in the "
+                     "estimated printing time reported after slicing (and written into the G-code and "
+                     "3MF). Timelapse itself still runs during the print; only the reported estimate "
+                     "changes. The printer's live remaining-time countdown is not affected.");
+    def->mode = comSimple;
+    def->set_default_value(new ConfigOptionBool(false));
+
     def = this->add("standby_temperature_delta", coInt);
     def->label = L("Temperature variation");
     //def->tooltip = L("Temperature difference to be applied when an extruder is not active. "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1507,6 +1507,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionPoints,             start_end_points))
     ((ConfigOptionEnum<TimelapseType>,    timelapse_type))
     ((ConfigOptionBool,               farthest_point_timelapse))
+    ((ConfigOptionBool,               exclude_timelapse_from_estimate))
     ((ConfigOptionFloat,              default_jerk))
     ((ConfigOptionFloat,              outer_wall_jerk))
     ((ConfigOptionFloat,              inner_wall_jerk))

--- a/src/slic3r/GUI/GCodeRenderer/BaseRenderer.cpp
+++ b/src/slic3r/GUI/GCodeRenderer/BaseRenderer.cpp
@@ -2609,6 +2609,11 @@ namespace Slic3r
                     if (auto timelapse_time_iter = m_gcode_result->skippable_part_time.find(SkipType::stTimelapse); timelapse_time_iter != m_gcode_result->skippable_part_time.end()) {
                         timelapse_time = timelapse_time_iter->second;
                     }
+                    // BBS: when the user excludes timelapse from the estimate, modes[].time is already
+                    // reduced by it, so hide the timelapse component here to keep the legend consistent
+                    // (avoids the "+ timelapse" line and double-subtracting it from model printing time).
+                    if (m_gcode_result->exclude_timelapse_time_from_estimate)
+                        timelapse_time = 0.0;
                     ImGui::Dummy(ImVec2(0.0f, ImGui::GetFontSize() * 0.1));
                     ImGui::Dummy({ window_padding, window_padding });
                     ImGui::SameLine();

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3243,6 +3243,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("spiral_mode_smooth", "spiral-vase#smooth");
         optgroup->append_single_option_line("spiral_mode_max_xy_smoothing", "spiral-vase#max-xy-smoothing");
         optgroup->append_single_option_line("timelapse_type", "Timelapse");
+        optgroup->append_single_option_line("exclude_timelapse_from_estimate", "Timelapse");
 
         optgroup->append_single_option_line("fuzzy_skin", "parameter/fuzzy-skin");
         optgroup->append_single_option_line("fuzzy_skin_mode");


### PR DESCRIPTION
### What

Adds an optional print setting, **Exclude timelapse time from estimate** (`exclude_timelapse_from_estimate`), which subtracts the duration of the timelapse blocks from the reported print time estimate. It defaults to `false`, so existing behaviour is unchanged unless the user opts in.

### Why

With timelapse enabled, the estimate includes the per-layer timelapse moves. On prints with many short layers this inflates the number noticeably relative to the same model sliced without timelapse, which makes it awkward to compare profiles or to estimate machine time when the timelapse footage is a by-product rather than the goal.

The timelapse still runs — only the reported estimate changes.

### How

The timelapse duration is already tracked as `skippable_part_time[SkipType::stTimelapse]`. When the option is on, that value is subtracted in two places so the preview and the G-code agree:

- `GCodeProcessor::update_estimated_times_stats()` — the statistics shown in the preview.
- `GCodeProcessor::TimeProcessor::post_process()` — the `; model printing time:` / `; estimated printing time` header written into the G-code. The value is carried in via `TimeProcessContext`.

`skippable_part_time` is accumulated across all enabled time modes, so the total is spread evenly over the enabled modes rather than subtracted in full from each one; otherwise it would over-subtract whenever more than one mode is enabled. Both call sites clamp at zero.

The preview legend (`BaseRenderer.cpp`) zeroes its local `timelapse_time` when the option is on, because `modes[].time` has already been reduced by it — this keeps the legend self-consistent and avoids subtracting the timelapse portion twice from the displayed model printing time.

The option is registered in `s_Preset_print_options` and appears in the Process tab under Others, directly below the existing `timelapse_type` setting.

### Scope / non-goals

- The printer's live remaining-time countdown is unaffected; this only changes what the slicer reports.
- No change to how timelapse G-code is generated, and no change in behaviour when the option is off.

### Testing

Built on Linux (GCC, Release, `SLIC3R_GUI=ON`) against `master`; the branch is a clean cherry-pick onto the current head and no upstream commit since has touched the seven files involved.

Happy to adjust the option name, its tooltip wording, or where it sits in the Process tab if you'd prefer something different.
