### PR TITLE
FIX: Lower-case domain-name in D-Bus interface names

### DIFF
--- a/src/slic3r/GUI/InstanceCheck.cpp
+++ b/src/slic3r/GUI/InstanceCheck.cpp
@@ -236,10 +236,10 @@ namespace instance_check_internal
 			dbus_uint32_t 	serial = 0;
 			const char* sigval = message_text.c_str();
 			//std::string		interface_name = "com.prusa3d.prusaslicer.InstanceCheck";
-			std::string		interface_name = "com.BambuLab.BambuStudio.InstanceCheck.Object" + version;
+			std::string		interface_name = "com.bambulab.BambuStudio.InstanceCheck.Object" + version;
 			std::string   	method_name = "AnotherInstance";
 			//std::string		object_name = "/com/prusa3d/prusaslicer/InstanceCheck";
-			std::string		object_name = "/com/BambuLab/BambuStudio/InstanceCheck/Object" + version;
+			std::string		object_name = "/com.bambulab/BambuStudio/InstanceCheck/Object" + version;
 
 
 			// initialise the error value
@@ -538,7 +538,7 @@ namespace MessageHandlerDBusInternal
 	        "       <arg name=\"data\" direction=\"out\" type=\"s\" />"
 	        "     </method>"
 	        "   </interface>"
-	        "   <interface name=\"com.BambuLab.BambuStudio.InstanceCheck\">"
+	        "   <interface name=\"com.bambulab.BambuStudio.InstanceCheck\">"
 	        "     <method name=\"AnotherInstance\">"
 	        "       <arg name=\"data\" direction=\"in\" type=\"s\" />"
 	        "     </method>"
@@ -576,7 +576,7 @@ namespace MessageHandlerDBusInternal
 	{
 		const char* interface_name = dbus_message_get_interface(message);
 	    const char* member_name    = dbus_message_get_member(message);
-	    std::string our_interface  = "com.BambuLab.BambuStudio.InstanceCheck.Object" + wxGetApp().get_instance_hash_string();
+	    std::string our_interface  = "com.bambulab.BambuStudio.InstanceCheck.Object" + wxGetApp().get_instance_hash_string();
 	    BOOST_LOG_TRIVIAL(trace) << "DBus message received: interface: " << interface_name << ", member: " << member_name;
 	    if (0 == strcmp("org.freedesktop.DBus.Introspectable", interface_name) && 0 == strcmp("Introspect", member_name)) {
 	        respond_to_introspect(connection, message);
@@ -596,8 +596,8 @@ void OtherInstanceMessageHandler::listen()
     int 				 name_req_val;
     DBusObjectPathVTable vtable;
     std::string 		 instance_hash  = wxGetApp().get_instance_hash_string();
-	std::string			 interface_name = "com.BambuLab.BambuStudio.InstanceCheck.Object" + instance_hash;
-    std::string			 object_name 	= "/com/BambuLab/BambuStudio/InstanceCheck/Object" + instance_hash;
+    std::string			 interface_name = "com.bambulab.BambuStudio.InstanceCheck.Object" + instance_hash;
+    std::string			 object_name 	= "/com.bambulab/BambuStudio/InstanceCheck/Object" + instance_hash;
 
     //BOOST_LOG_TRIVIAL(debug) << "init dbus listen " << interface_name << " " << object_name;
     dbus_error_init(&err);


### PR DESCRIPTION
Match D-Bus interface names to the (verified) Flatpak app on Flathub, as well as the AppStream naming guidelines:
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-id-generic

and lower-case the reverse domain name portion of the D-Bus interface and object names.

This will also fix the Flatpak being able to own the Instance object.

Fixes: a803118282d8 ("Fix DBus name case mismatch breaking Linux single-instance file passing")