### PR TITLE
Guard empty float-or-percent input

### DIFF
--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -118,7 +118,7 @@ void change_opt_value(DynamicPrintConfig& config, const t_config_option_key& opt
 		case coFloatOrPercent:{
 			std::string str = boost::any_cast<std::string>(value);
 			bool percent = false;
-			if (str.back() == '%') {
+			if (!str.empty() && str.back() == '%') {
 				str.pop_back();
 				percent = true;
 			}
@@ -128,7 +128,7 @@ void change_opt_value(DynamicPrintConfig& config, const t_config_option_key& opt
 		case coFloatsOrPercents:{
 			std::string str = boost::any_cast<std::string>(value);
 			bool percent = false;
-			if (str.back() == '%') {
+			if (!str.empty() && str.back() == '%') {
 				str.pop_back();
 				percent = true;
 			}


### PR DESCRIPTION
## Summary

- guard both float-or-percent parsing paths before calling `std::string::back()`
- preserve the existing percentage parsing behavior
- let empty input continue into the existing exception-based validation path

## Problem

`change_opt_value()` called `str.back()` for `coFloatOrPercent` and `coFloatsOrPercents` without first checking whether the input string was empty.

Calling `std::string::back()` on an empty string is undefined behavior and may crash before the surrounding exception handler can report the invalid value.

## Testing

- verified both parsing paths contain the empty-string guard
- ran `git diff --check`
- ran a targeted `GUI.cpp` syntax check using an existing compile database

No local full build was performed.
