### PR TITLE
Guard PIN-code backspace focus

### DIFF
--- a/src/slic3r/GUI/BindDialog.cpp
+++ b/src/slic3r/GUI/BindDialog.cpp
@@ -301,7 +301,8 @@ void PingCodeBindDialog::on_key_backspace(wxKeyEvent& event)
 
     if (event.GetKeyCode() == WXK_BACK && idx >= 0) {
         CallAfter([this, idx]() {
-            m_text_input_single_code[idx - 1]->SetFocus();
+            if (idx > 0)
+                m_text_input_single_code[idx - 1]->SetFocus();
             m_button_bind->Enable(false);
         });
     }


### PR DESCRIPTION
## Summary

Prevent the PIN-code dialog from focusing before the first input field when Backspace is pressed.

## Root cause

`PingCodeBindDialog::on_key_backspace()` accepted `idx == 0` and unconditionally focused `m_text_input_single_code[idx - 1]` from a deferred `CallAfter` callback.

Pressing Backspace in the first PIN field could therefore access the input array with index `-1`, causing undefined behavior.

## Change

Only move focus to the preceding PIN field when the current index is greater than zero. The confirm button is still disabled for Backspace in every valid field.

## Validation

- verified index zero cannot reach the `idx - 1` access
- verified later fields retain the existing previous-field focus behavior
- verified Backspace still disables the confirm button
- `git diff --check`
- targeted `BindDialog.cpp` syntax check when a matching compile database entry is available
- one GPG-signed commit

No local full build was performed. Full application validation remains delegated to Jenkins.