### PR TITLE
Raise Cool Plate SuperTack bed temp for P2S and X2D, PLA Basic, PETG Basic, and PETG HF 

### DIFF
--- a/resources/profiles/BBL/filament/Bambu PETG Basic @BBL P2S 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PETG Basic @BBL P2S 0.2 nozzle.json
@@ -57,10 +57,10 @@
         "0"
     ],
     "supertack_plate_temp": [
-        "60"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "70"
     ],
     "compatible_printers": [
         "Bambu Lab P2S 0.2 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PETG Basic @BBL P2S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PETG Basic @BBL P2S 0.4 nozzle.json
@@ -84,10 +84,10 @@
         "0"
     ],
     "supertack_plate_temp": [
-        "60"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "70"
     ],
     "compatible_printers": [
         "Bambu Lab P2S 0.4 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PETG Basic @BBL P2S 0.6 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PETG Basic @BBL P2S 0.6 nozzle.json
@@ -86,10 +86,10 @@
         "0"
     ],
     "supertack_plate_temp": [
-        "60"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "70"
     ],
     "compatible_printers": [
         "Bambu Lab P2S 0.6 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PETG Basic @BBL P2S 0.8 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PETG Basic @BBL P2S 0.8 nozzle.json
@@ -85,10 +85,10 @@
         "0"
     ],
     "supertack_plate_temp": [
-        "60"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "70"
     ],
     "compatible_printers": [
         "Bambu Lab P2S 0.8 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PETG Basic @BBL X2D 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PETG Basic @BBL X2D 0.2 nozzle.json
@@ -117,10 +117,10 @@
         "4"
     ],
     "supertack_plate_temp": [
-        "60"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "70"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.2 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PETG Basic @BBL X2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PETG Basic @BBL X2D 0.4 nozzle.json
@@ -126,10 +126,10 @@
         "4"
     ],
     "supertack_plate_temp": [
-        "60"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "70"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.4 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PETG HF @BBL P2S 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PETG HF @BBL P2S 0.2 nozzle.json
@@ -113,10 +113,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "60"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "70"
     ],
     "compatible_printers": [
         "Bambu Lab P2S 0.2 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PETG HF @BBL P2S 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PETG HF @BBL P2S 0.4 nozzle.json
@@ -113,10 +113,10 @@
         "0"
     ],
     "supertack_plate_temp": [
-        "60"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "70"
     ],
     "slow_down_layer_time": [
         "10"

--- a/resources/profiles/BBL/filament/Bambu PETG HF @BBL P2S 0.6 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PETG HF @BBL P2S 0.6 nozzle.json
@@ -116,10 +116,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "60"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "70"
     ],
     "compatible_printers": [
         "Bambu Lab P2S 0.6 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PETG HF @BBL P2S 0.8 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PETG HF @BBL P2S 0.8 nozzle.json
@@ -115,10 +115,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "60"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "70"
     ],
     "compatible_printers": [
         "Bambu Lab P2S 0.8 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PETG HF @BBL X2D 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PETG HF @BBL X2D 0.2 nozzle.json
@@ -156,10 +156,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "45"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "45"
+        "70"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.2 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PETG HF @BBL X2D 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PETG HF @BBL X2D 0.2 nozzle.json
@@ -156,10 +156,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "60"
+        "45"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "45"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.2 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PETG HF @BBL X2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PETG HF @BBL X2D 0.4 nozzle.json
@@ -164,10 +164,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "60"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "70"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.4 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PETG HF @BBL X2D 0.8 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PETG HF @BBL X2D 0.8 nozzle.json
@@ -156,10 +156,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "60"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "70"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.8 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PETG HF @BBL X2D.json
+++ b/resources/profiles/BBL/filament/Bambu PETG HF @BBL X2D.json
@@ -164,10 +164,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "60"
+        "70"
     ],
     "supertack_plate_temp_initial_layer": [
-        "60"
+        "70"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.6 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PLA Basic @BBL P2S 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PLA Basic @BBL P2S 0.2 nozzle.json
@@ -90,10 +90,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "40"
+        "45"
     ],
     "supertack_plate_temp_initial_layer": [
-        "40"
+        "45"
     ],
     "compatible_printers": [
         "Bambu Lab P2S 0.2 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PLA Basic @BBL P2S 0.6 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PLA Basic @BBL P2S 0.6 nozzle.json
@@ -102,10 +102,10 @@
         "0"
     ],
     "supertack_plate_temp": [
-        "40"
+        "45"
     ],
     "supertack_plate_temp_initial_layer": [
-        "40"
+        "45"
     ],
     "slow_down_min_speed": [
         "20",

--- a/resources/profiles/BBL/filament/Bambu PLA Basic @BBL P2S 0.8 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PLA Basic @BBL P2S 0.8 nozzle.json
@@ -98,10 +98,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "40"
+        "45"
     ],
     "supertack_plate_temp_initial_layer": [
-        "40"
+        "45"
     ],
     "compatible_printers": [
         "Bambu Lab P2S 0.8 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PLA Basic @BBL X2D 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PLA Basic @BBL X2D 0.2 nozzle.json
@@ -144,10 +144,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "40"
+        "45"
     ],
     "supertack_plate_temp_initial_layer": [
-        "40"
+        "45"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.2 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PLA Basic @BBL X2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PLA Basic @BBL X2D 0.4 nozzle.json
@@ -149,10 +149,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "40"
+        "45"
     ],
     "supertack_plate_temp_initial_layer": [
-        "40"
+        "45"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.4 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PLA Basic @BBL X2D 0.6 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PLA Basic @BBL X2D 0.6 nozzle.json
@@ -149,10 +149,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "40"
+        "45"
     ],
     "supertack_plate_temp_initial_layer": [
-        "40"
+        "45"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.6 nozzle"

--- a/resources/profiles/BBL/filament/Bambu PLA Basic @BBL X2D 0.8 nozzle.json
+++ b/resources/profiles/BBL/filament/Bambu PLA Basic @BBL X2D 0.8 nozzle.json
@@ -141,10 +141,10 @@
         "20"
     ],
     "supertack_plate_temp": [
-        "40"
+        "45"
     ],
     "supertack_plate_temp_initial_layer": [
-        "40"
+        "45"
     ],
     "compatible_printers": [
         "Bambu Lab X2D 0.8 nozzle"


### PR DESCRIPTION
Cool Plate SuperTack bed temps for X2D and P2S profiles were set to lower values to suit the newer Cool Plate SuperTack Pro build plate, as per comment https://github.com/bambulab/BambuStudio/pull/11431#issuecomment-5066046451

However, since that comment: 

- the [Cool Plate SuperTack Pro ](https://au.store.bambulab.com/products/bambu-cool-plate-supertack-pro) page on Bambu Store has been taken down.
- the [Cool Plate SuperTack ](https://au.store.bambulab.com/products/bambu-cool-plate-supertack) page on Bambu Store has been updated to offer the original SuperTack plate for the X2D and P2S

As per my testing, the lower temps set for the Pro plate are unreliable for the original SuperTack plate causing failures with both PLA Basic and PETG HF, similar to when the SuperTack plate was first released and had lower temps on the profiles originally. The SuperTack profiles ended up having their temps raised to 45C for PLA and 70C for PETG which solved the issues.

Since the original SuperTack plate is now being sold for these printers, and these profiles bear the name of the of the original SuperTack plate (without the "Pro" moniker) it stands to reason that the profiles included in Bambu Studio should support that plate properly with suitable temperatures. 

If/when the Pro variant returns, it should have no issue with the higher temp profiles but leaving them lower does cause issues for the original (apparently now, only available) variant.

Solves https://github.com/bambulab/BambuStudio/issues/11430