### PR TITLE
FIX: Fix missing device name for SpaceMouse Wireless BT

### DIFF
--- a/src/slic3r/GUI/Mouse3DController.cpp
+++ b/src/slic3r/GUI/Mouse3DController.cpp
@@ -136,6 +136,7 @@ static std::string format_device_string(int vid, int pid)
     case 0xc635: { ret += "spacemouse compact"; break; }
     case 0xc636: { ret += "spacemouse module"; break; }
     case 0xc638: { ret += "spacemouse pro wireless BT edition"; break; }
+    case 0xc63a: { ret += "spacemouse wireless (Bluetooth)"; break; }
     case 0xc640: { ret += "nulooq"; break; }
     case 0xc652: { ret += "3Dconnexion universal receiver"; break; }
     default:     { ret += "UNKNOWN"; break; }


### PR DESCRIPTION
Fixes: 1519fa69cb2e ("Mouse3DController: Add SpaceMouse Wireless BT support")