### PR TITLE
Resolve material types for unknown filament vendors

### DIFF
--- a/src/slic3r/GUI/DeviceWeb/device_page/src/features/filament-manager/AddEditDialog.tsx
+++ b/src/slic3r/GUI/DeviceWeb/device_page/src/features/filament-manager/AddEditDialog.tsx
@@ -1657,8 +1657,15 @@ export function AddEditDialog({
     if (!typeName) {
       const fullType = tray.fila_type || '';
       const typeCandidates = new Set<string>();
-      const vendorsForMatch = brandName ? presets.filter((v) => v.name === brandName) : presets;
-      vendorsForMatch.forEach((v) => v.types.forEach((tp) => { if (tp.name) typeCandidates.add(tp.name); }));
+      const matchingVendors = brandName
+        ? presets.filter((v) => v.name === brandName)
+        : [];
+      const vendorsForMatch = matchingVendors.length > 0
+        ? matchingVendors
+        : presets;
+      vendorsForMatch.forEach((v) => v.types.forEach((tp) => {
+        if (tp.name) typeCandidates.add(tp.name);
+      }));
       let matchedType = '';
       let seriesRemainder = '';
       for (const cand of typeCandidates) {

--- a/src/slic3r/GUI/DeviceWeb/device_page/src/features/filament-manager/buildSpoolFromTray.ts
+++ b/src/slic3r/GUI/DeviceWeb/device_page/src/features/filament-manager/buildSpoolFromTray.ts
@@ -135,8 +135,15 @@ export function resolveTrayPreset(
   if (!typeName) {
     const fullType = tray.fila_type || '';
     const typeCandidates = new Set<string>();
-    const vendorsForMatch = brandName ? presets.filter((v) => v.name === brandName) : presets;
-    vendorsForMatch.forEach((v) => v.types.forEach((tp) => { if (tp.name) typeCandidates.add(tp.name); }));
+    const matchingVendors = brandName
+      ? presets.filter((v) => v.name === brandName)
+      : [];
+    const vendorsForMatch = matchingVendors.length > 0
+      ? matchingVendors
+      : presets;
+    vendorsForMatch.forEach((v) => v.types.forEach((tp) => {
+      if (tp.name) typeCandidates.add(tp.name);
+    }));
     let matchedType = '';
     let seriesRemainder = '';
     for (const cand of typeCandidates) {


### PR DESCRIPTION
## Summary

Resolve known material types even when a third-party tray reports a vendor that does not exist in the local preset collection.

## Root cause

Material inference restricted candidate types to the reported vendor whenever the vendor string was non-empty. An unknown vendor therefore produced an empty candidate set and prevented otherwise recognizable material strings such as `PETG HF` from being parsed.

## Changes

- use matching-vendor types when the reported vendor exists
- fall back to material types from all presets when it does not
- keep the original reported brand
- keep single-slot and batch inference behavior aligned

## Validation

- TypeScript project check when local Node dependencies are available
- `git diff --check`
- one GPG-signed commit

No local full build was performed.
