### PR TITLE
Release calibration history refresh timer

### DIFF
--- a/src/slic3r/GUI/CaliHistoryDialog.cpp
+++ b/src/slic3r/GUI/CaliHistoryDialog.cpp
@@ -208,7 +208,11 @@ HistoryWindow::HistoryWindow(wxWindow* parent, const std::vector<PACalibResult>&
 
 HistoryWindow::~HistoryWindow()
 {
-    m_refresh_timer->Stop();
+    if (m_refresh_timer) {
+        m_refresh_timer->Stop();
+        delete m_refresh_timer;
+        m_refresh_timer = nullptr;
+    }
     m_show_history_dialog = false;
 }
 


### PR DESCRIPTION
## Summary

Release the Flow Dynamics calibration history refresh timer when the dialog is destroyed.

## Root cause

`HistoryWindow` allocated `m_refresh_timer` with `new wxTimer()`, but its destructor only stopped the timer. Repeatedly opening and closing the calibration history dialog therefore leaked one timer object per dialog instance.

## Changes

- stop the refresh timer before dialog destruction
- delete the dynamically allocated timer
- clear the pointer after deletion
- keep the existing refresh interval and event behavior unchanged

## Validation

- `git diff --check`
- targeted `CaliHistoryDialog.cpp` syntax check when a matching compile database entry is available
- one GPG-signed commit

No local full build was performed. Full application validation remains delegated to Jenkins.