### PR TITLE
Size calibration speed vectors correctly

### DIFF
--- a/src/slic3r/Utils/CalibUtils.cpp
+++ b/src/slic3r/Utils/CalibUtils.cpp
@@ -215,7 +215,7 @@ std::vector<double> generate_max_speed_parameter_value(const std::string &key)
     Flow flow = Flow(line_width, layer_height, nozzle_diameter);
 
     std::vector<double> speed_values;
-    speed_values.resize(extruder_nums * nozzle_volume_types.size());
+    speed_values.reserve(extruder_nums * nozzle_volume_types.size());
 
     for (size_t i = 0; i < extruder_nums; ++i) {
         int    index                         = get_index_for_extruder_parameter(filament_config, "filament_max_volumetric_speed", i, ExtruderType(extruder_types[i]),


### PR DESCRIPTION
## Summary

Return correctly sized speed vectors for calibration setup.

## Root cause

`generate_max_speed_parameter_value()` first resized the result vector to its final expected size and then appended the calculated values with `emplace_back()`.

The returned vector therefore contained:

- a leading block of default-initialized zero values
- the calculated values appended after that block
- twice the expected number of entries

The function is used when preparing internal solid infill and top surface speed values for calibration.

## Change

Reserve the expected capacity without changing the vector size before appending calculated values.

## Validation

- verified both active `Plater.cpp` call sites
- verified the function contains `reserve()` and no result-vector `resize()`
- `git diff --check`
- targeted `CalibUtils.cpp` syntax check when a matching compile database entry is available
- one GPG-signed commit

No local full build was performed. Full application validation remains delegated to Jenkins.