### PR TITLE
feat: add ARM64 slicer API Docker image workflow

### DIFF
--- a/.github/workflows/build-arm64-slicer.yml
+++ b/.github/workflows/build-arm64-slicer.yml
@@ -1,0 +1,71 @@
+name: Build ARM64 slicer API image
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/bambu-studio-api
+
+concurrency:
+  group: build-arm64-slicer
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 180
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore deps cache
+        id: cache-deps
+        uses: actions/cache@v5
+        with:
+          path: deps/build/destdir
+          key: arm64-deps-${{ hashFiles('deps/**') }}
+
+      - name: Install system dependencies
+        run: sudo ./BuildLinux.sh -ur
+
+      - name: Fix permissions
+        run: sudo chown -R $USER ./
+
+      - name: Build deps
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: ./BuildLinux.sh -dfr
+
+      - name: Build BambuStudio
+        run: ./BuildLinux.sh -sfr
+
+      - name: Stage build artifacts for Docker context
+        run: |
+          mkdir -p slicer-api/stage/bin slicer-api/stage/lib
+          cp build/src/BambuStudio slicer-api/stage/bin/bambu-studio
+          cp build/src/libav*.so* slicer-api/stage/lib/ 2>/dev/null || true
+          cp build/src/libsw*.so* slicer-api/stage/lib/ 2>/dev/null || true
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: slicer-api/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,5 @@ compile_commands.json
 # Legacy device_page bundle copies (runtime lives in resources/web/device_page/dist/)
 resources/web/device_page/assets/
 resources/web/device_page/index.html
+slicer-api/stage/
 

--- a/slicer-api/AppRun.sh
+++ b/slicer-api/AppRun.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+export LD_LIBRARY_PATH="${SELF_DIR}/lib:${LD_LIBRARY_PATH}"
+exec "${SELF_DIR}/bin/bambu-studio" "$@"

--- a/slicer-api/Dockerfile
+++ b/slicer-api/Dockerfile
@@ -1,0 +1,38 @@
+FROM node:20-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl git ca-certificates \
+      libgtk-3-0t64 libglib2.0-0t64 libgl1 libegl1 \
+      libgstreamer1.0-0 libgstreamer-gl1.0-0 \
+      libsecret-1-0 libosmesa6 libcurl4t64 libdbus-1-3 \
+      libglew2.2 libudev1 libmspack0 libxkbcommon0 \
+      libunwind8 libfuse2t64 libwebkit2gtk-4.1-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG SLICER_API_REPO=https://github.com/maziggy/orca-slicer-api.git
+ARG SLICER_API_BRANCH=bambuddy/profile-resolver
+RUN git clone --branch ${SLICER_API_BRANCH} --depth 1 \
+      ${SLICER_API_REPO} /app \
+    && cd /app && npm ci --production \
+    && apt-get purge -y git && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build artifacts are staged into slicer-api/stage/ by the CI workflow
+# because .dockerignore excludes /build/.
+COPY slicer-api/AppRun.sh /app/squashfs-root/AppRun
+COPY slicer-api/stage/bin/bambu-studio /app/squashfs-root/bin/bambu-studio
+COPY resources/ /app/squashfs-root/resources/
+COPY slicer-api/stage/lib/ /app/squashfs-root/lib/
+
+ENV LD_LIBRARY_PATH=/app/squashfs-root/lib
+
+RUN chmod +x /app/squashfs-root/AppRun /app/squashfs-root/bin/bambu-studio
+
+WORKDIR /app
+ENV NODE_ENV=production
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=30s \
+  CMD curl -f http://localhost:3000/health || exit 1
+
+CMD ["node", "server.js"]


### PR DESCRIPTION
GitHub Actions workflow that compiles BambuStudio natively on an ARM64 runner and packages it as a Docker image compatible with the maziggy/orca-slicer-api interface. The image is pushed to GHCR as a drop-in replacement for the x86_64-only bambu-studio-api image, enabling headless CLI slicing on ARM64 boards without QEMU emulation.


Claude-Session: https://claude.ai/code/session_01FooPihXuKUALPYQnZzi642