### PR TITLE
FIX: Remove boost::system dependency from Bambu Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,7 +407,7 @@ endif()
 # boost::process was introduced first in version 1.64.0,
 # boost::beast::detail::base64 was introduced first in version 1.66.0
 set(MINIMUM_BOOST_VERSION "1.83.0")
-set(_boost_components "system;filesystem;thread;log;locale;regex;chrono;atomic;date_time;iostreams")
+set(_boost_components "filesystem;thread;log;locale;regex;chrono;atomic;date_time;iostreams")
 find_package(Boost ${MINIMUM_BOOST_VERSION} REQUIRED COMPONENTS ${_boost_components})
 
 add_library(boost_libs INTERFACE)

--- a/cmake/modules/FindOpenVDB.cmake
+++ b/cmake/modules/FindOpenVDB.cmake
@@ -385,7 +385,7 @@ else()
 endif()
 find_package(TBB ${_quiet} ${_required} COMPONENTS tbb)
 find_package(ZLIB ${_quiet} ${_required})
-find_package(Boost ${_quiet} ${_required} COMPONENTS iostreams system )
+find_package(Boost ${_quiet} ${_required} COMPONENTS iostreams)
 
 # Use GetPrerequisites to see which libraries this OpenVDB lib has linked to
 # which we can query for optional deps. This basically runs ldd/otoll/objdump
@@ -493,7 +493,6 @@ endif()
 
 set(_OPENVDB_VISIBLE_DEPENDENCIES
   Boost::iostreams
-  Boost::system
   IlmBase::Half
 )
 

--- a/deps/OpenVDB/0002-Remove-boost-system-dep.patch
+++ b/deps/OpenVDB/0002-Remove-boost-system-dep.patch
@@ -1,0 +1,50 @@
+From 4bff28d0fe5617d0e21b111c10170530d98c7f33 Mon Sep 17 00:00:00 2001
+From: Bastien Nocera <hadess@hadess.net>
+Date: Sat, 1 Aug 2026 15:26:18 +0200
+Subject: [PATCH] Remove boost::system dep
+
+It is gone in Boost 1.89:
+https://github.com/boostorg/system/issues/132
+---
+ cmake/FindOpenVDB.cmake        | 1 -
+ openvdb/openvdb/CMakeLists.txt | 5 ++---
+ 2 files changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/cmake/FindOpenVDB.cmake b/cmake/FindOpenVDB.cmake
+index 86eaf8497b63..413ab8b7ea4a 100644
+--- a/cmake/FindOpenVDB.cmake
++++ b/cmake/FindOpenVDB.cmake
+@@ -650,7 +650,6 @@ endif()
+ 
+ set(_OPENVDB_VISIBLE_DEPENDENCIES
+   Boost::iostreams
+-  Boost::system
+ )
+ 
+ if(OpenVDB_USES_IMATH_HALF)
+diff --git a/openvdb/openvdb/CMakeLists.txt b/openvdb/openvdb/CMakeLists.txt
+index 73fb4f938cfb..a086a0b5cab9 100644
+--- a/openvdb/openvdb/CMakeLists.txt
++++ b/openvdb/openvdb/CMakeLists.txt
+@@ -119,7 +119,7 @@ endif()
+ 
+ find_package(Threads REQUIRED)
+ 
+-find_package(Boost ${MINIMUM_BOOST_VERSION} REQUIRED COMPONENTS iostreams system)
++find_package(Boost ${MINIMUM_BOOST_VERSION} REQUIRED COMPONENTS iostreams)
+ if(OPENVDB_FUTURE_DEPRECATION AND FUTURE_MINIMUM_BOOST_VERSION)
+   # The X.Y.Z boost version value isn't available until CMake 3.14
+   set(FULL_BOOST_VERSION "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
+@@ -241,8 +241,7 @@ endif()
+ # other headers.
+ 
+ list(APPEND OPENVDB_CORE_DEPENDENT_LIBS
+-  Boost::iostreams
+-  Boost::system)
++  Boost::iostreams)
+ 
+ if(WIN32)
+   # Boost headers contain #pragma commands on Windows which causes Boost
+-- 
+2.55.0
+

--- a/deps/OpenVDB/OpenVDB.cmake
+++ b/deps/OpenVDB/OpenVDB.cmake
@@ -19,7 +19,7 @@ set (_openvdb_vdbprint ON)
 bambustudio_add_cmake_project(OpenVDB    
     URL https://github.com/tamasmeszaros/openvdb/archive/a68fd58d0e2b85f01adeb8b13d7555183ab10aa5.zip # 8.2 patched
     URL_HASH SHA256=f353e7b99bd0cbfc27ac9082de51acf32a8bc0b3e21ff9661ecca6f205ec1d81
-    PATCH_COMMAND git apply ${OPENVDB_DIRECTORY_FLAG} --verbose --ignore-space-change --whitespace=fix ${CMAKE_CURRENT_LIST_DIR}/0001-clang19.patch
+    PATCH_COMMAND git apply ${OPENVDB_DIRECTORY_FLAG} --verbose --ignore-space-change --whitespace=fix ${CMAKE_CURRENT_LIST_DIR}/0001-clang19.patch ${CMAKE_CURRENT_LIST_DIR}/0002-Remove-boost-system-dep.patch
     # URL https://github.com/AcademySoftwareFoundation/openvdb/archive/refs/tags/v10.0.1.zip
     # URL_HASH SHA256=48C2CFA9853B58FA86282DF1F83F0E99D07858CC03EB2BA8227DC447A830100A
     DEPENDS dep_TBB ${BLOSC_PKG} dep_OpenEXR ${BOOST_PKG}


### PR DESCRIPTION
boost::system is gone in Boost 1.89:
https://github.com/boostorg/system/issues/132

And it was just a stub for years before that.