### PR TITLE
Keep calibration delete result alive

### DIFF
--- a/src/slic3r/GUI/CaliHistoryDialog.cpp
+++ b/src/slic3r/GUI/CaliHistoryDialog.cpp
@@ -436,7 +436,7 @@ void HistoryWindow::sync_history_data() {
         delete_button->SetBackgroundColour(*wxWHITE);
         delete_button->SetMinSize(wxSize(-1, FromDIP(24)));
         delete_button->SetCornerRadius(FromDIP(12));
-        delete_button->Bind(wxEVT_BUTTON, [this, gbSizer, i, &result, column_count](auto& e) {
+        delete_button->Bind(wxEVT_BUTTON, [this, gbSizer, i, result, column_count](auto& e) {
             if (m_ui_op_lock) {
                 return;
             } else {


### PR DESCRIPTION
## Summary

Keep the selected calibration history result alive for the asynchronous delete callback.

## Root cause

The delete button callback captured the range-for variable `result` by reference. The callback runs after `sync_history_data()` has returned, so that reference can outlive the loop variable and access invalid state.

The neighboring edit callback already captures the same result by value.

## Change

Capture `result` by value in the delete callback so every row retains its own stable calibration result.

## Validation

- verified the unsafe reference capture is gone
- verified delete and edit callbacks both retain result copies
- `git diff --check`
- targeted `CaliHistoryDialog.cpp` syntax check when a matching compile database entry is available
- one GPG-signed commit

No local full build was performed. Full application validation remains delegated to Jenkins.