### PR TITLE
feat: allow choosing another printer when printing files from printer storage

### DIFF
--- a/src/slic3r/GUI/Jobs/PrintJob.cpp
+++ b/src/slic3r/GUI/Jobs/PrintJob.cpp
@@ -202,7 +202,7 @@ void PrintJob::process()
         else
             curr_plate_idx = m_plater->get_partplate_list().get_curr_plate_index() + 1;
     }
-    else if(m_print_type == "from_sdcard_view") {
+    else if(m_print_type == "from_sdcard_view" || m_print_type == "from_sdcard_transfer") {
         curr_plate_idx = m_print_from_sdc_plate_idx;
     }
 
@@ -221,7 +221,7 @@ void PrintJob::process()
     params.password = m_access_code;
 
     // check access code and ip address
-    if (this->connection_type == "lan" && m_print_type == "from_normal") {
+    if (this->connection_type == "lan" && (m_print_type == "from_normal" || m_print_type == "from_sdcard_transfer")) {
         bool emmc_ok = false;
         bool ftp_ok = false;
         if (could_emmc_print) {
@@ -271,7 +271,8 @@ void PrintJob::process()
     params.connection_type      = this->connection_type;
     params.task_use_ams         = this->task_use_ams;
     params.task_bed_type        = this->task_bed_type;
-    params.print_type           = this->m_print_type;
+    // the network plugin only knows the built-in types; a transferred sdcard file is uploaded like a normal print
+    params.print_type           = (m_print_type == "from_sdcard_transfer") ? "from_normal" : this->m_print_type;
     params.auto_bed_leveling    = this->auto_bed_leveling;
     params.auto_flow_cali       = this->auto_flow_cali;
     params.auto_offset_cali     = this->auto_offset_cali;
@@ -308,7 +309,7 @@ void PrintJob::process()
             catch (...) {}
         }
 
-         if (m_print_type != "from_sdcard_view") {
+         if (m_print_type != "from_sdcard_view" && m_print_type != "from_sdcard_transfer") {
             auto model_name = model_info->metadata_items.find(BBL_DESIGNER_MODEL_TITLE_TAG);
             if (model_name != model_info->metadata_items.end()) {
                 try {

--- a/src/slic3r/GUI/MediaFilePanel.cpp
+++ b/src/slic3r/GUI/MediaFilePanel.cpp
@@ -708,6 +708,7 @@ void MediaFilePanel::doAction(size_t index, int action)
                     int gcode_file_count = Slic3r::GUI::wxGetApp().plater()->update_print_required_data(config, model, plate_data_list, file.name, file_path);
 
                     if (gcode_file_count > 0) {
+                        Slic3r::GUI::wxGetApp().plater()->set_sdcard_print_source(fs.get(), index, m_machine);
                         wxPostEvent(Slic3r::GUI::wxGetApp().plater(), SimpleEvent(EVT_PRINT_FROM_SDCARD_VIEW));
                     }
                     else {

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -23229,6 +23229,12 @@ int Plater::update_print_required_data(Slic3r::DynamicPrintConfig config, Slic3r
     return p->update_print_required_data(config, model, plate_data_list, file_name, file_path);
 }
 
+void Plater::set_sdcard_print_source(PrinterFileSystem* fs, size_t file_index, const std::string& dev_id)
+{
+    if (!p->m_select_machine_dlg) p->m_select_machine_dlg = new SelectMachineDialog(this);
+    p->m_select_machine_dlg->set_sdcard_print_source(fs, file_index, dev_id);
+}
+
 
 void Plater::undo_redo_topmost_string_getter(const bool is_undo, std::string& out_text)
 {

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -37,6 +37,7 @@ class wxScrolledWindow;
 class wxString;
 class ComboBox;
 class Button;
+class PrinterFileSystem;
 
 namespace Slic3r {
 class BackgroundSlicingProcess;
@@ -573,6 +574,7 @@ public:
     bool undo_redo_string_getter(const bool is_undo, int idx, const char** out_text);
     void undo_redo_topmost_string_getter(const bool is_undo, std::string& out_text);
     int update_print_required_data(Slic3r::DynamicPrintConfig config, Slic3r::Model model, Slic3r::PlateDataPtrs plate_data_list, std::string file_name, std::string file_path);
+    void set_sdcard_print_source(PrinterFileSystem* fs, size_t file_index, const std::string& dev_id);
     bool search_string_getter(int idx, const char** label, const char** tooltip);
     // For the memory statistics.
     const Slic3r::UndoRedo::Stack& undo_redo_stack_main() const;

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -16,6 +16,7 @@
 #include "Widgets/Label.hpp"
 #include "BackgroundSlicingProcess.hpp"
 #include "ConnectPrinter.hpp"
+#include "Printer/PrinterFileSystem.h"
 
 #include "slic3r/Utils/BBLUtil.hpp"
 
@@ -2117,7 +2118,7 @@ void SelectMachineDialog::on_ok_btn(wxCommandEvent &event)
 
     //Check Printer Model Id
     bool is_same_printer_type = is_same_printer_model();
-    if (!is_same_printer_type && (m_print_type == PrintFromType::FROM_NORMAL)) {
+    if (!is_same_printer_type && (m_print_type == PrintFromType::FROM_NORMAL || is_sdcard_cross_printer_send())) {
         confirm_text.push_back(ConfirmBeforeSendInfo(_L("The printer type selected when generating G-Code is not consistent with the currently selected printer. It is recommended that you use the same printer type for slicing.")));
         has_slice_warnings = true;
     }
@@ -3047,6 +3048,7 @@ void SelectMachineDialog::on_send_print()
     m_status_bar->set_prog_block();
     m_status_bar->set_cancel_callback_fina([this]() {
         BOOST_LOG_TRIVIAL(info) << "print_job: enter canceled";
+        release_source_download_binding();
         if (m_print_job) {
             if (m_print_job->is_running()) {
                 BOOST_LOG_TRIVIAL(info) << "print_job: canceled";
@@ -3069,6 +3071,13 @@ void SelectMachineDialog::on_send_print()
     sending_mode();
     if (m_print_job) { m_print_job->reset_print_stage(); }
     m_status_bar->enable_cancel_button();
+
+    // printing the source printer's file on another printer: transfer the file locally first,
+    // on_send_print() is re-entered once the download has finished
+    if (is_sdcard_cross_printer_send() && m_transferred_local_path.empty()) {
+        fetch_file_from_source_printer();
+        return;
+    }
 
     // get ams_mapping_result
     std::string ams_mapping_array;
@@ -3139,9 +3148,19 @@ void SelectMachineDialog::on_send_print()
         m_print_job->set_project_name(m_current_project_name.utf8_string());
     }
     else if(m_print_type == PrintFromType::FROM_SDCARD_VIEW){
-        BOOST_LOG_TRIVIAL(info) << "print_job: m_print_type = from_sdcard_view";
-        m_print_job->m_print_type = "from_sdcard_view";
-        //m_print_job->connection_type = "lan";
+        if (is_sdcard_cross_printer_send() && !m_transferred_local_path.empty()) {
+            // the file has been transferred from the source printer, upload it to the selected printer
+            BOOST_LOG_TRIVIAL(info) << "print_job: m_print_type = from_sdcard_transfer";
+            m_print_job->m_print_type = "from_sdcard_transfer";
+            m_print_job->job_data.is_from_plater = false;
+            m_print_job->job_data._3mf_path        = fs::path(m_transferred_local_path);
+            m_print_job->job_data._3mf_config_path = fs::path(m_transferred_local_path);
+        }
+        else {
+            BOOST_LOG_TRIVIAL(info) << "print_job: m_print_type = from_sdcard_view";
+            m_print_job->m_print_type = "from_sdcard_view";
+            //m_print_job->connection_type = "lan";
+        }
 
         try {
             m_print_job->m_print_from_sdc_plate_idx = m_required_data_plate_data_list[m_print_plate_idx]->plate_index + 1;
@@ -3389,7 +3408,151 @@ int SelectMachineDialog::update_print_required_data(Slic3r::DynamicPrintConfig c
 
     m_required_data_file_name = file_name;
     m_required_data_file_path = file_path;
+
+    // reset the source printer info; it is set again via set_sdcard_print_source() when available
+    release_source_download_binding();
+    m_source_fs.reset();
+    m_source_file_index = size_t(-1);
+    m_source_file_path.clear();
+    m_source_dev_id.clear();
+    m_transferred_local_path.clear();
+
     return m_required_data_plate_data_list.size();
+}
+
+void SelectMachineDialog::set_sdcard_print_source(PrinterFileSystem* fs, size_t file_index, const std::string& dev_id)
+{
+    release_source_download_binding();
+    m_transferred_local_path.clear();
+    m_source_fs.reset();
+    m_source_file_index = size_t(-1);
+    m_source_file_path.clear();
+    m_source_dev_id = dev_id;
+
+    if (!fs || file_index >= fs->GetCount()) return;
+
+    m_source_fs         = boost::weak_ptr<PrinterFileSystem>(fs->shared_from_this());
+    m_source_file_index = file_index;
+    const auto& file    = fs->GetFile(file_index);
+    m_source_file_path  = file.path.empty() ? file.name : file.path;
+}
+
+bool SelectMachineDialog::is_sdcard_cross_printer_send() const
+{
+    return m_print_type == PrintFromType::FROM_SDCARD_VIEW
+        && !m_source_dev_id.empty()
+        && !m_printer_last_select.empty()
+        && m_printer_last_select != m_source_dev_id;
+}
+
+void SelectMachineDialog::release_source_download_binding()
+{
+    if (!m_waiting_source_download) return;
+    m_waiting_source_download = false;
+    if (auto fs = m_source_fs.lock()) {
+        fs->DownloadCancel(m_source_file_index);
+        fs->Unbind(EVT_DOWNLOAD, &SelectMachineDialog::on_source_download_event, this);
+    }
+}
+
+void SelectMachineDialog::fetch_file_from_source_printer()
+{
+    auto fs = m_source_fs.lock();
+    if (!fs) {
+        m_status_bar->set_status_text(_L("Cannot access the source printer's storage. Please reopen the file from the printer's file list."));
+        Enable_Send_Button(true);
+        prepare_mode();
+        return;
+    }
+
+    // the file list may have been refreshed meanwhile, re-find the file by path
+    auto matches = [this](PrinterFileSystem::File const& f) {
+        return !m_source_file_path.empty() && (f.path.empty() ? f.name == m_source_file_path : f.path == m_source_file_path);
+    };
+    size_t index = m_source_file_index;
+    if (index >= fs->GetCount() || !matches(fs->GetFile(index))) {
+        index = size_t(-1);
+        for (size_t i = 0; i < fs->GetCount(); ++i) {
+            if (matches(fs->GetFile(i))) { index = i; break; }
+        }
+    }
+    if (index == size_t(-1)) {
+        m_status_bar->set_status_text(_L("The file no longer exists on the source printer."));
+        Enable_Send_Button(true);
+        prepare_mode();
+        return;
+    }
+    m_source_file_index = index;
+
+    const auto& file = fs->GetFile(index);
+    if (!file.local_path.empty() && fs->DownloadCheckFile(index)) {
+        // already downloaded before, reuse it
+        m_transferred_local_path = file.local_path;
+        CallAfter([this] { on_send_print(); });
+        return;
+    }
+
+    m_waiting_source_download = true;
+    fs->Bind(EVT_DOWNLOAD, &SelectMachineDialog::on_source_download_event, this);
+
+    bool     cancelled = false;
+    wxString msg       = _L("Transferring the print file from the source printer...");
+    m_status_bar->update_status(msg, cancelled, 0, true);
+
+    auto dl_dir = (boost::filesystem::temp_directory_path() / "bambu_sdcard_transfer").string();
+    fs->DownloadFiles(index, dl_dir);
+}
+
+void SelectMachineDialog::on_source_download_event(wxCommandEvent& e)
+{
+    e.Skip();
+    if (!m_waiting_source_download) return;
+    auto fs = m_source_fs.lock();
+    if (!fs) {
+        m_waiting_source_download = false;
+        m_status_bar->set_status_text(_L("Lost connection to the source printer while transferring the file."));
+        Enable_Send_Button(true);
+        prepare_mode();
+        return;
+    }
+    int result = e.GetExtraLong();
+
+    if (result == PrinterFileSystem::SUCCESS) {
+        // the file list may have been refreshed during the download, shifting the index,
+        // so match the completed download by file name as well
+        std::string local_path = e.GetString().utf8_string();
+        std::string source_name = boost::filesystem::path(m_source_file_path).filename().string();
+        if (local_path.empty() || boost::filesystem::path(local_path).filename().string() != source_name)
+            return; // another file's download
+        if (!boost::filesystem::path(local_path).has_parent_path())
+            return; // download-start notification carries the bare file name, not a path
+        if (!boost::filesystem::exists(local_path))
+            return;
+        m_waiting_source_download = false;
+        fs->Unbind(EVT_DOWNLOAD, &SelectMachineDialog::on_source_download_event, this);
+        m_transferred_local_path = local_path;
+        CallAfter([this] { on_send_print(); });
+        return;
+    }
+
+    if ((size_t)e.GetInt() != m_source_file_index) return;
+
+    if (result == PrinterFileSystem::CONTINUE) {
+        const auto& file = fs->GetFile(m_source_file_index);
+        int progress = file.DownloadProgress();
+        if (progress < 0) progress = 0;
+        bool     cancelled = false;
+        wxString msg       = _L("Transferring the print file from the source printer...");
+        m_status_bar->update_status(msg, cancelled, progress, true);
+        return;
+    }
+
+    m_waiting_source_download = false;
+    fs->Unbind(EVT_DOWNLOAD, &SelectMachineDialog::on_source_download_event, this);
+    if (result == PrinterFileSystem::ERROR_CANCEL) return; // handled by the cancel flow
+    m_status_bar->set_status_text(_L("Failed to transfer the print file from the source printer."));
+    Enable_Send_Button(true);
+    prepare_mode();
 }
 
 void  SelectMachineDialog::reset_timeout()
@@ -3913,7 +4076,8 @@ void SelectMachineDialog::update_show_status(MachineObject* obj_)
     }
 
     /*combobox check*/
-    if (m_print_type == PrintFromType::FROM_SDCARD_VIEW) {
+    if (m_print_type == PrintFromType::FROM_SDCARD_VIEW && m_source_fs.expired()) {
+        // no access to the source printer's file system, the file cannot be transferred elsewhere
         m_printer_box->GetPrinterComboBox()->Disable();
     } else {
         if (get_status() == PrintDialogStatus::PrintStatusRefreshingMachineList)
@@ -5312,6 +5476,7 @@ bool SelectMachineDialog::Show(bool show)
 
 SelectMachineDialog::~SelectMachineDialog()
 {
+    release_source_download_binding();
     delete m_refresh_timer;
 }
 

--- a/src/slic3r/GUI/SelectMachine.hpp
+++ b/src/slic3r/GUI/SelectMachine.hpp
@@ -50,6 +50,9 @@
 #define  PRINT_OPT_BG_GRAY       0xF8F8F8
 #define  PRINT_OPT_ITEM_BG_GRAY  0xEEEEEE
 
+#include <boost/weak_ptr.hpp>
+
+class PrinterFileSystem;
 
 // Previous definitions
 namespace Slic3r{
@@ -347,6 +350,14 @@ private:
     std::string                         m_required_data_file_name;
     std::string                         m_required_data_file_path;
 
+    // print-from-sdcard source printer info, used to transfer the file when another printer is selected
+    boost::weak_ptr<PrinterFileSystem>  m_source_fs;
+    size_t                              m_source_file_index{size_t(-1)};
+    std::string                         m_source_file_path;
+    std::string                         m_source_dev_id;
+    std::string                         m_transferred_local_path;
+    bool                                m_waiting_source_download{false};
+
     std::vector<POItem> ops_auto;
     std::vector<POItem> ops_no_auto;
 
@@ -564,6 +575,11 @@ public:
     void navigate_to_timelapse_page();
     bool is_timeout();
     int  update_print_required_data(Slic3r::DynamicPrintConfig config, Slic3r::Model model, Slic3r::PlateDataPtrs plate_data_list, std::string file_name, std::string file_path);
+    void set_sdcard_print_source(PrinterFileSystem* fs, size_t file_index, const std::string& dev_id);
+    bool is_sdcard_cross_printer_send() const;
+    void fetch_file_from_source_printer();
+    void on_source_download_event(wxCommandEvent& e);
+    void release_source_download_binding();
     void set_print_type(PrintFromType type) {m_print_type = type;};
     bool Show(bool show);
     bool do_ams_mapping(MachineObject *obj_,bool use_ams);


### PR DESCRIPTION
## Problem

When printing a file from a printer's storage (device page → files / print history → Print), the printer combobox in `SelectMachineDialog` is unconditionally disabled (`FROM_SDCARD_VIEW` mode). If the source printer is busy, the dialog shows *"The printer is busy on other print job"* and there is no way to print the job on another idle printer — the printer list cannot even be expanded.

## Solution

- The printer list stays **enabled** in `FROM_SDCARD_VIEW` mode (it is only disabled when the source printer's file system is not available).
- Selecting the **source printer** keeps the existing behavior (`start_sdcard_print`, the printer prints its local file).
- Selecting a **different printer** triggers a transfer: Studio downloads the `.gcode.3mf` from the source printer via `PrinterFileSystem` (progress + cancel supported in the dialog's status bar, previously downloaded files are reused), then sends it to the selected printer through the regular upload path — new `PrintJob` type `from_sdcard_transfer` (LAN FTP with cloud fallback), preserving the plate index, AMS mapping and print options.
- The printer-model mismatch warning now also covers cross-printer sends.
- `MediaFilePanel` passes the source printer's file system, file index and dev id to the dialog via a new `Plater::set_sdcard_print_source()`.

## Testing status

- Builds cleanly on Linux (Ubuntu 24.04 docker flow, `BuildLinux.sh -s`); no new compiler warnings in the touched files.
- The same-printer path is unchanged by design; the cross-printer path has been verified against a protocol-level printer simulator (MQTT/FTPS), **not yet against real hardware** — feedback from hardware testing is welcome.
