### PR TITLE
Fix DBus name case mismatch breaking Linux single-instance file passing

### DIFF
--- a/src/slic3r/GUI/InstanceCheck.cpp
+++ b/src/slic3r/GUI/InstanceCheck.cpp
@@ -236,7 +236,7 @@ namespace instance_check_internal
 			dbus_uint32_t 	serial = 0;
 			const char* sigval = message_text.c_str();
 			//std::string		interface_name = "com.prusa3d.prusaslicer.InstanceCheck";
-			std::string		interface_name = "com.bambulab.BambuStudio.InstanceCheck.Object" + version;
+			std::string		interface_name = "com.BambuLab.BambuStudio.InstanceCheck.Object" + version;
 			std::string   	method_name = "AnotherInstance";
 			//std::string		object_name = "/com/prusa3d/prusaslicer/InstanceCheck";
 			std::string		object_name = "/com/BambuLab/BambuStudio/InstanceCheck/Object" + version;
@@ -538,7 +538,7 @@ namespace MessageHandlerDBusInternal
 	        "       <arg name=\"data\" direction=\"out\" type=\"s\" />"
 	        "     </method>"
 	        "   </interface>"
-	        "   <interface name=\"com.bambulab.BambuStudio.InstanceCheck\">"
+	        "   <interface name=\"com.BambuLab.BambuStudio.InstanceCheck\">"
 	        "     <method name=\"AnotherInstance\">"
 	        "       <arg name=\"data\" direction=\"in\" type=\"s\" />"
 	        "     </method>"


### PR DESCRIPTION
## Problem

On Linux with `single_instance` enabled, opening a file in a second instance is supposed to forward the file path to the already-running instance via a DBus method call. This has been silently broken: the second instance just exits and nothing happens in the running instance.

The cause is a case mismatch in `src/slic3r/GUI/InstanceCheck.cpp`:

- The **sender** (`send_message`) builds the destination/interface name as `com.bambulab.BambuStudio.InstanceCheck.Object<hash>` (lowercase `bambulab`).
- The **listener** (`OtherInstanceMessageHandler::listen` / `handle_dbus_object_message`) registers and matches `com.BambuLab.BambuStudio.InstanceCheck.Object<hash>` (capital `B`, `L`).

DBus names are case-sensitive, so the method call targets a bus name nobody owns and is dropped.

Verified with `dbus-monitor`: the message is published to the lowercase name with no effect, while sending the identical message via `dbus-send` to the correctly-cased name is delivered and triggers the file load in the running instance.

## Fix

Align the sender's interface name with the listener's spelling, and fix the same casing in the introspection XML for consistency. The object path (`/com/BambuLab/...`) already matched on both sides.

Affects both X11 and Wayland.

## Testing

1. Set `"single_instance": "true"` under `app` in `<datadir>/BambuStudio.conf`.
2. Launch BambuStudio.
3. Launch a second instance with an STL path on the command line.
4. Before: nothing happens. After: the running instance comes forward and loads the file.