### PR TITLE
On Linux arm64 devices, Bambu Studio always downloads the network plugin

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -1600,6 +1600,11 @@ int GUI_App::download_plugin(std::string name, std::string package_name, Install
     json j;
     std::string err_msg;
 
+    if (name == "plugins" && !is_networking_plugin_available()) {
+        BOOST_LOG_TRIVIAL(info) << "[download_plugin]: no networking plug-in is published for this architecture, skip the download";
+        return -1;
+    }
+
     // get country_code
     AppConfig* app_config = wxGetApp().app_config;
     if (!app_config) {
@@ -1788,6 +1793,11 @@ int GUI_App::install_plugin(std::string name, std::string package_name, InstallP
 {
     bool cancel = false;
     std::string target_file_path = (fs::temp_directory_path() / package_name).string();
+
+    if (name == "plugins" && !is_networking_plugin_available()) {
+        BOOST_LOG_TRIVIAL(info) << "[install_plugin]: no networking plug-in is published for this architecture, skip the install";
+        return -1;
+    }
 
     BOOST_LOG_TRIVIAL(info) << "[install_plugin] enter";
     // get plugin folder
@@ -3638,6 +3648,9 @@ bool GUI_App::on_init_network(bool try_backup)
 {
     int  load_agent_dll       = Slic3r::NetworkAgent::initialize_network_module(false, !app_config->get_bool("ignore_module_cert"));
     bool create_network_agent = false;
+    // Never offer to re-download the plug-in when none is published for this architecture,
+    // otherwise the download is retried on every start and can never succeed.
+    const bool may_update_plugin = is_networking_plugin_available() && app_config->get("installed_networking") == "1";
 __retry:
     if (!load_agent_dll) {
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": on_init_network, load dll ok";
@@ -3647,7 +3660,7 @@ __retry:
             if (!bambu_source) {
                 BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": can not get bambu source module!";
                 m_networking_compatible = false;
-                if (app_config->get("installed_networking") == "1") {
+                if (may_update_plugin) {
                     m_networking_need_update = true;
                 }
             }
@@ -3662,13 +3675,13 @@ __retry:
                 goto __retry;
             }
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": on_init_network, version dismatch, need upload network module";
-            if (app_config->get("installed_networking") == "1") {
+            if (may_update_plugin) {
                 m_networking_need_update = true;
             }
         }
     } else {
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": on_init_network, load dll failed";
-        if (app_config->get("installed_networking") == "1") {
+        if (may_update_plugin) {
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": on_init_network, need upload network module";
             m_networking_need_update = true;
         }
@@ -4322,6 +4335,13 @@ void GUI_App::ShowUserGuide() {
 
 void GUI_App::ShowDownNetPluginDlg(bool post_login)
 {
+    if (!is_networking_plugin_available()) {
+        BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": no networking plug-in is published for this architecture, nothing to install";
+        show_info(static_cast<wxWindow *>(mainframe),
+                  _L("The Bambu Network Plug-in is not available for this processor architecture, so network related features are unavailable."),
+                  _L("Network Plug-in unavailable"));
+        return;
+    }
     try {
         auto iter = std::find_if(dialogStack.begin(), dialogStack.end(), [](auto dialog) {
             return dynamic_cast<DownloadProgressDialog *>(dialog) != nullptr;

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -683,6 +683,17 @@ public:
 #if defined(__WINDOWS__)
     bool            is_running_on_arm64() { return m_is_arm64; }
 #endif
+    // Bambu Lab publishes the network plug-in as a universal binary for macOS and with a
+    // separate arm64 build for Windows, but only as x86-64 binaries for Linux. So on any
+    // other Linux architecture (arm64, ...) there is nothing we could download and dlopen.
+    static bool     is_networking_plugin_available()
+    {
+#if defined(__linux__) && !defined(__x86_64__)
+        return false;
+#else
+        return true;
+#endif
+    }
 
 
     void            load_url(wxString url);

--- a/src/slic3r/GUI/NotificationManager.cpp
+++ b/src/slic3r/GUI/NotificationManager.cpp
@@ -2897,12 +2897,16 @@ void NotificationManager::bbl_close_seqprintinfo_notification()
 void NotificationManager::bbl_show_plugin_install_notification(const std::string &text)
 {
     std::string hyper_text;
-    auto callback = [](wxEvtHandler *) {
-        wxCommandEvent *evt = new wxCommandEvent(EVT_INSTALL_PLUGIN_NETWORKING);
-        wxQueueEvent(wxGetApp().plater(), evt);
-        return false;
-    };
-    hyper_text =  _u8L(" Click here to install it.");
+    std::function<bool(wxEvtHandler *)> callback;
+    // Without a plug-in published for this architecture there is nothing to offer installing.
+    if (GUI_App::is_networking_plugin_available()) {
+        callback = [](wxEvtHandler *) {
+            wxCommandEvent *evt = new wxCommandEvent(EVT_INSTALL_PLUGIN_NETWORKING);
+            wxQueueEvent(wxGetApp().plater(), evt);
+            return false;
+        };
+        hyper_text = _u8L(" Click here to install it.");
+    }
     NotificationData data{NotificationType::BBLPluginInstallHint, NotificationLevel::WarningNotificationLevel, 0, text, hyper_text, callback};
 
     for (std::unique_ptr<PopNotification> &notification : m_pop_notifications) {

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -1164,6 +1164,10 @@ bool PresetUpdater::priv::get_cached_plugins_version(std::string& cached_version
 
 void PresetUpdater::priv::sync_plugins(std::string http_url, std::string plugin_version)
 {
+    if (!GUI::GUI_App::is_networking_plugin_available()) {
+        BOOST_LOG_TRIVIAL(info) << "no need to sync plugins, none is published for this architecture.";
+        return;
+    }
     if (plugin_version == "00.00.00.00") {
         BOOST_LOG_TRIVIAL(info) << "non need to sync plugins for there is no plugins currently.";
         return;


### PR DESCRIPTION
On Linux arm64 devices, Bambu Studio always downloads the network plugin on startup, however this isn't available.

Fix this issue (#11737) by only downloading on Linux x86-64.