### PR TITLE
Add geometry-only 3MF import deep link

### DIFF
--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -39,6 +39,7 @@
       <key>CFBundleURLSchemes</key>
       <array>
         <string>bambustudioopen</string>
+        <string>bambustudio</string>
       </array>
     </dict>
   </array>

--- a/src/platform/osx/Info.plist.in
+++ b/src/platform/osx/Info.plist.in
@@ -35,6 +35,7 @@
       <key>CFBundleURLSchemes</key>
       <array>
         <string>bambustudioopen</string>
+        <string>bambustudio</string>
       </array>
     </dict>
   </array>

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -224,6 +224,8 @@ set(SLIC3R_GUI_SOURCES
     GUI/GUI_Preview.hpp
     GUI/GUI_App.cpp
     GUI/GUI_App.hpp
+    GUI/DeepLink.cpp
+    GUI/DeepLink.hpp
     GUI/GUI_Utils.cpp
     GUI/GUI_Utils.hpp
     GUI/I18N.cpp

--- a/src/slic3r/GUI/DeepLink.cpp
+++ b/src/slic3r/GUI/DeepLink.cpp
@@ -1,0 +1,91 @@
+#include "DeepLink.hpp"
+
+#include <array>
+
+namespace Slic3r {
+namespace GUI {
+
+namespace {
+
+struct DeepLinkPrefix
+{
+    std::string_view prefix;
+    RemoteModelAction action;
+};
+
+constexpr std::array<DeepLinkPrefix, 2> canonical_prefixes {{
+    {"bambustudio://open?", RemoteModelAction::OpenProject},
+    {"bambustudio://import?", RemoteModelAction::ImportModel},
+}};
+
+constexpr std::string_view legacy_macos_prefix = "bambustudioopen://";
+
+bool starts_with(std::string_view value, std::string_view prefix)
+{
+    return value.size() >= prefix.size() && value.substr(0, prefix.size()) == prefix;
+}
+
+std::optional<std::string_view> find_query_parameter(std::string_view query, std::string_view name)
+{
+    size_t parameter_start = 0;
+    while (parameter_start <= query.size()) {
+        const size_t parameter_end = query.find('&', parameter_start);
+        const std::string_view parameter = query.substr(
+            parameter_start,
+            parameter_end == std::string_view::npos ? std::string_view::npos : parameter_end - parameter_start);
+
+        if (starts_with(parameter, name)) {
+            const std::string_view value = parameter.substr(name.size());
+            if (!value.empty())
+                return value;
+            return std::nullopt;
+        }
+
+        if (parameter_end == std::string_view::npos)
+            break;
+        parameter_start = parameter_end + 1;
+    }
+
+    return std::nullopt;
+}
+
+} // namespace
+
+bool is_studio_deep_link_candidate(std::string_view url)
+{
+    for (const DeepLinkPrefix &candidate : canonical_prefixes) {
+        const std::string_view action_prefix = candidate.prefix.substr(0, candidate.prefix.size() - 1);
+        if (url == action_prefix || starts_with(url, candidate.prefix))
+            return true;
+    }
+    return starts_with(url, legacy_macos_prefix);
+}
+
+std::optional<StudioDeepLink> parse_studio_deep_link(std::string_view url)
+{
+    for (const DeepLinkPrefix &candidate : canonical_prefixes) {
+        if (!starts_with(url, candidate.prefix))
+            continue;
+
+        const std::string_view query = url.substr(candidate.prefix.size());
+        const auto file = find_query_parameter(query, "file=");
+        if (!file)
+            return std::nullopt;
+
+        // Preserve trailing parameters such as the existing optional &name=
+        // value. GUI_App decodes and validates this payload exactly once.
+        const size_t file_offset = static_cast<size_t>(file->data() - url.data());
+        return StudioDeepLink {candidate.action, std::string(url.substr(file_offset)), false};
+    }
+
+    if (starts_with(url, legacy_macos_prefix)) {
+        const std::string_view payload = url.substr(legacy_macos_prefix.size());
+        if (!payload.empty())
+            return StudioDeepLink {RemoteModelAction::OpenProject, std::string(payload), true};
+    }
+
+    return std::nullopt;
+}
+
+} // namespace GUI
+} // namespace Slic3r

--- a/src/slic3r/GUI/DeepLink.hpp
+++ b/src/slic3r/GUI/DeepLink.hpp
@@ -1,0 +1,39 @@
+#ifndef slic3r_GUI_DeepLink_hpp_
+#define slic3r_GUI_DeepLink_hpp_
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace Slic3r {
+namespace GUI {
+
+enum class RemoteModelAction : unsigned char
+{
+    OpenProject,
+    ImportModel
+};
+
+struct StudioDeepLink
+{
+    RemoteModelAction action;
+    std::string       encoded_download_info;
+    bool              legacy_macos_scheme { false };
+};
+
+struct RemoteModelDownloadRequest
+{
+    RemoteModelAction action;
+    std::string       download_info;
+};
+
+// Recognizes only Bambu Studio's supported model-download deep links. The
+// returned payload is intentionally left encoded; URL decoding and trust
+// validation remain in GUI_App, where the existing confirmation UI lives.
+std::optional<StudioDeepLink> parse_studio_deep_link(std::string_view url);
+bool is_studio_deep_link_candidate(std::string_view url);
+
+} // namespace GUI
+} // namespace Slic3r
+
+#endif // slic3r_GUI_DeepLink_hpp_

--- a/src/slic3r/GUI/DeepLink.hpp
+++ b/src/slic3r/GUI/DeepLink.hpp
@@ -8,6 +8,8 @@
 namespace Slic3r {
 namespace GUI {
 
+// Determines whether a downloaded 3MF replaces the current project or imports
+// only its model geometry into the current project.
 enum class RemoteModelAction : unsigned char
 {
     OpenProject,

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -1119,51 +1119,13 @@ void GUI_App::post_init()
             %this->init_params->input_files.size() %this->init_params->input_gcode;
 
         if (this->init_params->input_files.size() == 1 &&
-            boost::starts_with(this->init_params->input_files.front(), "bambustudio://open")) {
+            is_studio_deep_link_candidate(this->init_params->input_files.front())) {
+            auto request = prepare_model_download_from_deep_link(this->init_params->input_files.front());
+            if (request)
+                m_pending_model_download = std::move(*request);
 
-            std::string download_params_url = url_decode(this->init_params->input_files.front());
-            auto input_str_arr = split_str(download_params_url, "file=");
-            if (input_str_arr.size() > 1) {input_str_arr.erase(input_str_arr.begin());}
-
-            std::string download_url;
-#if BBL_RELEASE_TO_PUBLIC
-			short ext_url_open_state = -1; // -1 not set, wxNO not open, wxYES open
-            for (auto input_str : input_str_arr) {
-                if (boost::starts_with(input_str, "http://makerworld") ||
-                    boost::starts_with(input_str, "https://makerworld") ||
-                    boost::starts_with(input_str, "http://public-cdn.bblmw.com") ||
-                    boost::starts_with(input_str, "https://public-cdn.bblmw.com") ||
-                    boost::algorithm::contains(input_str, "amazonaws.com") ||
-                    boost::algorithm::contains(input_str, "aliyuncs.com")) {
-                    download_url = input_str;
-                }
-                else {
-                    if (ext_url_open_state == -1) {
-
-                        MessageDialog msg_dlg(nullptr,
-                                              _L("This file is not from a trusted site, do you want to open it anyway?"), "",
-                                              wxAPPLY | wxYES_NO);
-                        ext_url_open_state   = msg_dlg.ShowModal();
-                    }
-                    if (ext_url_open_state == wxID_YES) {
-                        download_url = input_str;
-                    }
-                }
-            }
-#else
-            for (auto input_str : input_str_arr) {
-                download_url = input_str;
-            }
-#endif
-            download_url = sanitize_download_url(download_url);
-
-            BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(", download_url %1%") % PathSanitizer::sanitize(download_url);
-
-            if (!download_url.empty()) {
-                m_download_file_url = from_u8(download_url);
-            }
-
-            m_open_method = "makerworld";
+            const auto deep_link = parse_studio_deep_link(this->init_params->input_files.front());
+            m_open_method = deep_link && deep_link->action == RemoteModelAction::ImportModel ? "deep_link_import" : "makerworld";
         }
         else {
             switch_to_3d = true;
@@ -3554,9 +3516,9 @@ bool GUI_App::on_init_inner()
 #endif
             this->post_init();
 
-            if (!m_download_file_url.empty()) {
-                request_model_download(m_download_file_url);
-                m_download_file_url = "";
+            if (m_pending_model_download) {
+                request_model_download(*m_pending_model_download);
+                m_pending_model_download.reset();
             }
 
             update_publish_status();
@@ -5150,9 +5112,63 @@ void GUI_App::handle_script_message(std::string msg)
 
 void GUI_App::request_model_download(wxString url)
 {
-    if (plater_) {
-        plater_->request_model_download(url);
+    request_model_download(RemoteModelDownloadRequest {RemoteModelAction::OpenProject, into_u8(url)});
+}
+
+void GUI_App::request_model_download(const RemoteModelDownloadRequest &request)
+{
+    if (plater_)
+        plater_->request_model_download(request);
+}
+
+std::optional<RemoteModelDownloadRequest> GUI_App::prepare_model_download_from_deep_link(const std::string &url)
+{
+    const auto deep_link = parse_studio_deep_link(url);
+    if (!deep_link)
+        return std::nullopt;
+
+    std::string download_url = url_decode(deep_link->encoded_download_info);
+#if BBL_RELEASE_TO_PUBLIC
+    const bool trusted = boost::starts_with(download_url, "http://makerworld") ||
+                         boost::starts_with(download_url, "https://makerworld") ||
+                         boost::starts_with(download_url, "http://public-cdn.bblmw.com") ||
+                         boost::starts_with(download_url, "https://public-cdn.bblmw.com") ||
+                         boost::algorithm::contains(download_url, "amazonaws.com") ||
+                         boost::algorithm::contains(download_url, "aliyuncs.com");
+    if (!trusted) {
+        MessageDialog msg_dlg(nullptr,
+                              _L("This file is not from a trusted site, do you want to open it anyway?"), "",
+                              wxAPPLY | wxYES_NO);
+        if (msg_dlg.ShowModal() != wxID_YES)
+            return std::nullopt;
     }
+#endif
+
+    download_url = sanitize_download_url(download_url);
+    if (download_url.empty())
+        return std::nullopt;
+
+    // Preserve the legacy macOS handler's explicit scheme check. Canonical
+    // bambustudio:// links keep the existing bambustudio://open behavior.
+    if (deep_link->legacy_macos_scheme &&
+        !boost::starts_with(download_url, "http://") &&
+        !boost::starts_with(download_url, "https://"))
+        return std::nullopt;
+
+    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(", download_url %1%") % PathSanitizer::sanitize(download_url);
+    return RemoteModelDownloadRequest {deep_link->action, std::move(download_url)};
+}
+
+void GUI_App::handle_studio_deep_link(const std::string &url)
+{
+    auto request = prepare_model_download_from_deep_link(url);
+    if (!request)
+        return;
+
+    if (m_post_initialized)
+        request_model_download(*request);
+    else
+        m_pending_model_download = std::move(*request);
 }
 
 std::string GUI_App::sanitize_download_url(const std::string &url)
@@ -7492,45 +7508,8 @@ void GUI_App::MacOpenURL(const wxString& url)
     BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << "get mac url " << url;
 #endif
 
-    if (!url.empty() && boost::starts_with(url, "bambustudioopen://")) {
-        auto input_str_arr = split_str(url.ToStdString(), "bambustudioopen://");
-        if (input_str_arr.size() > 1) {input_str_arr.erase(input_str_arr.begin());}
-
-        std::string download_origin_url;
-        for (auto input_str : input_str_arr) {
-            if (!input_str.empty()) download_origin_url = input_str;
-        }
-
-        std::string decoded_url = url_decode(download_origin_url);
-        std::string download_file_url;
-#if BBL_RELEASE_TO_PUBLIC
-        if (boost::starts_with(decoded_url, "http://makerworld") || boost::starts_with(decoded_url, "https://makerworld") ||
-            boost::starts_with(decoded_url, "http://public-cdn.bblmw.com") || boost::starts_with(decoded_url, "https://public-cdn.bblmw.com") ||
-            boost::algorithm::contains(decoded_url, "amazonaws.com") || boost::algorithm::contains(decoded_url, "aliyuncs.com")) {
-            download_file_url = decoded_url;
-        } else {
-            MessageDialog msg_dlg(nullptr, _L("This file is not from a trusted site, do you want to open it anyway?"), "", wxAPPLY | wxYES_NO);
-            if (msg_dlg.ShowModal() == wxID_YES) download_file_url = decoded_url;
-        }
-#else
-        download_file_url = decoded_url;
-#endif
-        download_file_url = sanitize_download_url(download_file_url);
-
-#if !BBL_RELEASE_TO_PUBLIC
-        BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << download_file_url;
-#endif
-
-        if (!download_file_url.empty() && (boost::starts_with(download_file_url, "http://") || boost::starts_with(download_file_url, "https://"))) {
-
-            if (m_post_initialized) {
-                request_model_download(download_file_url);
-            }
-            else {
-                m_download_file_url = download_file_url;
-            }
-        }
-    }
+    if (!url.empty() && parse_studio_deep_link(url.ToStdString()))
+        handle_studio_deep_link(url.ToStdString());
 }
 
 // wxWidgets override to get an event on open files.

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -3,7 +3,9 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
+#include "DeepLink.hpp"
 #include "ImGuiWrapper.hpp"
 #include "ConfigWizard.hpp"
 #include "libslic3r/Preset.hpp"
@@ -293,7 +295,9 @@ private:
 #endif
 
 //import model from mall
-    wxString       m_download_file_url;
+    std::optional<RemoteModelDownloadRequest> m_pending_model_download;
+
+    std::optional<RemoteModelDownloadRequest> prepare_model_download_from_deep_link(const std::string &url);
 
 //#ifdef _WIN32
     wxColour        m_color_label_modified;
@@ -537,6 +541,8 @@ public:
     std::string     handle_web_request(std::string cmd);
     void            handle_script_message(std::string msg);
     void            request_model_download(wxString url);
+    void            request_model_download(const RemoteModelDownloadRequest &request);
+    void            handle_studio_deep_link(const std::string &url);
     std::string     sanitize_download_url(const std::string& url);
     void            download_project(std::string project_id);
     void            request_project_download(std::string project_id);

--- a/src/slic3r/GUI/InstanceCheck.cpp
+++ b/src/slic3r/GUI/InstanceCheck.cpp
@@ -1,4 +1,5 @@
 #include "GUI_App.hpp"
+#include "DeepLink.hpp"
 #include "InstanceCheck.hpp"
 #include "Plater.hpp"
 
@@ -370,6 +371,7 @@ bool instance_check(int argc, char** argv, bool app_config_single_instance)
 namespace GUI {
 
 wxDEFINE_EVENT(EVT_LOAD_MODEL_OTHER_INSTANCE, LoadFromOtherInstanceEvent);
+wxDEFINE_EVENT(EVT_DEEP_LINK_OTHER_INSTANCE, DeepLinkFromOtherInstanceEvent);
 wxDEFINE_EVENT(EVT_INSTANCE_GO_TO_FRONT, InstanceGoToFrontEvent);
 
 void OtherInstanceMessageHandler::init(wxEvtHandler* callback_evt_handler)
@@ -498,9 +500,14 @@ void OtherInstanceMessageHandler::handle_message(const std::string& message)
 	}
 
 	std::vector<boost::filesystem::path> paths;
+	std::vector<std::string> deep_links;
 	// Skip the first argument, it is the path to the slicer executable.
 	auto it = args.begin();
 	for (++ it; it != args.end(); ++ it) {
+		if (parse_studio_deep_link(*it)) {
+			deep_links.emplace_back(*it);
+			continue;
+		}
 		boost::filesystem::path p = MessageHandlerInternal::get_path(*it);
 		if (! p.string().empty())
 			paths.emplace_back(p);
@@ -510,6 +517,10 @@ void OtherInstanceMessageHandler::handle_message(const std::string& message)
 		//if (evt_handler) {
 			wxPostEvent(m_callback_evt_handler, LoadFromOtherInstanceEvent(GUI::EVT_LOAD_MODEL_OTHER_INSTANCE, std::vector<boost::filesystem::path>(std::move(paths))));
 		//}
+	}
+	if (!deep_links.empty()) {
+		wxPostEvent(m_callback_evt_handler,
+			DeepLinkFromOtherInstanceEvent(GUI::EVT_DEEP_LINK_OTHER_INSTANCE, std::move(deep_links)));
 	}
 }
 

--- a/src/slic3r/GUI/InstanceCheck.hpp
+++ b/src/slic3r/GUI/InstanceCheck.hpp
@@ -45,6 +45,9 @@ class MainFrame;
 using LoadFromOtherInstanceEvent = Event<std::vector<boost::filesystem::path>>;
 wxDECLARE_EVENT(EVT_LOAD_MODEL_OTHER_INSTANCE, LoadFromOtherInstanceEvent);
 
+using DeepLinkFromOtherInstanceEvent = Event<std::vector<std::string>>;
+wxDECLARE_EVENT(EVT_DEEP_LINK_OTHER_INSTANCE, DeepLinkFromOtherInstanceEvent);
+
 using InstanceGoToFrontEvent = SimpleEvent;
 wxDECLARE_EVENT(EVT_INSTANCE_GO_TO_FRONT, InstanceGoToFrontEvent);
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -227,7 +227,8 @@ wxDEFINE_EVENT(EVT_SLICING_COMPLETED,               wxCommandEvent);
 wxDEFINE_EVENT(EVT_PROCESS_COMPLETED,               SlicingProcessCompletedEvent);
 wxDEFINE_EVENT(EVT_EXPORT_BEGAN,                    wxCommandEvent);
 wxDEFINE_EVENT(EVT_EXPORT_FINISHED,                 wxCommandEvent);
-wxDEFINE_EVENT(EVT_IMPORT_MODEL_ID,                 wxCommandEvent);
+using RemoteModelDownloadEvent = Event<RemoteModelDownloadRequest>;
+wxDEFINE_EVENT(EVT_IMPORT_MODEL_ID,                 RemoteModelDownloadEvent);
 wxDEFINE_EVENT(EVT_DOWNLOAD_PROJECT,                wxCommandEvent);
 wxDEFINE_EVENT(EVT_PUBLISH,                         wxCommandEvent);
 wxDEFINE_EVENT(EVT_OPEN_PLATESETTINGSDIALOG,        wxCommandEvent);
@@ -6914,7 +6915,7 @@ public:
     //BBS: add part plate related logic
     void on_plate_right_click(RBtnPlateEvent&);
     void on_plate_selected(SimpleEvent&);
-    void on_action_request_model_id(wxCommandEvent& evt);
+    void on_action_request_model_id(RemoteModelDownloadEvent& evt);
     void on_action_download_project(wxCommandEvent& evt);
     void on_slice_button_status(bool enable);
     //BBS: GUI refactor: GLToolbar
@@ -7650,6 +7651,12 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
         }
         wxGetApp().mainframe->Raise();
         this->q->load_files(input_files);
+    });
+    this->q->Bind(EVT_DEEP_LINK_OTHER_INSTANCE, [](DeepLinkFromOtherInstanceEvent& evt) {
+        BOOST_LOG_TRIVIAL(trace) << "Received deep link from other instance event.";
+        wxGetApp().mainframe->Raise();
+        for (const std::string &url : evt.data)
+            wxGetApp().handle_studio_deep_link(url);
     });
     this->q->Bind(EVT_INSTANCE_GO_TO_FRONT, [this](InstanceGoToFrontEvent &) {
         bring_instance_forward();
@@ -15416,11 +15423,11 @@ void Plater::priv::on_plate_selected(SimpleEvent&)
     sidebar->obj_list()->on_plate_selected(partplate_list.get_curr_plate_index());
 }
 
-void Plater::priv::on_action_request_model_id(wxCommandEvent& evt)
+void Plater::priv::on_action_request_model_id(RemoteModelDownloadEvent& evt)
 {
     BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << ":received import model id event\n" ;
     if (q != nullptr) {
-        q->import_model_id(evt.GetString());
+        q->import_model_id(evt.data);
     }
 }
 
@@ -18888,10 +18895,11 @@ int Plater::save_project(bool saveAs)
 }
 
 //BBS import model by model id
-void Plater::import_model_id(wxString download_info)
+void Plater::import_model_id(const RemoteModelDownloadRequest &request)
 {
     BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << __LINE__ << " start downloading";
 
+    const wxString download_info = from_u8(request.download_info);
     wxString download_origin_url = download_info;
     wxString download_url;
     wxString filename;
@@ -18942,8 +18950,10 @@ void Plater::import_model_id(wxString download_info)
 
     boost::filesystem::path target_path;
 
-    //reset params
-    p->project.reset();
+    // Opening a project replaces its metadata. Geometry-only imports must
+    // leave the current project's identity and settings untouched.
+    if (request.action == RemoteModelAction::OpenProject)
+        p->project.reset();
 
     /* prepare project and profile */
     boost::thread import_thread = Slic3r::create_thread([&percent, &cont, &cancel, &retry_count, max_retries, &msg, &target_path, &download_ok, download_url, &filename] {
@@ -19190,23 +19200,48 @@ void Plater::import_model_id(wxString download_info)
 
     if (download_ok) {
         BOOST_LOG_TRIVIAL(trace) << "import_model_id: target_path = " << PathSanitizer::sanitize(target_path);
-        /* load project */
-        auto result = this->load_project(target_path.wstring());
-        statistics_burial_data_form_mw();
-        if (result == (int)wxID_CANCEL) {
-            return;
-        }
-        /*BBS set project info after load project, project info is reset in load project */
-        //p->project.project_model_id = model_id;
-        //p->project.project_design_id = design_id;
-        AppConfig* config = wxGetApp().app_config;
-        if (config) {
-            p->project.project_country_code = config->get_country_code();
-        }
+        if (request.action == RemoteModelAction::OpenProject) {
+            /* load project */
+            auto result = this->load_project(target_path.wstring());
+            statistics_burial_data_form_mw();
+            if (result == (int)wxID_CANCEL) {
+                return;
+            }
+            /*BBS set project info after load project, project info is reset in load project */
+            //p->project.project_model_id = model_id;
+            //p->project.project_design_id = design_id;
+            AppConfig* config = wxGetApp().app_config;
+            if (config) {
+                p->project.project_country_code = config->get_country_code();
+            }
 
-        // show save new project
-        p->set_project_filename(target_path.wstring());
-        p->notification_manager->push_import_finished_notification(target_path.string(), target_path.parent_path().string(), false);
+            // show save new project
+            p->set_project_filename(target_path.wstring());
+            p->notification_manager->push_import_finished_notification(target_path.string(), target_path.parent_path().string(), false);
+        } else {
+            if ((only_gcode_mode() || using_exported_file()) && new_project() == wxID_CANCEL)
+                return;
+
+            const bool was_dirty = is_project_dirty();
+            std::string snapshot_label = "Import Object: ";
+            snapshot_label += encode_path(target_path.filename().string().c_str());
+            Plater::TakeSnapshot snapshot(this, snapshot_label);
+            const std::vector<size_t> loaded_objects = load_files({target_path}, LoadStrategy::LoadModel);
+            if (loaded_objects.empty()) {
+                // The snapshot itself is project-modifying. If no geometry was
+                // imported into an otherwise clean project, keep it clean.
+                if (!was_dirty) {
+                    p->undo_redo_stack_main().mark_current_as_saved();
+                    set_plater_dirty(false);
+                }
+                return;
+            }
+
+            set_plater_dirty(true);
+            wxGetApp().mainframe->update_title();
+            statistics_burial_data(target_path.string());
+            p->notification_manager->push_import_finished_notification(target_path.string(), target_path.parent_path().string(), false);
+        }
     }
     else {
         if (!msg.empty()) {
@@ -19224,11 +19259,9 @@ void Plater::download_project(const wxString& project_id)
     return;
 }
 
-void Plater::request_model_download(wxString url)
+void Plater::request_model_download(const RemoteModelDownloadRequest &request)
 {
-    wxCommandEvent* event = new wxCommandEvent(EVT_IMPORT_MODEL_ID);
-    event->SetString(url);
-    wxQueueEvent(this, event);
+    wxQueueEvent(this, new RemoteModelDownloadEvent(EVT_IMPORT_MODEL_ID, request));
 }
 
 void Plater::request_download_project(std::string project_id)

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -19,6 +19,7 @@
 #include "Jobs/Job.hpp"
 #include "Jobs/Worker.hpp"
 #include "Search.hpp"
+#include "DeepLink.hpp"
 #include "PartPlate.hpp"
 #include "GUI_App.hpp"
 #include "Jobs/PrintJob.hpp"
@@ -362,9 +363,9 @@ public:
     int load_project(wxString const & filename = "", wxString const & originfile = "-");
     int save_project(bool saveAs = false);
     //BBS download project by project id
-    void import_model_id(wxString download_info);
+    void import_model_id(const RemoteModelDownloadRequest &request);
     void download_project(const wxString& project_id);
-    void request_model_download(wxString url);
+    void request_model_download(const RemoteModelDownloadRequest &request);
     void request_download_project(std::string project_id);
     // BBS: check snapshot
     bool up_to_date(bool saved, bool backup);

--- a/tests/slic3rutils/slic3rutils_tests_main.cpp
+++ b/tests/slic3rutils/slic3rutils_tests_main.cpp
@@ -1,6 +1,52 @@
 #include <catch_main.hpp>
 
 #include "slic3r/Utils/Http.hpp"
+#include "slic3r/GUI/DeepLink.hpp"
+
+using Slic3r::GUI::RemoteModelAction;
+using Slic3r::GUI::is_studio_deep_link_candidate;
+using Slic3r::GUI::parse_studio_deep_link;
+
+TEST_CASE("Bambu Studio canonical deep links select their requested action", "[DeepLink]")
+{
+    const auto open = parse_studio_deep_link(
+        "bambustudio://open?file=https%3A%2F%2Fexample.com%2Fproject.3mf");
+    REQUIRE(open.has_value());
+    CHECK(open->action == RemoteModelAction::OpenProject);
+    CHECK(open->encoded_download_info == "https%3A%2F%2Fexample.com%2Fproject.3mf");
+    CHECK_FALSE(open->legacy_macos_scheme);
+
+    const auto import = parse_studio_deep_link(
+        "bambustudio://import?file=https%3A%2F%2Fexample.com%2Fmodel.3mf&name=model.3mf");
+    REQUIRE(import.has_value());
+    CHECK(import->action == RemoteModelAction::ImportModel);
+    CHECK(import->encoded_download_info == "https%3A%2F%2Fexample.com%2Fmodel.3mf&name=model.3mf");
+    CHECK_FALSE(import->legacy_macos_scheme);
+}
+
+TEST_CASE("Legacy macOS deep links remain project-open requests", "[DeepLink]")
+{
+    const auto link = parse_studio_deep_link(
+        "bambustudioopen://https%3A%2F%2Fexample.com%2Fproject.3mf");
+    REQUIRE(link.has_value());
+    CHECK(link->action == RemoteModelAction::OpenProject);
+    CHECK(link->encoded_download_info == "https%3A%2F%2Fexample.com%2Fproject.3mf");
+    CHECK(link->legacy_macos_scheme);
+}
+
+TEST_CASE("Unsupported or incomplete deep links are not forwarded", "[DeepLink]")
+{
+    CHECK(is_studio_deep_link_candidate("bambustudio://import"));
+    CHECK(is_studio_deep_link_candidate("bambustudio://open?file="));
+    CHECK_FALSE(parse_studio_deep_link("bambustudio://import"));
+    CHECK_FALSE(parse_studio_deep_link("bambustudio://import?file="));
+    CHECK_FALSE(parse_studio_deep_link("bambustudio://unknown?file=https%3A%2F%2Fexample.com%2Fmodel.3mf"));
+    CHECK_FALSE(parse_studio_deep_link("bambustudio://import?profile=fast"));
+    CHECK_FALSE(parse_studio_deep_link("bambustudio://import??file=https%3A%2F%2Fexample.com%2Fmodel.3mf"));
+    CHECK_FALSE(parse_studio_deep_link("/tmp/model.3mf"));
+    CHECK_FALSE(parse_studio_deep_link("https://example.com/model.3mf"));
+    CHECK_FALSE(is_studio_deep_link_candidate("bambustudio://unknown?file=x"));
+}
 
 TEST_CASE("Check SSL certificates paths", "[Http][NotWorking]") {
     
@@ -57,4 +103,3 @@ TEST_CASE("Http basic authentication", "[Http][NotWorking]") {
 
     REQUIRE(status == 200);
 }
-


### PR DESCRIPTION
## Why

We need a way to open a remote 3MF in the current Bambu Studio project without starting a new project or replacing the user’s existing setup.

The existing `bambustudio://open` action treats the downloaded 3MF as a project. This replaces the current project and may change its printer, filament, process, and plate settings.

This PR introduces a separate import action for cases where only the models from the remote 3MF should be added to the current project.

## What changed

A new backward-compatible deep-link action is available:

`bambustudio://import?file=<encoded-url>`

After downloading the 3MF, Bambu Studio sends it through the normal geometry-only model import workflow. This means:

- Models are added to the currently open project.
- The current printer, filament, process, and plate settings are preserved.
- The current project filename is retained.
- The import is added to the undo history.
- The project is marked as modified after a successful import.
- If no editable project is open, an empty project is created first.

The existing `bambustudio://open` behaviour is unchanged and continues to open the downloaded 3MF as a project.

The new action works during startup and through single-instance forwarding on Windows, macOS, and Linux. Legacy macOS deep links remain supported.

## Security

The import action uses the existing remote-download pipeline and does not widen its trust boundary. It retains the existing:

- Trusted-site confirmation
- URL decoding and sanitisation
- `.3mf` file validation
- 500 MB size limit
- Retry and cancellation handling
- Download progress UI
- Temporary-file and atomic-rename handling

Forwarded arguments are accepted as deep links only when they match a supported action and contain a non-empty `file` parameter.

## Verification

- Added focused tests for `open`, `import`, legacy macOS links, malformed links, unsupported actions, missing parameters, and forwarding classification.
- Built `slic3rutils_tests`, `libslic3r_gui`, and `BambuStudio`.
- Ran the focused deep-link tests successfully.
- Validated both macOS plist templates.
- Ran `git diff --check`.