### PR TITLE
FIX: Fix boost::format declaration

### DIFF
--- a/src/slic3r/GUI/DeviceCore/DevUtil.h
+++ b/src/slic3r/GUI/DeviceCore/DevUtil.h
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <stdexcept>
 
+#include <boost/format.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/lexical_cast.hpp>
 


### PR DESCRIPTION
```
In file included from /run/build/BambuStudio/src/slic3r/GUI/DeviceCore/DevAxis.cpp:2: /run/build/BambuStudio/src/slic3r/GUI/DeviceCore/DevUtil.h: In function ‘std::string Slic3r::s_get_diameter_str(float)’: /run/build/BambuStudio/src/slic3r/GUI/DeviceCore/DevUtil.h:173:20: error: ‘format’ is not a member of ‘boost’
  173 |     return (boost::format("%.2f") % diameter).str();
      |                    ^~~~~~
```