### PR TITLE
Fix placeholder expression assignment ownership

### DIFF
--- a/src/libslic3r/PlaceholderParser.cpp
+++ b/src/libslic3r/PlaceholderParser.cpp
@@ -211,12 +211,10 @@ namespace client
 
         expr &operator=(const expr &rhs)
         {
-            //BBS: avoid memory leak when call operator= directly before call reset()
-            if (this->type == TYPE_STRING && this->data.s) {
-                delete this->data.s;
-                this->data.s = nullptr;
-            }
+            if (this == &rhs)
+                return *this;
 
+            this->reset();
             this->type      = rhs.type;
             this->it_range  = rhs.it_range;
             if (rhs.type == TYPE_STRING)
@@ -228,10 +226,13 @@ namespace client
 
         expr &operator=(expr &&rhs)
         {
-            type            = rhs.type;
-            this->it_range  = rhs.it_range;
-            data.set(rhs.data);
-            rhs.type        = TYPE_EMPTY;
+            if (this != &rhs) {
+                this->reset();
+                this->type      = rhs.type;
+                this->it_range  = rhs.it_range;
+                this->data.set(rhs.data);
+                rhs.type        = TYPE_EMPTY;
+            }
             return *this;
         }
 


### PR DESCRIPTION
## Summary

- release existing string storage before copy or move assignment
- guard both copy and move self-assignment
- preserve move ownership transfer by marking the source expression empty

## Problem

The move-assignment operator overwrote an existing string allocation without releasing it first. The adjacent copy-assignment operator also deleted its own string before reading from the same object during self-assignment.

## Validation

- `git diff --check`
- one GPG-signed commit
- targeted native validation remains delegated to Jenkins

No local full build was performed.
