### PR TITLE
Improve Helio reliability, catalog consistency, and workflow safety

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -653,6 +653,10 @@ set(SLIC3R_GUI_SOURCES
     Utils/WxFontUtils.cpp
     Utils/HelioDragon.cpp
     Utils/HelioDragon.hpp
+    Utils/HelioRetryPolicy.cpp
+    Utils/HelioRetryPolicy.hpp
+    Utils/HelioSupportData.cpp
+    Utils/HelioSupportData.hpp
     Utils/FileTransferUtils.cpp
     Utils/FileTransferUtils.hpp
     Utils/FileTransferObject.cpp

--- a/src/slic3r/GUI/BackgroundSlicingProcess.hpp
+++ b/src/slic3r/GUI/BackgroundSlicingProcess.hpp
@@ -1,6 +1,7 @@
 #ifndef slic3r_GUI_BackgroundSlicingProcess_hpp_
 #define slic3r_GUI_BackgroundSlicingProcess_hpp_
 
+#include <cstdint>
 #include <string>
 #include <condition_variable>
 #include <mutex>
@@ -27,8 +28,8 @@ class SLAPrint;
 class HelioCompletionEvent : public wxEvent
 {
 public:
-    HelioCompletionEvent(wxEventType eventType, int winid, std::string in_path, std::string in_tmp_path, bool in_is_successful, std::string in_error_message = "", int ac = 0, std::string mean_impro = "", std::string std_impro = "")
-        : wxEvent(winid, eventType), tmp_path(in_tmp_path), path(in_path), is_successful(in_is_successful), error_message(in_error_message), action(ac), quality_mean_improvement(mean_impro), quality_std_improvement(std_impro){}
+    HelioCompletionEvent(wxEventType eventType, int winid, std::string in_path, std::string in_tmp_path, bool in_is_successful, std::string in_error_message = "", int ac = 0, std::string mean_impro = "", std::string std_impro = "", std::uint64_t in_generation = 0)
+        : wxEvent(winid, eventType), tmp_path(in_tmp_path), path(in_path), is_successful(in_is_successful), error_message(in_error_message), action(ac), quality_mean_improvement(mean_impro), quality_std_improvement(std_impro), generation(in_generation) {}
     virtual wxEvent *Clone() const { return new HelioCompletionEvent(*this); }
 
     std::string tmp_path;
@@ -36,19 +37,31 @@ public:
     bool        is_successful;
     std::string error_message;
     int action; //0-simulation 1-optimization
-    std::string quality_mean_improvement;	
-    std::string quality_std_improvement;	
+    std::string quality_mean_improvement;
+    std::string quality_std_improvement;
+    std::uint64_t generation;
+};
+
+class HelioActionEvent : public wxEvent
+{
+public:
+    HelioActionEvent(wxEventType eventType, int winid, std::uint64_t in_generation)
+        : wxEvent(winid, eventType), generation(in_generation) {}
+    virtual wxEvent *Clone() const { return new HelioActionEvent(*this); }
+    std::uint64_t generation;
 };
 
 class SlicingStatusEvent : public wxEvent
 {
 public:
-	SlicingStatusEvent(wxEventType eventType, int winid, const PrintBase::SlicingStatus &status) :
-		wxEvent(winid, eventType), status(std::move(status)) {}
-	virtual wxEvent *Clone() const { return new SlicingStatusEvent(*this); }
+    SlicingStatusEvent(wxEventType eventType, int winid, const PrintBase::SlicingStatus &status, std::uint64_t in_generation = 0) :
+        wxEvent(winid, eventType), status(std::move(status)), generation(in_generation) {}
+    virtual wxEvent *Clone() const { return new SlicingStatusEvent(*this); }
 
-	PrintBase::SlicingStatus status;
+    PrintBase::SlicingStatus status;
+    std::uint64_t generation;
 };
+
 
 class SlicingProcessCompletedEvent : public wxEvent
 {

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2814,6 +2814,8 @@ int GUI_App::OnExit()
     UnRegisterMacPowerCallBack();
 #endif
 
+    Slic3r::HelioQuery::shutdown_background_requests();
+
     stop_sync_user_preset();
 
     if (m_fila_manager_cloud_disp) {
@@ -4417,14 +4419,13 @@ void GUI_App::request_helio_pat(std::function<void(std::string)> func)
     Slic3r::HelioQuery::request_pat_token(func);
 }
 
-void GUI_App::request_helio_supported_data()
+void GUI_App::request_helio_supported_data(bool force_refresh)
 {
     std::string helio_api_url = Slic3r::HelioQuery::get_helio_api_url();
     std::string helio_api_key = Slic3r::HelioQuery::get_helio_pat();
 
-    if (!HelioQuery::global_printers_fully_loaded || !HelioQuery::global_materials_fully_loaded) {
-        Slic3r::HelioQuery::request_all_support_machine(helio_api_url, helio_api_key);
-        Slic3r::HelioQuery::request_all_support_materials(helio_api_url, helio_api_key);
+    if (Slic3r::HelioQuery::request_supported_data(helio_api_url, helio_api_key, force_refresh)) {
+        Slic3r::HelioQuery::clear_print_priority_cache();
     }
 }
 

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -592,7 +592,7 @@ public:
     //for helio slice
     bool            is_helio_enable();
     static void     request_helio_pat(std::function<void(std::string)> func);
-    static void     request_helio_supported_data();
+    static void     request_helio_supported_data(bool force_refresh = false);
 	//static std::vector<Slic3r::HelioQuery::SupportedPrinters> get_helio_support_printer_model();
 
     void                                               persist_window_geometry(wxTopLevelWindow *window, bool default_maximized = false);

--- a/src/slic3r/GUI/HelioHistoryDialog.cpp
+++ b/src/slic3r/GUI/HelioHistoryDialog.cpp
@@ -811,6 +811,9 @@ void HelioHistoryDialog::on_view_details_sim(const HelioQuery::SimulationRun& ru
 
 wxString HelioHistoryDialog::format_time_ago(const std::chrono::system_clock::time_point& timestamp)
 {
+    if (timestamp == std::chrono::system_clock::time_point{})
+        return _L("Unknown");
+
     auto now = std::chrono::system_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::seconds>(now - timestamp);
 

--- a/src/slic3r/GUI/HelioReleaseNote.cpp
+++ b/src/slic3r/GUI/HelioReleaseNote.cpp
@@ -1698,12 +1698,15 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
     bool has_heated_chamber = false;
     if (!printer_name.empty()) {
         std::string target_lower = boost::to_lower_copy(printer_name);
-        for (const auto& p : HelioQuery::global_supported_printers) {
-            if (p.native_name.empty()) continue;
-            std::string native_lower = boost::to_lower_copy(p.native_name);
-            if (target_lower == native_lower || target_lower.find(native_lower) != std::string::npos) {
-                has_heated_chamber = p.heated_chamber;
-                break;
+        const auto supported_printers = HelioQuery::supported_data_view().printers;
+        if (supported_printers) {
+            for (const auto& p : *supported_printers) {
+                if (p.native_name.empty()) continue;
+                std::string native_lower = boost::to_lower_copy(p.native_name);
+                if (target_lower == native_lower || target_lower.find(native_lower) != std::string::npos) {
+                    has_heated_chamber = p.heated_chamber;
+                    break;
+                }
             }
         }
     }
@@ -3794,9 +3797,20 @@ HelioSimulationResultsDialog::HelioSimulationResultsDialog(wxWindow *parent,
     m_button_enhance->Bind(wxEVT_LEFT_DOWN, &HelioSimulationResultsDialog::on_enhance_speed_quality, this);
     m_button_enhance->Bind(wxEVT_ENTER_WINDOW, [this](auto& e) { SetCursor(wxCURSOR_HAND); });
     m_button_enhance->Bind(wxEVT_LEAVE_WINDOW, [this](auto& e) { SetCursor(wxCURSOR_ARROW); });
+    wxStaticBitmap* save_icon = new wxStaticBitmap(this, wxID_ANY, create_scaled_bitmap("save", this, 24), wxDefaultPosition,
+        wxSize(FromDIP(24), FromDIP(24)));
+    save_icon->SetToolTip(_L("Save the simulated sliced 3MF locally"));
+    save_icon->Bind(wxEVT_ENTER_WINDOW, [this](auto& e) { SetCursor(wxCURSOR_HAND); });
+    save_icon->Bind(wxEVT_LEAVE_WINDOW, [this](auto& e) { SetCursor(wxCURSOR_ARROW); });
+    save_icon->Bind(wxEVT_LEFT_DOWN, [](wxMouseEvent& e) {
+        wxPostEvent(wxGetApp().plater(), SimpleEvent(EVT_GLTOOLBAR_EXPORT_SLICED_FILE));
+    });
+
 
     // Right-align the enhance button
     sizer_actions->Add(0, 0, 1, wxEXPAND, 0);
+    sizer_actions->Add(save_icon, 0, wxALIGN_CENTER, 0);
+    sizer_actions->Add(0, 0, 0, wxRIGHT, FromDIP(14));
     sizer_actions->Add(m_button_enhance, 0, wxALIGN_CENTER, 0);
 
     // Layout

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2174,6 +2174,8 @@ wxBoxSizer* MainFrame::create_side_tools()
                 m_slice_select = eSliceAll;
                 m_slice_enable = get_enable_slice_status();
                 m_slice_btn->Enable(m_slice_enable);
+                update_helio_button_state();
+
                 this->Layout();
                 if(m_slice_option_pop_up)
                     m_slice_option_pop_up->Dismiss();
@@ -2185,6 +2187,8 @@ wxBoxSizer* MainFrame::create_side_tools()
                 m_slice_select = eSlicePlate;
                 m_slice_enable = get_enable_slice_status();
                 m_slice_btn->Enable(m_slice_enable);
+                update_helio_button_state();
+
                 this->Layout();
                 if(m_slice_option_pop_up)
                     m_slice_option_pop_up->Dismiss();
@@ -2581,17 +2585,30 @@ void MainFrame::update_slice_print_status(SlicePrintEventType event, bool can_sl
     m_slice_enable = enable_slice;
     m_print_enable = enable_print;
 
-    /*for healio*/
-    if (expand_program_holder) {
-        expand_program_holder->updateExpandButtonBitmap(expand_helio_id, m_print_enable?"helio_icon_topbar":"helio_icon_topbar_disable");
-        expand_program_holder->EnableExpandButton(expand_helio_id, m_print_enable);
-    }
+    update_helio_button_state();
 
-
-    if (!old_slice_status && enable_slice)
+    if (!old_slice_status && enable_slice) {
         m_plater->stop_helio_process();
         m_plater->reset_check_status();
+    }
 }
+
+void MainFrame::update_helio_button_state()
+{
+    if (!expand_program_holder)
+        return;
+
+    const PartPlate* current_plate = m_plater != nullptr ? m_plater->get_partplate_list().get_curr_plate() : nullptr;
+    const bool helio_enabled = m_plater != nullptr && !m_plater->only_gcode_mode() &&
+                               !m_plater->using_exported_file() && current_plate != nullptr &&
+                               current_plate->is_slice_result_valid() && current_plate->can_slice() &&
+                               !m_plater->sidebar().has_broken_mixed_filament() &&
+                               !m_plater->is_background_process_slicing();
+    expand_program_holder->updateExpandButtonBitmap(expand_helio_id, helio_enabled ? "helio_icon_topbar" : "helio_icon_topbar_disable");
+    expand_program_holder->EnableExpandButton(expand_helio_id, helio_enabled);
+}
+
+
 
 
 void MainFrame::on_dpi_changed(const wxRect& suggested_rect)

--- a/src/slic3r/GUI/MainFrame.hpp
+++ b/src/slic3r/GUI/MainFrame.hpp
@@ -425,6 +425,8 @@ public:
     //BBS
     void update_side_button_style();
     void update_slice_print_status(SlicePrintEventType event, bool can_slice = true, bool can_print = true);
+    void update_helio_button_state();
+
 
     int select_device_page_count{ 0 };
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -264,7 +264,7 @@ wxDEFINE_EVENT(EVT_SWITCH_TO_PREPARE_TAB, wxCommandEvent);
 
 // helio
 wxDEFINE_EVENT(EVT_HELIO_PROCESSING_COMPLETED, HelioCompletionEvent);
-wxDEFINE_EVENT(EVT_HELIO_PROCESSING_STARTED, SimpleEvent);
+wxDEFINE_EVENT(EVT_HELIO_PROCESSING_STARTED, HelioActionEvent);
 wxDEFINE_EVENT(EVT_HELIO_INPUT_DLG, SimpleEvent);
 // end helio
 
@@ -6871,10 +6871,14 @@ public:
 
     // V2: single material path (feature flag OFF)
     int update_helio_background_process_v2(std::string& printer_id, std::string& material_id);
+    int update_helio_background_process_v2_once(std::string& printer_id, std::string& material_id);
     // V3: multi-material path (feature flag ON)
     int update_helio_background_process(std::string& printer_id,
                                          std::vector<HelioQuery::MaterialInput>& materials,
                                          bool& is_multi_color, bool& is_multi_material);
+    int update_helio_background_process_once(std::string& printer_id,
+                                              std::vector<HelioQuery::MaterialInput>& materials,
+                                              bool& is_multi_color, bool& is_multi_material);
 
     void clear_warnings();
     void add_warning(const Slic3r::PrintStateBase::Warning &warning, size_t oid);
@@ -6922,9 +6926,9 @@ public:
     void on_action_slice_plate(SimpleEvent&);
     void on_action_slice_all(SimpleEvent&);
     void on_helio_processing_complete(HelioCompletionEvent &);
-    void on_helio_processing_start(SimpleEvent &);
+    void on_helio_processing_start(HelioActionEvent &);
     void on_helio_input_dlg(SimpleEvent &);
-    void on_helio_process();
+    void on_helio_process(const PartPlate* expected_plate);
     void on_action_publish(wxCommandEvent &evt);
     void on_action_print_plate(SimpleEvent&);
     void on_action_print_all(SimpleEvent&);
@@ -12372,6 +12376,9 @@ void Plater::priv::on_select_preset(wxCommandEvent &evt)
 
 void Plater::priv::on_slicing_update(SlicingStatusEvent &evt)
 {
+    if (evt.status.is_helio && !helio_background_process.is_action_current(evt.generation)) {
+        return;
+    }
     BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << boost::format(": event_type %1%, percent %2%, text %3%") % evt.GetEventType() % evt.status.percent % evt.status.text;
     //BBS: add slice project logic
     std::string title_text = _u8L("Slicing");
@@ -12960,19 +12967,21 @@ static std::vector<std::string> extract_material_keywords(const std::string& mat
 
 // Helper function to find similar materials based on keywords
 static std::vector<HelioQuery::SupportedData> find_similar_materials(
+    const SupportDataCatalogPairView& support_data,
     const std::string& target_name,
     const std::vector<std::string>& keywords)
 {
     std::vector<HelioQuery::SupportedData> similar_materials;
+    const auto& supported_materials = support_data.materials;
 
-    if (keywords.empty()) {
+    if (keywords.empty() || !supported_materials) {
         return similar_materials;
     }
 
     std::string lower_target = target_name;
     boost::algorithm::to_lower(lower_target);
 
-    for (const HelioQuery::SupportedData& pdata : HelioQuery::global_supported_materials) {
+    for (const HelioQuery::SupportedData& pdata : *supported_materials) {
         if (pdata.native_name.empty()) {
             continue;
         }
@@ -13022,14 +13031,19 @@ static std::vector<std::string> extract_printer_keywords(const std::string& prin
 
 // Helper function to find similar printers based on keywords
 static std::vector<HelioQuery::SupportedData> find_similar_printers(
+    const SupportDataCatalogPairView& support_data,
     const std::string& target_name,
     const std::vector<std::string>& keywords)
 {
     std::vector<HelioQuery::SupportedData> similar_printers;
+    const auto& supported_printers = support_data.printers;
+    if (!supported_printers) {
+        return similar_printers;
+    }
 
     // If no keywords found, return all printers as options
     if (keywords.empty()) {
-        for (const HelioQuery::SupportedData& pdata : HelioQuery::global_supported_printers) {
+        for (const HelioQuery::SupportedData& pdata : *supported_printers) {
             if (!pdata.native_name.empty()) {
                 similar_printers.push_back(pdata);
             }
@@ -13040,7 +13054,7 @@ static std::vector<HelioQuery::SupportedData> find_similar_printers(
     std::string lower_target = target_name;
     boost::algorithm::to_lower(lower_target);
 
-    for (const HelioQuery::SupportedData& pdata : HelioQuery::global_supported_printers) {
+    for (const HelioQuery::SupportedData& pdata : *supported_printers) {
         if (pdata.native_name.empty()) {
             continue;
         }
@@ -13198,7 +13212,8 @@ struct FilamentSupportInfo {
 };
 
 // Helper function to check if a single filament is supported by Helio and get its material ID
-static FilamentSupportInfo check_filament_helio_support(const std::string& filament_preset_name, int extruder_index)
+static FilamentSupportInfo check_filament_helio_support(const SupportDataCatalogPairView& support_data,
+                                                        const std::string& filament_preset_name, int extruder_index)
 {
     FilamentSupportInfo info;
     info.preset_name = filament_preset_name;
@@ -13222,7 +13237,12 @@ static FilamentSupportInfo check_filament_helio_support(const std::string& filam
     // Find best (longest) match to prefer specific materials over generic ones
     size_t best_match_length = 0;
 
-    for (const HelioQuery::SupportedData& pdata : HelioQuery::global_supported_materials) {
+    const auto& supported_materials = support_data.materials;
+    if (!supported_materials) {
+        return info;
+    }
+
+    for (const HelioQuery::SupportedData& pdata : *supported_materials) {
         if (pdata.native_name.empty()) continue;
 
         std::string native_name = pdata.native_name;
@@ -13339,12 +13359,6 @@ public:
         warning_box->SetSizer(warning_sizer);
         main_sizer->Add(warning_box, 0, wxALL, wxWindowBase::FromDIP(15, this));
 
-        // Future support message
-        Label* future_msg = new Label(this, Label::Body_13,
-            _L("True multi-material support will be added in a future update."), LB_AUTO_WRAP);
-        future_msg->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#6B6B6B")));
-        future_msg->Wrap(wxWindowBase::FromDIP(470, this));
-        main_sizer->Add(future_msg, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, wxWindowBase::FromDIP(15, this));
 
         // Option 1: Proceed with single filament
         StaticBox* option1_box = new StaticBox(this, wxID_ANY, wxDefaultPosition,
@@ -13527,6 +13541,32 @@ public:
 
         option2_box->SetSizer(option2_sizer);
         main_sizer->Add(option2_box, 0, wxLEFT | wxRIGHT | wxBOTTOM, wxWindowBase::FromDIP(15, this));
+        wxColour option3_bg = is_dark_mode ? wxColour(30, 45, 70) : wxColour("#E3F2FD");
+        wxColour option3_border = is_dark_mode ? wxColour(100, 181, 246) : wxColour("#2196F3");
+        wxColour option3_text_color = is_dark_mode ? wxColour(240, 240, 240) : text_color;
+        // Option 3: Enable multi-material optimization
+        StaticBox* option3_box = new StaticBox(this, wxID_ANY, wxDefaultPosition,
+                                               wxSize(wxWindowBase::FromDIP(470, this), -1));
+        option3_box->SetBackgroundColor(StateColor(std::make_pair(option3_bg, (int)StateColor::Normal)));
+        option3_box->SetBackgroundColour(option3_bg);
+        option3_box->SetBorderColor(StateColor(std::make_pair(option3_border, (int)StateColor::Normal)));
+        option3_box->SetBorderWidth(1);
+        option3_box->SetCornerRadius(wxWindowBase::FromDIP(6, this));
+
+        wxBoxSizer* option3_sizer = new wxBoxSizer(wxVERTICAL);
+        option3_sizer->AddSpacer(wxWindowBase::FromDIP(12, this));
+        Label* option3_title = new Label(option3_box, Label::Head_14, _L("Option 3: Enable multi-material optimization"));
+        option3_title->SetForegroundColour(option3_text_color);
+        option3_sizer->Add(option3_title, 0, wxLEFT | wxRIGHT, wxWindowBase::FromDIP(16, this));
+        option3_sizer->AddSpacer(wxWindowBase::FromDIP(8, this));
+        Label* option3_desc = new Label(option3_box, Label::Body_13,
+            _L("Click third-party icon → Enable Helio Additive → Check \"Experimental: Enable multi-material support\""), LB_AUTO_WRAP);
+        option3_desc->SetForegroundColour(option3_text_color);
+        option3_desc->Wrap(wxWindowBase::FromDIP(440, this));
+        option3_sizer->Add(option3_desc, 0, wxEXPAND | wxLEFT | wxRIGHT, wxWindowBase::FromDIP(16, this));
+        option3_sizer->AddSpacer(wxWindowBase::FromDIP(12, this));
+        option3_box->SetSizer(option3_sizer);
+        main_sizer->Add(option3_box, 0, wxLEFT | wxRIGHT | wxBOTTOM, wxWindowBase::FromDIP(15, this));
 
         SetSizerAndFit(main_sizer);
         {
@@ -13865,9 +13905,10 @@ private:
 // Progress dialog shown while re-fetching supported printers/materials from Helio
 class HelioSyncProgressDialog : public DPIDialog {
 public:
-    HelioSyncProgressDialog(wxWindow* parent)
+    HelioSyncProgressDialog(wxWindow* parent, bool wait_for_refresh_completion = false)
         : DPIDialog(parent, wxID_ANY, _L("Syncing Data"),
                    wxDefaultPosition, wxDefaultSize, wxCAPTION)
+        , m_wait_for_refresh_completion(wait_for_refresh_completion)
     {
         SetBackgroundColour(StateColor::darkModeColorFor(*wxWHITE));
 
@@ -13884,7 +13925,12 @@ public:
                               wxSize(wxWindowBase::FromDIP(300, this), -1), wxGA_HORIZONTAL);
         m_gauge->Pulse();
         sizer->Add(m_gauge, 0, wxALIGN_CENTER | wxLEFT | wxRIGHT, wxWindowBase::FromDIP(20, this));
-        sizer->AddSpacer(wxWindowBase::FromDIP(20, this));
+        sizer->AddSpacer(wxWindowBase::FromDIP(10, this));
+
+        m_cancel_btn = new Button(this, _L("Cancel"));
+        m_cancel_btn->Bind(wxEVT_BUTTON, &HelioSyncProgressDialog::OnCancel, this);
+        sizer->Add(m_cancel_btn, 0, wxALIGN_CENTER | wxLEFT | wxRIGHT | wxBOTTOM, wxWindowBase::FromDIP(20, this));
+        sizer->AddSpacer(wxWindowBase::FromDIP(10, this));
 
         SetSizerAndFit(sizer);
         CentreOnParent();
@@ -13892,7 +13938,6 @@ public:
 
         m_timer = new wxTimer(this);
         Bind(wxEVT_TIMER, &HelioSyncProgressDialog::OnTimer, this);
-        m_start_time = std::chrono::steady_clock::now();
         m_timer->Start(500);
     }
 
@@ -13904,17 +13949,36 @@ public:
     }
 
     void on_dpi_changed(const wxRect& suggested_rect) override {}
+    bool was_cancelled_by_user() const { return m_cancelled_by_user; }
+
 
 private:
+    void OnCancel(wxCommandEvent&) {
+        m_cancelled_by_user = true;
+        if (m_timer) {
+            m_timer->Stop();
+        }
+        EndModal(wxID_CANCEL);
+    }
+
     void OnTimer(wxTimerEvent&) {
         m_gauge->Pulse();
-        if (HelioQuery::global_printers_fully_loaded && HelioQuery::global_materials_fully_loaded) {
+        const auto support_data = HelioQuery::supported_data_view();
+
+        if (m_wait_for_refresh_completion) {
+            if (support_data.printers_state != SupportDataLoadState::Loading &&
+                support_data.materials_state != SupportDataLoadState::Loading) {
+                const bool refresh_succeeded = support_data.printers_state == SupportDataLoadState::Ready &&
+                                               support_data.materials_state == SupportDataLoadState::Ready;
+                EndModal(refresh_succeeded ? wxID_OK : wxID_CANCEL);
+            }
+            return;
+        }
+        if (support_data.availability == SupportDataAvailability::Usable) {
             EndModal(wxID_OK);
             return;
         }
-        auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
-            std::chrono::steady_clock::now() - m_start_time).count();
-        if (elapsed >= 15) {
+        if (support_data.availability == SupportDataAvailability::LoadFailed) {
             EndModal(wxID_CANCEL);
             return;
         }
@@ -13922,14 +13986,68 @@ private:
 
     wxTimer* m_timer;
     wxGauge* m_gauge;
-    std::chrono::steady_clock::time_point m_start_time;
+    Button* m_cancel_btn;
+    bool m_wait_for_refresh_completion{false};
+    bool m_cancelled_by_user{false};
+
 };
+
+static std::string helio_support_data_error_details(const SupportDataCatalogPairView& support_data)
+{
+    std::string details = support_data.printers_last_error;
+    const std::string material_error = support_data.materials_last_error;
+    if (!material_error.empty()) {
+        if (!details.empty()) details += "\n";
+        details += material_error;
+    }
+    return details;
+}
+
+static bool refresh_helio_supported_data(wxWindow* parent)
+{
+    wxGetApp().request_helio_supported_data(true);
+    HelioSyncProgressDialog sync_dlg(parent, true);
+    if (sync_dlg.ShowModal() == wxID_OK) {
+        return true;
+    }
+    if (sync_dlg.was_cancelled_by_user()) {
+        return false;
+    }
+
+
+    const auto support_data = HelioQuery::supported_data_view();
+    wxString message = support_data.availability == SupportDataAvailability::Usable
+        ? _L("Helio could not refresh all printer and material data. The previous complete data remains available.")
+        : _L("Helio could not load complete printer and material data. Matching remains paused.");
+    const std::string details = helio_support_data_error_details(support_data);
+    if (!details.empty()) {
+        message += "\n\n";
+        message += wxString::FromUTF8(details);
+    }
+    MessageDialog failure_dialog(parent, message, _L("Helio Data Refresh Failed"), wxOK | wxICON_ERROR);
+    failure_dialog.ShowModal();
+    return false;
+}
 
 // ===========================================================================
 // V2 PATH: Single material_id, uses HelioMixedFilamentDialog for mixed types
 // Used when helio_multimaterial_enabled feature flag is OFF
 // ===========================================================================
+static constexpr int HELIO_SUPPORT_DATA_REFRESHED = -2;
+
 int Plater::priv::update_helio_background_process_v2(std::string& printer_id, std::string& material_id)
+{
+    for (;;) {
+        const int result = update_helio_background_process_v2_once(printer_id, material_id);
+        if (result != HELIO_SUPPORT_DATA_REFRESHED) {
+            return result;
+        }
+        printer_id.clear();
+        material_id.clear();
+    }
+}
+
+int Plater::priv::update_helio_background_process_v2_once(std::string& printer_id, std::string& material_id)
 {
     helio_using_reference_material = false; // Reset at start (Issue D fix)
 
@@ -13946,8 +14064,17 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
          return -1;
      }
 
+    const auto support_data = HelioQuery::supported_data_view();
+    const auto& supported_printers = support_data.printers;
+    const auto& supported_materials = support_data.materials;
+    if (support_data.availability != SupportDataAvailability::Usable ||
+        !supported_printers || !supported_materials) {
+        BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": Helio support-data snapshot is unavailable";
+        return -1;
+    }
+
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": preset_name = '" << preset_name << "', preset_pure_name = '" << preset_pure_name << "'";
-    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": global_supported_printers.size() = " << HelioQuery::global_supported_printers.size();
+    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": supported_printers.size() = " << supported_printers->size();
 
     std::string printer_target_name = preset_name;
     boost::trim(printer_target_name);
@@ -13963,7 +14090,7 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
 
     // Step 1: Try word-boundary matching
     auto [best_match_id, best_match_length] = match_printer_with_boundaries(
-        printer_target_name, HelioQuery::global_supported_printers);
+        printer_target_name, *supported_printers);
 
     if (!best_match_id.empty()) {
         helio_support = true;
@@ -13974,7 +14101,7 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
     // Step 2: Token-based matching
     if (!helio_support) {
         auto [token_printer_id, token_native_name] = match_printer_tokens(
-            printer_target_name, HelioQuery::global_supported_printers);
+            printer_target_name, *supported_printers);
 
         if (!token_printer_id.empty()) {
             wxString message = wxString::Format(
@@ -13997,7 +14124,7 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
     // Step 3: Reference printer selection dialog
     if (!helio_support) {
         std::vector<std::string> keywords = extract_printer_keywords(printer_target_name);
-        std::vector<HelioQuery::SupportedData> similar_printers = find_similar_printers(printer_target_name, keywords);
+        std::vector<HelioQuery::SupportedData> similar_printers = find_similar_printers(support_data, printer_target_name, keywords);
 
         if (!similar_printers.empty()) {
             wxArrayString printer_choices;
@@ -14051,7 +14178,7 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
     for (size_t i = 0; i < extruders.size(); ++i) {
         int extruder_idx = extruders[i] - 1;
         if (extruder_idx >= 0 && extruder_idx < (int)preset_filaments.size()) {
-            FilamentSupportInfo info = check_filament_helio_support(preset_filaments[extruder_idx], extruder_idx);
+            FilamentSupportInfo info = check_filament_helio_support(support_data, preset_filaments[extruder_idx], extruder_idx);
             all_filament_infos.push_back(info);
 
             if (info.is_supported) {
@@ -14106,7 +14233,7 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
         boost::trim(target_name);
 
         std::vector<std::string> keywords = extract_material_keywords(target_name);
-        std::vector<HelioQuery::SupportedData> similar_materials = find_similar_materials(target_name, keywords);
+        std::vector<HelioQuery::SupportedData> similar_materials = find_similar_materials(support_data, target_name, keywords);
 
         std::string default_material_id;
         for (const auto& info : all_filament_infos) {
@@ -14127,6 +14254,9 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
                 material_id = unsupported_dialog.get_selected_material_id();
                 helio_using_reference_material = true;
                 material_already_selected = true;
+            } else if (choice == 3 && refresh_helio_supported_data(
+                           static_cast<wxWindow*>(wxGetApp().mainframe))) {
+                return HELIO_SUPPORT_DATA_REFRESHED;
             } else {
                 return -1;
             }
@@ -14147,7 +14277,7 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
         size_t best_mat_match_length = 0;
         std::string best_mat_id;
 
-        for (HelioQuery::SupportedData pdata : HelioQuery::global_supported_materials) {
+        for (const HelioQuery::SupportedData& pdata : *supported_materials) {
             if (!pdata.native_name.empty()) {
                 std::string native_name = pdata.native_name;
                 size_t atPos = used_filament.find('@');
@@ -14190,7 +14320,7 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
             std::string best_token_material_id;
             std::string best_token_native_name;
 
-            for (HelioQuery::SupportedData pdata : HelioQuery::global_supported_materials) {
+            for (const HelioQuery::SupportedData& pdata : *supported_materials) {
                 if (!pdata.native_name.empty()) {
                     std::string native_name = pdata.native_name;
                     boost::algorithm::to_lower(native_name);
@@ -14248,7 +14378,7 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
                 boost::trim(target_name2);
 
                 std::vector<std::string> keywords = extract_material_keywords(target_name2);
-                std::vector<HelioQuery::SupportedData> similar_materials = find_similar_materials(target_name2, keywords);
+                std::vector<HelioQuery::SupportedData> similar_materials = find_similar_materials(support_data, target_name2, keywords);
 
                 if (!similar_materials.empty()) {
                     wxArrayString material_choices;
@@ -14261,7 +14391,7 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
                     // Collect unsupported filament info for dialog
                     std::vector<FilamentSupportInfo> unsupported_for_dialog;
                     unsupported_for_dialog.push_back(all_filament_infos.empty() ?
-                        check_filament_helio_support(used_filament, extruders.front() - 1) :
+                        check_filament_helio_support(support_data, used_filament, extruders.front() - 1) :
                         all_filament_infos[0]);
 
                     std::string default_mat_id;
@@ -14279,6 +14409,9 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
                         material_id = unsupported_dialog.get_selected_material_id();
                         is_supported_by_helio = true;
                         helio_using_reference_material = true;
+                    } else if (choice == 3 && refresh_helio_supported_data(
+                                   static_cast<wxWindow*>(wxGetApp().mainframe))) {
+                        return HELIO_SUPPORT_DATA_REFRESHED;
                     } else {
                         GUI::MessageDialog errordialog(nullptr,
                             wxString::Format(_L("Helio does not support materials %s.\n\nPlease choose an officially supported material. "), used_filament),
@@ -14338,6 +14471,23 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
                                                    std::vector<HelioQuery::MaterialInput>& materials,
                                                    bool& is_multi_color, bool& is_multi_material)
 {
+    for (;;) {
+        const int result = update_helio_background_process_once(printer_id, materials,
+                                                                 is_multi_color, is_multi_material);
+        if (result != HELIO_SUPPORT_DATA_REFRESHED) {
+            return result;
+        }
+        printer_id.clear();
+        materials.clear();
+        is_multi_color = false;
+        is_multi_material = false;
+    }
+}
+
+int Plater::priv::update_helio_background_process_once(std::string& printer_id,
+                                                        std::vector<HelioQuery::MaterialInput>& materials,
+                                                        bool& is_multi_color, bool& is_multi_material)
+{
     helio_using_reference_material = false; // Reset at start (Issue D fix)
     notification_manager->close_notification_of_type(NotificationType::HelioSlicingError);
     PresetBundle *           preset_bundle     = wxGetApp().preset_bundle;
@@ -14352,9 +14502,18 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
          return -1;
      }
 
+    const auto support_data = HelioQuery::supported_data_view();
+    const auto& supported_printers = support_data.printers;
+    const auto& supported_materials = support_data.materials;
+    if (support_data.availability != SupportDataAvailability::Usable ||
+        !supported_printers || !supported_materials) {
+        BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": Helio support-data snapshot is unavailable";
+        return -1;
+    }
+
     /*invalid printer preset*/
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": preset_name = '" << preset_name << "', preset_pure_name = '" << preset_pure_name << "'";
-    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": global_supported_printers.size() = " << HelioQuery::global_supported_printers.size();
+    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": supported_printers.size() = " << supported_printers->size();
 
     // For printer matching, use the full preset_name to handle modified names like "myBambu Lab H2Dsmells"
     std::string printer_target_name = preset_name;
@@ -14373,7 +14532,7 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
     // This finds the best (longest) match to prefer specific printers over generic ones
     // e.g., "H2D Pro" should match before "H2D" when both could match
     auto [best_match_id, best_match_length] = match_printer_with_boundaries(
-        printer_target_name, HelioQuery::global_supported_printers);
+        printer_target_name, *supported_printers);
 
     if (!best_match_id.empty()) {
         helio_support = true;
@@ -14385,7 +14544,7 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
     // This handles cases like "myBambu Lab H2Dsmells" or "yourH2Dfast"
     if (!helio_support) {
         auto [token_printer_id, token_native_name] = match_printer_tokens(
-            printer_target_name, HelioQuery::global_supported_printers);
+            printer_target_name, *supported_printers);
 
         if (!token_printer_id.empty()) {
             // Show confirmation dialog for token-based match
@@ -14414,7 +14573,7 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
 
         // Extract keywords and find similar printers
         std::vector<std::string> keywords = extract_printer_keywords(printer_target_name);
-        std::vector<HelioQuery::SupportedData> similar_printers = find_similar_printers(printer_target_name, keywords);
+        std::vector<HelioQuery::SupportedData> similar_printers = find_similar_printers(support_data, printer_target_name, keywords);
 
         if (!similar_printers.empty()) {
             // Create list of printer names for selection dialog
@@ -14685,7 +14844,7 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
     for (size_t i = 0; i < extruders.size(); ++i) {
         int extruder_idx = extruders[i] - 1; // Extruders are 1-indexed
         if (extruder_idx >= 0 && extruder_idx < (int)preset_filaments.size()) {
-            FilamentSupportInfo info = check_filament_helio_support(preset_filaments[extruder_idx], extruder_idx);
+            FilamentSupportInfo info = check_filament_helio_support(support_data, preset_filaments[extruder_idx], extruder_idx);
             all_filament_infos.push_back(info);
 
             if (info.is_supported) {
@@ -14760,7 +14919,7 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
         std::string best_token_material_id;
         std::string best_token_native_name;
 
-        for (const HelioQuery::SupportedData& pdata : HelioQuery::global_supported_materials) {
+        for (const HelioQuery::SupportedData& pdata : *supported_materials) {
             if (pdata.native_name.empty()) continue;
             std::string native_name = pdata.native_name;
             boost::algorithm::to_lower(native_name);
@@ -14809,7 +14968,7 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
 
         // No token match — show reference material selection dialog
         std::vector<std::string> keywords = extract_material_keywords(target_name);
-        std::vector<HelioQuery::SupportedData> similar_materials = find_similar_materials(target_name, keywords);
+        std::vector<HelioQuery::SupportedData> similar_materials = find_similar_materials(support_data, target_name, keywords);
 
         if (!similar_materials.empty()) {
             wxArrayString material_choices;
@@ -14831,7 +14990,7 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
 
             int choice = 0;
             std::string selected_ref_material_id;
-            do {
+            {
                 HelioUnsupportedFilamentsDialog unsupported_dialog(
                     static_cast<wxWindow*>(wxGetApp().mainframe),
                     unsupported_for_slot, similar_materials, default_material_id);
@@ -14843,23 +15002,12 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
                 if (choice == 3) {
                     // Re-fetch supported data from Helio
                     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": User chose to refresh supported data for slot " << i;
-                    std::string helio_api_url = HelioQuery::get_helio_api_url();
-                    std::string helio_api_key = HelioQuery::get_helio_pat();
-                    HelioQuery::request_all_support_machine(helio_api_url, helio_api_key);
-                    HelioQuery::request_all_support_materials(helio_api_url, helio_api_key);
-
-                    // Show progress dialog while data syncs
-                    HelioSyncProgressDialog sync_dlg(static_cast<wxWindow*>(wxGetApp().mainframe));
-                    sync_dlg.ShowModal();
-
-                    // Re-compute similar materials with refreshed data
-                    similar_materials = find_similar_materials(target_name, keywords);
-                    if (similar_materials.empty()) {
-                        BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": No similar materials found after refresh for slot " << i;
-                        break;
+                    if (!refresh_helio_supported_data(static_cast<wxWindow*>(wxGetApp().mainframe))) {
+                        return -1;
                     }
+                    return HELIO_SUPPORT_DATA_REFRESHED;
                 }
-            } while (choice == 3);
+            }
 
             if (choice == 1) {
                 materials[i].materialId = selected_ref_material_id;
@@ -14923,6 +15071,9 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
 
 void Plater::priv::on_helio_processing_complete(HelioCompletionEvent &a)
 {
+    if (!helio_background_process.is_action_current(a.generation)) {
+        return;
+    }
     if (a.is_successful) {
         this->reset_gcode_toolpaths();
 
@@ -15001,8 +15152,11 @@ void Plater::priv::on_helio_processing_complete(HelioCompletionEvent &a)
     }
 }
 
-void Plater::priv::on_helio_processing_start(SimpleEvent &a)
+void Plater::priv::on_helio_processing_start(HelioActionEvent &a)
 {
+    if (!helio_background_process.is_action_current(a.generation)) {
+        return;
+    }
     notification_manager->close_notification_of_type(GUI::NotificationType::SignDetected);
     notification_manager->close_notification_of_type(GUI::NotificationType::ExportFinished);
     notification_manager->set_slicing_progress_began(true);
@@ -15010,8 +15164,20 @@ void Plater::priv::on_helio_processing_start(SimpleEvent &a)
 }
 
 //BBS: GUI refactor: slice with helio
-void Plater::priv::on_helio_process()
+void Plater::priv::on_helio_process(const PartPlate* expected_plate)
 {
+    auto helio_launch_allowed = [this, expected_plate]() {
+        const PartPlate* current_plate = partplate_list.get_curr_plate();
+        return current_plate != nullptr && current_plate == expected_plate &&
+               current_plate->is_slice_result_valid() && current_plate->can_slice() &&
+               !q->only_gcode_mode() && !q->using_exported_file() &&
+               !sidebar->has_broken_mixed_filament(current_plate) &&
+               !q->is_background_process_slicing();
+    };
+
+    if (!helio_launch_allowed())
+        return;
+
     std::string helio_api_url = Slic3r::HelioQuery::get_helio_api_url();
     std::string helio_api_key = Slic3r::HelioQuery::get_helio_pat();
 
@@ -15061,25 +15227,40 @@ void Plater::priv::on_helio_process()
 
         while (dlg.ShowModal() == wxID_OK)
         {
+            if (!helio_launch_allowed())
+                return;
+
             if (partplate_list.get_curr_plate()->empty()) return;
             GCodeProcessorResult* g_result = background_process.get_current_gcode_result();
 
             /*simulation*/
             int action = dlg.get_action();
-            helio_background_process.set_action(action);
 
             if (action == 0) {
                 bool valid = false;
                 HelioQuery::SimulationInput data = dlg.get_simulation_input(valid);
                 if (!valid) { continue; }
 
-                helio_background_process.set_simulation_input_data(data);
-                if (multimaterial_enabled) {
-                    helio_background_process.init(helio_api_key, helio_api_url, printer_id, materials, is_multi_color, is_multi_material, g_result, preview, [this]() {});
-                } else {
-                    helio_background_process.init(helio_api_key, helio_api_url, printer_id, material_id, g_result, preview, [this]() {});
+                const bool initialized = multimaterial_enabled
+                    ? helio_background_process.init(helio_api_key, helio_api_url, printer_id, materials, is_multi_color,
+                                                    is_multi_material, g_result, preview, [this]() {})
+                    : helio_background_process.init(helio_api_key, helio_api_url, printer_id, material_id, g_result,
+                                                    preview, [this]() {});
+                if (!initialized) {
+                    MessageDialog dlg(nullptr, _L("Previous Helio action is still stopping; try again shortly"),
+                                      _L("Helio Additive"), wxOK | wxICON_WARNING);
+                    dlg.ShowModal();
+                    continue;
                 }
-                helio_background_process.helio_thread_start(background_process.m_mutex, background_process.m_condition, background_process.m_state, notification_manager);
+                helio_background_process.set_action(action);
+                helio_background_process.set_simulation_input_data(data);
+                if (!helio_background_process.helio_thread_start(background_process.m_mutex, background_process.m_condition,
+                                                                 background_process.m_state, notification_manager)) {
+                    MessageDialog dlg(nullptr, _L("Previous Helio action is still stopping; try again shortly"),
+                                      _L("Helio Additive"), wxOK | wxICON_WARNING);
+                    dlg.ShowModal();
+                    continue;
+                }
                 BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << ":helio simulation process called (V" << (multimaterial_enabled ? "3" : "2") << ")";
 
                 if (wxGetApp().getAgent()) {
@@ -15095,13 +15276,26 @@ void Plater::priv::on_helio_process()
                 HelioQuery::OptimizationInput data = dlg.get_optimization_input(valid);
                 if (!valid) { continue; }
 
-                helio_background_process.set_optimization_input_data(data);
-                if (multimaterial_enabled) {
-                    helio_background_process.init(helio_api_key, helio_api_url, printer_id, materials, is_multi_color, is_multi_material, g_result, preview, [this]() {});
-                } else {
-                    helio_background_process.init(helio_api_key, helio_api_url, printer_id, material_id, g_result, preview, [this]() {});
+                const bool initialized = multimaterial_enabled
+                    ? helio_background_process.init(helio_api_key, helio_api_url, printer_id, materials, is_multi_color,
+                                                    is_multi_material, g_result, preview, [this]() {})
+                    : helio_background_process.init(helio_api_key, helio_api_url, printer_id, material_id, g_result,
+                                                    preview, [this]() {});
+                if (!initialized) {
+                    MessageDialog dlg(nullptr, _L("Previous Helio action is still stopping; try again shortly"),
+                                      _L("Helio Additive"), wxOK | wxICON_WARNING);
+                    dlg.ShowModal();
+                    continue;
                 }
-                helio_background_process.helio_thread_start(background_process.m_mutex, background_process.m_condition, background_process.m_state, notification_manager);
+                helio_background_process.set_action(action);
+                helio_background_process.set_optimization_input_data(data);
+                if (!helio_background_process.helio_thread_start(background_process.m_mutex, background_process.m_condition,
+                                                                 background_process.m_state, notification_manager)) {
+                    MessageDialog dlg(nullptr, _L("Previous Helio action is still stopping; try again shortly"),
+                                      _L("Helio Additive"), wxOK | wxICON_WARNING);
+                    dlg.ShowModal();
+                    continue;
+                }
                 BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << ":helio optimization process called (V" << (multimaterial_enabled ? "3" : "2") << ")";
 
                 if (wxGetApp().getAgent()) {
@@ -15119,6 +15313,12 @@ void Plater::priv::on_helio_process()
 
 void Plater::priv::on_helio_input_dlg(SimpleEvent &a)
 {
+    const PartPlate* current_plate = partplate_list.get_curr_plate();
+    if (current_plate == nullptr || !current_plate->is_slice_result_valid() ||
+        !current_plate->can_slice() || q->only_gcode_mode() || q->using_exported_file() ||
+        sidebar->has_broken_mixed_filament(current_plate) || q->is_background_process_slicing())
+        return;
+
     std::string helio_api_key = Slic3r::HelioQuery::get_helio_pat();
 
     if (helio_api_key.empty()) {
@@ -15150,16 +15350,40 @@ void Plater::priv::on_helio_input_dlg(SimpleEvent &a)
         }
     }
     else {
-        if (!HelioQuery::global_printers_fully_loaded || !HelioQuery::global_materials_fully_loaded) {
+        const SupportDataAvailability availability = HelioQuery::supported_data_view().availability;
+        if (availability == SupportDataAvailability::Usable) {
+            on_helio_process(current_plate);
+        }
+        else if (availability == SupportDataAvailability::Synchronizing) {
             wxGetApp().request_helio_supported_data();
             auto dlg = MessageDialog(nullptr, _L("The printer list and material list are being synchronized. Please try again later."), _L("Synchronizing Helio"), wxOK | wxICON_WARNING);
             dlg.ShowModal();
         }
         else {
-            on_helio_process();
+                const std::string details = helio_support_data_error_details(HelioQuery::supported_data_view());
+
+                wxString message = _L("Helio could not load the supported printer and material lists. Matching has been paused so unavailable data is not treated as an unsupported material.");
+                if (!details.empty()) {
+                    message += "\n\n";
+                    message += wxString::FromUTF8(details);
+                }
+                MessageDialog dlg(nullptr, message, _L("Helio Data Load Failed"), wxYES_NO | wxNO_DEFAULT | wxICON_ERROR);
+                dlg.SetButtonLabel(wxID_YES, _L("Retry"));
+                dlg.SetButtonLabel(wxID_NO, _L("Cancel"));
+                if (dlg.ShowModal() != wxID_YES) {
+                    return;
+                }
+
+                wxGetApp().request_helio_supported_data(true);
+                HelioSyncProgressDialog sync_dlg(static_cast<wxWindow*>(wxGetApp().mainframe), true);
+                sync_dlg.ShowModal();
+                if (HelioQuery::supported_data_view().availability == SupportDataAvailability::Usable) {
+                    on_helio_process(current_plate);
+                    return;
+                }
+            }
         }
     }
-}
 
 //BBS: GUI refactor: slice all
 void Plater::priv::on_action_slice_all(SimpleEvent&)

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -54,6 +54,7 @@ class SLAPrint;
 class PartPlateList;
 class SlicingStatusEvent;
 class HelioCompletionEvent;
+class HelioActionEvent;
 enum SLAPrintObjectStep : unsigned int;
 enum class ConversionType : int;
 class DevAms;
@@ -128,7 +129,7 @@ wxDECLARE_EVENT(EVT_SWITCH_TO_PREPARE_TAB, wxCommandEvent);
 
 // helio
 wxDECLARE_EVENT(EVT_HELIO_PROCESSING_COMPLETED, HelioCompletionEvent);
-wxDECLARE_EVENT(EVT_HELIO_PROCESSING_STARTED, SimpleEvent);
+wxDECLARE_EVENT(EVT_HELIO_PROCESSING_STARTED, HelioActionEvent);
 wxDECLARE_EVENT(EVT_HELIO_INPUT_DLG, SimpleEvent);
 // end helio
 wxDECLARE_EVENT(EVT_GCODE_VIEWER_CHANGED, SimpleEvent);

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -5,6 +5,9 @@
 #include <wx/file.h>
 #include <boost/optional.hpp>
 #include <boost/asio/ip/address.hpp>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include <vector>
 #include <boost/format.hpp>
 #include "PrintHost.hpp"
@@ -21,18 +24,261 @@
 #include "../GUI/HelioReleaseNote.hpp"
 #include "wx/app.h"
 #include "cstdio"
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <cstdint>
+#include <ctime>
+#include <sstream>
 #include <thread>
 
 namespace Slic3r {
 
-std::vector<HelioQuery::SupportedData> HelioQuery::global_supported_printers;
-std::vector<HelioQuery::SupportedData> HelioQuery::global_supported_materials;
-bool HelioQuery::global_printers_fully_loaded = false;
-bool HelioQuery::global_materials_fully_loaded = false;
 std::map<std::string, std::vector<HelioQuery::PrintPriorityOption>> HelioQuery::global_print_priority_cache;
 
 std::string HelioQuery::last_simulation_trace_id;
 std::string HelioQuery::last_optimization_trace_id;  
+
+namespace {
+
+thread_local std::uint64_t helio_worker_generation = 0;
+
+constexpr int HELIO_CREATE_MAX_ATTEMPTS = 4;
+constexpr int HELIO_UPLOAD_MAX_ATTEMPTS = 4;
+constexpr int HELIO_MAX_POLL_BACKOFF_SECONDS = 30;
+constexpr int HELIO_MAX_TRANSIENT_POLL_FAILURES = 60;
+
+struct HelioPrintPriorityCacheState
+{
+    std::mutex   mutex;
+    std::uint64_t generation{0};
+};
+
+HelioPrintPriorityCacheState& helio_print_priority_cache_state()
+{
+    // Requests are joined during GUI shutdown. Leak the synchronization state
+    // as an additional guard against static destruction order regressions.
+    static HelioPrintPriorityCacheState* state = new HelioPrintPriorityCacheState;
+    return *state;
+}
+
+class HelioRequestWorkers
+{
+public:
+    using Task = std::function<void(const std::atomic_bool&)>;
+
+    bool start(Task task)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_stopping.load(std::memory_order_acquire)) {
+            return false;
+        }
+
+        reap_finished_locked();
+        auto finished = std::make_shared<std::atomic_bool>(false);
+        try {
+            m_workers.reserve(m_workers.size() + 1);
+            m_workers.emplace_back();
+            Worker& worker = m_workers.back();
+            worker.finished = finished;
+            worker.thread = std::thread([this, task = std::move(task), finished]() mutable {
+                try {
+                    task(m_stopping);
+                } catch (...) {
+                    // SupportDataCatalogStore::run normally contains failures.
+                    // Keep the owner safe if one escapes unexpectedly.
+                }
+                finished->store(true, std::memory_order_release);
+            });
+        } catch (...) {
+            if (!m_workers.empty() && m_workers.back().finished == finished &&
+                !m_workers.back().thread.joinable()) {
+                m_workers.pop_back();
+            }
+            return false;
+        }
+        return true;
+    }
+
+    void shutdown()
+    {
+        std::vector<Worker> workers;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_stopping.store(true, std::memory_order_release);
+            workers.swap(m_workers);
+        }
+        for (Worker& worker : workers) {
+            if (worker.thread.joinable()) {
+                worker.thread.join();
+            }
+        }
+    }
+
+private:
+    struct Worker
+    {
+        std::thread                       thread;
+        std::shared_ptr<std::atomic_bool> finished;
+    };
+
+    void reap_finished_locked()
+    {
+        auto worker = m_workers.begin();
+        while (worker != m_workers.end()) {
+            if (!worker->finished->load(std::memory_order_acquire)) {
+                ++worker;
+                continue;
+            }
+            if (worker->thread.joinable()) {
+                worker->thread.join();
+            }
+            worker = m_workers.erase(worker);
+        }
+    }
+
+    std::mutex          m_mutex;
+    std::atomic_bool    m_stopping{false};
+    std::vector<Worker> m_workers;
+};
+
+HelioRequestWorkers& helio_request_workers()
+{
+    // GUI_App::OnExit joins these workers before Http's global curl cleanup.
+    // Keep the owner process-lived so static destruction cannot race a load.
+    static HelioRequestWorkers* workers = new HelioRequestWorkers;
+    return *workers;
+}
+
+bool helio_starts_with(const std::string& value, const std::string& prefix)
+{
+    return value.size() >= prefix.size() && std::equal(prefix.begin(), prefix.end(), value.begin());
+}
+
+std::string helio_generate_idempotency_key()
+{
+    return boost::uuids::to_string(boost::uuids::random_generator()());
+}
+
+std::string helio_generate_retry_job_name(const std::string& idempotency_key)
+{
+    const std::string unique_suffix = idempotency_key.empty() ? helio_generate_idempotency_key().substr(0, 8) :
+                                                                idempotency_key.substr(0, 8);
+    const std::string timestamped_name = HelioQuery::generateTimestampedString();
+    const size_t timestamp_pos = timestamped_name.find_last_of(' ');
+    if (timestamp_pos == std::string::npos) {
+        return timestamped_name + " " + unique_suffix;
+    }
+    return timestamped_name.substr(0, timestamp_pos) + " " + unique_suffix + timestamped_name.substr(timestamp_pos);
+}
+
+void helio_attach_idempotency_key(Http& http, const std::string& idempotency_key)
+{
+    if (!idempotency_key.empty()) {
+        http.header("Idempotency-Key", idempotency_key);
+    }
+}
+
+std::string helio_http_status_message(unsigned status, const std::string& body = std::string())
+{
+    std::string message = (boost::format("HTTP status: %1%") % status).str();
+    if (!body.empty()) {
+        message += ", body: " + body;
+    }
+    return message;
+}
+
+std::string helio_bearer_token_from_authorization(const std::string& authorization)
+{
+    const std::string bearer_prefix = "Bearer ";
+    if (helio_starts_with(authorization, bearer_prefix)) {
+        return authorization.substr(bearer_prefix.size());
+    }
+    return authorization;
+}
+
+int helio_next_poll_backoff_seconds(int transient_failures)
+{
+    return std::min(HELIO_MAX_POLL_BACKOFF_SECONDS, 3 + transient_failures * 3);
+}
+
+bool helio_should_cancel(const std::function<bool()>& should_cancel)
+{
+    return should_cancel && should_cancel();
+}
+
+bool helio_sleep_for_retry_or_cancel(int seconds, const std::function<bool()>& should_cancel)
+{
+    for (int elapsed = 0; elapsed < seconds; ++elapsed) {
+        if (helio_should_cancel(should_cancel)) {
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    return !helio_should_cancel(should_cancel);
+}
+
+bool helio_adopt_recent_simulation_by_name(const std::string& helio_api_url,
+                                           const std::string& helio_api_key,
+                                           const std::string& job_name,
+                                           HelioQuery::CreateSimulationResult& result)
+{
+    if (job_name.empty()) {
+        return false;
+    }
+
+    HelioQuery::GetRecentRunsResult recent_runs =
+        HelioQuery::get_recent_runs(helio_api_url, helio_bearer_token_from_authorization(helio_api_key));
+    if (!recent_runs.success) {
+        return false;
+    }
+
+    for (const HelioQuery::SimulationRun& run : recent_runs.simulations) {
+        if (run.name == job_name && !run.id.empty()) {
+            result.status = recent_runs.status == 0 ? 200 : recent_runs.status;
+            result.success = true;
+            result.id = run.id;
+            result.name = run.name;
+            result.error.clear();
+            BOOST_LOG_TRIVIAL(info) << "Helio create_simulation adopted existing run after retry: " << run.id;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool helio_adopt_recent_optimization_by_name(const std::string& helio_api_url,
+                                             const std::string& helio_api_key,
+                                             const std::string& job_name,
+                                             HelioQuery::CreateOptimizationResult& result)
+{
+    if (job_name.empty()) {
+        return false;
+    }
+
+    HelioQuery::GetRecentRunsResult recent_runs =
+        HelioQuery::get_recent_runs(helio_api_url, helio_bearer_token_from_authorization(helio_api_key));
+    if (!recent_runs.success) {
+        return false;
+    }
+
+    for (const HelioQuery::OptimizationRun& run : recent_runs.optimizations) {
+        if (run.name == job_name && !run.id.empty()) {
+            result.status = recent_runs.status == 0 ? 200 : recent_runs.status;
+            result.success = true;
+            result.id = run.id;
+            result.name = run.name;
+            result.error.clear();
+            BOOST_LOG_TRIVIAL(info) << "Helio create_optimization adopted existing run after retry: " << run.id;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+} // namespace
 
 std::string extract_trace_id(const std::string& headers) {
     // Validate input to prevent crashes
@@ -67,40 +313,41 @@ std::string extract_trace_id(const std::string& headers) {
     }
 }
 
-std::string format_error(std::string body)
+std::string helio_join_messages(const std::vector<std::string>& messages)
 {
-    std::string message;
-    nlohmann::json parsed_obj = nlohmann::json::parse(body);
-    if (parsed_obj.contains("errors")) {
-        nlohmann::json err_arr = parsed_obj["errors"];
-
-        if (err_arr.is_array()) {
-            size_t error_count = err_arr.size();
-            for (size_t i = 0; i < error_count; ++i) {
-                nlohmann::json err_obj = err_arr[i];
-
-                if (err_obj.contains("message")) {
-                    std::string current_msg = err_obj["message"].get<std::string>();
-                    if (error_count > 1) {
-                        message += std::to_string(i + 1) + ". " + current_msg;
-                    }
-                    else {
-                        message = current_msg;
-                    }
-
-                    if (error_count > 1 && i != error_count - 1) {
-                        message += "\n";
-                    }
-                }
-            }
+    std::string joined;
+    for (size_t i = 0; i < messages.size(); ++i) {
+        if (messages.size() > 1) {
+            joined += std::to_string(i + 1) + ". ";
         }
-        else if (err_arr.is_object()) {
-            if (err_arr.contains("message")) {
-                message = err_arr["message"].get<std::string>();
-            }
+        joined += messages[i];
+        if (i + 1 < messages.size()) {
+            joined += "\n";
         }
     }
-    return message;
+    return joined;
+}
+
+std::string format_error(const std::string& body)
+{
+    const nlohmann::json parsed_obj = nlohmann::json::parse(body);
+    if (!helio_has_graphql_errors(parsed_obj)) {
+        return {};
+    }
+
+    std::vector<std::string> messages;
+    const nlohmann::json& errors = parsed_obj["errors"];
+    if (errors.is_array()) {
+        for (const nlohmann::json& error : errors) {
+            if (error.is_object() && error.contains("message") && error["message"].is_string()) {
+                messages.push_back(error["message"].get<std::string>());
+            }
+        }
+    } else if (errors.is_object() && errors.contains("message") && errors["message"].is_string()) {
+        messages.push_back(errors["message"].get<std::string>());
+    }
+
+    return helio_join_messages(messages);
 }
 
 double HelioQuery::convert_speed(float mm_per_second) {
@@ -202,188 +449,124 @@ void HelioQuery::request_remaining_optimizations(const std::string & helio_api_u
         .perform();
 }
 
-void HelioQuery::request_support_machine(const std::string helio_api_url, const std::string helio_api_key, int page, int retries_left)
+namespace {
+
+SupportDataHttpResponse helio_fetch_support_data_page(SupportDataCatalogKind kind,
+                                                       const std::string& helio_api_url,
+                                                       const std::string& helio_api_key,
+                                                       int page,
+                                                       const std::atomic_bool& stopping)
 {
-    std::string query_body = R"( {
-            "query": "query GetPrinters($page: Int) { printers(page: $page, pageSize: 20) { pages pageInfo { hasNextPage } objects { ... on Printer  { id name heatedChamber alternativeNames { bambustudio } } } } }",
-            "variables": {"page": %1%}
-		} )";
+    const char* query = kind == SupportDataCatalogKind::Printers
+        ? "query GetPrinters($page: Int) { printers(page: $page, pageSize: 20) { pages pageInfo { hasNextPage } objects { ... on Printer { id name heatedChamber alternativeNames { bambustudio } } } } }"
+        : "query GetMaterials($page: Int) { materials(page: $page, pageSize: 20) { pages pageInfo { hasNextPage } objects { ... on Material { id name feedstock alternativeNames { bambustudio } } } } }";
 
-    query_body = boost::str(boost::format(query_body) % page);
+    json request_body;
+    request_body["query"] = query;
+    request_body["variables"]["page"] = page;
 
-    std::string url_copy  = helio_api_url;
-    std::string key_copy  = helio_api_key;
-    int         page_copy = page;
-
+    SupportDataHttpResponse response;
     std::string response_headers;
-    auto http = Http::post(url_copy);
-
+    auto http = Http::post(helio_api_url);
     http.header("Content-Type", "application/json")
         .header("Authorization", "Bearer " + helio_api_key)
         .header("HelioAdditive-Client-Name", SLIC3R_APP_NAME)
         .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
-        .set_post_body(query_body);
-
-    http.timeout_connect(20)
+        .set_post_body(request_body.dump())
+        .timeout_connect(20)
         .timeout_max(100)
-        .on_complete([url_copy, key_copy, page_copy, retries_left](std::string body, unsigned status) {
-            nlohmann::json                         parsed_obj = nlohmann::json::parse(body);
-            std::vector<HelioQuery::SupportedData> supported_printers;
-
-            try {
-                if (parsed_obj.contains("data") && parsed_obj["data"].contains("printers")) {
-                    auto materials = parsed_obj["data"]["printers"];
-                    if (materials.contains("objects") && materials["objects"].is_array()) {
-                        for (const auto &pobj : materials["objects"]) {
-                            HelioQuery::SupportedData sp;
-                            if (pobj.contains("id") && !pobj["id"].is_null()) { sp.id = pobj["id"].get<std::string>(); }
-                            if (pobj.contains("name") && !pobj["id"].is_null()) { sp.name = pobj["name"].get<std::string>(); }
-                            if (pobj.contains("heatedChamber") && pobj["heatedChamber"].is_boolean()) { sp.heated_chamber = pobj["heatedChamber"].get<bool>(); }
-
-                            if (pobj.contains("alternativeNames") && pobj["alternativeNames"].is_object()) {
-                                auto alternativeNames = pobj["alternativeNames"];
-
-                                if (alternativeNames.contains("bambustudio") && !alternativeNames["bambustudio"].is_null()) {
-                                    sp.native_name = alternativeNames["bambustudio"].get<std::string>();
-                                }
-                            }
-
-                            supported_printers.push_back(sp);
-                        }
-                    }
-
-                    HelioQuery::global_supported_printers.insert(HelioQuery::global_supported_printers.end(), supported_printers.begin(), supported_printers.end());
-
-                    if (materials.contains("pageInfo") && materials["pageInfo"].contains("hasNextPage") && materials["pageInfo"]["hasNextPage"].get<bool>()) {
-                        HelioQuery::request_support_machine(url_copy, key_copy, page_copy + 1, retries_left);
-                    } else {
-                        HelioQuery::global_printers_fully_loaded = true;
-                        BOOST_LOG_TRIVIAL(info) << "Helio: all printer pages loaded, total: " << HelioQuery::global_supported_printers.size();
-                    }
-                }
-            } catch (const std::exception& e) {
-                BOOST_LOG_TRIVIAL(error) << "Helio request_support_machine (page " << page_copy << ", retries=" << retries_left << "): " << e.what();
-                if (retries_left > 0) {
-                    std::this_thread::sleep_for(std::chrono::seconds(2));
-                    HelioQuery::request_support_machine(url_copy, key_copy, page_copy, retries_left - 1);
-                } else {
-                    HelioQuery::global_printers_fully_loaded = true;
-                }
-            } catch (...) {
-                BOOST_LOG_TRIVIAL(error) << "Helio request_support_machine (page " << page_copy << ", retries=" << retries_left << "): unknown error";
-                if (retries_left > 0) {
-                    std::this_thread::sleep_for(std::chrono::seconds(2));
-                    HelioQuery::request_support_machine(url_copy, key_copy, page_copy, retries_left - 1);
-                } else {
-                    HelioQuery::global_printers_fully_loaded = true;
-                }
-            }
+        .on_header_callback([&response_headers](std::string headers) {
+            response_headers = std::move(headers);
         })
-        .on_error([url_copy, key_copy, page_copy, retries_left](std::string body, std::string error, unsigned status) {
-            BOOST_LOG_TRIVIAL(error) << "request_support_machine error (page " << page_copy << ", retries=" << retries_left << "): " << error << ", status: " << status << ", body: " << body;
-            if (retries_left > 0) {
-                std::this_thread::sleep_for(std::chrono::seconds(2));
-                HelioQuery::request_support_machine(url_copy, key_copy, page_copy, retries_left - 1);
-            } else {
-                HelioQuery::global_printers_fully_loaded = true;
-            }
+        .on_complete([&response](std::string body, unsigned status) {
+            response.status = status;
+            response.body = std::move(body);
         })
-        .perform();
+        .on_error([&response](std::string body, std::string error, unsigned status) {
+            response.status = status;
+            response.body = std::move(body);
+            response.error = std::move(error);
+        })
+        .on_progress([&stopping](Http::Progress, bool& cancel) {
+            cancel = stopping.load(std::memory_order_acquire);
+        })
+        .perform_sync();
+
+    response.trace_id = extract_trace_id(response_headers);
+    return response;
 }
 
-void HelioQuery::request_support_material(const std::string helio_api_url, const std::string helio_api_key, int page, int retries_left)
+SupportDataCatalogPairCoordinator& helio_support_data_coordinator()
 {
-    std::string query_body = R"( {
-			"query": "query GetMaterias($page: Int) { materials(page: $page, pageSize: 20) { pages pageInfo { hasNextPage } objects { ... on Material  { id name feedstock alternativeNames { bambustudio } } } } }",
-            "variables": {"page": %1%}
-		} )";
+    // Workers are joined by GUI_App::OnExit before Http's global curl cleanup.
+    static SupportDataCatalogPairCoordinator* coordinator = new SupportDataCatalogPairCoordinator;
+    return *coordinator;
+}
 
-    query_body = boost::str(boost::format(query_body) % page);
-
-    std::string url_copy  = helio_api_url;
-    std::string key_copy  = helio_api_key;
-    int         page_copy = page;
-
-    auto http = Http::post(url_copy);
-
-    http.header("Content-Type", "application/json")
-        .header("Authorization", "Bearer " + helio_api_key)
-        .header("HelioAdditive-Client-Name", SLIC3R_APP_NAME)
-        .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
-        .set_post_body(query_body);
-
-    http.timeout_connect(20)
-        .timeout_max(100)
-        .on_complete([url_copy, key_copy, page_copy, retries_left](std::string body, unsigned status) {
-            BOOST_LOG_TRIVIAL(info) << "request_support_material" << body;
-            nlohmann::json                         parsed_obj = nlohmann::json::parse(body);
-            std::vector<HelioQuery::SupportedData> supported_materials;
-
-            try {
-                if (parsed_obj.contains("data") && parsed_obj["data"].contains("materials")) {
-                    auto materials = parsed_obj["data"]["materials"];
-                    if (materials.contains("objects") && materials["objects"].is_array()) {
-                        for (const auto &pobj : materials["objects"]) {
-                            HelioQuery::SupportedData sp;
-                            if (pobj.contains("id") && !pobj["id"].is_null()) { sp.id = pobj["id"].get<std::string>(); }
-                            if (pobj.contains("name") && !pobj["id"].is_null()) { sp.name = pobj["name"].get<std::string>(); }
-                            if (pobj.contains("feedstock") && !pobj["feedstock"].is_null()) { sp.feedstock = pobj["feedstock"].get<std::string>(); }
-                            if (pobj.contains("alternativeNames") && pobj["alternativeNames"].is_object()) {
-                                auto alternativeNames = pobj["alternativeNames"];
-
-                                //bambu materials
-                                if (alternativeNames.contains("bambustudio") && !alternativeNames["bambustudio"].is_null()) {
-                                    sp.native_name = alternativeNames["bambustudio"].get<std::string>();
-                                }
-                                //third party materials
-                                else {
-                                    if (pobj.contains("name") && !pobj["id"].is_null()) { sp.native_name = pobj["name"].get<std::string>(); }
-                                }
-                            }
-                            // Only include materials with feedstock type FILAMENT
-                            if (sp.feedstock == "FILAMENT") {
-                                supported_materials.push_back(sp);
-                            }
-                        }
+bool helio_request_support_data(const std::string& helio_api_url,
+                                const std::string& helio_api_key,
+                                bool force_refresh)
+{
+    auto& coordinator = helio_support_data_coordinator();
+    std::uint64_t generation = 0;
+    if (!coordinator.try_begin(helio_api_url, helio_api_key, force_refresh, &generation))
+        return false;
+    const bool worker_started = helio_request_workers().start(
+        [&coordinator, generation, helio_api_url, helio_api_key](const std::atomic_bool& stopping) {
+            coordinator.run(
+                generation,
+                [&helio_api_url, &helio_api_key, &stopping](SupportDataCatalogKind kind, int page) {
+                    if (stopping.load(std::memory_order_acquire)) {
+                        SupportDataHttpResponse response;
+                        response.error = "Helio support-data request stopped during shutdown";
+                        return response;
                     }
+                    return helio_fetch_support_data_page(kind, helio_api_url, helio_api_key, page, stopping);
+                },
+                [&stopping](int seconds) {
+                    for (int elapsed = 0; elapsed < seconds * 10 && !stopping.load(std::memory_order_acquire); ++elapsed)
+                        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                },
+                [](const SupportDataLoadAttempt& attempt) {
+                    BOOST_LOG_TRIVIAL(warning)
+                        << "Helio support-data load: catalog="
+                        << (attempt.kind == SupportDataCatalogKind::Printers ? "printers" : "materials")
+                        << ", page=" << attempt.page
+                        << ", retry-kind=" << helio_retry_kind_name(attempt.retry_kind)
+                        << ", attempt=" << attempt.attempt << "/" << attempt.max_attempts
+                        << ", status=" << attempt.status
+                        << ", trace-id=" << attempt.trace_id
+                        << ", error=" << attempt.error;
+                });
+        });
+    if (worker_started)
+        return true;
 
-                    HelioQuery::global_supported_materials.insert(HelioQuery::global_supported_materials.end(), supported_materials.begin(), supported_materials.end());
+    coordinator.run(generation, [](SupportDataCatalogKind, int) {
+        SupportDataHttpResponse response;
+        response.error = "Failed to start Helio support-data worker";
+        return response;
+    });
+    return false;
+}
 
-                    if (materials.contains("pageInfo") && materials["pageInfo"].contains("hasNextPage") && materials["pageInfo"]["hasNextPage"].get<bool>()) {
-                        HelioQuery::request_support_material(url_copy, key_copy, page_copy + 1, retries_left);
-                    } else {
-                        HelioQuery::global_materials_fully_loaded = true;
-                        BOOST_LOG_TRIVIAL(info) << "Helio: all material pages loaded, total: " << HelioQuery::global_supported_materials.size();
-                    }
-                }
-            } catch (const std::exception& e) {
-                BOOST_LOG_TRIVIAL(error) << "Helio request_support_material (page " << page_copy << ", retries=" << retries_left << "): " << e.what();
-                if (retries_left > 0) {
-                    std::this_thread::sleep_for(std::chrono::seconds(2));
-                    HelioQuery::request_support_material(url_copy, key_copy, page_copy, retries_left - 1);
-                } else {
-                    HelioQuery::global_materials_fully_loaded = true;
-                }
-            } catch (...) {
-                BOOST_LOG_TRIVIAL(error) << "Helio request_support_material (page " << page_copy << ", retries=" << retries_left << "): unknown error";
-                if (retries_left > 0) {
-                    std::this_thread::sleep_for(std::chrono::seconds(2));
-                    HelioQuery::request_support_material(url_copy, key_copy, page_copy, retries_left - 1);
-                } else {
-                    HelioQuery::global_materials_fully_loaded = true;
-                }
-            }
-        })
-        .on_error([url_copy, key_copy, page_copy, retries_left](std::string body, std::string error, unsigned status) {
-            BOOST_LOG_TRIVIAL(error) << "request_support_material error (page " << page_copy << ", retries=" << retries_left << "): " << error << ", status: " << status << ", body: " << body;
-            if (retries_left > 0) {
-                std::this_thread::sleep_for(std::chrono::seconds(2));
-                HelioQuery::request_support_material(url_copy, key_copy, page_copy, retries_left - 1);
-            } else {
-                HelioQuery::global_materials_fully_loaded = true;
-            }
-        })
-        .perform();
+} // namespace
+
+bool HelioQuery::request_supported_data(const std::string& helio_api_url,
+                                        const std::string& helio_api_key,
+                                        bool force_refresh)
+{
+    return helio_request_support_data(helio_api_url, helio_api_key, force_refresh);
+}
+
+SupportDataCatalogPairView HelioQuery::supported_data_view()
+{
+    return helio_support_data_coordinator().view();
+}
+
+void HelioQuery::shutdown_background_requests()
+{
+    helio_request_workers().shutdown();
 }
 
 void HelioQuery::request_print_priority_options(
@@ -399,99 +582,132 @@ void HelioQuery::request_print_priority_options(
     } )";
 
     query_body = boost::str(boost::format(query_body) % material_id);
+    const bool is_china = GUI::wxGetApp().app_config->get("region") == "China";
 
-    auto http = Http::post(helio_api_url);
-
-    // Add Accept-Language header if Chinese region
-    bool is_china = GUI::wxGetApp().app_config->get("region") == "China";
-
-    http.header("Content-Type", "application/json")
-        .header("Authorization", "Bearer " + helio_api_key)
-        .header("HelioAdditive-Client-Name", SLIC3R_APP_NAME)
-        .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION));
-
-    if (is_china) {
-        http.header("Accept-Language", "zh-CN");
+    std::uint64_t cache_generation = 0;
+    {
+        HelioPrintPriorityCacheState& cache = helio_print_priority_cache_state();
+        std::lock_guard<std::mutex> lock(cache.mutex);
+        cache_generation = cache.generation;
     }
 
-    http.set_post_body(query_body);
-
-    // Use shared_ptr to prevent stack corruption in async callbacks
-    auto response_headers = std::make_shared<std::string>();
-    http.timeout_connect(10)
-        .timeout_max(30)
-        .on_header_callback([response_headers](std::string headers) {
-            *response_headers += headers;
-        })
-        .on_complete([callback, material_id, response_headers](std::string body, unsigned status) {
-            BOOST_LOG_TRIVIAL(info) << "request_print_priority_options response: " << body;
-
-            GetPrintPriorityOptionsResult result;
-            result.status = status;
-            result.success = false;
-            result.trace_id = extract_trace_id(*response_headers);
-
-            try {
-                nlohmann::json parsed_obj = nlohmann::json::parse(body);
-
-                if (parsed_obj.contains("data") && parsed_obj["data"].contains("printPriorityOptions")) {
-                    auto options_array = parsed_obj["data"]["printPriorityOptions"];
-                    if (options_array.is_array()) {
-                        for (const auto& opt : options_array) {
-                            PrintPriorityOption option;
-                            if (opt.contains("value") && !opt["value"].is_null()) {
-                                option.value = opt["value"].get<std::string>();
-                            }
-                            if (opt.contains("label") && !opt["label"].is_null()) {
-                                option.label = opt["label"].get<std::string>();
-                            }
-                            if (opt.contains("isAvailable") && !opt["isAvailable"].is_null()) {
-                                option.isAvailable = opt["isAvailable"].get<bool>();
-                            } else {
-                                option.isAvailable = true; // Default to available
-                            }
-                            if (opt.contains("description") && !opt["description"].is_null()) {
-                                option.description = opt["description"].get<std::string>();
-                            }
-                            result.options.push_back(option);
-                        }
-                        result.success = true;
-
-                        // Cache the results
-                        global_print_priority_cache[material_id] = result.options;
-                    }
-                } else if (parsed_obj.contains("errors")) {
-                    // GraphQL errors
-                    result.error = "API error";
-                    if (parsed_obj["errors"].is_array() && !parsed_obj["errors"].empty()) {
-                        result.error = parsed_obj["errors"][0].value("message", "Unknown error");
-                    }
-                }
-            } catch (const std::exception& e) {
-                result.error = std::string("Parse error: ") + e.what();
-                BOOST_LOG_TRIVIAL(error) << "request_print_priority_options parse error: " << e.what()
-                                        << ", trace-id: " << result.trace_id;
+    const bool worker_started = helio_request_workers().start(
+        [helio_api_url, helio_api_key, material_id, callback,
+         query_body = std::move(query_body), is_china, cache_generation]
+        (const std::atomic_bool& stopping) {
+            if (stopping.load(std::memory_order_acquire)) {
+                return;
             }
 
-            callback(result);
-        })
-        .on_error([callback, response_headers](std::string body, std::string error, unsigned status) {
-            BOOST_LOG_TRIVIAL(error) << "request_print_priority_options error: " << error
-                                    << ", status: " << status << ", body: " << body;
-            GetPrintPriorityOptionsResult result;
-            result.success = false;
-            result.error = error;
-            result.status = status;
-            result.trace_id = extract_trace_id(*response_headers);
-            callback(result);
-        })
-        .perform();
+            auto http = Http::post(helio_api_url);
+            http.header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + helio_api_key)
+                .header("HelioAdditive-Client-Name", SLIC3R_APP_NAME)
+                .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION));
+            if (is_china) {
+                http.header("Accept-Language", "zh-CN");
+            }
+            http.set_post_body(query_body);
+
+            auto response_headers = std::make_shared<std::string>();
+            http.timeout_connect(10)
+                .timeout_max(30)
+                .on_header_callback([response_headers](std::string headers) {
+                    *response_headers += headers;
+                })
+                .on_complete([callback, material_id, response_headers, cache_generation, &stopping]
+                             (std::string body, unsigned status) {
+                    if (stopping.load(std::memory_order_acquire)) {
+                        return;
+                    }
+                    BOOST_LOG_TRIVIAL(info) << "request_print_priority_options response: " << body;
+
+                    GetPrintPriorityOptionsResult result;
+                    result.status = status;
+                    result.trace_id = extract_trace_id(*response_headers);
+
+                    try {
+                        nlohmann::json parsed_obj = nlohmann::json::parse(body);
+
+                        if (parsed_obj.contains("data") && parsed_obj["data"].contains("printPriorityOptions")) {
+                            auto options_array = parsed_obj["data"]["printPriorityOptions"];
+                            if (options_array.is_array()) {
+                                for (const auto& opt : options_array) {
+                                    PrintPriorityOption option;
+                                    if (opt.contains("value") && !opt["value"].is_null()) {
+                                        option.value = opt["value"].get<std::string>();
+                                    }
+                                    if (opt.contains("label") && !opt["label"].is_null()) {
+                                        option.label = opt["label"].get<std::string>();
+                                    }
+                                    if (opt.contains("isAvailable") && !opt["isAvailable"].is_null()) {
+                                        option.isAvailable = opt["isAvailable"].get<bool>();
+                                    }
+                                    if (opt.contains("description") && !opt["description"].is_null()) {
+                                        option.description = opt["description"].get<std::string>();
+                                    }
+                                    result.options.push_back(std::move(option));
+                                }
+                                result.success = true;
+
+                                HelioPrintPriorityCacheState& cache = helio_print_priority_cache_state();
+                                std::lock_guard<std::mutex> lock(cache.mutex);
+                                if (cache_generation == cache.generation) {
+                                    global_print_priority_cache[material_id] = result.options;
+                                } else {
+                                    result.success = false;
+                                    result.options.clear();
+                                    result.error = "Helio support data was refreshed while print priorities were loading";
+                                }
+                            }
+                        } else if (helio_has_graphql_errors(parsed_obj)) {
+                            result.error = "API error";
+                            if (parsed_obj["errors"].is_array() && !parsed_obj["errors"].empty()) {
+                                result.error = parsed_obj["errors"][0].value("message", "Unknown error");
+                            }
+                        }
+                    } catch (const std::exception& e) {
+                        result.error = std::string("Parse error: ") + e.what();
+                        BOOST_LOG_TRIVIAL(error) << "request_print_priority_options parse error: " << e.what()
+                                                 << ", trace-id: " << result.trace_id;
+                    }
+
+                    if (!stopping.load(std::memory_order_acquire)) {
+                        callback(result);
+                    }
+                })
+                .on_error([callback, response_headers, &stopping]
+                          (std::string body, std::string error, unsigned status) {
+                    if (stopping.load(std::memory_order_acquire)) {
+                        return;
+                    }
+                    BOOST_LOG_TRIVIAL(error) << "request_print_priority_options error: " << error
+                                             << ", status: " << status << ", body: " << body;
+                    GetPrintPriorityOptionsResult result;
+                    result.error = std::move(error);
+                    result.status = status;
+                    result.trace_id = extract_trace_id(*response_headers);
+                    callback(result);
+                })
+                .on_progress([&stopping](Http::Progress, bool& cancel) {
+                    cancel = stopping.load(std::memory_order_acquire);
+                })
+                .perform_sync();
+        });
+
+    if (!worker_started && callback) {
+        GetPrintPriorityOptionsResult result;
+        result.error = "Failed to start Helio print-priority request";
+        callback(result);
+    }
 }
 
 std::vector<HelioQuery::PrintPriorityOption> HelioQuery::get_cached_print_priority_options(
     const std::string& material_id
 )
 {
+    HelioPrintPriorityCacheState& cache = helio_print_priority_cache_state();
+    std::lock_guard<std::mutex> lock(cache.mutex);
     auto it = global_print_priority_cache.find(material_id);
     if (it != global_print_priority_cache.end()) {
         return it->second;
@@ -501,6 +717,9 @@ std::vector<HelioQuery::PrintPriorityOption> HelioQuery::get_cached_print_priori
 
 void HelioQuery::clear_print_priority_cache()
 {
+    HelioPrintPriorityCacheState& cache = helio_print_priority_cache_state();
+    std::lock_guard<std::mutex> lock(cache.mutex);
+    ++cache.generation;
     global_print_priority_cache.clear();
 }
 
@@ -626,6 +845,7 @@ void HelioQuery::optimization_feedback(const std::string helio_api_url, const st
 HelioQuery::PresignedURLResult HelioQuery::create_presigned_url(const std::string helio_api_url, const std::string helio_api_key)
 {
     HelioQuery::PresignedURLResult res;
+    res.status = 0;
     std::string                    query_body = R"( {
 			"query": "query getPresignedUrl($fileName: String!) { getPresignedUrl(fileName: $fileName) { mimeType url key } }",
 			"variables": {
@@ -648,29 +868,57 @@ HelioQuery::PresignedURLResult HelioQuery::create_presigned_url(const std::strin
     http.timeout_connect(20)
         .timeout_max(100)
         .on_header_callback([&res](std::string header_line) {
-            std::string lower_line;
-            for (unsigned char c : header_line) {
-                lower_line += static_cast<char>(std::tolower(c));
-            }
-            auto trace_id = extract_trace_id(lower_line);
+            auto trace_id = extract_trace_id(header_line);
             if(!trace_id.empty()){
                 res.trace_id = trace_id;
             }
         })
         .on_complete([&res](std::string body, unsigned status) {
-            nlohmann::json parsed_obj = nlohmann::json::parse(body);
-            res.status                = status;
-            if (parsed_obj.contains("error")) {
-                res.error = parsed_obj["error"];
-            } else {
+            res.status = status;
+            if (helio_is_terminal_http_status(status)) {
+                res.error = helio_http_status_message(status, body);
+                return;
+            }
+            if (status != 200) {
+                res.error = helio_http_status_message(status, body);
+                res.retry_kind = helio_classify_retry(status, body);
+                return;
+            }
+            try {
+                nlohmann::json parsed_obj = nlohmann::json::parse(body);
+                if (helio_has_graphql_errors(parsed_obj)) {
+                    res.error = format_error(body);
+                    res.retry_kind = helio_classify_graphql_response(status, parsed_obj);
+                    if (res.error.empty()) {
+                        res.error = parsed_obj["errors"].dump();
+                    }
+                    return;
+                }
+                if (parsed_obj.contains("error")) {
+                    res.error = parsed_obj["error"].is_string() ? parsed_obj["error"].get<std::string>() : parsed_obj["error"].dump();
+                    return;
+                }
+                if (!parsed_obj.contains("data") || !parsed_obj["data"].contains("getPresignedUrl") ||
+                    parsed_obj["data"]["getPresignedUrl"].is_null()) {
+                    res.error = "Presigned URL response is incomplete";
+                    res.retry_kind = HelioRetryKind::Transient;
+                    return;
+                }
                 res.key      = parsed_obj["data"]["getPresignedUrl"]["key"];
                 res.mimeType = parsed_obj["data"]["getPresignedUrl"]["mimeType"];
                 res.url      = parsed_obj["data"]["getPresignedUrl"]["url"];
+            } catch (const std::exception& e) {
+                res.error = std::string("Failed to parse presigned URL response: ") + e.what();
+                res.retry_kind = HelioRetryKind::Transient;
+            } catch (...) {
+                res.error = "Failed to parse presigned URL response";
+                res.retry_kind = HelioRetryKind::Transient;
             }
         })
         .on_error([&res](std::string body, std::string error, unsigned status) {
             res.error  = (boost::format("error: %1%, message: %2%") % error % body).str();
             res.status = status;
+            res.retry_kind = helio_classify_retry(status, body, error);
         })
         .perform_sync();
 
@@ -680,6 +928,7 @@ HelioQuery::PresignedURLResult HelioQuery::create_presigned_url(const std::strin
 HelioQuery::UploadFileResult HelioQuery::upload_file_to_presigned_url(const std::string file_path_string, const std::string upload_url)
 {
     UploadFileResult res;
+    res.success = false;
 
     Http http = Http::put(upload_url);
     http.header("Content-Type", "application/octet-stream")
@@ -733,7 +982,6 @@ HelioQuery::PollResult HelioQuery::poll_gcode_status(const std::string& helio_ap
                                                      const std::string& gcode_id) 
 {
     HelioQuery::PollResult result;
-    result.success = false;
 
     std::string poll_query = R"( {
         "query": "query GcodeV2($id: ID!) { gcodeV2(id: $id) { id name sizeKb status progress errors errorsV2 { line type } restrictions restrictionsV2 { description restriction } } }",
@@ -747,12 +995,35 @@ HelioQuery::PollResult HelioQuery::poll_gcode_status(const std::string& helio_ap
         .set_post_body(poll_body)
         .timeout_connect(10)
         .timeout_max(30)
+        .on_header_callback([&result](std::string header_line) {
+            const std::string trace_id = extract_trace_id(header_line);
+            if (!trace_id.empty()) {
+                result.trace_id = trace_id;
+            }
+        })
         .on_complete([&result](std::string poll_body, unsigned poll_status) {
+            result.status = poll_status;
+            if (helio_is_terminal_http_status(poll_status)) {
+                result.error = helio_http_status_message(poll_status, poll_body);
+                return;
+            }
+            if (poll_status != 200) {
+                result.error = helio_http_status_message(poll_status, poll_body);
+                result.retry_kind = helio_classify_retry(poll_status, poll_body);
+                return;
+            }
+
             try {
                 json poll_obj = json::parse(poll_body);
-                if (!poll_obj["data"]["gcodeV2"].is_null()) {
+                if (helio_has_graphql_errors(poll_obj)) {
+                    result.error = format_error(poll_body);
+                    result.retry_kind = helio_classify_graphql_response(poll_status, poll_obj);
+                    return;
+                }
+                if (poll_obj.contains("data") && poll_obj["data"].contains("gcodeV2") &&
+                    !poll_obj["data"]["gcodeV2"].is_null()) {
                     auto gcode_data = poll_obj["data"]["gcodeV2"];
-                    
+
                     // Verify status field exists and is valid before considering the response successful
                     if (gcode_data.contains("status") && gcode_data["status"].is_string()) {
                         result.status_str = gcode_data["status"];
@@ -827,14 +1098,26 @@ HelioQuery::PollResult HelioQuery::poll_gcode_status(const std::string& helio_ap
                         result.success = true;
                     }
                 }
+
+                if (!result.success && result.error.empty()) {
+                    result.error = _u8L("Helio GCode status response is incomplete");
+                    result.retry_kind = HelioRetryKind::Transient;
+                }
             }
             catch (const std::exception& e) {
+                result.error = std::string("Helio GCode status response parse failed: ") + e.what();
+                result.retry_kind = HelioRetryKind::Transient;
                 BOOST_LOG_TRIVIAL(error) << "Helio poll_gcode_status: " << e.what();
             } catch (...) {
+                result.error = _u8L("Helio GCode status response parse failed");
+                result.retry_kind = HelioRetryKind::Transient;
                 BOOST_LOG_TRIVIAL(error) << "Helio poll_gcode_status: unknown error";
             }
         })
         .on_error([&result](std::string poll_body, std::string poll_error, unsigned poll_status) {
+            result.status = poll_status;
+            result.error = poll_error.empty() ? poll_body : poll_error;
+            result.retry_kind = helio_classify_retry(poll_status, poll_body, poll_error);
             BOOST_LOG_TRIVIAL(error) << "Helio poll_gcode_status error: " << poll_error << ", status: " << poll_status;
         })
         .perform_sync();
@@ -842,14 +1125,215 @@ HelioQuery::PollResult HelioQuery::poll_gcode_status(const std::string& helio_ap
     return result;
 }
 
+namespace {
+
+HelioQuery::CreateGCodeResult helio_create_gcode_and_poll(const std::string& helio_api_url,
+                                                           const std::string& helio_api_key,
+                                                           const std::string& query_body,
+                                                           const std::string& response_field,
+                                                           const std::string& idempotency_key,
+                                                           const std::function<bool()>& should_cancel)
+{
+    HelioQuery::CreateGCodeResult res;
+    HelioRetryController create_retry_controller;
+
+    for (int attempt = 1; attempt <= HELIO_CREATE_MAX_ATTEMPTS; ++attempt) {
+        if (helio_should_cancel(should_cancel)) {
+            res.error = _u8L("Helio action canceled");
+            return res;
+        }
+
+        HelioQuery::CreateGCodeResult attempt_res;
+        HelioRetryKind retry_kind = HelioRetryKind::None;
+
+        auto http = Http::post(helio_api_url);
+        http.header("Content-Type", "application/json")
+            .header("Authorization", helio_api_key)
+            .header("HelioAdditive-Client-Name", SLIC3R_APP_NAME)
+            .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
+            .set_post_body(query_body);
+        helio_attach_idempotency_key(http, idempotency_key);
+
+        if (GUI::wxGetApp().app_config->get("language") == "zh_CN") {
+            http.header("Accept-Language", "zh-CN");
+        }
+
+        http.timeout_connect(20)
+            .timeout_max(100)
+            .on_header_callback([&attempt_res](std::string header_line) {
+                const std::string trace_id = extract_trace_id(header_line);
+                if (!trace_id.empty()) {
+                    attempt_res.trace_id = trace_id;
+                }
+            })
+            .on_complete([&attempt_res, &retry_kind, &response_field](std::string body, unsigned status) {
+                attempt_res.status = status;
+                if (helio_is_terminal_http_status(status)) {
+                    attempt_res.error = helio_http_status_message(status, body);
+                    return;
+                }
+                if (status != 200) {
+                    attempt_res.error = helio_http_status_message(status, body);
+                    retry_kind = helio_classify_retry(status, body);
+                    return;
+                }
+
+                try {
+                    const json parsed_obj = json::parse(body);
+                    if (helio_has_graphql_errors(parsed_obj)) {
+                        attempt_res.error = format_error(body);
+                        retry_kind = helio_classify_graphql_response(status, parsed_obj);
+                        return;
+                    }
+                    if (!parsed_obj.contains("data") || !parsed_obj["data"].contains(response_field) ||
+                        parsed_obj["data"][response_field].is_null()) {
+                        attempt_res.error = _u8L("Helio GCode creation response is incomplete");
+                        retry_kind = HelioRetryKind::Transient;
+                        return;
+                    }
+
+                    const auto& gcode = parsed_obj["data"][response_field];
+                    attempt_res.id = gcode.value("id", "");
+                    attempt_res.name = gcode.value("name", "");
+                    attempt_res.sizeKb = gcode.value("sizeKb", 0.0f);
+                    attempt_res.status_str = gcode.value("status", "");
+                    attempt_res.progress = gcode.value("progress", 0.0f);
+                    if (attempt_res.id.empty() || attempt_res.status_str.empty()) {
+                        attempt_res.error = _u8L("Helio GCode creation response is incomplete");
+                        retry_kind = HelioRetryKind::Transient;
+                        return;
+                    }
+                    attempt_res.success = true;
+                } catch (const std::exception& e) {
+                    attempt_res.error = std::string("Failed to parse response: ") + e.what();
+                    retry_kind = HelioRetryKind::Transient;
+                } catch (...) {
+                    attempt_res.error = _u8L("Failed to parse response");
+                    retry_kind = HelioRetryKind::Transient;
+                }
+            })
+            .on_error([&attempt_res, &retry_kind](std::string body, std::string error, unsigned status) {
+                attempt_res.status = status;
+                attempt_res.error = error.empty() ? body : error;
+                retry_kind = helio_classify_retry(status, body, error);
+            })
+            .perform_sync();
+
+        res = attempt_res;
+        if (res.success) {
+            break;
+        }
+
+        const bool should_retry = create_retry_controller.should_retry(retry_kind) &&
+                                  attempt < HELIO_CREATE_MAX_ATTEMPTS;
+        if (!should_retry) {
+            break;
+        }
+
+        BOOST_LOG_TRIVIAL(warning) << "Helio GCode create retry: kind=" << helio_retry_kind_name(retry_kind)
+                                   << ", attempt=" << attempt << ", status=" << res.status
+                                   << ", trace-id=" << res.trace_id;
+        if (!helio_sleep_for_retry_or_cancel(attempt * 2, should_cancel)) {
+            res.error = _u8L("Helio action canceled");
+            return res;
+        }
+    }
+
+    if (!res.success) {
+        return res;
+    }
+    if (helio_should_cancel(should_cancel)) {
+        res.success = false;
+        res.error = _u8L("Helio action canceled");
+        return res;
+    }
+    if (res.status_str == "ERROR" || res.status_str == "RESTRICTED") {
+        res.success = false;
+        res.error = (boost::format("GCode creation failed with status: %1%") % res.status_str).str();
+        return res;
+    }
+
+    HelioRetryController poll_retry_controller;
+    int poll_count = 0;
+    while (res.status_str != "READY" && res.status_str != "ERROR" &&
+           res.status_str != "RESTRICTED" && poll_count < 60 &&
+           !helio_should_cancel(should_cancel)) {
+        if (!helio_sleep_for_retry_or_cancel(2, should_cancel)) {
+            res.success = false;
+            res.error = _u8L("Helio action canceled");
+            return res;
+        }
+        HelioQuery::PollResult poll_res = HelioQuery::poll_gcode_status(helio_api_url, helio_api_key, res.id);
+        ++poll_count;
+
+        if (!poll_res.success) {
+            const bool policy_allows_retry = poll_retry_controller.should_retry(poll_res.retry_kind);
+            const bool has_retry_budget = poll_count < 60 ||
+                                          poll_res.retry_kind == HelioRetryKind::BackendAuth;
+            if (policy_allows_retry && has_retry_budget) {
+                const int failed_poll_attempt = poll_count;
+                // The narrow backend-auth retry is additional to the normal
+                // polling budget so an occurrence on poll 60 still gets its
+                // promised single retry.
+                if (poll_res.retry_kind == HelioRetryKind::BackendAuth) {
+                    --poll_count;
+                }
+                BOOST_LOG_TRIVIAL(warning) << "Helio GCode poll retry: kind="
+                                           << helio_retry_kind_name(poll_res.retry_kind)
+                                           << ", attempt=" << failed_poll_attempt << ", status=" << poll_res.status
+                                           << ", trace-id=" << poll_res.trace_id;
+                continue;
+            }
+            res.success = false;
+            res.error = poll_res.error.empty() ? _u8L("Helio GCode status check failed") : poll_res.error;
+            return res;
+        }
+
+        poll_retry_controller.reset();
+        res.status_str = poll_res.status_str;
+        res.progress = poll_res.progress;
+        res.sizeKb = poll_res.sizeKb;
+
+        if (!poll_res.errors.empty()) {
+            res.success = false;
+            res.error = helio_join_messages(poll_res.errors);
+            return res;
+        }
+        if (res.status_str == "ERROR" || res.status_str == "RESTRICTED") {
+            res.success = false;
+            if (res.status_str == "RESTRICTED" && !poll_res.restrictions.empty()) {
+                res.error = helio_join_messages(poll_res.restrictions);
+            } else {
+                res.error = (boost::format("GCode creation failed with status: %1%") % res.status_str).str();
+            }
+            return res;
+        }
+    }
+
+    if (helio_should_cancel(should_cancel)) {
+        res.success = false;
+        res.error = _u8L("Helio action canceled");
+        return res;
+    }
+    if (res.status_str != "READY") {
+        res.success = false;
+        res.error = _u8L("Helio GCode creation timed out while checking status");
+    }
+    return res;
+}
+
+} // namespace
+
 // V2: single material — createGcodeV2 mutation
 HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
                                                        const std::string helio_api_url,
                                                        const std::string helio_api_key,
                                                        const std::string printer_id,
-                                                       const std::string filament_id)
+                                                       const std::string filament_id,
+                                                       const std::string idempotency_key,
+                                                       std::function<bool()> should_cancel)
 {
-    HelioQuery::CreateGCodeResult res;
+    const std::string effective_idempotency_key = idempotency_key.empty() ? helio_generate_idempotency_key() : idempotency_key;
     std::string query_body_template = R"( {
 			"query": "mutation CreateGcode($input: CreateGcodeInputV2!) { createGcodeV2(input: $input) { id name sizeKb status progress } }",
 			"variables": {
@@ -865,144 +1349,11 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
 
     std::vector<std::string> key_split;
     boost::split(key_split, key, boost::is_any_of("/"));
-    std::string gcode_name = key_split.back();
-    std::string query_body = (boost::format(query_body_template) % gcode_name % printer_id % filament_id % key).str();
-
-    auto http = Http::post(helio_api_url);
-
-    http.header("Content-Type", "application/json")
-        .header("Authorization", helio_api_key)
-        .header("HelioAdditive-Client-Name", SLIC3R_APP_NAME)
-        .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
-        .set_post_body(query_body);
-
-    if (GUI::wxGetApp().app_config->get("language") == "zh_CN") {
-        http.header("Accept-Language", "zh-CN");
-    }
-
-    http.timeout_connect(20)
-        .timeout_max(100)
-        .on_header_callback([&res](std::string header_line) {
-            std::string lower_line;
-            for (unsigned char c : header_line) {
-                lower_line += static_cast<char>(std::tolower(c));
-            }
-            auto trace_id = extract_trace_id(lower_line);
-            if (!trace_id.empty()) {
-                res.trace_id = trace_id;
-            }
-        })
-        .on_complete([&res, helio_api_url, helio_api_key](std::string body, unsigned status) {
-        res.status = status;
-        try {
-            json parsed_obj = json::parse(body);
-            if (parsed_obj.contains("errors")) {
-                std::string message = format_error(body);
-                res.error = message;
-                res.success = false;
-                return;
-            }
-
-            auto gcode = parsed_obj["data"]["createGcodeV2"];
-            if (gcode.is_null()) {
-                res.success = false;
-                res.error = _u8L("Failed to create GCodeV2");
-                return;
-            }
-
-            res.success = true;
-            res.id = gcode["id"];
-            res.name = gcode["name"];
-            res.sizeKb = gcode["sizeKb"];
-            res.status_str = gcode["status"];
-            res.progress = gcode["progress"];
-
-            // Check for errors in initial response
-            if (gcode.contains("errors") && !gcode["errors"].is_null()) {
-                auto errors_data = gcode["errors"];
-                if (errors_data.is_array() && !errors_data.empty()) {
-                    std::string error_message;
-                    for (size_t i = 0; i < errors_data.size(); ++i) {
-                        if (errors_data[i].is_string()) {
-                            std::string current_error = errors_data[i].get<std::string>();
-                            if (errors_data.size() > 1) {
-                                error_message += std::to_string(i + 1) + ". " + current_error;
-                                if (i != errors_data.size() - 1) {
-                                    error_message += "\n";
-                                }
-                            } else {
-                                error_message = current_error;
-                            }
-                        }
-                    }
-                    res.success = false;
-                    res.error = error_message;
-                    return;
-                }
-            }
-
-            int poll_count = 0;
-            while (res.status_str != "READY" && res.status_str != "ERROR" && res.status_str != "RESTRICTED" && poll_count < 60) {
-                std::this_thread::sleep_for(std::chrono::seconds(2));
-
-                PollResult poll_res = poll_gcode_status(helio_api_url, helio_api_key, res.id);
-
-                if (poll_res.success) {
-                    res.status_str = poll_res.status_str;
-                    res.progress = poll_res.progress;
-                    res.sizeKb = poll_res.sizeKb;
-
-                    if (!poll_res.errors.empty()) {
-                        std::string error_message;
-                        for (size_t i = 0; i < poll_res.errors.size(); ++i) {
-                            if (poll_res.errors.size() > 1) {
-                                error_message += std::to_string(i + 1) + ". " + poll_res.errors[i];
-                                if (i != poll_res.errors.size() - 1) error_message += "\n";
-                            } else {
-                                error_message = poll_res.errors[i];
-                            }
-                        }
-                        res.success = false;
-                        res.error = error_message;
-                        return;
-                    }
-
-                    if (res.status_str == "ERROR" || res.status_str == "RESTRICTED") {
-                        res.success = false;
-                        if (res.status_str == "RESTRICTED" && !poll_res.restrictions.empty()) {
-                            std::string restriction_message;
-                            for (size_t i = 0; i < poll_res.restrictions.size(); ++i) {
-                                if (poll_res.restrictions.size() > 1) {
-                                    restriction_message += std::to_string(i + 1) + ". " + poll_res.restrictions[i];
-                                    if (i != poll_res.restrictions.size() - 1) restriction_message += "\n";
-                                } else {
-                                    restriction_message = poll_res.restrictions[i];
-                                }
-                            }
-                            res.error = restriction_message;
-                        } else {
-                            res.error = (boost::format("GCode creation failed with status: %1%") % res.status_str).str();
-                        }
-                        return;
-                    }
-                }
-
-                poll_count++;
-            }
-        }
-        catch (...) {
-            res.success = false;
-            res.error = _u8L("Failed to parse response");
-        }
-        })
-        .on_error([&res](std::string body, std::string error, unsigned status) {
-            res.success = false;
-            res.error  = error;
-            res.status = status;
-        })
-        .perform_sync();
-
-    return res;
+    const std::string gcode_name = key_split.back();
+    const std::string query_body = (boost::format(query_body_template) % gcode_name % printer_id % filament_id % key).str();
+    return helio_create_gcode_and_poll(helio_api_url, helio_api_key, query_body,
+                                       "createGcodeV2", effective_idempotency_key,
+                                       should_cancel);
 }
 
 // V3: multi-material — createGcodeV3 mutation
@@ -1012,9 +1363,11 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
                                                           const std::string printer_id,
                                                           const std::vector<MaterialInput>& materials,
                                                           bool isMultiColor,
-                                                          bool isMultiMaterial)
+                                                          bool isMultiMaterial,
+                                                          const std::string idempotency_key,
+                                                          std::function<bool()> should_cancel)
 {
-    HelioQuery::CreateGCodeResult res;
+    const std::string effective_idempotency_key = idempotency_key.empty() ? helio_generate_idempotency_key() : idempotency_key;
 
     std::vector<std::string> key_split;
     boost::split(key_split, key, boost::is_any_of("/"));
@@ -1045,156 +1398,19 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
         {"isMultiMaterial", isMultiMaterial}
     };
     std::string query_body = request_body.dump();
-
-    auto http = Http::post(helio_api_url);
-
-    http.header("Content-Type", "application/json")
-        .header("Authorization", helio_api_key)
-        .header("HelioAdditive-Client-Name", SLIC3R_APP_NAME)
-        .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
-        .set_post_body(query_body);
-
-    if (GUI::wxGetApp().app_config->get("language") == "zh_CN") {
-        http.header("Accept-Language", "zh-CN");
-    }
-
-    http.timeout_connect(20)
-        .timeout_max(100)
-        .on_header_callback([&res](std::string header_line) {
-            std::string lower_line;
-            for (unsigned char c : header_line) {
-                lower_line += static_cast<char>(std::tolower(c));
-            }
-            auto trace_id = extract_trace_id(lower_line);
-            if (!trace_id.empty()) {
-                res.trace_id = trace_id;
-            }
-        })
-        .on_complete([&res, helio_api_url, helio_api_key](std::string body, unsigned status) {
-        res.status = status;
-        try {
-            json parsed_obj = json::parse(body);
-            if (parsed_obj.contains("errors")) {
-                std::string message = format_error(body);
-                res.error = message;
-                res.success = false;
-                return;
-            }
-
-            auto gcode = parsed_obj["data"]["createGcodeV3"];
-            if (gcode.is_null()) {
-                res.success = false;
-                res.error = _u8L("Failed to create GCodeV3");
-                return;
-            }
-
-            res.success = true;
-            res.id = gcode["id"];
-            res.name = gcode["name"];
-            res.sizeKb = gcode["sizeKb"];
-            res.status_str = gcode["status"];
-            res.progress = gcode["progress"];
-
-            // Check for errors in initial response
-            if (gcode.contains("errors") && !gcode["errors"].is_null()) {
-                auto errors_data = gcode["errors"];
-                if (errors_data.is_array() && !errors_data.empty()) {
-                    std::string error_message;
-                    for (size_t i = 0; i < errors_data.size(); ++i) {
-                        if (errors_data[i].is_string()) {
-                            std::string current_error = errors_data[i].get<std::string>();
-                            if (errors_data.size() > 1) {
-                                error_message += std::to_string(i + 1) + ". " + current_error;
-                                if (i != errors_data.size() - 1) {
-                                    error_message += "\n";
-                                }
-                            } else {
-                                error_message = current_error;
-                            }
-                        }
-                    }
-                    res.success = false;
-                    res.error = error_message;
-                    return;
-                }
-            }
-
-            int poll_count = 0;
-            while (res.status_str != "READY" && res.status_str != "ERROR" && res.status_str != "RESTRICTED" && poll_count < 60) {
-                std::this_thread::sleep_for(std::chrono::seconds(2));
-
-                PollResult poll_res = poll_gcode_status(helio_api_url, helio_api_key, res.id);
-
-                if (poll_res.success) {
-                    res.status_str = poll_res.status_str;
-                    res.progress = poll_res.progress;
-                    res.sizeKb = poll_res.sizeKb;
-                    
-                    // Check for errors during polling
-                    if (!poll_res.errors.empty()) {
-                        std::string error_message;
-                        for (size_t i = 0; i < poll_res.errors.size(); ++i) {
-                            if (poll_res.errors.size() > 1) {
-                                error_message += std::to_string(i + 1) + ". " + poll_res.errors[i];
-                                if (i != poll_res.errors.size() - 1) {
-                                    error_message += "\n";
-                                }
-                            } else {
-                                error_message = poll_res.errors[i];
-                            }
-                        }
-                        res.success = false;
-                        res.error = error_message;
-                        return;
-                    }
-                    
-                    // Handle ERROR/RESTRICTED status even if errors array is empty
-                    if (res.status_str == "ERROR" || res.status_str == "RESTRICTED") {
-                        res.success = false;
-                        // For RESTRICTED, use restriction details if available
-                        if (res.status_str == "RESTRICTED" && !poll_res.restrictions.empty()) {
-                            std::string restriction_message;
-                            for (size_t i = 0; i < poll_res.restrictions.size(); ++i) {
-                                if (poll_res.restrictions.size() > 1) {
-                                    restriction_message += std::to_string(i + 1) + ". " + poll_res.restrictions[i];
-                                    if (i != poll_res.restrictions.size() - 1) restriction_message += "\n";
-                                } else {
-                                    restriction_message = poll_res.restrictions[i];
-                                }
-                            }
-                            res.error = restriction_message;
-                        } else {
-                            res.error = (boost::format("GCode creation failed with status: %1%") % res.status_str).str();
-                        }
-                        return;
-                    }
-                }
-
-                poll_count++;
-            }
-        }
-        catch (...) {
-            res.success = false;
-            res.error = _u8L("Failed to parse response");
-        }
-        })
-        .on_error([&res](std::string body, std::string error, unsigned status) {
-            res.success = false;
-            res.error  = error;
-            res.status = status;
-        })
-        .perform_sync();
-
-    return res;
+    return helio_create_gcode_and_poll(helio_api_url, helio_api_key, query_body,
+                                       "createGcodeV3", effective_idempotency_key,
+                                       should_cancel);
 }
 
 std::string HelioQuery::generate_simulation_graphql_query(const std::string &gcode_id,
                                                           float temperatureStabilizationHeight,
                                                           float airTemperatureAboveBuildPlate,
-                                                          float stabilizedAirTemperature)
+                                                          float stabilizedAirTemperature,
+                                                          const std::string& job_name)
 {
     CNumericLocalesSetter locales_setter;
-    std::string name = generateTimestampedString();
+    std::string name = job_name.empty() ? generateTimestampedString() : job_name;
 
     std::string base_query = R"( {
         "query": "mutation CreateSimulation($input: CreateSimulationInput!) { createSimulation(input: $input) { id name progress status gcode { id name } printer { id name } material { id name } reportJsonUrl thermalIndexGcodeUrl estimatedSimulationDurationSeconds insertedAt updatedAt } }",
@@ -1246,10 +1462,11 @@ std::string HelioQuery::generate_optimization_graphql_query(const std::string& g
     double minExtruderFlowRate,
     double maxExtruderFlowRate,
     int layersToOptimizeStart,
-    int layersToOptimizeEnd)
+    int layersToOptimizeEnd,
+    const std::string& job_name)
 {
     CNumericLocalesSetter locales_setter;
-    std::string name = generateTimestampedString();
+    std::string name = job_name.empty() ? generateTimestampedString() : job_name;
 
     // basic query structure
     std::string base_query = R"( {
@@ -1369,7 +1586,10 @@ std::string HelioQuery::create_optimization_default_get(const std::string helio_
 HelioQuery::CreateSimulationResult HelioQuery::create_simulation(const std::string helio_api_url,
                                                                  const std::string helio_api_key,
                                                                  const std::string gcode_id,
-                                                                 SimulationInput sinput)
+                                                                 SimulationInput sinput,
+                                                                 const std::string job_name,
+                                                                 const std::string idempotency_key,
+                                                                 std::function<bool()> should_cancel)
 {
     /*field processing*/
     const float chamber_temp = sinput.chamber_temp;
@@ -1386,57 +1606,156 @@ HelioQuery::CreateSimulationResult HelioQuery::create_simulation(const std::stri
     const float initial_room_temp_kelvin        = initial_room_airtemp == -1 ? -1 : initial_room_airtemp + 273.15;
     const float object_proximity_airtemp_kelvin = chamber_temp == -1 ? -1 : chamber_temp + 273.15;
     const float layer_threshold_meters          = layer_threshold / 1000;
+    const std::string effective_idempotency_key = idempotency_key.empty() ? helio_generate_idempotency_key() : idempotency_key;
+    const std::string effective_job_name = job_name.empty() ? helio_generate_retry_job_name(effective_idempotency_key) : job_name;
 
     std::string query_body = generate_simulation_graphql_query(gcode_id,
                                                     layer_threshold_meters,
                                                     initial_room_temp_kelvin,
-                                                    object_proximity_airtemp_kelvin
+                                                    object_proximity_airtemp_kelvin,
+                                                    effective_job_name
     );
 
     HelioQuery::CreateSimulationResult res;
-    auto http = Http::post(helio_api_url);
+    res.reset();
 
-    http.header("Content-Type", "application/json")
-        .header("Authorization", helio_api_key)
-        .header("HelioAdditive-Client-Name", SLIC3R_APP_NAME)
-        .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
-        .set_post_body(query_body);
-
-    if (GUI::wxGetApp().app_config->get("language") == "zh_CN") {
-        http.header("Accept-Language", "zh-CN");
+    if (helio_should_cancel(should_cancel)) {
+        res.error = _u8L("Helio action canceled");
+        return res;
     }
 
-    http.timeout_connect(20)
-        .timeout_max(100)
-        .on_complete([&res](std::string body, unsigned status) {
-            nlohmann::json parsed_obj = nlohmann::json::parse(body);
-            res.status                = status;
-            if (parsed_obj.contains("errors")) {
-                std::string message = format_error(body);
-                res.error   = message;
-                res.success = false;
-            } else {
-                res.success = true;
-                res.id      = parsed_obj["data"]["createSimulation"]["id"];
-                res.name    = parsed_obj["data"]["createSimulation"]["name"];
+    HelioRetryController retry_controller;
+    for (int attempt = 1; attempt <= HELIO_CREATE_MAX_ATTEMPTS; ++attempt) {
+        if (helio_should_cancel(should_cancel)) {
+            res.error = _u8L("Helio action canceled");
+            break;
+        }
+
+        HelioQuery::CreateSimulationResult attempt_res;
+        attempt_res.reset();
+        HelioRetryKind attempt_retry_kind = HelioRetryKind::None;
+
+        auto http = Http::post(helio_api_url);
+
+        http.header("Content-Type", "application/json")
+            .header("Authorization", helio_api_key)
+            .header("HelioAdditive-Client-Name", SLIC3R_APP_NAME)
+            .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
+            .set_post_body(query_body);
+        helio_attach_idempotency_key(http, effective_idempotency_key);
+
+        if (GUI::wxGetApp().app_config->get("language") == "zh_CN") {
+            http.header("Accept-Language", "zh-CN");
+        }
+
+        http.timeout_connect(20)
+            .timeout_max(100)
+            .on_complete([&attempt_res, &attempt_retry_kind](std::string body, unsigned status) {
+                attempt_res.status = status;
+                if (helio_is_terminal_http_status(status)) {
+                    attempt_res.error = helio_http_status_message(status, body);
+                    attempt_res.success = false;
+                    return;
+                }
+                if (status != 200) {
+                    attempt_res.error = helio_http_status_message(status, body);
+                    attempt_res.success = false;
+                    attempt_retry_kind = helio_classify_retry(status, body);
+                    return;
+                }
+
+                try {
+                    nlohmann::json parsed_obj = nlohmann::json::parse(body);
+                    if (helio_has_graphql_errors(parsed_obj)) {
+                        std::string message = format_error(body);
+                        attempt_res.error   = message;
+                        attempt_res.success = false;
+                        attempt_retry_kind = helio_classify_graphql_response(status, parsed_obj);
+                    } else if (parsed_obj.contains("data") && parsed_obj["data"].contains("createSimulation") &&
+                               parsed_obj["data"]["createSimulation"].is_object()) {
+                        const nlohmann::json& simulation = parsed_obj["data"]["createSimulation"];
+                        attempt_res.id = simulation.value("id", "");
+                        attempt_res.name = simulation.value("name", "");
+                        if (!attempt_res.id.empty()) {
+                            attempt_res.success = true;
+                        } else {
+                            attempt_res.success = false;
+                            attempt_res.error = _u8L("Failed to create Simulation");
+                            attempt_retry_kind = HelioRetryKind::Transient;
+                        }
+                    } else {
+                        attempt_res.success = false;
+                        attempt_res.error = _u8L("Failed to create Simulation");
+                        attempt_retry_kind = HelioRetryKind::Transient;
+                    }
+                } catch (const std::exception& e) {
+                    attempt_res.success = false;
+                    attempt_res.error = std::string("Failed to parse response: ") + e.what();
+                    attempt_retry_kind = HelioRetryKind::Transient;
+                } catch (...) {
+                    attempt_res.success = false;
+                    attempt_res.error = _u8L("Failed to parse response");
+                    attempt_retry_kind = HelioRetryKind::Transient;
+                }
+            })
+            .on_error([&attempt_res, &attempt_retry_kind](std::string body, std::string error, unsigned status) {
+                attempt_res.success = false;
+                attempt_res.error  = error.empty() ? body : error;
+                attempt_res.status = status;
+                attempt_retry_kind = helio_classify_retry(status, body, error);
+            })
+            .on_header_callback([&attempt_res](std::string header_line) {
+                auto trace_id = extract_trace_id(header_line);
+                if (!trace_id.empty()) {
+                    attempt_res.trace_id = trace_id;
+                }
+            })
+            .perform_sync();
+
+        res = attempt_res;
+        if (res.success) {
+            if (helio_should_cancel(should_cancel)) {
+                if (!res.id.empty()) {
+                    HelioQuery::stop_simulation(helio_api_url, helio_api_key, res.id);
+                }
+                res.reset();
+                res.error = _u8L("Helio action canceled");
             }
-        })
-        .on_error([&res](std::string body, std::string error, unsigned status) {
-            res.success = false;
-            res.error  = error;
-            res.status = status;
-        })
-        .on_header_callback([&res](std::string header_line) {
-            std::string lower_line;
-            for (unsigned char c : header_line) {
-                lower_line += static_cast<char>(std::tolower(c));
+            break;
+        }
+
+        const bool policy_allows_retry = retry_controller.should_retry(attempt_retry_kind);
+        if (policy_allows_retry && attempt_retry_kind != HelioRetryKind::BackendAuth &&
+            helio_adopt_recent_simulation_by_name(helio_api_url, helio_api_key, effective_job_name, res)) {
+            if (helio_should_cancel(should_cancel)) {
+                if (!res.id.empty()) {
+                    HelioQuery::stop_simulation(helio_api_url, helio_api_key, res.id);
+                }
+                res.reset();
+                res.error = _u8L("Helio action canceled");
             }
-            auto trace_id = extract_trace_id(lower_line);
-            if (!trace_id.empty()) {
-                res.trace_id = trace_id;
-            }
-        })
-        .perform_sync();
+            break;
+        }
+
+        if (helio_should_cancel(should_cancel)) {
+            res.error = _u8L("Helio action canceled");
+            break;
+        }
+
+        if (!policy_allows_retry || attempt >= HELIO_CREATE_MAX_ATTEMPTS) {
+            break;
+        }
+
+        BOOST_LOG_TRIVIAL(warning) << "Helio simulation create retry: kind="
+                                   << helio_retry_kind_name(attempt_retry_kind)
+                                   << ", attempt=" << attempt << ", status=" << res.status
+                                   << ", trace-id=" << res.trace_id;
+
+        if (!helio_sleep_for_retry_or_cancel(std::min(8, attempt * 2), should_cancel)) {
+            res.error = _u8L("Helio action canceled");
+            break;
+        }
+    }
 
     return res;
 }
@@ -1509,43 +1828,75 @@ HelioQuery::CheckSimulationProgressResult HelioQuery::check_simulation_progress(
     http.timeout_connect(20)
         .timeout_max(100)
         .on_header_callback([&res](std::string header_line) {
-            std::string lower_line;
-            for (unsigned char c : header_line) {
-                lower_line += static_cast<char>(std::tolower(c));
-            }
-            auto trace_id = extract_trace_id(lower_line);
+            auto trace_id = extract_trace_id(header_line);
             if (!trace_id.empty()) {
                 res.trace_id = trace_id;
             }
         })
         .on_complete([&res](std::string body, unsigned status) {
-            nlohmann::json parsed_obj = nlohmann::json::parse(body);
-            res.status                = status;
-            if (parsed_obj.contains("errors")) {
-                std::string message = format_error(body);
-                res.error = message;
-            } else {
-                if (parsed_obj["data"]["simulation"]["status"] == "FAILED") {
+            res.status = status;
+            res.retry_kind = HelioRetryKind::None;
+
+            if (helio_is_terminal_http_status(status)) {
+                res.error = helio_http_status_message(status, body);
+                return;
+            }
+            if (status != 200) {
+                res.error = helio_http_status_message(status, body);
+                res.retry_kind = helio_classify_retry(status, body);
+                return;
+            }
+
+            try {
+                nlohmann::json parsed_obj = nlohmann::json::parse(body);
+                if (helio_has_graphql_errors(parsed_obj)) {
+                    std::string message = format_error(body);
+                    res.error = message;
+                    res.retry_kind = helio_classify_graphql_response(status, parsed_obj);
+                    return;
+                }
+
+                if (!parsed_obj.contains("data") || !parsed_obj["data"].contains("simulation") ||
+                    parsed_obj["data"]["simulation"].is_null()) {
+                    res.error = _u8L("Helio simulation response is incomplete");
+                    res.retry_kind = HelioRetryKind::Transient;
+                    return;
+                }
+
+                auto simulation = parsed_obj["data"]["simulation"];
+                if (!simulation.contains("status") || !simulation["status"].is_string()) {
+                    res.error = _u8L("Helio simulation response is incomplete");
+                    res.retry_kind = HelioRetryKind::Transient;
+                    return;
+                }
+
+                const std::string status_str = simulation["status"].get<std::string>();
+                if (status_str == "FAILED") {
                     res.error = _u8L("Helio simulation task failed");
                 }
 
-                res.id = parsed_obj["data"]["simulation"]["id"];
-                res.name = parsed_obj["data"]["simulation"]["name"];
-                res.progress = parsed_obj["data"]["simulation"]["progress"];
-                res.is_finished = parsed_obj["data"]["simulation"]["status"] == "FINISHED";
+                res.id = simulation.value("id", "");
+                res.name = simulation.value("name", "");
+                res.progress = simulation.value("progress", 0.0f);
+                res.is_finished = status_str == "FINISHED";
                 if (res.is_finished) {
-                    res.url = parsed_obj["data"]["simulation"]["thermalIndexGcodeUrl"];
+                    res.url = simulation.value("thermalIndexGcodeUrl", "");
+                    if (res.url.empty()) {
+                        res.is_finished = false;
+                        res.error = _u8L("Helio simulation response is incomplete");
+                        res.retry_kind = HelioRetryKind::Transient;
+                        return;
+                    }
                     
                     // Parse printInfo if present
-                    if (parsed_obj["data"]["simulation"].contains("printInfo") && 
-                        !parsed_obj["data"]["simulation"]["printInfo"].is_null()) {
-                        auto printInfo = parsed_obj["data"]["simulation"]["printInfo"];
+                    if (simulation.contains("printInfo") && !simulation["printInfo"].is_null()) {
+                        auto printInfo = simulation["printInfo"];
                         PrintInfo info;
-                        info.printOutcome = printInfo["printOutcome"];
+                        info.printOutcome = printInfo.value("printOutcome", "");
                         if (printInfo.contains("printOutcomeDescription") && printInfo["printOutcomeDescription"].is_string()) {
                             info.printOutcomeDescription = printInfo["printOutcomeDescription"];
                         }
-                        info.temperatureDirection = printInfo["temperatureDirection"];
+                        info.temperatureDirection = printInfo.value("temperatureDirection", "");
                         if (printInfo.contains("temperatureDirectionDescription") && printInfo["temperatureDirectionDescription"].is_string()) {
                             info.temperatureDirectionDescription = printInfo["temperatureDirectionDescription"];
                         }
@@ -1553,8 +1904,8 @@ HelioQuery::CheckSimulationProgressResult HelioQuery::check_simulation_progress(
                         if (printInfo.contains("caveats") && printInfo["caveats"].is_array()) {
                             for (const auto& caveat : printInfo["caveats"]) {
                                 Caveat c;
-                                c.caveatType = caveat["caveatType"];
-                                c.description = caveat["description"];
+                                c.caveatType = caveat.value("caveatType", "");
+                                c.description = caveat.value("description", "");
                                 info.caveats.push_back(c);
                             }
                         }
@@ -1562,15 +1913,13 @@ HelioQuery::CheckSimulationProgressResult HelioQuery::check_simulation_progress(
                     }
                     
                     // Parse speedFactor if present
-                    if (parsed_obj["data"]["simulation"].contains("speedFactor") && 
-                        !parsed_obj["data"]["simulation"]["speedFactor"].is_null()) {
-                        res.simulationResult.speedFactor = parsed_obj["data"]["simulation"]["speedFactor"];
+                    if (simulation.contains("speedFactor") && !simulation["speedFactor"].is_null()) {
+                        res.simulationResult.speedFactor = simulation["speedFactor"];
                     }
                     
                     // Parse suggestedFixes if present
-                    if (parsed_obj["data"]["simulation"].contains("suggestedFixes") && 
-                        parsed_obj["data"]["simulation"]["suggestedFixes"].is_array()) {
-                        for (const auto& fixJson : parsed_obj["data"]["simulation"]["suggestedFixes"]) {
+                    if (simulation.contains("suggestedFixes") && simulation["suggestedFixes"].is_array()) {
+                        for (const auto& fixJson : simulation["suggestedFixes"]) {
                             SuggestedFix fix;
                             if (fixJson.contains("category") && fixJson["category"].is_string()) {
                                 fix.category = fixJson["category"];
@@ -1592,11 +1941,18 @@ HelioQuery::CheckSimulationProgressResult HelioQuery::check_simulation_progress(
                         }
                     }
                 }
+            } catch (const std::exception& e) {
+                res.error = std::string("Helio simulation response parse failed: ") + e.what();
+                res.retry_kind = HelioRetryKind::Transient;
+            } catch (...) {
+                res.error = _u8L("Helio simulation response parse failed");
+                res.retry_kind = HelioRetryKind::Transient;
             }
         })
         .on_error([&res](std::string body, std::string error, unsigned status) {
-            res.error  = error;
+            res.error  = error.empty() ? body : error;
             res.status = status;
+            res.retry_kind = helio_classify_retry(status, body, error);
         })
         .perform_sync();
 
@@ -1606,10 +1962,15 @@ HelioQuery::CheckSimulationProgressResult HelioQuery::check_simulation_progress(
 Slic3r::HelioQuery::CreateOptimizationResult HelioQuery::create_optimization(const std::string helio_api_url, 
                                                                              const std::string helio_api_key, 
                                                                              const std::string gcode_id,
-                                                                             OptimizationInput oinput)
+                                                                             OptimizationInput oinput,
+                                                                             const std::string job_name,
+                                                                             const std::string idempotency_key,
+                                                                             std::function<bool()> should_cancel)
 {
 
     std::string query_body;
+    const std::string effective_idempotency_key = idempotency_key.empty() ? helio_generate_idempotency_key() : idempotency_key;
+    const std::string effective_job_name = job_name.empty() ? helio_generate_retry_job_name(effective_idempotency_key) : job_name;
 
     /*print priority*/
     const std::string print_priority = oinput.print_priority;
@@ -1650,7 +2011,8 @@ Slic3r::HelioQuery::CreateOptimizationResult HelioQuery::create_optimization(con
             min_volumetric_speed,
             max_volumetric_speed,
             oinput.layers_to_optimize[0],
-            oinput.layers_to_optimize[1]);
+            oinput.layers_to_optimize[1],
+            effective_job_name);
     }
     else {
         query_body = generate_optimization_graphql_query(gcode_id,
@@ -1665,53 +2027,150 @@ Slic3r::HelioQuery::CreateOptimizationResult HelioQuery::create_optimization(con
             oinput.min_volumetric_speed,
             oinput.max_volumetric_speed,
             oinput.layers_to_optimize[0],
-            oinput.layers_to_optimize[1]);
+            oinput.layers_to_optimize[1],
+            effective_job_name);
     }
     
 
     HelioQuery::CreateOptimizationResult res;
-    auto http = Http::post(helio_api_url);
-    http.header("Content-Type", "application/json")
-        .header("Authorization", helio_api_key)
-        .header("HelioAdditive-Client-Name", SLIC3R_APP_NAME)
-        .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
-        .set_post_body(query_body);
+    res.reset();
 
-    if (GUI::wxGetApp().app_config->get("language") == "zh_CN") {
-        http.header("Accept-Language", "zh-CN");
+    if (helio_should_cancel(should_cancel)) {
+        res.error = _u8L("Helio action canceled");
+        return res;
     }
 
-    http.timeout_connect(20)
-        .timeout_max(100)
-        .on_header_callback([&res](std::string header_line) {
-            std::string lower_line;
-            for (unsigned char c : header_line) {
-                lower_line += static_cast<char>(std::tolower(c));
+    HelioRetryController retry_controller;
+    for (int attempt = 1; attempt <= HELIO_CREATE_MAX_ATTEMPTS; ++attempt) {
+        if (helio_should_cancel(should_cancel)) {
+            res.error = _u8L("Helio action canceled");
+            break;
+        }
+
+        HelioQuery::CreateOptimizationResult attempt_res;
+        attempt_res.reset();
+        HelioRetryKind attempt_retry_kind = HelioRetryKind::None;
+
+        auto http = Http::post(helio_api_url);
+        http.header("Content-Type", "application/json")
+            .header("Authorization", helio_api_key)
+            .header("HelioAdditive-Client-Name", SLIC3R_APP_NAME)
+            .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
+            .set_post_body(query_body);
+        helio_attach_idempotency_key(http, effective_idempotency_key);
+
+        if (GUI::wxGetApp().app_config->get("language") == "zh_CN") {
+            http.header("Accept-Language", "zh-CN");
+        }
+
+        http.timeout_connect(20)
+            .timeout_max(100)
+            .on_header_callback([&attempt_res](std::string header_line) {
+                auto trace_id = extract_trace_id(header_line);
+                if (!trace_id.empty()) {
+                    attempt_res.trace_id = trace_id;
+                }
+            })
+            .on_complete([&attempt_res, &attempt_retry_kind](std::string body, unsigned status) {
+                attempt_res.status = status;
+                if (helio_is_terminal_http_status(status)) {
+                    attempt_res.error = helio_http_status_message(status, body);
+                    attempt_res.success = false;
+                    return;
+                }
+                if (status != 200) {
+                    attempt_res.error = helio_http_status_message(status, body);
+                    attempt_res.success = false;
+                    attempt_retry_kind = helio_classify_retry(status, body);
+                    return;
+                }
+
+                try {
+                    nlohmann::json parsed_obj = nlohmann::json::parse(body);
+                    if (helio_has_graphql_errors(parsed_obj)) {
+                        std::string message = format_error(body);
+                        attempt_res.error   = message;
+                        attempt_res.success = false;
+                        attempt_retry_kind = helio_classify_graphql_response(status, parsed_obj);
+                    } else if (parsed_obj.contains("data") && parsed_obj["data"].contains("createOptimization") &&
+                               parsed_obj["data"]["createOptimization"].is_object()) {
+                        const nlohmann::json& optimization = parsed_obj["data"]["createOptimization"];
+                        attempt_res.id = optimization.value("id", "");
+                        attempt_res.name = optimization.value("name", "");
+                        if (!attempt_res.id.empty()) {
+                            attempt_res.success = true;
+                        } else {
+                            attempt_res.success = false;
+                            attempt_res.error = _u8L("Failed to create Optimization");
+                            attempt_retry_kind = HelioRetryKind::Transient;
+                        }
+                    } else {
+                        attempt_res.success = false;
+                        attempt_res.error = _u8L("Failed to create Optimization");
+                        attempt_retry_kind = HelioRetryKind::Transient;
+                    }
+                } catch (const std::exception& e) {
+                    attempt_res.success = false;
+                    attempt_res.error = std::string("Failed to parse response: ") + e.what();
+                    attempt_retry_kind = HelioRetryKind::Transient;
+                } catch (...) {
+                    attempt_res.success = false;
+                    attempt_res.error = _u8L("Failed to parse response");
+                    attempt_retry_kind = HelioRetryKind::Transient;
+                }
+            })
+            .on_error([&attempt_res, &attempt_retry_kind](std::string body, std::string error, unsigned status) {
+                attempt_res.success = false;
+                attempt_res.error   = error.empty() ? body : error;
+                attempt_res.status  = status;
+                attempt_retry_kind = helio_classify_retry(status, body, error);
+            })
+            .perform_sync();
+
+        res = attempt_res;
+        if (res.success) {
+            if (helio_should_cancel(should_cancel)) {
+                if (!res.id.empty()) {
+                    HelioQuery::stop_optimization(helio_api_url, helio_api_key, res.id);
+                }
+                res.reset();
+                res.error = _u8L("Helio action canceled");
             }
-            auto trace_id = extract_trace_id(lower_line);
-            if (!trace_id.empty()) {
-                res.trace_id = trace_id;
+            break;
+        }
+
+        const bool policy_allows_retry = retry_controller.should_retry(attempt_retry_kind);
+        if (policy_allows_retry && attempt_retry_kind != HelioRetryKind::BackendAuth &&
+            helio_adopt_recent_optimization_by_name(helio_api_url, helio_api_key, effective_job_name, res)) {
+            if (helio_should_cancel(should_cancel)) {
+                if (!res.id.empty()) {
+                    HelioQuery::stop_optimization(helio_api_url, helio_api_key, res.id);
+                }
+                res.reset();
+                res.error = _u8L("Helio action canceled");
             }
-        })
-        .on_complete([&res](std::string body, unsigned status) {
-            nlohmann::json parsed_obj = nlohmann::json::parse(body);
-            res.status                = status;
-            if (parsed_obj.contains("errors")) {
-                std::string message = format_error(body);
-                res.error   = message;
-                res.success = false;
-            } else {
-                res.success = true;
-                res.id      = parsed_obj["data"]["createOptimization"]["id"];
-                res.name    = parsed_obj["data"]["createOptimization"]["name"];
-            }
-        })
-        .on_error([&res](std::string body, std::string error, unsigned status) {
-            res.success = false;
-            res.error   = error;
-            res.status  = status;
-        })
-        .perform_sync();
+            break;
+        }
+
+        if (helio_should_cancel(should_cancel)) {
+            res.error = _u8L("Helio action canceled");
+            break;
+        }
+
+        if (!policy_allows_retry || attempt >= HELIO_CREATE_MAX_ATTEMPTS) {
+            break;
+        }
+
+        BOOST_LOG_TRIVIAL(warning) << "Helio optimization create retry: kind="
+                                   << helio_retry_kind_name(attempt_retry_kind)
+                                   << ", attempt=" << attempt << ", status=" << res.status
+                                   << ", trace-id=" << res.trace_id;
+
+        if (!helio_sleep_for_retry_or_cancel(std::min(8, attempt * 2), should_cancel)) {
+            res.error = _u8L("Helio action canceled");
+            break;
+        }
+    }
 
     return res;
 }
@@ -1784,41 +2243,80 @@ Slic3r::HelioQuery::CheckOptimizationResult HelioQuery::check_optimization_progr
     http.timeout_connect(20)
         .timeout_max(100)
         .on_header_callback([&res](std::string header_line) {
-            std::string lower_line;
-            for (unsigned char c : header_line) {
-                lower_line += static_cast<char>(std::tolower(c));
-            }
-            auto trace_id = extract_trace_id(lower_line);
+            auto trace_id = extract_trace_id(header_line);
             if (!trace_id.empty()) {
                 res.trace_id = trace_id;
             }
         })
         .on_complete([&res](std::string body, unsigned status) {
-            nlohmann::json parsed_obj = nlohmann::json::parse(body);
-            res.status                = status;
+            res.status = status;
+            res.retry_kind = HelioRetryKind::None;
 
-            if (parsed_obj.contains("errors")) {
-                std::string message = format_error(body);
-                res.error = message;
-            } else {
-                if (parsed_obj["data"]["optimization"]["status"] == "FAILED") {
+            if (helio_is_terminal_http_status(status)) {
+                res.error = helio_http_status_message(status, body);
+                return;
+            }
+            if (status != 200) {
+                res.error = helio_http_status_message(status, body);
+                res.retry_kind = helio_classify_retry(status, body);
+                return;
+            }
+
+            try {
+                nlohmann::json parsed_obj = nlohmann::json::parse(body);
+                if (helio_has_graphql_errors(parsed_obj)) {
+                    std::string message = format_error(body);
+                    res.error = message;
+                    res.retry_kind = helio_classify_graphql_response(status, parsed_obj);
+                    return;
+                }
+
+                if (!parsed_obj.contains("data") || !parsed_obj["data"].contains("optimization") ||
+                    parsed_obj["data"]["optimization"].is_null()) {
+                    res.error = _u8L("Helio optimization response is incomplete");
+                    res.retry_kind = HelioRetryKind::Transient;
+                    return;
+                }
+
+                auto optimization = parsed_obj["data"]["optimization"];
+                if (!optimization.contains("status") || !optimization["status"].is_string()) {
+                    res.error = _u8L("Helio optimization response is incomplete");
+                    res.retry_kind = HelioRetryKind::Transient;
+                    return;
+                }
+
+                const std::string status_str = optimization["status"].get<std::string>();
+                if (status_str == "FAILED") {
                     res.error = _u8L("Helio optimization task failed");
                 }
 
-                res.id = parsed_obj["data"]["optimization"]["id"];
-                res.name = parsed_obj["data"]["optimization"]["name"];
-                res.progress = parsed_obj["data"]["optimization"]["progress"];
-                res.is_finished = parsed_obj["data"]["optimization"]["status"] == "FINISHED";
+                res.id = optimization.value("id", "");
+                res.name = optimization.value("name", "");
+                res.progress = optimization.value("progress", 0.0f);
+                res.is_finished = status_str == "FINISHED";
                 if (res.is_finished) {
-                    res.qualityStdImprovement = parsed_obj["data"]["optimization"]["qualityStdImprovement"];
-                    res.qualityMeanImprovement = parsed_obj["data"]["optimization"]["qualityMeanImprovement"];
-                    res.url = parsed_obj["data"]["optimization"]["optimizedGcodeWithThermalIndexesUrl"];
+                    res.qualityStdImprovement = optimization.value("qualityStdImprovement", "");
+                    res.qualityMeanImprovement = optimization.value("qualityMeanImprovement", "");
+                    res.url = optimization.value("optimizedGcodeWithThermalIndexesUrl", "");
+                    if (res.url.empty()) {
+                        res.is_finished = false;
+                        res.error = _u8L("Helio optimization response is incomplete");
+                        res.retry_kind = HelioRetryKind::Transient;
+                        return;
+                    }
                 }
+            } catch (const std::exception& e) {
+                res.error = std::string("Helio optimization response parse failed: ") + e.what();
+                res.retry_kind = HelioRetryKind::Transient;
+            } catch (...) {
+                res.error = _u8L("Helio optimization response parse failed");
+                res.retry_kind = HelioRetryKind::Transient;
             }
         })
         .on_error([&res](std::string body, std::string error, unsigned status) {
-            res.error  = error;
+            res.error  = error.empty() ? body : error;
             res.status = status;
+            res.retry_kind = helio_classify_retry(status, body, error);
         })
         .perform_sync();
 
@@ -1840,14 +2338,75 @@ std::string HelioQuery::generate_default_optimization_query(const std::string& g
     return query_body;
 }
 
-void HelioBackgroundProcess::helio_thread_start(std::mutex&                                slicing_mutex,
-                                                std::condition_variable&                   slicing_condition,
-                                                BackgroundSlicingProcess::State&           slicing_state,
-                                                std::unique_ptr<GUI::NotificationManager>& notification_manager)
+bool HelioBackgroundProcess::begin_action()
 {
-    m_thread = create_thread([this, &slicing_mutex, &slicing_condition, &slicing_state, &notification_manager] {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_thread.joinable()) {
+        if (!m_worker_completed)
+            return false;
+        m_thread.join();
+    }
+
+    ++m_action_generation;
+    m_state = STATE_STARTED;
+    return true;
+}
+
+void HelioBackgroundProcess::stop()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    ++m_action_generation;
+    m_state = STATE_CANCELED;
+}
+
+bool HelioBackgroundProcess::was_canceled()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_state == STATE_CANCELED ||
+           (helio_worker_generation != 0 && helio_worker_generation != m_action_generation);
+}
+
+bool HelioBackgroundProcess::is_action_current(std::uint64_t generation)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return generation != 0 && generation == m_action_generation;
+}
+
+void HelioBackgroundProcess::set_state(State state)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (helio_worker_generation == 0 || helio_worker_generation == m_action_generation) {
+        m_state = state;
+    }
+}
+
+bool HelioBackgroundProcess::helio_thread_start(std::mutex&                                slicing_mutex,
+                                                 std::condition_variable&                   slicing_condition,
+                                                 BackgroundSlicingProcess::State&           slicing_state,
+                                                 std::unique_ptr<GUI::NotificationManager>& notification_manager)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_thread.joinable())
+        return false;
+
+    const std::uint64_t generation = m_action_generation;
+    m_state = STATE_STARTED;
+    m_worker_completed = false;
+    m_thread = create_thread([this, generation, &slicing_mutex, &slicing_condition, &slicing_state, &notification_manager] {
+        helio_worker_generation = generation;
+        struct CompletionGuard {
+            HelioBackgroundProcess& process;
+            ~CompletionGuard()
+            {
+                helio_worker_generation = 0;
+                std::lock_guard<std::mutex> lock(process.m_mutex);
+                process.m_worker_completed = true;
+            }
+        } completion_guard{*this};
+
         this->helio_threaded_process_start(slicing_mutex, slicing_condition, slicing_state, notification_manager);
     });
+    return true;
 }
 
 void HelioBackgroundProcess::stop_current_helio_action()
@@ -1903,20 +2462,22 @@ void HelioBackgroundProcess::helio_threaded_process_start(std::mutex&           
 
     if ((slicing_state == BackgroundSlicingProcess::STATE_FINISHED || slicing_state == BackgroundSlicingProcess::STATE_IDLE) &&
         !was_canceled()) {
-        wxPostEvent(GUI::wxGetApp().plater(), GUI::SimpleEvent(GUI::EVT_HELIO_PROCESSING_STARTED));
+        wxPostEvent(GUI::wxGetApp().plater(), HelioActionEvent(GUI::EVT_HELIO_PROCESSING_STARTED, 0, helio_worker_generation));
 
         Slic3r::PrintBase::SlicingStatus status = Slic3r::PrintBase::SlicingStatus(0.0, "Helio: Process Started");
         status.is_helio = true;
         Slic3r::SlicingStatusEvent*      evt    = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
+        evt->generation = helio_worker_generation;
         wxQueueEvent(GUI::wxGetApp().plater(), evt);
 
-        BOOST_LOG_TRIVIAL(debug) << boost::format("url: %1%, key: %2%") % helio_api_url % helio_api_key;
+        BOOST_LOG_TRIVIAL(debug) << "Helio process started";
 
         /*check api url*/
         if (helio_api_url.empty()) {
             set_state(STATE_CANCELED);
             Slic3r::HelioCompletionEvent *evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "", false,
                 _u8L("Helio API endpoint is empty, please check the configuration."));
+            evt->generation = helio_worker_generation;
             wxQueueEvent(GUI::wxGetApp().plater(), evt);
             return;
         }
@@ -1926,62 +2487,116 @@ void HelioBackgroundProcess::helio_threaded_process_start(std::mutex&           
             set_state(STATE_CANCELED);
             Slic3r::HelioCompletionEvent *evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "", false,
                 _u8L("Personal assecc token is empty, please fill in the correct token."));
+            evt->generation = helio_worker_generation;
             wxQueueEvent(GUI::wxGetApp().plater(), evt);
             return;
         }
 
-        HelioQuery::PresignedURLResult create_presigned_url_res = HelioQuery::create_presigned_url(helio_api_url, helio_api_key);
+        HelioQuery::PresignedURLResult create_presigned_url_res{};
+        HelioQuery::UploadFileResult upload_file_res{};
+        bool upload_success = false;
+        HelioRetryController presigned_retry_controller;
 
-        if (create_presigned_url_res.error.empty() && create_presigned_url_res.status == 200 && !was_canceled()) {
-            status = Slic3r::PrintBase::SlicingStatus(5, _u8L("Helio: Presigned URL Created"));
+        for (int attempt = 1; attempt <= HELIO_UPLOAD_MAX_ATTEMPTS && !was_canceled(); ++attempt) {
+            status = Slic3r::PrintBase::SlicingStatus(
+                3, (boost::format("Helio: preparing upload (%1%/%2%)") % attempt % HELIO_UPLOAD_MAX_ATTEMPTS).str());
             status.is_helio = true;
-            evt    = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
+            evt = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
+            evt->generation = helio_worker_generation;
             wxQueueEvent(GUI::wxGetApp().plater(), evt);
 
-            HelioQuery::UploadFileResult upload_file_res = HelioQuery::upload_file_to_presigned_url(m_gcode_result->filename,
-                                                                                                    create_presigned_url_res.url);
-
-            if (upload_file_res.success && !was_canceled()) {
-                status = Slic3r::PrintBase::SlicingStatus(10, _u8L("Helio: file successfully uploaded"));
-                evt    = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
-                wxQueueEvent(GUI::wxGetApp().plater(), evt);
-
-                HelioQuery::CreateGCodeResult create_gcode_res;
-                if (use_v3) {
-                    create_gcode_res = HelioQuery::create_gcode_v3(create_presigned_url_res.key, helio_api_url,
-                                                                   helio_api_key, printer_id, materials,
-                                                                   is_multi_color, is_multi_material);
-                } else {
-                    create_gcode_res = HelioQuery::create_gcode(create_presigned_url_res.key, helio_api_url,
-                                                                helio_api_key, printer_id, filament_id);
-                }
-
-                if (action == 0) {
-                    create_simulation_step(create_gcode_res, notification_manager);
-                }
-                else if (action == 1) {
-                    create_optimization_step(create_gcode_res, notification_manager);
-                }
-
-            } else {
-                set_state(STATE_CANCELED);
-
-                Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "", false,
-                                                                                     _u8L("Helio: file upload failed"));
-                wxQueueEvent(GUI::wxGetApp().plater(), evt);
+            create_presigned_url_res = HelioQuery::create_presigned_url(helio_api_url, helio_api_key);
+            if (was_canceled()) {
+                break;
             }
+            if (create_presigned_url_res.error.empty() && create_presigned_url_res.status == 200) {
+                presigned_retry_controller.reset();
+                status = Slic3r::PrintBase::SlicingStatus(5, _u8L("Helio: Presigned URL Created"));
+                status.is_helio = true;
+                evt = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
+                evt->generation = helio_worker_generation;
+                wxQueueEvent(GUI::wxGetApp().plater(), evt);
+
+                if (was_canceled()) {
+                    break;
+                }
+                upload_file_res = HelioQuery::upload_file_to_presigned_url(m_gcode_result->filename,
+                                                                           create_presigned_url_res.url);
+                if (upload_file_res.success) {
+                    upload_success = true;
+                    break;
+                }
+
+                BOOST_LOG_TRIVIAL(warning) << "Helio upload attempt " << attempt << " failed: " << upload_file_res.error;
+            } else {
+                BOOST_LOG_TRIVIAL(warning) << "Helio presigned URL attempt " << attempt
+                                           << " failed: retry-kind="
+                                           << helio_retry_kind_name(create_presigned_url_res.retry_kind)
+                                           << ", status=" << create_presigned_url_res.status
+                                           << ", trace-id=" << create_presigned_url_res.trace_id
+                                           << ", error=" << create_presigned_url_res.error;
+                if (!presigned_retry_controller.should_retry(create_presigned_url_res.retry_kind)) {
+                    break;
+                }
+            }
+
+            if (attempt < HELIO_UPLOAD_MAX_ATTEMPTS &&
+                !helio_sleep_for_retry_or_cancel(std::min(8, attempt * 2), [this]() { return was_canceled(); })) {
+                break;
+            }
+        }
+
+        if (upload_success && !was_canceled()) {
+            status = Slic3r::PrintBase::SlicingStatus(10, _u8L("Helio: file successfully uploaded"));
+            status.is_helio = true;
+            evt    = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
+            evt->generation = helio_worker_generation;
+            wxQueueEvent(GUI::wxGetApp().plater(), evt);
+
+            const std::string create_gcode_idempotency_key = helio_generate_idempotency_key();
+            HelioQuery::CreateGCodeResult create_gcode_res;
+            if (use_v3) {
+                create_gcode_res = HelioQuery::create_gcode_v3(create_presigned_url_res.key, helio_api_url,
+                                                               helio_api_key, printer_id, materials,
+                                                               is_multi_color, is_multi_material,
+                                                               create_gcode_idempotency_key,
+                                                               [this]() { return was_canceled(); });
+            } else {
+                create_gcode_res = HelioQuery::create_gcode(create_presigned_url_res.key, helio_api_url,
+                                                            helio_api_key, printer_id, filament_id,
+                                                            create_gcode_idempotency_key,
+                                                            [this]() { return was_canceled(); });
+            }
+
+            if (action == 0) {
+                create_simulation_step(create_gcode_res, notification_manager);
+            }
+            else if (action == 1) {
+                create_optimization_step(create_gcode_res, notification_manager);
+            }
+        } else if (was_canceled()) {
+            set_state(STATE_CANCELED);
         } else {
-            std::string presigned_url_message = (boost::format("error: %1%") % create_presigned_url_res.error).str();
+            std::string presigned_url_message;
+            if (!create_presigned_url_res.error.empty() || create_presigned_url_res.status != 200) {
+                presigned_url_message = (boost::format("error: %1%") % create_presigned_url_res.error).str();
+            } else {
+                presigned_url_message = _u8L("Helio: file upload failed");
+                if (!upload_file_res.error.empty()) {
+                    presigned_url_message += "\n" + upload_file_res.error;
+                }
+            }
 
             if (create_presigned_url_res.status == 401) {
                 presigned_url_message += "\n ";
-                presigned_url_message += _u8L("Please make sure you have the corrent API key set in preferences.");
+                presigned_url_message += _u8L("Please make sure you have the correct API key set in preferences.");
             }
 
             set_state(STATE_CANCELED);
 
             Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "", false,
                                                                                  presigned_url_message);
+            evt->generation = helio_worker_generation;
             wxQueueEvent(GUI::wxGetApp().plater(), evt);
         }
     } else {
@@ -1995,10 +2610,13 @@ void HelioBackgroundProcess::create_simulation_step(HelioQuery::CreateGCodeResul
         Slic3r::PrintBase::SlicingStatus status = Slic3r::PrintBase::SlicingStatus(15, _u8L("Helio: GCode created successfully"));
         status.is_helio = true;
         Slic3r::SlicingStatusEvent*      evt    = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
+        evt->generation = helio_worker_generation;
         wxQueueEvent(GUI::wxGetApp().plater(), evt);
 
         const std::string gcode_id = create_gcode_res.id;
-        HelioQuery::CreateSimulationResult create_simulation_res = HelioQuery::create_simulation(helio_api_url, helio_api_key, gcode_id, simulation_input_data);
+        HelioQuery::CreateSimulationResult create_simulation_res =
+            HelioQuery::create_simulation(helio_api_url, helio_api_key, gcode_id, simulation_input_data,
+                                          std::string(), std::string(), [this]() { return was_canceled(); });
         current_simulation_result = create_simulation_res;
         current_optimization_result.reset();
         // Clear previous stored result since we're starting a new simulation
@@ -2008,92 +2626,134 @@ void HelioBackgroundProcess::create_simulation_step(HelioQuery::CreateGCodeResul
             HelioQuery::last_simulation_trace_id = create_simulation_res.trace_id;  
         }
 
+        if (was_canceled()) {
+            set_state(STATE_CANCELED);
+            return;
+        }
+
         if (create_simulation_res.success && !was_canceled()) {
             status = Slic3r::PrintBase::SlicingStatus(20, _u8L("Helio: simulation successfully created"));
             evt    = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
+            evt->generation = helio_worker_generation;
             wxQueueEvent(GUI::wxGetApp().plater(), evt);
 
-            int times_tried            = 0;
-            int max_unsuccessful_tries = 5;
-            int times_queried          = 0;
+            int transient_failures = 0;
+            int times_queried      = 0;
+            HelioRetryController backend_auth_retry_controller;
 
             while (!was_canceled()) {
+                int sleep_seconds = 3;
                 HelioQuery::CheckSimulationProgressResult check_simulation_progress_res =
                     HelioQuery::check_simulation_progress(helio_api_url, helio_api_key, create_simulation_res.id);
 
-                if (check_simulation_progress_res.status == 200) {
-                    times_tried = 0;
-                    if (check_simulation_progress_res.error.empty()) {
-                        std::string trailing_dots = "";
-
-                        for (int i = 0; i < (times_queried % 3); i++) {
-                            trailing_dots += "....";
-                        }
-
-                        status = Slic3r::PrintBase::SlicingStatus(35 + (80 - 35) * (check_simulation_progress_res.progress / 100.0f),
-                                                                  _u8L("Helio: simulation working") + trailing_dots);
-                        evt    = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
-                        wxQueueEvent(GUI::wxGetApp().plater(), evt);
-                        if (check_simulation_progress_res.is_finished) {
-                            // Start loading preview in background immediately (don't wait for dialog)
-                            int original_time_seconds = static_cast<int>(m_gcode_result->print_statistics.modes[0].time);
-                            std::string url = check_simulation_progress_res.url;
-                            std::string filename = m_gcode_result->filename;
-                            HelioQuery::SimulationResult sim_result = check_simulation_progress_res.simulationResult;
-
-                            // Store simulation result to current plate for later access (e.g., "View Summary" button)
-                            GUI::wxGetApp().plater()->CallAfter([sim_result, original_time_seconds]() {
-                                auto* plate = GUI::wxGetApp().plater()->get_partplate_list().get_curr_plate();
-                                if (plate) {
-                                    HelioPlateResult helio_result;
-                                    helio_result.action = 0;  // Simulation
-                                    helio_result.simulation_result = sim_result;
-                                    helio_result.original_print_time_seconds = original_time_seconds;
-                                    helio_result.is_valid = true;
-                                    plate->set_helio_result(helio_result);
-                                }
-                            });
-
-                            // Start preview loading in background thread immediately
-                            std::string simulated_gcode_path = create_path_for_simulated_gcode(filename);
-                            HelioQuery::RatingData rating_data;
-                            save_downloaded_gcode_and_load_preview(url,
-                                                                   simulated_gcode_path, filename,
-                                                                   notification_manager, rating_data);
-
-                            // Show simulation results dialog on main thread (non-blocking for preview)
-                            // Capture roles_times for calculating optimizable sections
-                            auto roles_times = m_gcode_result->print_statistics.modes[0].roles_times;
-                            GUI::wxGetApp().plater()->CallAfter([sim_result, original_time_seconds, roles_times]() {
-                                // This runs on the main thread
-                                GUI::HelioSimulationResultsDialog results_dlg(nullptr, sim_result, original_time_seconds, roles_times);
-                                results_dlg.ShowModal();
-                            });
-                            break;
-                        }
+                const bool retryable = check_simulation_progress_res.retry_kind != HelioRetryKind::None &&
+                    backend_auth_retry_controller.should_retry(check_simulation_progress_res.retry_kind);
+                if (retryable) {
+                    if (check_simulation_progress_res.retry_kind == HelioRetryKind::Transient) {
+                        transient_failures++;
+                        sleep_seconds = helio_next_poll_backoff_seconds(transient_failures);
                     } else {
+                        transient_failures = 0;
+                    }
+                    if (check_simulation_progress_res.retry_kind == HelioRetryKind::Transient &&
+                        transient_failures >= HELIO_MAX_TRANSIENT_POLL_FAILURES) {
                         set_state(STATE_CANCELED);
 
-                        BOOST_LOG_TRIVIAL(error) << "Helio simulation progress check returned error: " << check_simulation_progress_res.error;
-                        
-                        std::string error_msg = _u8L("Helio: simulation failed") + "\n" + check_simulation_progress_res.error;
-                        Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "",
-                                                                                             false, error_msg);
-                        wxQueueEvent(GUI::wxGetApp().plater(), evt);
+                        const std::string last_error = check_simulation_progress_res.error.empty() ?
+                            _u8L("transient progress checks did not recover") : check_simulation_progress_res.error;
+                        const std::string error_msg = _u8L("Helio: simulation failed") + "\n" +
+                            (boost::format("Exceeded retry limit after %1% consecutive transient progress checks. Last error: %2%") %
+                             transient_failures % last_error).str();
+                        Slic3r::HelioCompletionEvent* completion_evt =
+                            new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "", false, error_msg);
+                        completion_evt->generation = helio_worker_generation;
+                        wxQueueEvent(GUI::wxGetApp().plater(), completion_evt);
+                        break;
+                    }
+                    status = Slic3r::PrintBase::SlicingStatus(
+                        35, (boost::format("Helio: Simulation check retrying in %1% seconds") % sleep_seconds).str());
+                    status.is_helio = true;
+                    evt = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
+                    evt->generation = helio_worker_generation;
+                    wxQueueEvent(GUI::wxGetApp().plater(), evt);
+                    BOOST_LOG_TRIVIAL(warning) << "Helio simulation progress check retry: kind="
+                                               << helio_retry_kind_name(check_simulation_progress_res.retry_kind)
+                                               << ", attempt=" << (times_queried + 1)
+                                               << ", status=" << check_simulation_progress_res.status
+                                               << ", trace-id=" << check_simulation_progress_res.trace_id
+                                               << ", error=" << check_simulation_progress_res.error;
+                } else if (check_simulation_progress_res.status == 200 && check_simulation_progress_res.error.empty()) {
+                    transient_failures = 0;
+                    backend_auth_retry_controller.reset();
+                    std::string trailing_dots = "";
+
+                    for (int i = 0; i < (times_queried % 3); i++) {
+                        trailing_dots += "....";
+                    }
+
+                    status = Slic3r::PrintBase::SlicingStatus(35 + (80 - 35) * (check_simulation_progress_res.progress / 100.0f),
+                                                              _u8L("Helio: simulation working") + trailing_dots);
+                    status.is_helio = true;
+                    evt = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
+                    evt->generation = helio_worker_generation;
+                    wxQueueEvent(GUI::wxGetApp().plater(), evt);
+                    if (check_simulation_progress_res.is_finished) {
+                        // Start loading preview in background immediately (don't wait for dialog)
+                        int original_time_seconds = static_cast<int>(m_gcode_result->print_statistics.modes[0].time);
+                        std::string url = check_simulation_progress_res.url;
+                        std::string filename = m_gcode_result->filename;
+                        HelioQuery::SimulationResult sim_result = check_simulation_progress_res.simulationResult;
+
+                        // Store simulation result to current plate for later access (e.g., "View Summary" button)
+                        GUI::wxGetApp().plater()->CallAfter([process = this, generation = helio_worker_generation, sim_result, original_time_seconds]() {
+                            if (!process->is_action_current(generation)) {
+                                return;
+                            }
+                            auto* plate = GUI::wxGetApp().plater()->get_partplate_list().get_curr_plate();
+                            if (plate) {
+                                HelioPlateResult helio_result;
+                                helio_result.action = 0;
+                                helio_result.simulation_result = sim_result;
+                                helio_result.original_print_time_seconds = original_time_seconds;
+                                helio_result.is_valid = true;
+                                plate->set_helio_result(helio_result);
+                            }
+                        });
+
+                        // Start preview loading in background thread immediately
+                        std::string simulated_gcode_path = create_path_for_simulated_gcode(filename);
+                        HelioQuery::RatingData rating_data;
+                        save_downloaded_gcode_and_load_preview(url, simulated_gcode_path, filename, notification_manager, rating_data);
+
+                        // Show simulation results dialog on main thread (non-blocking for preview)
+                        // Capture roles_times for calculating optimizable sections
+                        auto roles_times = m_gcode_result->print_statistics.modes[0].roles_times;
+                        GUI::wxGetApp().plater()->CallAfter([process = this, generation = helio_worker_generation, sim_result, original_time_seconds, roles_times]() {
+                            if (!process->is_action_current(generation)) {
+                                return;
+                            }
+                            GUI::HelioSimulationResultsDialog results_dlg(nullptr, sim_result, original_time_seconds, roles_times);
+                            results_dlg.ShowModal();
+                        });
                         break;
                     }
                 } else {
-                    times_tried++;
-                    status = Slic3r::PrintBase::SlicingStatus(35, _u8L("Helio: Simulation check failed"));
-                    evt    = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
-                    wxQueueEvent(GUI::wxGetApp().plater(), evt);
+                    set_state(STATE_CANCELED);
 
-                    if (times_tried >= max_unsuccessful_tries)
-                        break;
+                    BOOST_LOG_TRIVIAL(error) << "Helio simulation progress check returned error: " << check_simulation_progress_res.error;
+
+                    std::string error_msg = _u8L("Helio: simulation failed") + "\n" + check_simulation_progress_res.error;
+                    Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "",
+                                                                                         false, error_msg);
+                    evt->generation = helio_worker_generation;
+                    wxQueueEvent(GUI::wxGetApp().plater(), evt);
+                    break;
                 }
 
                 times_queried++;
-                boost::this_thread ::sleep_for(boost::chrono::seconds(3));
+                if (!helio_sleep_for_retry_or_cancel(sleep_seconds, [this]() { return was_canceled(); })) {
+                    break;
+                }
             }
 
         } else {
@@ -2110,6 +2770,7 @@ void HelioBackgroundProcess::create_simulation_step(HelioQuery::CreateGCodeResul
             }
             
             Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "", false, error);
+            evt->generation = helio_worker_generation;
             wxQueueEvent(GUI::wxGetApp().plater(), evt);
         }
 
@@ -2127,6 +2788,7 @@ void HelioBackgroundProcess::create_simulation_step(HelioQuery::CreateGCodeResul
         }
 
         Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "", false, error);
+        evt->generation = helio_worker_generation;
         wxQueueEvent(GUI::wxGetApp().plater(), evt);
     }
 }
@@ -2137,10 +2799,13 @@ void HelioBackgroundProcess::create_optimization_step(HelioQuery::CreateGCodeRes
         Slic3r::PrintBase::SlicingStatus status = Slic3r::PrintBase::SlicingStatus(15,_u8L( "Helio: GCode created successfully"));
         status.is_helio = true;
         Slic3r::SlicingStatusEvent* evt = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
+        evt->generation = helio_worker_generation;
         wxQueueEvent(GUI::wxGetApp().plater(), evt);
 
         const std::string gcode_id = create_gcode_res.id;
-        HelioQuery::CreateOptimizationResult create_optimization_res = HelioQuery::create_optimization(helio_api_url, helio_api_key, gcode_id, optimization_input_data);
+        HelioQuery::CreateOptimizationResult create_optimization_res =
+            HelioQuery::create_optimization(helio_api_url, helio_api_key, gcode_id, optimization_input_data,
+                                            std::string(), std::string(), [this]() { return was_canceled(); });
         current_optimization_result = create_optimization_res;
         current_simulation_result.reset();
         // Clear previous stored result since we're starting a new optimization
@@ -2150,112 +2815,121 @@ void HelioBackgroundProcess::create_optimization_step(HelioQuery::CreateGCodeRes
             HelioQuery::last_optimization_trace_id = create_optimization_res.trace_id;
         }
 
+        if (was_canceled()) {
+            set_state(STATE_CANCELED);
+            return;
+        }
+
         if (create_optimization_res.success && !was_canceled()) {
             status = Slic3r::PrintBase::SlicingStatus(20, _u8L("Helio: optimization successfully created"));
             evt = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
+            evt->generation = helio_worker_generation;
             wxQueueEvent(GUI::wxGetApp().plater(), evt);
 
-            int times_tried = 0;
-            int max_unsuccessful_tries = 5;
+            int transient_failures = 0;
             int times_queried = 0;
+            HelioRetryController backend_auth_retry_controller;
 
             while (!was_canceled()) {
+                int sleep_seconds = 3;
                 HelioQuery::CheckOptimizationResult check_optimzaion_progress_res =
                     HelioQuery::check_optimization_progress(helio_api_url, helio_api_key, create_optimization_res.id);
 
-                if (check_optimzaion_progress_res.status == 200) {
-                    times_tried = 0;
-                    if (check_optimzaion_progress_res.error.empty()) {
-                        std::string trailing_dots = "";
-
-                        for (int i = 0; i < (times_queried % 3); i++) {
-                            trailing_dots += "....";
-                        }
-
-                        status = Slic3r::PrintBase::SlicingStatus(35 + (80 - 35) * (check_optimzaion_progress_res.progress / 100.0f),
-                            _u8L("Helio: optimization working") + trailing_dots);
-                        evt = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
-                        wxQueueEvent(GUI::wxGetApp().plater(), evt);
-                        if (check_optimzaion_progress_res.is_finished) {
-                            // notification_manager->push_notification((boost::format("Helio: Optimzaion finished.")).str());
-                            std::string optimized_gcode_path = HelioBackgroundProcess::create_path_for_optimization_gcode(
-                                m_gcode_result->filename);
-
-
-                            HelioQuery::RatingData rating_data;
-                            rating_data.action = 1;
-                            rating_data.qualityMeanImprovement = check_optimzaion_progress_res.qualityMeanImprovement;
-                            rating_data.qualityStdImprovement =check_optimzaion_progress_res.qualityStdImprovement;
-
-                            HelioBackgroundProcess::save_downloaded_gcode_and_load_preview(check_optimzaion_progress_res.url,
-                                optimized_gcode_path, m_gcode_result->filename,
-                                notification_manager, rating_data);
-                            break;
-                        }
+                const bool retryable = check_optimzaion_progress_res.retry_kind != HelioRetryKind::None &&
+                    backend_auth_retry_controller.should_retry(check_optimzaion_progress_res.retry_kind);
+                if (retryable) {
+                    if (check_optimzaion_progress_res.retry_kind == HelioRetryKind::Transient) {
+                        transient_failures++;
+                        sleep_seconds = helio_next_poll_backoff_seconds(transient_failures);
+                    } else {
+                        transient_failures = 0;
                     }
-                    else {
+                    if (check_optimzaion_progress_res.retry_kind == HelioRetryKind::Transient &&
+                        transient_failures >= HELIO_MAX_TRANSIENT_POLL_FAILURES) {
                         set_state(STATE_CANCELED);
-                        
-                        BOOST_LOG_TRIVIAL(error) << "Helio optimization progress check returned error: " << check_optimzaion_progress_res.error;
-                        
-                        std::string error_msg = _u8L("Helio: optimization failed") + "\n" + check_optimzaion_progress_res.error;
-                        Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "",
-                            false, error_msg);
-                        wxQueueEvent(GUI::wxGetApp().plater(), evt);
+
+                        const std::string last_error = check_optimzaion_progress_res.error.empty() ?
+                            _u8L("transient progress checks did not recover") : check_optimzaion_progress_res.error;
+                        const std::string error_msg = _u8L("Helio: optimization failed") + "\n" +
+                            (boost::format("Exceeded retry limit after %1% consecutive transient progress checks. Last error: %2%") %
+                             transient_failures % last_error).str();
+                        Slic3r::HelioCompletionEvent* completion_evt =
+                            new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "", false, error_msg);
+                        completion_evt->generation = helio_worker_generation;
+                        wxQueueEvent(GUI::wxGetApp().plater(), completion_evt);
                         break;
                     }
-                }
-                else {
-                    times_tried++;
-
-                    status = Slic3r::PrintBase::SlicingStatus(35, _u8L("Helio: Optimzaion check failed"));
+                    status = Slic3r::PrintBase::SlicingStatus(
+                        35, (boost::format("Helio: Optimization check retrying in %1% seconds") % sleep_seconds).str());
+                    status.is_helio = true;
                     evt = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
+                    evt->generation = helio_worker_generation;
                     wxQueueEvent(GUI::wxGetApp().plater(), evt);
-
-                    if (times_tried >= max_unsuccessful_tries)
+                    BOOST_LOG_TRIVIAL(warning) << "Helio optimization progress check retry: kind="
+                                               << helio_retry_kind_name(check_optimzaion_progress_res.retry_kind)
+                                               << ", attempt=" << (times_queried + 1)
+                                               << ", status=" << check_optimzaion_progress_res.status
+                                               << ", trace-id=" << check_optimzaion_progress_res.trace_id
+                                               << ", error=" << check_optimzaion_progress_res.error;
+                } else if (check_optimzaion_progress_res.status == 200 && check_optimzaion_progress_res.error.empty()) {
+                    transient_failures = 0;
+                    backend_auth_retry_controller.reset();
+                    std::string trailing_dots = "";
+                    for (int i = 0; i < (times_queried % 3); i++) {
+                        trailing_dots += "....";
+                    }
+                    status = Slic3r::PrintBase::SlicingStatus(35 + (80 - 35) * (check_optimzaion_progress_res.progress / 100.0f),
+                        _u8L("Helio: optimization working") + trailing_dots);
+                    status.is_helio = true;
+                    evt = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
+                    evt->generation = helio_worker_generation;
+                    wxQueueEvent(GUI::wxGetApp().plater(), evt);
+                    if (check_optimzaion_progress_res.is_finished) {
+                        std::string optimized_gcode_path = HelioBackgroundProcess::create_path_for_optimization_gcode(m_gcode_result->filename);
+                        HelioQuery::RatingData rating_data;
+                        rating_data.action = 1;
+                        rating_data.qualityMeanImprovement = check_optimzaion_progress_res.qualityMeanImprovement;
+                        rating_data.qualityStdImprovement = check_optimzaion_progress_res.qualityStdImprovement;
+                        HelioBackgroundProcess::save_downloaded_gcode_and_load_preview(check_optimzaion_progress_res.url,
+                            optimized_gcode_path, m_gcode_result->filename, notification_manager, rating_data);
                         break;
+                    }
+                } else {
+                    set_state(STATE_CANCELED);
+                    BOOST_LOG_TRIVIAL(error) << "Helio optimization progress check returned error: " << check_optimzaion_progress_res.error;
+                    std::string error_msg = _u8L("Helio: optimization failed") + "\n" + check_optimzaion_progress_res.error;
+                    Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "", false, error_msg);
+                    evt->generation = helio_worker_generation;
+                    wxQueueEvent(GUI::wxGetApp().plater(), evt);
+                    break;
                 }
-
                 times_queried++;
-                boost::this_thread::sleep_for(boost::chrono::seconds(3));
+                if (!helio_sleep_for_retry_or_cancel(sleep_seconds, [this]() { return was_canceled(); })) {
+                    break;
+                }
             }
-
-        }
-        else {
+        } else {
             set_state(STATE_CANCELED);
-
-            std::string error;
-            try {
-                error = _u8L("Helio: Failed to create Optimization") + "\n" + create_optimization_res.error;
-            }
-            catch (const std::exception& e) {
-                BOOST_LOG_TRIVIAL(error) << "Helio create_optimization_step format error: " << e.what();
-            } catch (...) {
-                BOOST_LOG_TRIVIAL(error) << "Helio create_optimization_step format error: unknown error";
-            }
-
-            Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "", false,
+            Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(
+                GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "", false,
                 (boost::format("Helio: Failed to create Optimization\n%1%") % create_optimization_res.error).str());
+            evt->generation = helio_worker_generation;
             wxQueueEvent(GUI::wxGetApp().plater(), evt);
         }
-
-    }
-    else {
+    } else {
         set_state(STATE_CANCELED);
-
         std::string error;
         try {
             error = _u8L("Helio: Failed to create GCode") + "\n" + create_gcode_res.error;
-        }
-        catch (const std::exception& e) {
+        } catch (const std::exception& e) {
             BOOST_LOG_TRIVIAL(error) << "Helio create_optimization_step gcode error: " << e.what();
             error = "Helio: Failed to create GCode";
         } catch (...) {
             BOOST_LOG_TRIVIAL(error) << "Helio create_optimization_step gcode: unknown error";
             error = "Helio: Failed to create GCode";
         }
-
         Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "", false, error);
+        evt->generation = helio_worker_generation;
         wxQueueEvent(GUI::wxGetApp().plater(), evt);
     }
 }
@@ -2269,6 +2943,7 @@ void HelioBackgroundProcess::save_downloaded_gcode_and_load_preview(std::string 
     unsigned    response_status = 0;
     std::string downloaded_gcode;
     std::string response_error;
+    const std::uint64_t action_generation = helio_worker_generation;
 
     int number_of_attempts                  = 0;
     int max_attempts                        = 7;
@@ -2288,7 +2963,16 @@ void HelioBackgroundProcess::save_downloaded_gcode_and_load_preview(std::string 
                     response_status = status;
                     response_error  = (boost::format("status: %1%, error: %2%") % status % body).str();
                 })
+                .timeout_connect(20)
+                .timeout_max(100)
+                .on_progress([this, action_generation](Http::Progress, bool& cancel) {
+                    cancel = was_canceled() || !is_action_current(action_generation);
+                })
                 .perform_sync();
+
+            if (was_canceled() || !is_action_current(action_generation)) {
+                return;
+            }
 
             if (response_status != 200) {
                 number_of_attempts++;
@@ -2296,6 +2980,7 @@ void HelioBackgroundProcess::save_downloaded_gcode_and_load_preview(std::string 
                     80, (boost::format("Helio: Could not download file. Attempts left %1%") % (max_attempts - number_of_attempts)).str());
                 status.is_helio = true;
                 Slic3r::SlicingStatusEvent* evt = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
+                evt->generation = helio_worker_generation;
                 wxQueueEvent(GUI::wxGetApp().plater(), evt);
                 number_of_seconds_till_next_attempt = number_of_attempts * 5;
             }
@@ -2317,13 +3002,20 @@ void HelioBackgroundProcess::save_downloaded_gcode_and_load_preview(std::string 
                                                                                            .str());
             status.is_helio = true;
             Slic3r::SlicingStatusEvent*      evt    = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
+            evt->generation = helio_worker_generation;
             wxQueueEvent(GUI::wxGetApp().plater(), evt);
         }
-            boost::this_thread::sleep_for(boost::chrono::seconds(1));
+            if (!helio_sleep_for_retry_or_cancel(1, [this]() { return was_canceled(); })) {
+                break;
+            }
             number_of_seconds_till_next_attempt--;
     }
 
-    if (response_error.empty() && !was_canceled()) {
+    if (was_canceled() || !is_action_current(action_generation)) {
+        return;
+    }
+
+    if (response_error.empty()) {
         wxFile file(wxString::FromUTF8(helio_gcode_path), wxFile::write);
         if (file.IsOpened()) {
             file.Write(downloaded_gcode.data(), downloaded_gcode.size());
@@ -2333,6 +3025,7 @@ void HelioBackgroundProcess::save_downloaded_gcode_and_load_preview(std::string 
         Slic3r::PrintBase::SlicingStatus status = Slic3r::PrintBase::SlicingStatus(100, _u8L("Helio: GCode downloaded successfully"));
         status.is_helio = true;
         Slic3r::SlicingStatusEvent*      evt    = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, status);
+        evt->generation = helio_worker_generation;
         wxQueueEvent(GUI::wxGetApp().plater(), evt);
         HelioBackgroundProcess::load_helio_file_to_viwer(helio_gcode_path, tmp_path, rating_data);
     } else {
@@ -2352,12 +3045,16 @@ void HelioBackgroundProcess::save_downloaded_gcode_and_load_preview(std::string 
 
         Slic3r::HelioCompletionEvent* evt =
             new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "", false, error);
+        evt->generation = helio_worker_generation;
         wxQueueEvent(GUI::wxGetApp().plater(), evt);
     }
 }
 
 void HelioBackgroundProcess::load_helio_file_to_viwer(std::string file_path, std::string tmp_path, HelioQuery::RatingData rating_data)
 {
+    if (!is_action_current(helio_worker_generation)) {
+        return;
+    }
     const Vec3d origin = GUI::wxGetApp().plater()->get_partplate_list().get_current_plate_origin();
     auto old_result = GUI::wxGetApp().plater()->get_partplate_list().get_curr_plate()->get_gcode_result();
     // auto old_group_result = GUI::wxGetApp().plater()->get_partplate_list().get_curr_plate()->get_gcode_result()->nozzle_group_result;
@@ -2377,6 +3074,7 @@ void HelioBackgroundProcess::load_helio_file_to_viwer(std::string file_path, std
     set_state(STATE_FINISHED);
 
     Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, file_path, tmp_path, true, "", rating_data.action, rating_data.qualityMeanImprovement, rating_data.qualityStdImprovement);
+    evt->generation = helio_worker_generation;
     wxQueueEvent(GUI::wxGetApp().plater(), evt);
 }
 
@@ -2391,7 +3089,7 @@ HelioQuery::GetRecentRunsResult HelioQuery::get_recent_runs(const std::string& h
 
     // GraphQL query for both optimizations and simulations
     std::string query_body = R"({
-        "query": "query GetRecentRuns {\n  optimizations {\n    objects {\n      ... on Optimization {\n        id\n        name\n        status\n        optimizedGcodeWithThermalIndexesUrl\n        qualityMeanImprovement\n        qualityStdImprovement\n        gcode {\n          gcodeUrl\n          gcodeKey\n          material {\n            id\n            name\n          }\n          printer {\n            id\n            name\n          }\n          numberOfLayers\n          slicer\n        }\n      }\n    }\n  }\n  simulations {\n    objects {\n      ... on Simulation {\n        id\n        name\n        status\n        thermalIndexGcodeUrl\n        gcode {\n          gcodeUrl\n          gcodeKey\n          material {\n            id\n            name\n          }\n          printer {\n            id\n            name\n          }\n          numberOfLayers\n          slicer\n        }\n        printInfo {\n          printOutcome\n        }\n      }\n    }\n  }\n}",
+        "query": "query GetRecentRuns {\n  optimizations(page: 1, pageSize: 10) {\n    objects {\n      ... on Optimization {\n        id\n        name\n        status\n        optimizedGcodeWithThermalIndexesUrl\n        qualityMeanImprovement\n        qualityStdImprovement\n        gcode {\n          gcodeUrl\n          gcodeKey\n          material {\n            id\n            name\n          }\n          printer {\n            id\n            name\n          }\n          numberOfLayers\n          slicer\n        }\n      }\n    }\n  }\n  simulations(page: 1, pageSize: 10) {\n    objects {\n      ... on Simulation {\n        id\n        name\n        status\n        thermalIndexGcodeUrl\n        gcode {\n          gcodeUrl\n          gcodeKey\n          material {\n            id\n            name\n          }\n          printer {\n            id\n            name\n          }\n          numberOfLayers\n          slicer\n        }\n        printInfo {\n          printOutcome\n        }\n      }\n    }\n  }\n}",
         "variables": {}
     })";
 
@@ -2406,8 +3104,8 @@ HelioQuery::GetRecentRunsResult HelioQuery::get_recent_runs(const std::string& h
     // Create temporary vectors to avoid issues with reference capture and reallocation
     std::vector<OptimizationRun> temp_optimizations;
     std::vector<SimulationRun> temp_simulations;
-    temp_optimizations.reserve(50);  // Reserve space to avoid reallocation
-    temp_simulations.reserve(50);
+    temp_optimizations.reserve(10);
+    temp_simulations.reserve(10);
 
     bool success = false;
     std::string error_msg;
@@ -2627,20 +3325,21 @@ HelioQuery::GetRecentRunsResult HelioQuery::get_recent_runs(const std::string& h
     result.status = status_code;
 
     if (success) {
-        // Sort by timestamp descending (newest first)
-        try {
-            std::sort(temp_optimizations.begin(), temp_optimizations.end(),
-                [](const OptimizationRun& a, const OptimizationRun& b) {
-                    return a.timestamp > b.timestamp;
-                });
-
-            std::sort(temp_simulations.begin(), temp_simulations.end(),
-                [](const SimulationRun& a, const SimulationRun& b) {
-                    return a.timestamp > b.timestamp;
-                });
-        } catch (const std::exception& e) {
-            BOOST_LOG_TRIVIAL(error) << "Failed to sort recent runs: " << e.what();
-        }
+        // Sort valid timestamps newest-first; malformed or missing timestamps
+        // are deliberately placed after all valid runs.
+        const auto newest_first = [](const auto& a, const auto& b) {
+            const bool a_has_timestamp = a.timestamp != std::chrono::system_clock::time_point{};
+            const bool b_has_timestamp = b.timestamp != std::chrono::system_clock::time_point{};
+            if (a_has_timestamp != b_has_timestamp)
+                return a_has_timestamp;
+            if (a.timestamp != b.timestamp)
+                return a.timestamp > b.timestamp;
+            if (a.name != b.name)
+                return a.name < b.name;
+            return a.id < b.id;
+        };
+        std::sort(temp_optimizations.begin(), temp_optimizations.end(), newest_first);
+        std::sort(temp_simulations.begin(), temp_simulations.end(), newest_first);
 
         // Move the sorted data to result
         result.optimizations = std::move(temp_optimizations);
@@ -2656,44 +3355,61 @@ HelioQuery::GetRecentRunsResult HelioQuery::get_recent_runs(const std::string& h
 // Helper function to parse timestamp from run name
 std::chrono::system_clock::time_point HelioQuery::parse_timestamp_from_name(const std::string& name)
 {
-    try {
-        // Parse timestamp from name format: "BambuSlicer 2026-01-23T07:52:27"
-        // Extract the ISO timestamp using simple string parsing
-        size_t pos = name.find_last_of(' ');
-        if (pos != std::string::npos && pos + 1 < name.length()) {
-            std::string timestamp_str = name.substr(pos + 1);
+    constexpr size_t timestamp_length = 19;
+    const auto invalid_timestamp = std::chrono::system_clock::time_point{};
 
-            // Parse ISO 8601 format: YYYY-MM-DDTHH:MM:SS
-            if (timestamp_str.length() >= 19) {
-                std::tm tm = {};
-                tm.tm_year = std::stoi(timestamp_str.substr(0, 4)) - 1900;
-                tm.tm_mon = std::stoi(timestamp_str.substr(5, 2)) - 1;
-                tm.tm_mday = std::stoi(timestamp_str.substr(8, 2));
-                tm.tm_hour = std::stoi(timestamp_str.substr(11, 2));
-                tm.tm_min = std::stoi(timestamp_str.substr(14, 2));
-                tm.tm_sec = std::stoi(timestamp_str.substr(17, 2));
-                tm.tm_isdst = 0; // UTC has no DST
+    for (size_t pos = name.size(); pos >= timestamp_length; --pos) {
+        const size_t start = pos - timestamp_length;
+        const std::string timestamp = name.substr(start, timestamp_length);
+        if (timestamp[4] != '-' || timestamp[7] != '-' || timestamp[10] != 'T' ||
+            timestamp[13] != ':' || timestamp[16] != ':')
+            continue;
 
-                // Parse as UTC time (timestamps from API are in UTC)
-                std::time_t time;
+        const auto parse_number = [&timestamp](size_t offset) {
+            if (!std::isdigit(static_cast<unsigned char>(timestamp[offset])) ||
+                !std::isdigit(static_cast<unsigned char>(timestamp[offset + 1])))
+                return -1;
+            return (timestamp[offset] - '0') * 10 + timestamp[offset + 1] - '0';
+        };
+        if (!std::isdigit(static_cast<unsigned char>(timestamp[0])) ||
+            !std::isdigit(static_cast<unsigned char>(timestamp[1])) ||
+            !std::isdigit(static_cast<unsigned char>(timestamp[2])) ||
+            !std::isdigit(static_cast<unsigned char>(timestamp[3])))
+            continue;
+
+        const int year = (timestamp[0] - '0') * 1000 + (timestamp[1] - '0') * 100 +
+                         (timestamp[2] - '0') * 10 + timestamp[3] - '0';
+        const int month = parse_number(5);
+        const int day = parse_number(8);
+        const int hour = parse_number(11);
+        const int minute = parse_number(14);
+        const int second = parse_number(17);
+        const bool leap_year = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+        constexpr int days_in_month[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+        const int max_day = month >= 1 && month <= 12
+            ? days_in_month[month - 1] + (month == 2 && leap_year ? 1 : 0)
+            : 0;
+        if (year < 1 || month < 1 || day < 1 || day > max_day ||
+            hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 59)
+            continue;
+
+        std::tm utc = {};
+        utc.tm_year = year - 1900;
+        utc.tm_mon = month - 1;
+        utc.tm_mday = day;
+        utc.tm_hour = hour;
+        utc.tm_min = minute;
+        utc.tm_sec = second;
 #ifdef _WIN32
-                time = _mkgmtime(&tm);
+        const std::time_t parsed = _mkgmtime(&utc);
 #else
-                time = timegm(&tm);
+        const std::time_t parsed = timegm(&utc);
 #endif
-                if (time != -1) {
-                    return std::chrono::system_clock::from_time_t(time);
-                }
-            }
-        }
-    } catch (const std::exception& e) {
-        BOOST_LOG_TRIVIAL(error) << "Failed to parse timestamp from name: " << name << ", error: " << e.what();
-    } catch (...) {
-        BOOST_LOG_TRIVIAL(error) << "Failed to parse timestamp from name: " << name;
+        if (parsed != -1)
+            return std::chrono::system_clock::from_time_t(parsed);
     }
 
-    // If parsing fails, return current time
-    return std::chrono::system_clock::now();
+    return invalid_timestamp;
 }
 
 } // namespace Slic3r

--- a/src/slic3r/Utils/HelioDragon.hpp
+++ b/src/slic3r/Utils/HelioDragon.hpp
@@ -2,6 +2,7 @@
 #define slic3r_HelioDragon_hpp_
 
 #include <string>
+#include <cstdint>
 #include <wx/string.h>
 #include <boost/optional.hpp>
 #include <boost/filesystem.hpp>
@@ -10,6 +11,8 @@
 #include <boost/nowide/cstdio.hpp>
 
 #include <condition_variable>
+#include <functional>
+#include <memory>
 #include <mutex>
 #include <boost/thread.hpp>
 #include <wx/event.h>
@@ -23,6 +26,8 @@
 #include "libslic3r/GCode/GCodeProcessor.hpp"
 #include "../GUI/GUI_Preview.hpp"
 #include "../GUI/Plater.hpp"
+#include "HelioRetryPolicy.hpp"
+#include "HelioSupportData.hpp"
 #include <vector>
 
 namespace Slic3r {
@@ -42,6 +47,7 @@ class HelioQuery
 {
 public:
     using MaterialInput = HelioMaterialInput;
+    using SupportedData = HelioSupportedData;
     struct SimulationInput
     {
         float chamber_temp{ -1 };
@@ -69,7 +75,8 @@ public:
 
     struct PresignedURLResult
     {
-        unsigned    status;
+        unsigned    status{0};
+        HelioRetryKind retry_kind{HelioRetryKind::None};
         std::string key;
         std::string mimeType;
         std::string url;
@@ -79,48 +86,43 @@ public:
 
     struct UploadFileResult
     {
-        bool        success;
+        bool        success{false};
         std::string error;
         std::string trace_id;
-    };
-
-    struct SupportedData
-    {
-        std::string id;
-        std::string name;
-        std::string native_name;
-        std::string feedstock;
-        bool heated_chamber{false};
     };
 
     struct PrintPriorityOption {
         std::string value;        // Enum value: "SPEED_AND_STRENGTH"
         std::string label;        // Display text: "Speed & Strength"
-        bool isAvailable;         // Whether enabled for this material
+        bool isAvailable{true};   // Whether enabled for this material
         std::string description;  // Tooltip text
     };
 
     struct GetPrintPriorityOptionsResult {
-        bool success;
+        bool success{false};
         std::vector<PrintPriorityOption> options;
         std::string error;
-        unsigned status;
+        unsigned status{0};
         std::string trace_id;
     };
 
     struct PollResult {
         std::string status_str;
-        int progress;
-        int sizeKb;
-        bool success;
+        int progress{0};
+        int sizeKb{0};
+        bool success{false};
+        unsigned status{0};
+        HelioRetryKind retry_kind{HelioRetryKind::None};
+        std::string error;
+        std::string trace_id;
         std::vector<std::string> errors;
         std::vector<std::string> restrictions;
     };
 
     struct CreateGCodeResult
     {
-        unsigned    status;
-        bool        success;
+        unsigned    status{0};
+        bool        success{false};
         std::string name;
         std::string id;
         std::string error;
@@ -129,15 +131,15 @@ public:
         std::string trace_id;
 
         // V2 API fields
-        float       sizeKb;
+        float       sizeKb{0.0f};
         std::string status_str;
-        float       progress;
+        float       progress{0.0f};
     };
 
     struct CreateSimulationResult
     {
-        unsigned    status;
-        bool        success;
+        unsigned    status{0};
+        bool        success{false};
         std::string name;
         std::string id;
         std::string error;
@@ -149,13 +151,14 @@ public:
             name    = "";
             id      = "";
             error   = "";
+            trace_id.clear();
         };
     };
 
     struct CreateOptimizationResult
     {
-        unsigned    status;
-        bool        success;
+        unsigned    status{0};
+        bool        success{false};
         std::string name;
         std::string id;
         std::string error;
@@ -167,6 +170,7 @@ public:
             name    = "";
             id      = "";
             error   = "";
+            trace_id.clear();
         };
     };
 
@@ -202,9 +206,10 @@ public:
 
     struct CheckSimulationProgressResult
     {
-        unsigned    status;
-        bool        is_finished;
-        float       progress;
+        unsigned    status{0};
+        bool        is_finished{false};
+        HelioRetryKind retry_kind{HelioRetryKind::None};
+        float       progress{0.0f};
         std::string id;
         std::string name;
         std::string url;
@@ -215,9 +220,10 @@ public:
 
     struct CheckOptimizationResult
     {
-        unsigned    status;
-        bool        is_finished;
-        float       progress;
+        unsigned    status{0};
+        bool        is_finished{false};
+        HelioRetryKind retry_kind{HelioRetryKind::None};
+        float       progress{0.0f};
         std::string id;
         std::string name;
         std::string url;
@@ -285,8 +291,11 @@ public:
     static std::string get_helio_api_url();
     static std::string get_helio_pat();
     static void set_helio_pat(std::string pat);
-    static void request_support_machine(const std::string helio_api_url, const std::string helio_api_key, int page, int retries_left = 3);
-    static void request_support_material(const std::string helio_api_url, const std::string helio_api_key, int page, int retries_left = 3);
+    static bool request_supported_data(const std::string& helio_api_url,
+                                       const std::string& helio_api_key,
+                                       bool force_refresh = false);
+    static SupportDataCatalogPairView supported_data_view();
+    static void shutdown_background_requests();
     static void request_pat_token(std::function<void(std::string)> func);
     static void optimization_feedback(const std::string helio_api_url, const std::string helio_api_key, std::string optimization_id, float rating, std::string comment);
     static PresignedURLResult create_presigned_url(const std::string helio_api_url, const std::string helio_api_key);
@@ -301,7 +310,9 @@ public:
                                            const std::string helio_api_url,
                                            const std::string helio_api_key,
                                            const std::string printer_id,
-                                           const std::string filament_id);
+                                           const std::string filament_id,
+                                           const std::string idempotency_key = std::string(),
+                                           std::function<bool()> should_cancel = nullptr);
 
     // V3: multi-material (used when feature flag helio_multimaterial_enabled is ON)
     static CreateGCodeResult  create_gcode_v3(const std::string key,
@@ -309,23 +320,9 @@ public:
                                               const std::string helio_api_key,
                                               const std::string printer_id,
                                               const std::vector<MaterialInput>& materials,
-                                              bool isMultiColor, bool isMultiMaterial);
-
-    static void request_all_support_machine(const std::string helio_api_url, const std::string helio_api_key)
-    {
-        global_printers_fully_loaded = false;
-        global_supported_printers.clear();
-        clear_print_priority_cache();
-        request_support_machine(helio_api_url, helio_api_key, 1);
-    }
-
-    static void request_all_support_materials(const std::string helio_api_url, const std::string helio_api_key)
-    {
-        global_materials_fully_loaded = false;
-        global_supported_materials.clear();
-        clear_print_priority_cache();
-        request_support_material(helio_api_url, helio_api_key, 1);
-    }
+                                              bool isMultiColor, bool isMultiMaterial,
+                                              const std::string idempotency_key = std::string(),
+                                              std::function<bool()> should_cancel = nullptr);
 
     static void request_print_priority_options(
         const std::string& helio_api_url,
@@ -344,7 +341,10 @@ public:
     static CreateSimulationResult create_simulation(const std::string helio_api_url,
                                                     const std::string helio_api_key,
                                                     const std::string gcode_id,
-                                                    SimulationInput sinput);
+                                                    SimulationInput sinput,
+                                                    const std::string job_name = std::string(),
+                                                    const std::string idempotency_key = std::string(),
+                                                    std::function<bool()> should_cancel = nullptr);
 
     static void stop_simulation(const std::string helio_api_url,
                                                   const std::string helio_api_key,
@@ -359,7 +359,10 @@ public:
     static CreateOptimizationResult create_optimization(const std::string helio_api_url,
                                                         const std::string helio_api_key,
                                                         const std::string gcode_id,
-                                                        OptimizationInput oinput);
+                                                        OptimizationInput oinput,
+                                                        const std::string job_name = std::string(),
+                                                        const std::string idempotency_key = std::string(),
+                                                        std::function<bool()> should_cancel = nullptr);
 
     static void stop_optimization(const std::string helio_api_url,
                                             const std::string helio_api_key,
@@ -377,7 +380,8 @@ public:
     static std::string generate_simulation_graphql_query(const std::string& gcode_id, 
                                                          float temperatureStabilizationHeight = -1, 
                                                          float airTemperatureAboveBuildPlate = -1,
-                                                         float stabilizedAirTemperature = -1);
+                                                         float stabilizedAirTemperature = -1,
+                                                         const std::string& job_name = std::string());
 
     static std::string generate_optimization_graphql_query(const std::string& gcode_id,
                                                            const std::string& printPriority,
@@ -391,7 +395,8 @@ public:
                                                            double minExtruderFlowRate = -1,
                                                            double maxExtruderFlowRate = -1,
                                                            int layersToOptimizeStart = -1,
-                                                           int layersToOptimizeEnd = -1);
+                                                           int layersToOptimizeEnd = -1,
+                                                           const std::string& job_name = std::string());
     static std::string generateTimestampedString()
     {
         // Get the current UTC time
@@ -404,10 +409,6 @@ public:
         return "BambuSlicer " + iso_datetime;
     }
 
-    static std::vector<SupportedData> global_supported_printers;
-    static std::vector<SupportedData> global_supported_materials;
-    static bool global_printers_fully_loaded;
-    static bool global_materials_fully_loaded;
     static std::map<std::string, std::vector<PrintPriorityOption>> global_print_priority_cache;
     static std::string last_simulation_trace_id;
     static std::string last_optimization_trace_id;
@@ -464,8 +465,9 @@ public:
     };
 
 private:
-    State m_state;
-
+    State         m_state { STATE_INITIAL };
+    std::uint64_t m_action_generation { 0 };
+    bool          m_worker_completed { true };
 public:
     std::mutex              m_mutex;
     std::condition_variable m_condition;
@@ -482,7 +484,7 @@ public:
     bool                    is_multi_material{false};
     bool                    use_v3{false}; // true when V3 multi-material path is active
 
-    int                     action; //0-simulation 1-optimization
+    int                     action{-1}; // 0=simulation, 1=optimization
 
     /*task data*/
     HelioQuery::CreateSimulationResult current_simulation_result;
@@ -535,12 +537,7 @@ public:
         optimization_input_data = data;
     }
 
-    void stop()
-    {
-        m_mutex.lock();
-        m_state = STATE_CANCELED;
-        m_mutex.unlock();
-    }
+    void stop();
 
     bool is_running()
     {
@@ -551,20 +548,11 @@ public:
         return running_state;
     }
 
-    bool was_canceled()
-    {
-        m_mutex.lock();
-        bool canceled_state = (m_state == STATE_CANCELED);
-        m_mutex.unlock();
-        return canceled_state;
-    }
+    bool was_canceled();
+    bool is_action_current(std::uint64_t generation);
 
-    void set_state(State state)
-    {
-        m_mutex.lock();
-        m_state = state;
-        m_mutex.unlock();
-    }
+
+    void set_state(State state);
 
     State get_state()
     {
@@ -584,23 +572,25 @@ public:
                                       BackgroundSlicingProcess::State&           slicing_state,
                                       std::unique_ptr<GUI::NotificationManager>& notification_manager);
 
-    void helio_thread_start(std::mutex&                                slicing_mutex,
+    bool helio_thread_start(std::mutex&                                slicing_mutex,
                             std::condition_variable&                   slicing_condition,
                             BackgroundSlicingProcess::State&           slicing_state,
                             std::unique_ptr<GUI::NotificationManager>& notification_manager);
 
-    HelioBackgroundProcess() {}
+    // Invalidates the prior action and reaps it only after it has completed.
+    // Returns false immediately while a previous worker is still stopping.
+    bool begin_action();
 
     ~HelioBackgroundProcess()
     {
-        m_gcode_result = nullptr;
-        if (m_thread.joinable()) {
+        stop();
+        if (m_thread.joinable())
             m_thread.join();
-        }
+        m_gcode_result = nullptr;
     }
 
     // V2 init: single filament_id (used when feature flag is OFF)
-    void init(std::string                   api_key,
+    bool init(std::string                   api_key,
               std::string                   api_url,
               std::string                   printer_id,
               std::string                   filament_id,
@@ -608,7 +598,8 @@ public:
               Slic3r::GUI::Preview*         preview,
               std::function<void()>         function)
     {
-        m_state = STATE_STARTED;
+        if (!begin_action())
+            return false;
         m_gcode_processor.reset();
         helio_origin_key  = api_key;
         helio_api_key     = "Bearer " + api_key;
@@ -622,10 +613,11 @@ public:
         m_gcode_result    = gcode_result;
         m_preview         = preview;
         m_update_function = function;
+        return true;
     }
 
     // V3 init: multi-material (used when feature flag is ON)
-    void init(std::string                   api_key,
+    bool init(std::string                   api_key,
               std::string                   api_url,
               std::string                   printer_id,
               const std::vector<HelioQuery::MaterialInput>& materials,
@@ -635,7 +627,8 @@ public:
               Slic3r::GUI::Preview*         preview,
               std::function<void()>         function)
     {
-        m_state = STATE_STARTED;
+        if (!begin_action())
+            return false;
         m_gcode_processor.reset();
         helio_origin_key       = api_key;
         helio_api_key          = "Bearer " + api_key;
@@ -649,18 +642,29 @@ public:
         m_gcode_result         = gcode_result;
         m_preview              = preview;
         m_update_function      = function;
+        return true;
     }
+
 
     void reset()
     {
-        m_state = STATE_INITIAL;
+        stop();
+        boost::thread completed_thread;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (m_thread.joinable() && m_worker_completed)
+                completed_thread.swap(m_thread);
+            else if (m_thread.joinable())
+                return;
+        }
+        if (completed_thread.joinable())
+            completed_thread.join();
         m_gcode_processor.reset();
         m_gcode_result = nullptr;
     }
-
     void set_helio_api_key(std::string api_key);
     void set_gcode_result(Slic3r::GCodeProcessorResult* gcode_result);
-    void create_simulation_step(HelioQuery::CreateGCodeResult create_gcode_res,std::unique_ptr<GUI::NotificationManager>& notification_manager);
+    void create_simulation_step(HelioQuery::CreateGCodeResult create_gcode_res, std::unique_ptr<GUI::NotificationManager>& notification_manager);
     void create_optimization_step(HelioQuery::CreateGCodeResult create_gcode_res, std::unique_ptr<GUI::NotificationManager>& notification_manager);
     void save_downloaded_gcode_and_load_preview(std::string                                file_download_url,
                                                 std::string                                helio_gcode_path,

--- a/src/slic3r/Utils/HelioRetryPolicy.cpp
+++ b/src/slic3r/Utils/HelioRetryPolicy.cpp
@@ -1,0 +1,212 @@
+#include "HelioRetryPolicy.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+namespace Slic3r {
+
+namespace {
+
+constexpr const char HELIO_FAILED_TO_DESERIALIZE_SUBGRAPH_RESPONSE[] =
+    "failed to deserialize subgraph response";
+
+std::string helio_lower_copy(const std::string& value)
+{
+    std::string lowered;
+    lowered.reserve(value.size());
+    for (unsigned char c : value) {
+        lowered += static_cast<char>(std::tolower(c));
+    }
+    return lowered;
+}
+
+bool helio_error_object_has_exact_backend_auth_error(const nlohmann::json& error)
+{
+    return error.is_object() && error.contains("message") && error["message"].is_string() &&
+           error["message"].get<std::string>() == HELIO_BACKEND_AUTH_401_MESSAGE;
+}
+
+bool helio_error_object_has_message(const nlohmann::json& error)
+{
+    return error.is_object() && error.contains("message") && error["message"].is_string();
+}
+
+bool helio_graphql_errors_have_transient_message(const nlohmann::json& errors)
+{
+    const auto has_transient_message = [](const nlohmann::json& error) {
+        return error.is_object() && error.contains("message") && error["message"].is_string() &&
+               helio_is_transient_error_message(error["message"].get<std::string>());
+    };
+
+    if (errors.is_array()) {
+        return std::any_of(errors.begin(), errors.end(), has_transient_message);
+    }
+    return has_transient_message(errors);
+}
+
+} // namespace
+
+bool helio_is_terminal_http_status(unsigned status) noexcept
+{
+    return status == 401 || status == 403 || status == 404;
+}
+
+bool helio_is_transient_http_status(unsigned status) noexcept
+{
+    return status == 0 || status == 408 || status == 425 || status == 429 || status >= 500;
+}
+
+bool helio_is_transient_error_message(const std::string& message)
+{
+    const std::string lower = helio_lower_copy(message);
+    if (lower == HELIO_FAILED_TO_DESERIALIZE_SUBGRAPH_RESPONSE) {
+        return true;
+    }
+
+    static const std::vector<std::string> transient_markers = {
+        "temporar",
+        "timeout",
+        "timed out",
+        "try again",
+        "rate limit",
+        "too many requests",
+        "network",
+        "connection",
+        "disconnect",
+        "reset by peer",
+        "econn",
+        "unavailable",
+        "gateway",
+        "service unavailable",
+        "internal server",
+        "deadline",
+        "overloaded"
+    };
+
+    return std::any_of(transient_markers.begin(), transient_markers.end(), [&lower](const std::string& marker) {
+        return lower.find(marker) != std::string::npos;
+    });
+}
+
+bool helio_has_graphql_errors(const nlohmann::json& response)
+{
+    if (!response.is_object() || !response.contains("errors")) {
+        return false;
+    }
+
+    const nlohmann::json& errors = response["errors"];
+    if (errors.is_array()) {
+        return std::any_of(errors.begin(), errors.end(), helio_error_object_has_message);
+    }
+    return helio_error_object_has_message(errors);
+}
+
+bool helio_has_exact_backend_auth_error(const nlohmann::json& response)
+{
+    if (!helio_has_graphql_errors(response)) {
+        return false;
+    }
+
+    const nlohmann::json& errors = response["errors"];
+    if (errors.is_array()) {
+        return std::any_of(errors.begin(), errors.end(), helio_error_object_has_exact_backend_auth_error);
+    }
+    return helio_error_object_has_exact_backend_auth_error(errors);
+}
+
+HelioRetryKind helio_classify_graphql_response(unsigned status, const nlohmann::json& response)
+{
+    if (status != 200 || !response.is_object() || !response.contains("errors")) {
+        return HelioRetryKind::None;
+    }
+
+    if (!helio_has_graphql_errors(response)) {
+        return HelioRetryKind::Transient;
+    }
+
+    if (helio_has_exact_backend_auth_error(response)) {
+        return HelioRetryKind::BackendAuth;
+    }
+
+    return helio_graphql_errors_have_transient_message(response["errors"]) ? HelioRetryKind::Transient :
+                                                                             HelioRetryKind::None;
+}
+
+HelioRetryKind helio_classify_graphql_response(unsigned status, const std::string& body)
+{
+    if (helio_is_terminal_http_status(status) || status != 200) {
+        return HelioRetryKind::None;
+    }
+
+    try {
+        return helio_classify_graphql_response(status, nlohmann::json::parse(body));
+    } catch (...) {
+        return HelioRetryKind::None;
+    }
+}
+
+HelioRetryKind helio_classify_retry(unsigned status,
+                                    const std::string& body,
+                                    const std::string& transport_error)
+{
+    if (helio_is_terminal_http_status(status)) {
+        return HelioRetryKind::None;
+    }
+    if (status == 200) {
+        return helio_classify_graphql_response(status, body);
+    }
+    if (helio_is_transient_http_status(status)) {
+        return HelioRetryKind::Transient;
+    }
+
+    // A completed non-transient HTTP status remains terminal even if its body
+    // happens to contain words such as "temporary" or the nested auth text.
+    (void) body;
+    (void) transport_error;
+    return HelioRetryKind::None;
+}
+
+const char* helio_retry_kind_name(HelioRetryKind kind) noexcept
+{
+    switch (kind) {
+    case HelioRetryKind::None:        return "none";
+    case HelioRetryKind::Transient:   return "transient";
+    case HelioRetryKind::BackendAuth: return "backend-auth";
+    }
+    return "unknown";
+}
+
+HelioRetryController::HelioRetryController(unsigned max_consecutive_backend_auth_retries) noexcept
+    : m_max_consecutive_backend_auth_retries(max_consecutive_backend_auth_retries)
+{}
+
+bool HelioRetryController::should_retry(HelioRetryKind kind) noexcept
+{
+    if (kind == HelioRetryKind::BackendAuth) {
+        ++m_consecutive_backend_auth_failures;
+        return m_consecutive_backend_auth_failures <= m_max_consecutive_backend_auth_retries;
+    }
+
+    m_consecutive_backend_auth_failures = 0;
+    return kind == HelioRetryKind::Transient;
+}
+
+void HelioRetryController::reset() noexcept
+{
+    m_consecutive_backend_auth_failures = 0;
+}
+
+unsigned HelioRetryController::consecutive_backend_auth_failures() const noexcept
+{
+    return m_consecutive_backend_auth_failures;
+}
+
+unsigned HelioRetryController::max_consecutive_backend_auth_retries() const noexcept
+{
+    return m_max_consecutive_backend_auth_retries;
+}
+
+} // namespace Slic3r

--- a/src/slic3r/Utils/HelioRetryPolicy.hpp
+++ b/src/slic3r/Utils/HelioRetryPolicy.hpp
@@ -1,0 +1,75 @@
+#ifndef slic3r_HelioRetryPolicy_hpp_
+#define slic3r_HelioRetryPolicy_hpp_
+
+#include <string>
+
+#include "nlohmann/json_fwd.hpp"
+
+namespace Slic3r {
+
+enum class HelioRetryKind
+{
+    None,
+    Transient,
+    BackendAuth
+};
+
+inline constexpr const char HELIO_BACKEND_AUTH_401_MESSAGE[] =
+    "Authentication failed: Auth service returned status 401";
+
+bool helio_is_terminal_http_status(unsigned status) noexcept;
+bool helio_is_transient_http_status(unsigned status) noexcept;
+bool helio_is_transient_error_message(const std::string& message);
+
+// GraphQL errors are usable only when at least one entry contains a string
+// message. Empty, null, or structurally invalid errors members are malformed
+// HTTP-200 responses and must fall through to transient handling.
+bool helio_has_graphql_errors(const nlohmann::json& response);
+
+// The backend-auth condition is deliberately narrow: it is recognized only
+// when an HTTP 200 GraphQL response contains an errors[].message (or an
+// errors.message object) equal to HELIO_BACKEND_AUTH_401_MESSAGE.
+bool helio_has_exact_backend_auth_error(const nlohmann::json& response);
+
+// Classifies a parsed HTTP 200 GraphQL response. A response without GraphQL
+// errors has no retry classification. Unrecognized GraphQL errors are terminal
+// unless one of their messages has an ordinary transient marker.
+HelioRetryKind helio_classify_graphql_response(unsigned status, const nlohmann::json& response);
+
+// Parses and classifies a GraphQL response body. Invalid JSON is terminal, while
+// a parsed HTTP 200 response with a malformed errors member is transient. Actual
+// HTTP authentication/authorization/not-found statuses are terminal.
+HelioRetryKind helio_classify_graphql_response(unsigned status, const std::string& body);
+
+// Classifies a completed HTTP or transport failure. Only status 0,
+// 408/425/429, and 5xx responses are ordinary transients. HTTP 200 delegates
+// to GraphQL classification. Other HTTP statuses are terminal.
+HelioRetryKind helio_classify_retry(unsigned status,
+                                    const std::string& body = std::string(),
+                                    const std::string& transport_error = std::string());
+
+const char* helio_retry_kind_name(HelioRetryKind kind) noexcept;
+
+// Tracks the special one-retry policy for consecutive backend-auth failures.
+// Call should_retry exactly once per response. Ordinary transient failures are
+// retryable but break the backend-auth streak; total attempt limits remain the
+// responsibility of the caller.
+class HelioRetryController
+{
+public:
+    explicit HelioRetryController(unsigned max_consecutive_backend_auth_retries = 1) noexcept;
+
+    bool should_retry(HelioRetryKind kind) noexcept;
+    void reset() noexcept;
+
+    unsigned consecutive_backend_auth_failures() const noexcept;
+    unsigned max_consecutive_backend_auth_retries() const noexcept;
+
+private:
+    unsigned m_consecutive_backend_auth_failures{0};
+    unsigned m_max_consecutive_backend_auth_retries{1};
+};
+
+} // namespace Slic3r
+
+#endif // slic3r_HelioRetryPolicy_hpp_

--- a/src/slic3r/Utils/HelioSupportData.cpp
+++ b/src/slic3r/Utils/HelioSupportData.cpp
@@ -1,0 +1,551 @@
+#include "HelioSupportData.hpp"
+
+#include "nlohmann/json.hpp"
+
+#include <exception>
+#include <iterator>
+#include <sstream>
+#include <utility>
+
+namespace Slic3r {
+
+namespace {
+
+using json = nlohmann::json;
+
+std::string catalog_name(SupportDataCatalogKind kind)
+{
+    return kind == SupportDataCatalogKind::Printers ? "printers" : "materials";
+}
+
+std::string http_error(const SupportDataHttpResponse& response)
+{
+    if (!response.error.empty()) {
+        return response.error;
+    }
+
+    std::ostringstream message;
+    message << "HTTP status: " << response.status;
+    if (!response.body.empty()) {
+        message << ", body: " << response.body;
+    }
+    return message.str();
+}
+
+std::string graphql_error(const json& response)
+{
+    if (!response.contains("errors")) {
+        return {};
+    }
+
+    const json& errors = response["errors"];
+    std::ostringstream message;
+
+    if (errors.is_array()) {
+        bool first = true;
+        for (const json& error : errors) {
+            if (!error.is_object() || !error.contains("message") || !error["message"].is_string()) {
+                continue;
+            }
+            if (!first) {
+                message << '\n';
+            }
+            message << error["message"].get<std::string>();
+            first = false;
+        }
+    } else if (errors.is_object() && errors.contains("message") && errors["message"].is_string()) {
+        message << errors["message"].get<std::string>();
+    }
+
+    const std::string result = message.str();
+    return result.empty() ? errors.dump() : result;
+}
+
+SupportDataPageResult failed_page(const SupportDataHttpResponse& response,
+                                  HelioRetryKind                 retry_kind,
+                                  std::string                    error)
+{
+    SupportDataPageResult result;
+    result.status     = response.status;
+    result.retry_kind = retry_kind;
+    result.error      = std::move(error);
+    result.trace_id   = response.trace_id;
+    return result;
+}
+
+SupportDataPageResult incomplete_page(const SupportDataHttpResponse& response, std::string error)
+{
+    return failed_page(response, HelioRetryKind::Transient, std::move(error));
+}
+
+bool required_string(const json& object, const char* key, std::string& value)
+{
+    if (!object.contains(key) || !object[key].is_string()) {
+        return false;
+    }
+    value = object[key].get<std::string>();
+    return !value.empty();
+}
+
+void log_attempt(const SupportDataCatalogStore::Logger& logger, const SupportDataLoadAttempt& attempt) noexcept
+{
+    if (!logger) {
+        return;
+    }
+    try {
+        logger(attempt);
+    } catch (...) {
+        // Diagnostics must not affect catalog publication or retry behavior.
+    }
+}
+
+} // namespace
+
+SupportDataPageResult parse_support_data_page(SupportDataCatalogKind        kind,
+                                              int                           page,
+                                              const SupportDataHttpResponse& response)
+{
+    const HelioRetryKind response_retry_kind = helio_classify_retry(response.status, response.body, response.error);
+
+    if (response.status != 200) {
+        return failed_page(response, response_retry_kind, http_error(response));
+    }
+
+    json parsed;
+    try {
+        parsed = json::parse(response.body);
+    } catch (const std::exception& e) {
+        return failed_page(response,
+                           response_retry_kind,
+                           std::string("Malformed Helio support-data response: ") + e.what());
+    } catch (...) {
+        return failed_page(response, response_retry_kind, "Malformed Helio support-data response");
+    }
+
+    if (helio_has_graphql_errors(parsed)) {
+        return failed_page(response, response_retry_kind, graphql_error(parsed));
+    }
+
+    const std::string payload_name = catalog_name(kind);
+    if (!parsed.contains("data") || !parsed["data"].is_object() ||
+        !parsed["data"].contains(payload_name) || !parsed["data"][payload_name].is_object()) {
+        return incomplete_page(response, "Helio support-data response is missing data payload: " + payload_name);
+    }
+
+    const json& payload = parsed["data"][payload_name];
+    if (!payload.contains("pages") || !payload["pages"].is_number_integer() ||
+        !payload.contains("pageInfo") || !payload["pageInfo"].is_object() ||
+        !payload["pageInfo"].contains("hasNextPage") || !payload["pageInfo"]["hasNextPage"].is_boolean() ||
+        !payload.contains("objects") || !payload["objects"].is_array()) {
+        return incomplete_page(response, "Helio " + payload_name + " page metadata is incomplete");
+    }
+
+    int  total_pages = 0;
+    bool has_next_page = false;
+    try {
+        total_pages   = payload["pages"].get<int>();
+        has_next_page = payload["pageInfo"]["hasNextPage"].get<bool>();
+    } catch (const std::exception& e) {
+        return incomplete_page(response, std::string("Helio ") + payload_name + " pagination metadata is invalid: " + e.what());
+    } catch (...) {
+        return incomplete_page(response, "Helio " + payload_name + " pagination metadata is invalid");
+    }
+    const json& objects = payload["objects"];
+
+    if (page < 1 || total_pages < 1 || page > total_pages || objects.empty()) {
+        return incomplete_page(response, "Helio " + payload_name + " page is empty or out of range");
+    }
+    if ((has_next_page && page >= total_pages) || (!has_next_page && page < total_pages)) {
+        return incomplete_page(response, "Helio " + payload_name + " pagination metadata is inconsistent");
+    }
+
+    SupportDataPageResult result;
+    result.status        = response.status;
+    result.trace_id      = response.trace_id;
+    result.total_pages   = total_pages;
+    result.has_next_page = has_next_page;
+
+    try {
+        for (const json& object : objects) {
+            if (!object.is_object()) {
+                return incomplete_page(response, "Helio " + payload_name + " page contains an invalid object");
+            }
+
+            HelioSupportedData item;
+            if (!required_string(object, "id", item.id) || !required_string(object, "name", item.name)) {
+                return incomplete_page(response, "Helio " + payload_name + " page contains an incomplete object");
+            }
+
+            if (kind == SupportDataCatalogKind::Printers) {
+                if (object.contains("heatedChamber")) {
+                    if (!object["heatedChamber"].is_boolean()) {
+                        return incomplete_page(response, "Helio printers page contains an invalid heatedChamber value");
+                    }
+                    item.heated_chamber = object["heatedChamber"].get<bool>();
+                }
+            } else {
+                if (!required_string(object, "feedstock", item.feedstock)) {
+                    return incomplete_page(response, "Helio materials page contains an incomplete feedstock value");
+                }
+            }
+
+            if (object.contains("alternativeNames") && !object["alternativeNames"].is_null()) {
+                if (!object["alternativeNames"].is_object()) {
+                    return incomplete_page(response, "Helio " + payload_name + " page contains invalid alternativeNames");
+                }
+                const json& alternative_names = object["alternativeNames"];
+                if (alternative_names.contains("bambustudio") && !alternative_names["bambustudio"].is_null()) {
+                    if (!alternative_names["bambustudio"].is_string()) {
+                        return incomplete_page(response, "Helio " + payload_name + " page contains an invalid Bambu Studio name");
+                    }
+                    item.native_name = alternative_names["bambustudio"].get<std::string>();
+                }
+            }
+
+            if (kind == SupportDataCatalogKind::Materials && item.native_name.empty()) {
+                item.native_name = item.name;
+            }
+
+            if (kind == SupportDataCatalogKind::Printers || item.feedstock == "FILAMENT") {
+                result.items.push_back(std::move(item));
+            }
+        }
+    } catch (const std::exception& e) {
+        return incomplete_page(response, std::string("Failed to parse Helio ") + payload_name + " page: " + e.what());
+    } catch (...) {
+        return incomplete_page(response, "Failed to parse Helio " + payload_name + " page");
+    }
+
+    result.success    = true;
+    result.retry_kind = HelioRetryKind::None;
+    return result;
+}
+
+SupportDataAvailability support_data_availability(const SupportDataCatalogView& printers,
+                                                  const SupportDataCatalogView& materials) noexcept
+{
+    if (printers.has_usable_snapshot() && materials.has_usable_snapshot()) {
+        return SupportDataAvailability::Usable;
+    }
+
+    if ((!printers.has_usable_snapshot() && printers.state == SupportDataLoadState::Failed) ||
+        (!materials.has_usable_snapshot() && materials.state == SupportDataLoadState::Failed)) {
+        return SupportDataAvailability::LoadFailed;
+    }
+
+    if ((!printers.has_usable_snapshot() &&
+         (printers.state == SupportDataLoadState::NotLoaded || printers.state == SupportDataLoadState::Loading)) ||
+        (!materials.has_usable_snapshot() &&
+         (materials.state == SupportDataLoadState::NotLoaded || materials.state == SupportDataLoadState::Loading))) {
+        return SupportDataAvailability::Synchronizing;
+    }
+
+    // Ready without a non-empty snapshot violates the store invariant and must
+    // not be interpreted as a genuine unsupported printer/material catalog.
+    return SupportDataAvailability::LoadFailed;
+}
+
+SupportDataCatalogStore::SupportDataCatalogStore(SupportDataCatalogKind kind)
+    : m_kind(kind)
+{}
+
+bool SupportDataCatalogStore::try_begin(bool force_refresh)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_state == SupportDataLoadState::Loading) {
+        return false;
+    }
+    if (m_snapshot && !force_refresh) {
+        return false;
+    }
+    if (m_state == SupportDataLoadState::Ready && !force_refresh) {
+        return false;
+    }
+
+    m_state       = SupportDataLoadState::Loading;
+    m_last_error.clear();
+    m_run_claimed = false;
+    return true;
+}
+
+bool SupportDataCatalogStore::claim_run()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_state != SupportDataLoadState::Loading || m_run_claimed) {
+        return false;
+    }
+    m_run_claimed = true;
+    return true;
+}
+
+bool SupportDataCatalogStore::run(const PageFetcher&   fetcher,
+                                  const RetrySleeper& sleeper,
+                                  const Logger&       logger)
+{
+    if (!claim_run()) {
+        return false;
+    }
+
+    try {
+        return run_impl(fetcher, sleeper, logger);
+    } catch (const std::exception& e) {
+        fail(std::string("Helio support-data load failed: ") + e.what());
+    } catch (...) {
+        fail("Helio support-data load failed");
+    }
+    return false;
+}
+
+bool SupportDataCatalogStore::run_impl(const PageFetcher&   fetcher,
+                                       const RetrySleeper& sleeper,
+                                       const Logger&       logger)
+{
+    if (!fetcher) {
+        fail("No Helio support-data page fetcher was provided");
+        return false;
+    }
+
+    std::vector<HelioSupportedData> staging;
+    int                             page = 1;
+    int                             expected_total_pages = 0;
+
+    while (true) {
+        SupportDataPageResult page_result;
+        bool                  page_loaded = false;
+        HelioRetryController  retry_controller;
+
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS_PER_PAGE; ++attempt) {
+            SupportDataHttpResponse response;
+            try {
+                response = fetcher(m_kind, page);
+            } catch (const std::exception& e) {
+                response.error = std::string("Helio support-data fetch failed: ") + e.what();
+            } catch (...) {
+                response.error = "Helio support-data fetch failed";
+            }
+
+            page_result = parse_support_data_page(m_kind, page, response);
+            if (page_result.success && expected_total_pages != 0 &&
+                page_result.total_pages != expected_total_pages) {
+                page_result.success = false;
+                page_result.retry_kind = HelioRetryKind::Transient;
+                page_result.error = "Helio support-data total page count changed during pagination";
+            }
+            if (page_result.success) {
+                page_loaded = true;
+                break;
+            }
+
+            const bool will_retry = attempt < MAX_ATTEMPTS_PER_PAGE &&
+                                    retry_controller.should_retry(page_result.retry_kind);
+            SupportDataLoadAttempt log_entry;
+            log_entry.kind         = m_kind;
+            log_entry.page         = page;
+            log_entry.attempt      = attempt;
+            log_entry.max_attempts = MAX_ATTEMPTS_PER_PAGE;
+            log_entry.status       = page_result.status;
+            log_entry.retry_kind   = page_result.retry_kind;
+            log_entry.will_retry   = will_retry;
+            log_entry.error        = page_result.error;
+            log_entry.trace_id     = page_result.trace_id;
+            log_attempt(logger, log_entry);
+
+            if (!will_retry) {
+                break;
+            }
+
+            if (sleeper) {
+                try {
+                    sleeper(attempt * 2);
+                } catch (const std::exception& e) {
+                    page_result.error = std::string("Helio support-data retry wait failed: ") + e.what();
+                    break;
+                } catch (...) {
+                    page_result.error = "Helio support-data retry wait failed";
+                    break;
+                }
+            }
+        }
+
+        if (!page_loaded) {
+            fail(page_result.error.empty() ? "Helio support-data request failed" : std::move(page_result.error));
+            return false;
+        }
+
+        if (expected_total_pages == 0) {
+            expected_total_pages = page_result.total_pages;
+        }
+        staging.insert(staging.end(),
+                       std::make_move_iterator(page_result.items.begin()),
+                       std::make_move_iterator(page_result.items.end()));
+
+        if (!page_result.has_next_page) {
+            break;
+        }
+        ++page;
+    }
+
+    if (staging.empty()) {
+        fail("Helio support-data response contained no supported entries");
+        return false;
+    }
+
+    publish(std::move(staging));
+    return true;
+}
+
+void SupportDataCatalogStore::publish(std::vector<HelioSupportedData>&& complete_snapshot)
+{
+    auto snapshot = std::make_shared<const std::vector<HelioSupportedData>>(std::move(complete_snapshot));
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_snapshot    = std::move(snapshot);
+    m_state       = SupportDataLoadState::Ready;
+    m_last_error.clear();
+    m_run_claimed = false;
+}
+
+void SupportDataCatalogStore::fail(std::string error)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_state       = SupportDataLoadState::Failed;
+    m_last_error  = std::move(error);
+    m_run_claimed = false;
+}
+
+SupportDataLoadState SupportDataCatalogStore::state() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_state;
+}
+
+SupportDataCatalogStore::Snapshot SupportDataCatalogStore::snapshot() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_snapshot;
+}
+
+std::string SupportDataCatalogStore::last_error() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_last_error;
+}
+
+bool SupportDataCatalogStore::has_usable_snapshot() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_snapshot && !m_snapshot->empty();
+}
+
+SupportDataCatalogView SupportDataCatalogStore::view() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return {m_state, m_snapshot, m_last_error};
+}
+
+
+bool SupportDataCatalogPairCoordinator::try_begin(const std::string& api_url,
+                                                   const std::string& api_key,
+                                                   bool force_refresh,
+                                                   std::uint64_t* generation)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    const bool same_source = api_url == m_api_url && api_key == m_api_key;
+    if (m_loading && same_source)
+        return false;
+    if (same_source && m_view.availability == SupportDataAvailability::Usable && !force_refresh)
+        return false;
+
+    ++m_generation;
+    m_api_url = api_url;
+    m_api_key = api_key;
+    m_loading = true;
+    m_view.source_generation = m_generation;
+    m_view.printers_state = SupportDataLoadState::Loading;
+    m_view.materials_state = SupportDataLoadState::Loading;
+    m_view.printers_last_error.clear();
+    m_view.materials_last_error.clear();
+    if (!same_source) {
+        m_view.printers.reset();
+        m_view.materials.reset();
+    }
+    m_view.availability = support_data_availability(
+        {m_view.printers_state, m_view.printers, m_view.printers_last_error},
+        {m_view.materials_state, m_view.materials, m_view.materials_last_error});
+    if (generation != nullptr)
+        *generation = m_generation;
+    return true;
+}
+
+bool SupportDataCatalogPairCoordinator::is_active_locked(std::uint64_t generation) const noexcept
+{
+    return m_loading && generation == m_generation;
+}
+
+void SupportDataCatalogPairCoordinator::fail_active(std::uint64_t generation, std::string error)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (!is_active_locked(generation))
+        return;
+    m_loading = false;
+    m_view.printers_state = SupportDataLoadState::Failed;
+    m_view.materials_state = SupportDataLoadState::Failed;
+    m_view.printers_last_error = error;
+    m_view.materials_last_error = std::move(error);
+    m_view.availability = support_data_availability(
+        {m_view.printers_state, m_view.printers, m_view.printers_last_error},
+        {m_view.materials_state, m_view.materials, m_view.materials_last_error});
+}
+
+bool SupportDataCatalogPairCoordinator::run(std::uint64_t generation, const PageFetcher& fetcher,
+                                            const RetrySleeper& sleeper, const Logger& logger)
+{
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (!is_active_locked(generation))
+            return false;
+    }
+
+    SupportDataCatalogStore printers(SupportDataCatalogKind::Printers);
+    SupportDataCatalogStore materials(SupportDataCatalogKind::Materials);
+    printers.try_begin();
+    const bool printers_loaded = printers.run(fetcher, sleeper, logger);
+    if (!printers_loaded) {
+        fail_active(generation, printers.last_error());
+        return false;
+    }
+    materials.try_begin();
+    const bool materials_loaded = materials.run(fetcher, sleeper, logger);
+    if (!materials_loaded) {
+        fail_active(generation, materials.last_error());
+        return false;
+    }
+
+    const auto printer_snapshot = printers.snapshot();
+    const auto material_snapshot = materials.snapshot();
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (!is_active_locked(generation))
+        return false;
+    m_loading = false;
+    m_view.printers = printer_snapshot;
+    m_view.materials = material_snapshot;
+    m_view.printers_state = SupportDataLoadState::Ready;
+    m_view.materials_state = SupportDataLoadState::Ready;
+    m_view.printers_last_error.clear();
+    m_view.materials_last_error.clear();
+    m_view.availability = SupportDataAvailability::Usable;
+    return true;
+}
+
+SupportDataCatalogPairView SupportDataCatalogPairCoordinator::view() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_view;
+}
+
+std::uint64_t SupportDataCatalogPairCoordinator::active_generation() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_generation;
+}
+} // namespace Slic3r

--- a/src/slic3r/Utils/HelioSupportData.hpp
+++ b/src/slic3r/Utils/HelioSupportData.hpp
@@ -1,0 +1,190 @@
+#ifndef slic3r_HelioSupportData_hpp_
+#define slic3r_HelioSupportData_hpp_
+
+#include "HelioRetryPolicy.hpp"
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace Slic3r {
+
+struct HelioSupportedData
+{
+    std::string id;
+    std::string name;
+    std::string native_name;
+    std::string feedstock;
+    bool        heated_chamber{false};
+};
+
+enum class SupportDataLoadState
+{
+    NotLoaded,
+    Loading,
+    Ready,
+    Failed
+};
+
+enum class SupportDataCatalogKind
+{
+    Printers,
+    Materials
+};
+
+struct SupportDataHttpResponse
+{
+    unsigned    status{0};
+    std::string body;
+    std::string error;
+    std::string trace_id;
+};
+
+struct SupportDataPageResult
+{
+    bool                            success{false};
+    bool                            has_next_page{false};
+    int                             total_pages{0};
+    unsigned                        status{0};
+    HelioRetryKind                  retry_kind{HelioRetryKind::None};
+    std::vector<HelioSupportedData> items;
+    std::string                     error;
+    std::string                     trace_id;
+};
+
+SupportDataPageResult parse_support_data_page(SupportDataCatalogKind       kind,
+                                              int                          page,
+                                              const SupportDataHttpResponse& response);
+
+struct SupportDataCatalogView
+{
+    using Snapshot = std::shared_ptr<const std::vector<HelioSupportedData>>;
+
+    SupportDataLoadState state{SupportDataLoadState::NotLoaded};
+    Snapshot             snapshot;
+    std::string          last_error;
+
+    bool has_usable_snapshot() const noexcept { return snapshot && !snapshot->empty(); }
+};
+
+enum class SupportDataAvailability
+{
+    Usable,
+    Synchronizing,
+    LoadFailed
+};
+
+SupportDataAvailability support_data_availability(const SupportDataCatalogView& printers,
+                                                  const SupportDataCatalogView& materials) noexcept;
+
+
+struct SupportDataLoadAttempt
+{
+    SupportDataCatalogKind kind{SupportDataCatalogKind::Printers};
+    int                    page{1};
+    int                    attempt{1};
+    int                    max_attempts{4};
+    unsigned               status{0};
+    HelioRetryKind         retry_kind{HelioRetryKind::None};
+    bool                   will_retry{false};
+    std::string            error;
+    std::string            trace_id;
+};
+
+class SupportDataCatalogStore
+{
+public:
+    using Snapshot     = SupportDataCatalogView::Snapshot;
+    using PageFetcher  = std::function<SupportDataHttpResponse(SupportDataCatalogKind, int)>;
+    using RetrySleeper = std::function<void(int)>;
+    using Logger       = std::function<void(const SupportDataLoadAttempt&)>;
+
+    static constexpr int MAX_ATTEMPTS_PER_PAGE = 4;
+
+    explicit SupportDataCatalogStore(SupportDataCatalogKind kind);
+
+    SupportDataCatalogStore(const SupportDataCatalogStore&) = delete;
+    SupportDataCatalogStore& operator=(const SupportDataCatalogStore&) = delete;
+
+    // Starts a load if one is needed. A previous immutable snapshot is retained
+    // while a forced refresh is in progress. Overlapping loads are always
+    // rejected, including overlapping forced refreshes.
+    bool try_begin(bool force_refresh = false);
+
+    // Runs a load accepted by try_begin(). The fetcher is synchronous so the
+    // production caller can choose its background execution mechanism while
+    // tests can supply deterministic responses and a no-op sleeper.
+    bool run(const PageFetcher&  fetcher,
+             const RetrySleeper& sleeper = RetrySleeper(),
+             const Logger&       logger = Logger());
+
+    SupportDataCatalogKind kind() const noexcept { return m_kind; }
+    SupportDataLoadState   state() const;
+    Snapshot               snapshot() const;
+    std::string            last_error() const;
+    bool                   has_usable_snapshot() const;
+    SupportDataCatalogView view() const;
+
+private:
+    bool claim_run();
+    bool run_impl(const PageFetcher& fetcher, const RetrySleeper& sleeper, const Logger& logger);
+    void publish(std::vector<HelioSupportedData>&& complete_snapshot);
+    void fail(std::string error);
+
+    const SupportDataCatalogKind m_kind;
+    mutable std::mutex           m_mutex;
+    SupportDataLoadState         m_state{SupportDataLoadState::NotLoaded};
+    Snapshot                     m_snapshot;
+    std::string                  m_last_error;
+    bool                         m_run_claimed{false};
+};
+
+// A coherent, immutable observation of both support-data catalogs. Source and
+// generation are intentionally opaque: callers can use them only to compare
+// views, never to expose credentials.
+struct SupportDataCatalogPairView
+{
+    using Snapshot = SupportDataCatalogView::Snapshot;
+
+    Snapshot                printers;
+    Snapshot                materials;
+    SupportDataLoadState    printers_state{SupportDataLoadState::NotLoaded};
+    SupportDataLoadState    materials_state{SupportDataLoadState::NotLoaded};
+    std::string             printers_last_error;
+    std::string             materials_last_error;
+    SupportDataAvailability availability{SupportDataAvailability::Synchronizing};
+    std::uint64_t           source_generation{0};
+};
+
+class SupportDataCatalogPairCoordinator
+{
+public:
+    using PageFetcher  = SupportDataCatalogStore::PageFetcher;
+    using RetrySleeper = SupportDataCatalogStore::RetrySleeper;
+    using Logger       = SupportDataCatalogStore::Logger;
+
+    bool try_begin(const std::string& api_url, const std::string& api_key, bool force_refresh = false,
+                   std::uint64_t* generation = nullptr);
+    bool run(std::uint64_t generation, const PageFetcher& fetcher,
+             const RetrySleeper& sleeper = RetrySleeper(), const Logger& logger = Logger());
+    SupportDataCatalogPairView view() const;
+    std::uint64_t active_generation() const;
+
+private:
+    bool is_active_locked(std::uint64_t generation) const noexcept;
+    void fail_active(std::uint64_t generation, std::string error);
+
+    mutable std::mutex         m_mutex;
+    std::string                m_api_url;
+    std::string                m_api_key;
+    std::uint64_t              m_generation{0};
+    bool                       m_loading{false};
+    SupportDataCatalogPairView m_view;
+};
+
+} // namespace Slic3r
+
+#endif // slic3r_HelioSupportData_hpp_

--- a/tests/slic3rutils/CMakeLists.txt
+++ b/tests/slic3rutils/CMakeLists.txt
@@ -1,6 +1,9 @@
 get_filename_component(_TEST_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 add_executable(${_TEST_NAME}_tests
     ${_TEST_NAME}_tests_main.cpp
+    helio_retry_policy_tests.cpp
+    helio_support_data_tests.cpp
+    helio_recent_runs_tests.cpp
     )
 
 target_link_libraries(${_TEST_NAME}_tests test_common libslic3r_gui libslic3r)

--- a/tests/slic3rutils/helio_recent_runs_tests.cpp
+++ b/tests/slic3rutils/helio_recent_runs_tests.cpp
@@ -1,0 +1,25 @@
+#include <catch2/catch.hpp>
+
+#include "slic3r/Utils/HelioDragon.hpp"
+
+TEST_CASE("Helio recent run timestamps reject malformed names", "[Helio][RecentRuns]")
+{
+    using Slic3r::HelioQuery;
+    const auto invalid_timestamp = std::chrono::system_clock::time_point{};
+
+    REQUIRE(HelioQuery::parse_timestamp_from_name("BambuSlicer 2026-02-28T12:34:56") != invalid_timestamp);
+    REQUIRE(HelioQuery::parse_timestamp_from_name("BambuSlicer 2026-02-29T12:34:56") == invalid_timestamp);
+    REQUIRE(HelioQuery::parse_timestamp_from_name("BambuSlicer 2026-13-01T12:34:56") == invalid_timestamp);
+    REQUIRE(HelioQuery::parse_timestamp_from_name("BambuSlicer not-a-timestamp") == invalid_timestamp);
+    REQUIRE(HelioQuery::parse_timestamp_from_name("") == invalid_timestamp);
+}
+
+TEST_CASE("Helio recent run timestamps preserve chronological ordering", "[Helio][RecentRuns]")
+{
+    using Slic3r::HelioQuery;
+
+    const auto earlier = HelioQuery::parse_timestamp_from_name("BambuSlicer 2026-01-23T07:52:27");
+    const auto later = HelioQuery::parse_timestamp_from_name("BambuSlicer 2026-01-24T07:52:27 retry");
+
+    REQUIRE(earlier < later);
+}

--- a/tests/slic3rutils/helio_retry_policy_tests.cpp
+++ b/tests/slic3rutils/helio_retry_policy_tests.cpp
@@ -1,0 +1,164 @@
+#include <catch2/catch.hpp>
+
+#include "slic3r/Utils/HelioRetryPolicy.hpp"
+
+#include "nlohmann/json.hpp"
+
+namespace {
+
+std::string graphql_errors(std::initializer_list<std::string> messages)
+{
+    nlohmann::json errors = nlohmann::json::array();
+    for (const std::string& message : messages) {
+        errors.push_back({{"message", message}});
+    }
+    return nlohmann::json({{"errors", std::move(errors)}}).dump();
+}
+
+} // namespace
+
+TEST_CASE("Helio retry policy narrowly recognizes nested backend auth failures", "[Helio][RetryPolicy]")
+{
+    using namespace Slic3r;
+
+    const std::string exact_response = graphql_errors({HELIO_BACKEND_AUTH_401_MESSAGE});
+    REQUIRE(helio_classify_graphql_response(200, exact_response) == HelioRetryKind::BackendAuth);
+    REQUIRE(helio_classify_retry(200, exact_response) == HelioRetryKind::BackendAuth);
+
+    const nlohmann::json parsed = nlohmann::json::parse(exact_response);
+    REQUIRE(helio_has_exact_backend_auth_error(parsed));
+    REQUIRE(helio_classify_graphql_response(200, parsed) == HelioRetryKind::BackendAuth);
+
+    SECTION("near matches remain terminal")
+    {
+        REQUIRE(helio_classify_retry(200, graphql_errors({
+            "Authentication failed: Auth service returned status 401."
+        })) == HelioRetryKind::None);
+        REQUIRE(helio_classify_retry(200, graphql_errors({
+            "authentication failed: auth service returned status 401"
+        })) == HelioRetryKind::None);
+        REQUIRE(helio_classify_retry(200, graphql_errors({
+            "Authentication failed: Auth service returned status 401 "
+        })) == HelioRetryKind::None);
+    }
+
+    SECTION("multiple ordinary GraphQL errors do not become backend auth")
+    {
+        const std::string response = graphql_errors({
+            "Authentication failed",
+            "Auth service returned status 401",
+            "Material is unsupported"
+        });
+        REQUIRE(helio_classify_retry(200, response) == HelioRetryKind::None);
+    }
+
+    SECTION("malformed sibling errors do not hide an exact backend auth error")
+    {
+        const nlohmann::json response = {
+            {"errors", nlohmann::json::array({
+                {{"message", 401}},
+                nlohmann::json::object(),
+                {{"message", HELIO_BACKEND_AUTH_401_MESSAGE}}
+            })}
+        };
+        REQUIRE(helio_classify_retry(200, response.dump()) == HelioRetryKind::BackendAuth);
+    }
+}
+
+TEST_CASE("Helio retry policy classifies ordinary transient failures", "[Helio][RetryPolicy]")
+{
+    using namespace Slic3r;
+
+    REQUIRE(helio_classify_retry(200, "not-json") == HelioRetryKind::None);
+    REQUIRE(helio_classify_retry(200, graphql_errors({"Service temporarily unavailable"})) ==
+            HelioRetryKind::Transient);
+    REQUIRE(helio_classify_retry(200, graphql_errors({"Request deadline exceeded"})) ==
+            HelioRetryKind::Transient);
+    REQUIRE(helio_classify_retry(200, graphql_errors({"Invalid printer ID"})) == HelioRetryKind::None);
+
+    SECTION("malformed GraphQL errors members are transient")
+    {
+        REQUIRE(helio_classify_retry(200, R"({"errors":[]})") == HelioRetryKind::Transient);
+        REQUIRE(helio_classify_retry(200, R"({"errors":null})") == HelioRetryKind::Transient);
+        REQUIRE(helio_classify_retry(200, R"({"errors":[{}]})") == HelioRetryKind::Transient);
+    }
+
+    for (const unsigned status : {0u, 408u, 425u, 429u, 500u, 502u, 503u, 599u}) {
+        INFO("HTTP status " << status);
+        REQUIRE(helio_classify_retry(status) == HelioRetryKind::Transient);
+        REQUIRE(helio_is_transient_http_status(status));
+    }
+}
+
+TEST_CASE("Helio retry policy recognizes only the reported subgraph deserialization error",
+          "[Helio][RetryPolicy]")
+{
+    using namespace Slic3r;
+
+    REQUIRE(helio_classify_retry(200, graphql_errors({"Failed to deserialize subgraph response"})) ==
+            HelioRetryKind::Transient);
+    REQUIRE(helio_classify_retry(200, graphql_errors({"FAILED TO DESERIALIZE SUBGRAPH RESPONSE"})) ==
+            HelioRetryKind::Transient);
+
+    for (const std::string& message : {
+             "Failed to deserialize subgraph response.",
+             "Failed to deserialize subgraph response from materials",
+             "Failed to deserialize response",
+             "Material is unsupported"
+         }) {
+        INFO(message);
+        REQUIRE(helio_classify_retry(200, graphql_errors({message})) == HelioRetryKind::None);
+    }
+}
+
+TEST_CASE("Actual HTTP authentication failures are terminal", "[Helio][RetryPolicy]")
+{
+    using namespace Slic3r;
+
+    const std::string exact_response = graphql_errors({HELIO_BACKEND_AUTH_401_MESSAGE});
+    for (const unsigned status : {401u, 403u, 404u}) {
+        INFO("HTTP status " << status);
+        REQUIRE(helio_is_terminal_http_status(status));
+        REQUIRE(helio_classify_graphql_response(status, exact_response) == HelioRetryKind::None);
+        REQUIRE(helio_classify_retry(status, exact_response, HELIO_BACKEND_AUTH_401_MESSAGE) ==
+                HelioRetryKind::None);
+    }
+}
+
+TEST_CASE("Helio retry controller permits only one consecutive backend auth retry", "[Helio][RetryPolicy]")
+{
+    using namespace Slic3r;
+
+    HelioRetryController controller;
+    REQUIRE(controller.consecutive_backend_auth_failures() == 0);
+
+    REQUIRE(controller.should_retry(HelioRetryKind::BackendAuth));
+    REQUIRE(controller.consecutive_backend_auth_failures() == 1);
+
+    REQUIRE_FALSE(controller.should_retry(HelioRetryKind::BackendAuth));
+    REQUIRE(controller.consecutive_backend_auth_failures() == 2);
+}
+
+TEST_CASE("Helio retry controller resets the backend auth streak", "[Helio][RetryPolicy]")
+{
+    using namespace Slic3r;
+
+    SECTION("a recovered response starts a fresh streak")
+    {
+        HelioRetryController controller;
+        REQUIRE(controller.should_retry(HelioRetryKind::BackendAuth));
+        REQUIRE_FALSE(controller.should_retry(HelioRetryKind::None));
+        REQUIRE(controller.consecutive_backend_auth_failures() == 0);
+        REQUIRE(controller.should_retry(HelioRetryKind::BackendAuth));
+    }
+
+    SECTION("an ordinary transient failure breaks the backend auth streak")
+    {
+        HelioRetryController controller;
+        REQUIRE(controller.should_retry(HelioRetryKind::BackendAuth));
+        REQUIRE(controller.should_retry(HelioRetryKind::Transient));
+        REQUIRE(controller.consecutive_backend_auth_failures() == 0);
+        REQUIRE(controller.should_retry(HelioRetryKind::BackendAuth));
+        REQUIRE_FALSE(controller.should_retry(HelioRetryKind::BackendAuth));
+    }
+}

--- a/tests/slic3rutils/helio_support_data_tests.cpp
+++ b/tests/slic3rutils/helio_support_data_tests.cpp
@@ -1,0 +1,571 @@
+#include <catch2/catch.hpp>
+
+#include "slic3r/Utils/HelioSupportData.hpp"
+
+#include "nlohmann/json.hpp"
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using Slic3r::SupportDataCatalogKind;
+using Slic3r::SupportDataCatalogStore;
+using Slic3r::SupportDataHttpResponse;
+
+SupportDataHttpResponse printer_page(int page,
+                                     int total_pages,
+                                     bool has_next_page,
+                                     std::initializer_list<std::pair<std::string, std::string>> printers)
+{
+    nlohmann::json objects = nlohmann::json::array();
+    for (const auto& printer : printers) {
+        objects.push_back({
+            {"id", printer.first},
+            {"name", printer.second},
+            {"heatedChamber", false},
+            {"alternativeNames", {{"bambustudio", printer.second}}}
+        });
+    }
+
+    nlohmann::json body = {
+        {"data", {{"printers", {
+            {"pages", total_pages},
+            {"pageInfo", {{"hasNextPage", has_next_page}}},
+            {"objects", std::move(objects)}
+        }}}}
+    };
+    return {200, body.dump(), {}, "trace-printers-" + std::to_string(page)};
+}
+
+SupportDataHttpResponse material_page(int page,
+                                      int total_pages,
+                                      bool has_next_page,
+                                      std::initializer_list<std::pair<std::string, std::string>> materials)
+{
+    nlohmann::json objects = nlohmann::json::array();
+    for (const auto& material : materials) {
+        objects.push_back({
+            {"id", material.first},
+            {"name", material.second},
+            {"feedstock", "FILAMENT"},
+            {"alternativeNames", {{"bambustudio", material.second}}}
+        });
+    }
+
+    nlohmann::json body = {
+        {"data", {{"materials", {
+            {"pages", total_pages},
+            {"pageInfo", {{"hasNextPage", has_next_page}}},
+            {"objects", std::move(objects)}
+        }}}}
+    };
+    return {200, body.dump(), {}, "trace-materials-" + std::to_string(page)};
+}
+
+SupportDataHttpResponse graphql_error(const std::string& message,
+                                      const std::string& trace_id = "trace-graphql")
+{
+    return {200, nlohmann::json({{"errors", {{{"message", message}}}}}).dump(), {}, trace_id};
+}
+
+void seed_printers(SupportDataCatalogStore& store,
+                   const std::string& id = "printer-old",
+                   const std::string& name = "Bambu Lab Old")
+{
+    REQUIRE(store.try_begin());
+    REQUIRE(store.run([&](SupportDataCatalogKind kind, int page) {
+        REQUIRE(kind == SupportDataCatalogKind::Printers);
+        REQUIRE(page == 1);
+        return printer_page(1, 1, false, {{id, name}});
+    }));
+}
+
+void seed_materials(SupportDataCatalogStore& store,
+                    const std::string& id = "material-old",
+                    const std::string& name = "Old PLA")
+{
+    REQUIRE(store.try_begin());
+    REQUIRE(store.run([&](SupportDataCatalogKind kind, int page) {
+        REQUIRE(kind == SupportDataCatalogKind::Materials);
+        REQUIRE(page == 1);
+        return material_page(1, 1, false, {{id, name}});
+    }));
+}
+
+void require_failed_response(const SupportDataHttpResponse& response, int expected_fetches)
+{
+    using namespace Slic3r;
+
+    SupportDataCatalogStore store(SupportDataCatalogKind::Printers);
+    int fetches = 0;
+    REQUIRE(store.try_begin());
+    REQUIRE_FALSE(store.run([&](SupportDataCatalogKind, int) {
+        ++fetches;
+        return response;
+    }));
+    REQUIRE(fetches == expected_fetches);
+    REQUIRE(store.state() == SupportDataLoadState::Failed);
+    REQUIRE_FALSE(store.snapshot());
+    REQUIRE_FALSE(store.last_error().empty());
+}
+
+bool contains_native_name(const SupportDataCatalogStore::Snapshot& snapshot, const std::string& name)
+{
+    return snapshot && std::any_of(snapshot->begin(), snapshot->end(), [&](const Slic3r::HelioSupportedData& item) {
+        return item.native_name == name;
+    });
+}
+
+} // namespace
+
+TEST_CASE("Helio support catalog publishes complete pagination atomically", "[Helio][SupportData]")
+{
+    using namespace Slic3r;
+
+    SupportDataCatalogStore store(SupportDataCatalogKind::Printers);
+    std::vector<int> requested_pages;
+
+    REQUIRE(store.try_begin());
+    REQUIRE(store.state() == SupportDataLoadState::Loading);
+    REQUIRE_FALSE(store.snapshot());
+
+    REQUIRE(store.run([&](SupportDataCatalogKind kind, int page) {
+        REQUIRE(kind == SupportDataCatalogKind::Printers);
+        requested_pages.push_back(page);
+        return page == 1
+            ? printer_page(1, 2, true, {{"printer-1", "Bambu Lab P1S"}})
+            : printer_page(2, 2, false, {{"printer-2", "Bambu Lab X1C"}});
+    }));
+
+    REQUIRE(requested_pages == std::vector<int>{1, 2});
+    REQUIRE(store.state() == SupportDataLoadState::Ready);
+    REQUIRE(store.last_error().empty());
+
+    const auto snapshot = store.snapshot();
+    REQUIRE(snapshot);
+    REQUIRE(snapshot->size() == 2);
+    REQUIRE((*snapshot)[0].id == "printer-1");
+    REQUIRE((*snapshot)[1].id == "printer-2");
+}
+
+TEST_CASE("Helio support catalog recovers transient pages with bounded backoff", "[Helio][SupportData]")
+{
+    using namespace Slic3r;
+
+    SupportDataCatalogStore store(SupportDataCatalogKind::Materials);
+    std::vector<int> sleeps;
+    std::vector<SupportDataLoadAttempt> attempts;
+    int fetches = 0;
+
+    REQUIRE(store.try_begin());
+    REQUIRE(store.run(
+        [&](SupportDataCatalogKind, int) {
+            ++fetches;
+            if (fetches == 1) return SupportDataHttpResponse{503, {}, "service unavailable", "trace-503"};
+            if (fetches == 2) return graphql_error("Service temporarily unavailable");
+            if (fetches == 3) return graphql_error("Request deadline exceeded");
+            return material_page(1, 1, false, {{"material-1", "Bambu PLA Basic"}});
+        },
+        [&](int seconds) { sleeps.push_back(seconds); },
+        [&](const SupportDataLoadAttempt& attempt) { attempts.push_back(attempt); }));
+
+    REQUIRE(fetches == 4);
+    REQUIRE(sleeps == std::vector<int>{2, 4, 6});
+    REQUIRE(attempts.size() == 3);
+    REQUIRE(attempts[0].attempt == 1);
+    REQUIRE(attempts[0].status == 503);
+    REQUIRE(attempts[0].retry_kind == HelioRetryKind::Transient);
+    REQUIRE(attempts[0].trace_id == "trace-503");
+    REQUIRE(attempts[2].attempt == 3);
+    REQUIRE(attempts[2].will_retry);
+    REQUIRE(store.state() == SupportDataLoadState::Ready);
+}
+
+TEST_CASE("Helio support catalog recovers the reported subgraph deserialization failure",
+          "[Helio][SupportData]")
+{
+    using namespace Slic3r;
+
+    SupportDataCatalogStore store(SupportDataCatalogKind::Materials);
+    std::vector<int> sleeps;
+    std::vector<SupportDataLoadAttempt> attempts;
+    int fetches = 0;
+
+    REQUIRE(store.try_begin());
+    REQUIRE(store.run(
+        [&](SupportDataCatalogKind kind, int page) {
+            REQUIRE(kind == SupportDataCatalogKind::Materials);
+            REQUIRE(page == 1);
+            ++fetches;
+            if (fetches == 1) {
+                return graphql_error("Failed to deserialize subgraph response", "trace-subgraph-first");
+            }
+            return material_page(1, 1, false, {{"material-1", "Bambu PLA Basic"}});
+        },
+        [&](int seconds) { sleeps.push_back(seconds); },
+        [&](const SupportDataLoadAttempt& attempt) { attempts.push_back(attempt); }));
+
+    REQUIRE(fetches == 2);
+    REQUIRE(sleeps == std::vector<int>{2});
+    REQUIRE(attempts.size() == 1);
+    REQUIRE(attempts[0].attempt == 1);
+    REQUIRE(attempts[0].retry_kind == HelioRetryKind::Transient);
+    REQUIRE(attempts[0].will_retry);
+    REQUIRE(attempts[0].error == "Failed to deserialize subgraph response");
+    REQUIRE(attempts[0].trace_id == "trace-subgraph-first");
+    REQUIRE(store.state() == SupportDataLoadState::Ready);
+    REQUIRE(store.last_error().empty());
+    REQUIRE(store.snapshot());
+    REQUIRE(store.snapshot()->size() == 1);
+    REQUIRE((*store.snapshot())[0].id == "material-1");
+}
+
+TEST_CASE("Helio support catalog rejects malformed and incomplete successful responses", "[Helio][SupportData]")
+{
+    SECTION("malformed JSON is terminal")
+    {
+        require_failed_response({200, "not-json", {}, "trace-malformed"}, 1);
+    }
+
+    SECTION("recognized transient GraphQL errors retry")
+    {
+        require_failed_response(graphql_error("Request temporarily unavailable"), 4);
+    }
+
+    SECTION("unrecognized GraphQL errors are terminal")
+    {
+        require_failed_response(graphql_error("Invalid printer selection"), 1);
+    }
+
+    SECTION("missing payload is transient")
+    {
+        require_failed_response({200, R"({"data":{}})", {}, "trace-missing"}, 4);
+    }
+
+    SECTION("empty GraphQL errors without a payload are malformed and transient")
+    {
+        require_failed_response({200, R"({"errors":[]})", {}, "trace-empty-errors"}, 4);
+        require_failed_response({200, R"({"errors":null})", {}, "trace-null-errors"}, 4);
+    }
+
+    SECTION("empty object pages are transient")
+    {
+        require_failed_response(printer_page(1, 1, false, {}), 4);
+    }
+
+    SECTION("missing page metadata is transient")
+    {
+        const std::string body = R"({"data":{"printers":{"objects":[{"id":"p1","name":"P1"}]}}})";
+        require_failed_response({200, body, {}, "trace-metadata"}, 4);
+    }
+
+    SECTION("inconsistent pagination is transient")
+    {
+        require_failed_response(printer_page(1, 2, false, {{"p1", "P1"}}), 4);
+    }
+}
+
+TEST_CASE("Helio support catalog never retries terminal HTTP authentication statuses", "[Helio][SupportData]")
+{
+    for (const unsigned status : {401u, 403u, 404u}) {
+        DYNAMIC_SECTION("HTTP " << status)
+        {
+            require_failed_response({status, "unauthorized", "request failed", "trace-terminal"}, 1);
+        }
+    }
+}
+
+TEST_CASE("Helio support catalog does not publish a successful partial prefix", "[Helio][SupportData]")
+{
+    using namespace Slic3r;
+
+    SupportDataCatalogStore store(SupportDataCatalogKind::Printers);
+    int page_one_fetches = 0;
+    int page_two_fetches = 0;
+
+    REQUIRE(store.try_begin());
+    REQUIRE_FALSE(store.run([&](SupportDataCatalogKind, int page) {
+        if (page == 1) {
+            ++page_one_fetches;
+            return printer_page(1, 2, true, {{"partial-printer", "Partial Printer"}});
+        }
+        ++page_two_fetches;
+        return SupportDataHttpResponse{503, {}, "unavailable", "trace-page-two"};
+    }));
+
+    REQUIRE(page_one_fetches == 1);
+    REQUIRE(page_two_fetches == 4);
+    REQUIRE(store.state() == SupportDataLoadState::Failed);
+    REQUIRE_FALSE(store.snapshot());
+}
+
+TEST_CASE("Helio support catalog retains a good snapshot after forced refresh failure", "[Helio][SupportData]")
+{
+    using namespace Slic3r;
+
+    SupportDataCatalogStore store(SupportDataCatalogKind::Printers);
+    seed_printers(store);
+    const auto original = store.snapshot();
+
+    REQUIRE(store.try_begin(true));
+    REQUIRE(store.state() == SupportDataLoadState::Loading);
+    REQUIRE(store.snapshot() == original);
+
+    REQUIRE_FALSE(store.run([](SupportDataCatalogKind, int) {
+        return SupportDataHttpResponse{401, "unauthorized", {}, "trace-refresh"};
+    }));
+
+    REQUIRE(store.state() == SupportDataLoadState::Failed);
+    REQUIRE(store.snapshot() == original);
+    REQUIRE(store.has_usable_snapshot());
+    REQUIRE((*store.snapshot())[0].id == "printer-old");
+}
+
+TEST_CASE("Helio support catalog exhausts subgraph retries without publishing a forced refresh prefix",
+          "[Helio][SupportData]")
+{
+    using namespace Slic3r;
+
+    SupportDataCatalogStore store(SupportDataCatalogKind::Printers);
+    seed_printers(store);
+    const auto original = store.snapshot();
+    std::vector<int> sleeps;
+    std::vector<SupportDataLoadAttempt> attempts;
+    int page_one_fetches = 0;
+    int page_two_fetches = 0;
+
+    REQUIRE(store.try_begin(true));
+    REQUIRE_FALSE(store.run(
+        [&](SupportDataCatalogKind kind, int page) {
+            REQUIRE(kind == SupportDataCatalogKind::Printers);
+            if (page == 1) {
+                ++page_one_fetches;
+                return printer_page(1, 2, true, {{"printer-new", "Bambu Lab New"}});
+            }
+            ++page_two_fetches;
+            return graphql_error("FAILED TO DESERIALIZE SUBGRAPH RESPONSE",
+                                 "trace-subgraph-" + std::to_string(page_two_fetches));
+        },
+        [&](int seconds) { sleeps.push_back(seconds); },
+        [&](const SupportDataLoadAttempt& attempt) { attempts.push_back(attempt); }));
+
+    REQUIRE(page_one_fetches == 1);
+    REQUIRE(page_two_fetches == SupportDataCatalogStore::MAX_ATTEMPTS_PER_PAGE);
+    REQUIRE(sleeps == std::vector<int>{2, 4, 6});
+    REQUIRE(attempts.size() == SupportDataCatalogStore::MAX_ATTEMPTS_PER_PAGE);
+    for (std::size_t index = 0; index < attempts.size(); ++index) {
+        INFO("attempt " << index + 1);
+        REQUIRE(attempts[index].page == 2);
+        REQUIRE(attempts[index].attempt == static_cast<int>(index + 1));
+        REQUIRE(attempts[index].max_attempts == SupportDataCatalogStore::MAX_ATTEMPTS_PER_PAGE);
+        REQUIRE(attempts[index].retry_kind == HelioRetryKind::Transient);
+        REQUIRE(attempts[index].error == "FAILED TO DESERIALIZE SUBGRAPH RESPONSE");
+        REQUIRE(attempts[index].trace_id == "trace-subgraph-" + std::to_string(index + 1));
+        REQUIRE(attempts[index].will_retry == (index + 1 < attempts.size()));
+    }
+    REQUIRE(store.state() == SupportDataLoadState::Failed);
+    REQUIRE(store.last_error() == "FAILED TO DESERIALIZE SUBGRAPH RESPONSE");
+    REQUIRE(store.snapshot() == original);
+    REQUIRE(store.snapshot()->size() == 1);
+    REQUIRE((*store.snapshot())[0].id == "printer-old");
+}
+
+TEST_CASE("Helio support catalog requires force to replace a completed snapshot", "[Helio][SupportData]")
+{
+    using namespace Slic3r;
+
+    SupportDataCatalogStore store(SupportDataCatalogKind::Printers);
+    seed_printers(store);
+    const auto original = store.snapshot();
+
+    REQUIRE_FALSE(store.try_begin(false));
+    REQUIRE(store.snapshot() == original);
+
+    REQUIRE(store.try_begin(true));
+    REQUIRE(store.run([](SupportDataCatalogKind, int) {
+        return printer_page(1, 1, false, {{"printer-new", "Bambu Lab New"}});
+    }));
+
+    REQUIRE(store.state() == SupportDataLoadState::Ready);
+    REQUIRE(store.snapshot() != original);
+    REQUIRE(store.snapshot()->size() == 1);
+    REQUIRE((*store.snapshot())[0].id == "printer-new");
+}
+
+TEST_CASE("Helio support catalog suppresses overlapping normal and forced requests", "[Helio][SupportData]")
+{
+    using namespace Slic3r;
+
+    SupportDataCatalogStore store(SupportDataCatalogKind::Materials);
+    REQUIRE(store.try_begin());
+    REQUIRE(store.state() == SupportDataLoadState::Loading);
+    REQUIRE_FALSE(store.try_begin(false));
+    REQUIRE_FALSE(store.try_begin(true));
+
+    REQUIRE(store.run([](SupportDataCatalogKind, int) {
+        return material_page(1, 1, false, {{"material-1", "PLA"}});
+    }));
+    REQUIRE_FALSE(store.try_begin(false));
+}
+
+TEST_CASE("Helio support catalog retries exact backend auth only once", "[Helio][SupportData]")
+{
+    using namespace Slic3r;
+
+    SECTION("one exact backend auth response recovers")
+    {
+        SupportDataCatalogStore store(SupportDataCatalogKind::Printers);
+        std::vector<int> sleeps;
+        int fetches = 0;
+
+        REQUIRE(store.try_begin());
+        REQUIRE(store.run(
+            [&](SupportDataCatalogKind, int) {
+                ++fetches;
+                if (fetches == 1) return graphql_error(HELIO_BACKEND_AUTH_401_MESSAGE);
+                return printer_page(1, 1, false, {{"p1", "P1"}});
+            },
+            [&](int seconds) { sleeps.push_back(seconds); }));
+
+        REQUIRE(fetches == 2);
+        REQUIRE(sleeps == std::vector<int>{2});
+        REQUIRE(store.state() == SupportDataLoadState::Ready);
+    }
+
+    SECTION("a repeated exact backend auth response stops")
+    {
+        SupportDataCatalogStore store(SupportDataCatalogKind::Printers);
+        std::vector<int> sleeps;
+        int fetches = 0;
+
+        REQUIRE(store.try_begin());
+        REQUIRE_FALSE(store.run(
+            [&](SupportDataCatalogKind, int) {
+                ++fetches;
+                return graphql_error(HELIO_BACKEND_AUTH_401_MESSAGE);
+            },
+            [&](int seconds) { sleeps.push_back(seconds); }));
+
+        REQUIRE(fetches == 2);
+        REQUIRE(sleeps == std::vector<int>{2});
+        REQUIRE(store.state() == SupportDataLoadState::Failed);
+    }
+}
+
+TEST_CASE("Helio catalog availability distinguishes unavailable from genuinely unsupported", "[Helio][SupportData]")
+{
+    using namespace Slic3r;
+
+    SupportDataCatalogStore printers(SupportDataCatalogKind::Printers);
+    SupportDataCatalogStore materials(SupportDataCatalogKind::Materials);
+
+    REQUIRE(support_data_availability(printers.view(), materials.view()) ==
+            SupportDataAvailability::Synchronizing);
+
+    seed_printers(printers, "unrelated-printer", "Unrelated Printer");
+    REQUIRE(support_data_availability(printers.view(), materials.view()) ==
+            SupportDataAvailability::Synchronizing);
+
+    seed_materials(materials, "unrelated-material", "Unrelated Material");
+    REQUIRE(support_data_availability(printers.view(), materials.view()) ==
+            SupportDataAvailability::Usable);
+    REQUIRE_FALSE(contains_native_name(materials.snapshot(), "Bambu PLA Basic"));
+
+    const auto stale_materials = materials.snapshot();
+    REQUIRE(materials.try_begin(true));
+    REQUIRE_FALSE(materials.run([](SupportDataCatalogKind, int) {
+        return SupportDataHttpResponse{403, "forbidden", {}, "trace-stale"};
+    }));
+    REQUIRE(materials.snapshot() == stale_materials);
+    REQUIRE(materials.state() == SupportDataLoadState::Failed);
+    REQUIRE(support_data_availability(printers.view(), materials.view()) ==
+            SupportDataAvailability::Usable);
+
+    SupportDataCatalogStore failed_without_snapshot(SupportDataCatalogKind::Materials);
+    REQUIRE(failed_without_snapshot.try_begin());
+    REQUIRE_FALSE(failed_without_snapshot.run([](SupportDataCatalogKind, int) {
+        return SupportDataHttpResponse{404, "not found", {}, "trace-failed"};
+    }));
+    REQUIRE(support_data_availability(printers.view(), failed_without_snapshot.view()) ==
+            SupportDataAvailability::LoadFailed);
+}
+
+TEST_CASE("Helio support catalog pair publishes one source atomically", "[Helio][SupportData]")
+{
+    using namespace Slic3r;
+    SupportDataCatalogPairCoordinator coordinator;
+    bool saw_no_half = false;
+
+    REQUIRE(coordinator.try_begin("A", "key-A"));
+    const auto generation_a = coordinator.active_generation();
+    const auto loading = coordinator.view();
+    REQUIRE(loading.availability == SupportDataAvailability::Synchronizing);
+    REQUIRE_FALSE(loading.printers);
+    REQUIRE_FALSE(loading.materials);
+    REQUIRE(coordinator.run(generation_a, [&](SupportDataCatalogKind kind, int) {
+        if (kind == SupportDataCatalogKind::Materials) {
+            const auto during_load = coordinator.view();
+            saw_no_half = !during_load.printers && !during_load.materials;
+            return material_page(1, 1, false, {{"material-A", "material-A"}});
+        }
+        return printer_page(1, 1, false, {{"printer-A", "printer-A"}});
+    }));
+    const auto ready_a = coordinator.view();
+    REQUIRE(ready_a.availability == SupportDataAvailability::Usable);
+    REQUIRE((*ready_a.printers)[0].id == "printer-A");
+    REQUIRE((*ready_a.materials)[0].id == "material-A");
+    REQUIRE(saw_no_half);
+    REQUIRE(coordinator.try_begin("A", "key-A", true));
+    REQUIRE_FALSE(coordinator.run(coordinator.active_generation(), [](SupportDataCatalogKind kind, int) {
+        return kind == SupportDataCatalogKind::Printers
+            ? printer_page(1, 1, false, {{"printer-new", "printer-new"}})
+            : SupportDataHttpResponse{401, "unauthorized", {}, "trace"};
+    }));
+    const auto rollback = coordinator.view();
+    REQUIRE(rollback.availability == SupportDataAvailability::Usable);
+    REQUIRE((*rollback.printers)[0].id == "printer-A");
+    REQUIRE((*rollback.materials)[0].id == "material-A");
+    REQUIRE(coordinator.try_begin("A", "key-B"));
+    const auto generation_b = coordinator.active_generation();
+    const auto hidden_a = coordinator.view();
+    REQUIRE(hidden_a.availability == SupportDataAvailability::Synchronizing);
+    REQUIRE_FALSE(hidden_a.printers);
+    REQUIRE_FALSE(hidden_a.materials);
+    REQUIRE_FALSE(coordinator.run(generation_b, [](SupportDataCatalogKind, int) {
+        return SupportDataHttpResponse{403, "forbidden", {}, "trace"};
+    }));
+    const auto failed_b = coordinator.view();
+    REQUIRE(failed_b.availability == SupportDataAvailability::LoadFailed);
+    REQUIRE_FALSE(failed_b.printers);
+    REQUIRE_FALSE(failed_b.materials);
+}
+
+TEST_CASE("Helio support catalog pair rejects stale generations and never mixes catalogs", "[Helio][SupportData]")
+{
+    using namespace Slic3r;
+    SupportDataCatalogPairCoordinator coordinator;
+    REQUIRE(coordinator.try_begin("A", "key-A"));
+    const auto generation_a = coordinator.active_generation();
+    REQUIRE(coordinator.try_begin("B", "key-B"));
+    const auto generation_b = coordinator.active_generation();
+    REQUIRE_FALSE(coordinator.run(generation_a, [](SupportDataCatalogKind kind, int) {
+        return kind == SupportDataCatalogKind::Printers
+            ? printer_page(1, 1, false, {{"printer-A", "printer-A"}})
+            : material_page(1, 1, false, {{"material-A", "material-A"}});
+    }));
+    const auto before_b = coordinator.view();
+    REQUIRE_FALSE(before_b.printers);
+    REQUIRE_FALSE(before_b.materials);
+    REQUIRE(coordinator.run(generation_b, [](SupportDataCatalogKind kind, int) {
+        return kind == SupportDataCatalogKind::Printers
+            ? printer_page(1, 1, false, {{"printer-B", "printer-B"}})
+            : material_page(1, 1, false, {{"material-B", "material-B"}});
+    }));
+    const auto ready_b = coordinator.view();
+    REQUIRE(ready_b.availability == SupportDataAvailability::Usable);
+    REQUIRE((*ready_b.printers)[0].id == "printer-B");
+    REQUIRE((*ready_b.materials)[0].id == "material-B");
+}


### PR DESCRIPTION
# Improve Helio reliability, catalog consistency, and workflow safety

## Summary

This change hardens the Helio Additive integration against transient network failures, cancellation races, stale support data, and stale sliced output. It also completes several workflow fixes around history ordering, unsupported printers, multi-material guidance, simulation exports, and slicer validation errors.

The upstream submission is intentionally packaged as one commit so the reliability and state-management changes land as a coherent unit.

## Why this is needed

The previous workflow had limited, operation-specific recovery and did not consistently distinguish transient from terminal failures or protect retries against duplicate and stale results. In practice, long-running simulations and optimizations may encounter transient HTTP failures, interrupted uploads, delayed GraphQL responses, user cancellation, region changes, or a new action starting while an older worker is still stopping.

Those conditions could cause several user-visible failures:

- a simulation or optimization failing after a recoverable network interruption;
- a retried mutation creating duplicate backend runs;
- stale workers continuing after cancellation or publishing results into a newer action;
- partially refreshed printer and material catalogs being combined;
- history results appearing out of order or malformed timestamps displaying as extremely old dates;
- Helio using stale G-code after the project enters a slicer validation error;
- the Helio action being incorrectly disabled for valid unsupported/reference-printer workflows;
- simulation results lacking the same sliced-3MF export offered by optimization results.

## What changed

### Resilient and idempotent network operations

- Add a shared Helio retry policy for HTTP, transport, GraphQL, and backend-authentication failures.
- Retry ordinary transient failures with bounded backoff instead of failing immediately.
- Reuse one idempotency key across create retries, reducing duplicate-creation risk.
- For simulation and optimization creates, use a unique stable run name and adopt a matching recent run when a response is lost after server acceptance.
- Make upload retry waits cancellation-aware.
- Bound progress polling and distinguish transient polling failures from terminal backend failures.
- Harden response parsing so malformed or incomplete data produces controlled errors rather than unchecked field access.

### Cancellation, worker lifecycle, and stale-event protection

- Track Helio action generations through start, progress, completion, and slicing events.
- Ignore completion events belonging to a canceled or superseded generation.
- Prevent a new action from reviving or reusing an older worker that is still stopping.
- Reject a new start without canceling the action already in progress.
- Avoid blocking the GUI while an earlier worker is still shutting down; return promptly and ask the user to try again shortly.
- Join support-data and print-priority request workers during application exit.
- Run print-priority requests off the GUI thread and prevent a support-data refresh from publishing stale cache entries.

### Consistent printer and material support data

- Load paginated printer and material catalogs completely rather than assuming a single page.
- Publish immutable catalog snapshots only after a complete load.
- Keep the last usable snapshot available when a refresh fails.
- Treat the printer/material pair as one catalog generation so a run cannot mix new printer data with stale material data.
- Reuse the action's captured snapshots throughout printer and material matching.
- Invalidate catalog and cache source state when the API URL or credentials change so the next request loads the correct source.
- Track per-catalog load state and expose pair availability to the GUI as `Synchronizing`, `Usable`, or `LoadFailed` when data is present or loading fails.

### Helio history behavior

- Limit history requests to the latest 10 simulations and latest 10 optimizations.
- Sort returned runs newest first, placing missing or invalid timestamps last.
- Parse run timestamps defensively and display `Unknown` when a timestamp cannot be recovered.

### Safer launch eligibility and stale G-code prevention

- Keep Helio available for valid native slices on unsupported/reference printers.
- Keep Helio disabled for standalone or imported G-code modes.
- Disable Helio while background slicing is active.
- Require the current plate to have both a valid slice result and a valid live slicer state.
- Block launch for slicer validation errors and broken mixed-filament definitions, even if an older valid G-code result remains on the plate.
- Revalidate the original plate after modal dialogs and immediately before starting network work, preventing a plate change from combining old selections with another plate's G-code.
- Preserve the official top-bar Helio icon assets when updating enabled/disabled state.

### Workflow and UI corrections

- Replace obsolete wording that implied true multi-material support was only a future feature.
- Point users to the existing experimental multi-material optimization preference.
- Add sliced-3MF export to simulation results, matching the existing optimization workflow.
- Clarify support-data errors and simulation export tooltips.

## Tests

Adds focused coverage for:

- retry classification and retry-controller limits;
- paginated support-data loading, malformed/partial-response rejection, and bounded retry behavior;
- snapshot preservation, overlapping-request suppression, atomic pair publication, and stale-generation rejection;
- recent-run timestamp parsing, including malformed names and retry suffixes.

Test files:

- `tests/slic3rutils/helio_retry_policy_tests.cpp`
- `tests/slic3rutils/helio_support_data_tests.cpp`
- `tests/slic3rutils/helio_recent_runs_tests.cpp`

## Validation

- `git diff --cached --check`
- conflict-marker scan after applying the change to current official `master`
- independent static adversarial review of the current upstream-base integration
- prior downstream manual testing covered Mac and Windows simulation/optimization workflows, unsupported printers, multi-material guidance, sliced-3MF export, cancellation/restart behavior, and support-data refresh behavior; it was not rerun against this upstream base

This local checkout does not have a configured dependency build or generated wxWidgets headers, so a full local BambuStudio compile was not run. The upstream CI build matrix should complete before this draft is marked ready for review.

## Integration notes

- Based on official `bambulab/BambuStudio` commit `12f17b06f4f537f9c03162d08bb70cf733c42839`.
- The feature originated as three linear downstream commits and is squashed here into one signed upstream commit.
- The commit changes 20 files: 13 modified and 7 added.
- The only conflict against current official `master` was the Helio top-bar icon rename in `MainFrame.cpp`; the resolution keeps the new validation-aware state calculation and the official `helio_icon_topbar` / `helio_icon_topbar_disable` assets.
- No submodule or binary changes are included.

## Reviewer focus areas

- cancellation and generation transitions when a new action is requested while an older worker is stopping;
- retry classification, idempotent create handling, and retryable uploads;
- atomic printer/material catalog generation handling;
- plate identity and slicer-validation checks around nested modal dialogs;
- application shutdown while Helio background requests are active.
