### PR TITLE
Preserve confirmed empty AMS spool weights

### DIFF
--- a/src/slic3r/GUI/DeviceCore/DevFilaSystem.cpp
+++ b/src/slic3r/GUI/DeviceCore/DevFilaSystem.cpp
@@ -118,7 +118,8 @@ std::optional<int> DevAmsTray::get_filament_remain_weight() const
 {
     // Prefer the accurate per-gram value reported by firmware; -1 means not edited/not provided.
     if (remain_g >= 0) {
-        return remain_g > 0 ? std::optional<int>(remain_g) : std::nullopt;
+        // Zero is a valid, known value: the spool is empty.
+        return remain_g;
     }
 
     if (weight.empty()) {
@@ -133,7 +134,8 @@ std::optional<int> DevAmsTray::get_filament_remain_weight() const
         BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << "invalid filament weight " << weight;
     }
 
-    if (weight_int.has_value() && weight_int.value() > 0) {
+    if (weight_int.has_value() && weight_int.value() >= 0) {
+        // Preserve a calculated zero instead of treating it as unknown.
         return weight_int;
     } else {
         return std::nullopt;

--- a/src/slic3r/GUI/DeviceWeb/device_page/src/features/filament-manager/AddEditDialog.tsx
+++ b/src/slic3r/GUI/DeviceWeb/device_page/src/features/filament-manager/AddEditDialog.tsx
@@ -1743,13 +1743,18 @@ export function AddEditDialog({
     // it anyway.
     const trayNetInit = parseInt(String(tray.weight ?? '0'), 10) || 0;
     const currentNet = getTrayCurrentNetWeight(tray);
-    setTotalNetWeight(trayNetInit > 0 ? trayNetInit : 1000);
-    setCurrentNetWeight(currentNet > 0 ? currentNet : (trayNetInit > 0 ? trayNetInit : 1000));
+    const totalNet = trayNetInit > 0 ? trayNetInit : 1000;
+    setTotalNetWeight(totalNet);
+    setCurrentNetWeight(
+      currentNet !== null
+        ? Math.min(Math.max(currentNet, 0), totalNet)
+        : totalNet,
+    );
     setAmsLockedFields({
       brand: !!brandName,
       material: !!typeName || !!filamentName,
       color: !!sanitizedColor,
-      weight: trayNetInit > 0 || currentNet > 0,
+      weight: trayNetInit > 0 || currentNet !== null,
     });
   };
 
@@ -2129,7 +2134,7 @@ export function AddEditDialog({
                               <div className="text-[12px] leading-[19px] text-fm-text-secondary">
                                 {(() => {
                                   const cur = getTrayCurrentNetWeight(tray);
-                                  return cur > 0 ? `${cur}g` : '—';
+                                  return cur !== null ? `${cur}g` : '—';
                                 })()}
                               </div>
                             </div>
@@ -2180,7 +2185,7 @@ export function AddEditDialog({
                           <span className="text-[11px] leading-[16px] text-fm-text-detail">
                             {(() => {
                               const cur = getTrayCurrentNetWeight(item.tray);
-                              return cur > 0 ? `${cur}g` : '—';
+                              return cur !== null ? `${cur}g` : '—';
                             })()}
                           </span>
                         </div>

--- a/src/slic3r/GUI/DeviceWeb/device_page/src/features/filament-manager/buildSpoolFromTray.ts
+++ b/src/slic3r/GUI/DeviceWeb/device_page/src/features/filament-manager/buildSpoolFromTray.ts
@@ -59,11 +59,11 @@ function normalizePresetFilamentName(
 // DevAmsTray::get_filament_remain_weight() (prefer firmware-reported
 // per-gram `remain_g`, fall back to `weight * remain%`); the result is
 // serialized as `remain_weight` by FilamentManagerVM::build_ams_data. This
-// helper is a thin accessor over that field. `null` / `undefined` /
-// non-positive values mean "no weight to show" and the caller paints `—`.
-export function getTrayCurrentNetWeight(tray: AmsTray): number {
+// helper is a thin accessor over that field. `null` / `undefined` mean
+// unknown; zero is a known empty spool and must be preserved.
+export function getTrayCurrentNetWeight(tray: AmsTray): number | null {
   const rw = tray.remain_weight;
-  return typeof rw === 'number' && rw > 0 ? rw : 0;
+  return typeof rw === 'number' && rw >= 0 ? rw : null;
 }
 
 export interface TrayResolution {
@@ -74,7 +74,7 @@ export interface TrayResolution {
   sanitizedColor: string;
   traySanitizedColors: string[];
   trayNetInit: number;
-  currentNet: number;
+  currentNet: number | null;
   matchedSettingId: string;
 }
 
@@ -200,8 +200,8 @@ export function buildSpoolFromTray(input: BuildSpoolFromTrayInput): BuildSpoolFr
   const initialWeight = resolved.trayNetInit > 0
     ? Math.min(resolved.trayNetInit, MAX_NET_WEIGHT_GRAMS)
     : 1000;
-  const currentWeight = resolved.currentNet > 0
-    ? Math.min(resolved.currentNet, initialWeight)
+  const currentWeight = resolved.currentNet !== null
+    ? Math.min(Math.max(resolved.currentNet, 0), initialWeight)
     : initialWeight;
   const remainPct = initialWeight > 0
     ? Math.min(100, Math.max(0, Math.round(currentWeight * 100 / initialWeight)))

--- a/src/slic3r/GUI/DeviceWeb/device_page/tests/buildSpoolFromTray.test.ts
+++ b/src/slic3r/GUI/DeviceWeb/device_page/tests/buildSpoolFromTray.test.ts
@@ -173,7 +173,36 @@ assert.doesNotMatch(vmSource, /t\["tag_uid"\]\s*=\s*tray->tag_uid\s*;/);
 assert.match(vmSource, /tag_uid\.size\(\)\s*==\s*16\s*&&\s*tag_uid\.substr\(12,\s*2\)\s*==\s*"01"/);
 assert.match(vmSource, /t\["tray_id_name"\]\s*=\s*tray->tray_id_name\s*;/);
 assert.match(filaSystemSource, /ParseVal\(j_tray,\s*"tray_id_name",\s*curr_tray->tray_id_name/);
-assert.match(cloudSyncSource, /j\["trayIdName"\]\s*=\s*s\.tray_id_name\s*;/);
+assert.match(
+  cloudSyncSource,
+  /const std::string tray_id_name\s*=\s*s\.tray_id_name\.empty\(\)\s*\?\s*tray_id_name_by_filament_color\(s\)\s*:\s*s\.tray_id_name\s*;/,
+  'cloud serialization preserves or derives trayIdName',
+);
+assert.match(
+  cloudSyncSource,
+  /j\["trayIdName"\]\s*=\s*tray_id_name\s*;/,
+  'cloud payload writes the resolved trayIdName',
+);
+assert.match(
+  cloudSyncSource,
+  /const bool has_known_net_weight\s*=\s*s\.net_weight\s*>\s*0\.0\s*\|\|\s*\(s\.net_weight\s*==\s*0\.0\s*&&\s*s\.remain_percent\s*==\s*0\)\s*;/,
+  'zero net weight is known only when remain_percent also reports empty',
+);
+assert.match(
+  cloudSyncSource,
+  /const double material_weight\s*=\s*has_known_net_weight\s*\?\s*s\.net_weight\s*:/,
+  'a known current net weight takes precedence over legacy fallback data',
+);
+assert.match(
+  cloudSyncSource,
+  /if \(has_known_net_weight \|\| material_weight > 0\.0\)\s*j\["netWeight"\]\s*=\s*static_cast<int64_t>\(material_weight \+ 0\.5\)\s*;/,
+  'confirmed empty spools emit netWeight zero while unknown values keep the fallback',
+);
+assert.match(
+  filaSystemSource,
+  /if \(remain_g >= 0\)\s*\{\s*\/\/ Zero is a valid, known value:[\s\S]*?return remain_g;\s*\}/,
+  'known firmware remain_g=0 must stay distinguishable from unknown',
+);
 
 // ---- 1. RFID tray + setting_id resolves the preset ----
 
@@ -257,6 +286,35 @@ assert.equal(built1.isMultiHex, false);
 assert.deepEqual(built1.payload.colors, []);
 assert.equal(built1.payload.color_type, 2);
 
+// ---- 3b. A firmware-confirmed empty spool must remain empty ----
+
+const emptyTray: AmsTray = {
+  ...rfidTray,
+  slot_id: '6',
+  tag_uid: 'TRAY-UUID-EMPTY',
+  remain: 0,
+  remain_weight: 0,
+};
+
+const builtEmpty = buildSpoolFromTray({
+  tray: emptyTray,
+  unit,
+  devId: 'dev-1',
+  presets,
+  spools,
+});
+assert.equal(builtEmpty.payload.initial_weight, 1000);
+assert.equal(
+  builtEmpty.payload.net_weight,
+  0,
+  'known remain_weight=0 must not fall back to the full initial weight',
+);
+assert.equal(
+  builtEmpty.payload.remain_percent,
+  0,
+  'known empty AMS spool must be persisted as 0 percent',
+);
+
 // ---- 4. partitionTraysForBatchCreate routes the right buckets ----
 
 const { creates, updates } = partitionTraysForBatchCreate([built1, built2, built3]);
@@ -314,13 +372,13 @@ assert.equal(
 );
 assert.equal(
   getTrayCurrentNetWeight({ slot_id: '0', is_exists: true, weight: 1000, remain: 50, remain_g: -1, remain_weight: null }),
-  0,
-  'null remain_weight (helper returned std::nullopt) reads as 0',
+  null,
+  'null remain_weight stays unknown',
 );
 assert.equal(
   getTrayCurrentNetWeight({ slot_id: '0', is_exists: true, weight: 1000, remain: 50 }),
-  0,
-  'absent remain_weight reads as 0 — no TS-side fallback computation',
+  null,
+  'absent remain_weight stays unknown',
 );
 assert.equal(
   getTrayCurrentNetWeight({ slot_id: '0', is_exists: true, weight: 1000, remain: 0, remain_weight: 0 }),

--- a/src/slic3r/GUI/fila_manager/wgtFilaManagerCloudSync.cpp
+++ b/src/slic3r/GUI/fila_manager/wgtFilaManagerCloudSync.cpp
@@ -319,16 +319,35 @@ nlohmann::json wgtFilaManagerCloudSync::spool_to_cloud_json(const FilamentSpool&
     // 总净重 to the 当前净重 whenever the two differed (e.g. 当前=200,
     // 总=1500 was pushed as netWeight=200, totalNetWeight=200 and the
     // row came back from cloud showing 200/200 instead of 200/1500).
-    const double material_weight = s.net_weight > 0.0
+    // A zero net_weight is known to mean empty only when remain_percent also
+    // reports zero. Otherwise zero may merely be the struct's default for an
+    // unknown value. Positive net_weight always takes precedence, including
+    // for legacy rows that still carry an empty-spool weight.
+    const bool has_known_net_weight =
+        s.net_weight > 0.0 ||
+        (s.net_weight == 0.0 && s.remain_percent == 0);
+
+    const double material_weight = has_known_net_weight
         ? s.net_weight
-        : ((s.initial_weight > s.spool_weight) ? (s.initial_weight - s.spool_weight) : 0.0);
-    const double total_net_weight = (s.spool_weight > 0.0 && s.initial_weight > s.spool_weight)
-        ? (s.initial_weight - s.spool_weight)
-        : s.initial_weight;
-    if (material_weight > 0.0)
-        j["netWeight"] = static_cast<int64_t>(material_weight + 0.5);
+        : ((s.initial_weight > s.spool_weight)
+            ? (s.initial_weight - s.spool_weight)
+            : 0.0);
+
+    const double total_net_weight =
+        (s.spool_weight > 0.0 &&
+         s.initial_weight > s.spool_weight)
+            ? (s.initial_weight - s.spool_weight)
+            : s.initial_weight;
+
+    // Emit zero only for a confirmed empty spool. Unknown zero values retain
+    // the existing fallback behaviour.
+    if (has_known_net_weight || material_weight > 0.0)
+        j["netWeight"] =
+            static_cast<int64_t>(material_weight + 0.5);
+
     if (total_net_weight > 0.0)
-        j["totalNetWeight"] = static_cast<int64_t>(total_net_weight + 0.5);
+        j["totalNetWeight"] =
+            static_cast<int64_t>(total_net_weight + 0.5);
 
     if (!s.note.empty())
         j["note"] = s.note;


### PR DESCRIPTION
## Summary

Preserve a confirmed empty AMS spool as `0 g` and `0%` throughout device parsing, the web filament manager, and cloud serialization.

## Root cause

A remaining weight of zero was treated as equivalent to an unknown value. Later fallbacks reconstructed the full initial weight and could persist an empty spool as full.

## Changes

- preserve firmware-reported and calculated zero remaining weight
- distinguish unknown remaining weight from confirmed `0 g`
- keep single-slot and batch payloads at `0 g` and `0%`
- serialize confirmed empty spools with `netWeight: 0`
- retain existing fallback behavior for genuinely unknown weight
- update regression and source-contract coverage

## Validation

- `buildSpoolFromTray.test.ts` when local Node dependencies are available
- TypeScript project check when local Node dependencies are available
- `git diff --check`
- one GPG-signed commit

Full native validation remains delegated to Jenkins.

No local full build was performed.
