### PR TITLE
ENH: Add "Lock horizon" option for 3Dconnexion devices

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -1284,7 +1284,7 @@ void AppConfig::set_recent_projects(const std::vector<std::string>& recent_proje
 }
 
 void AppConfig::set_mouse_device(const std::string& name, double translation_speed, double translation_deadzone,
-                                 float rotation_speed, float rotation_deadzone, double zoom_speed, bool swap_yz)
+                                 float rotation_speed, float rotation_deadzone, double zoom_speed, bool swap_yz, bool lock_horizon)
 {
     std::string key = std::string("mouse_device:") + name;
     auto it = m_storage.find(key);
@@ -1298,6 +1298,7 @@ void AppConfig::set_mouse_device(const std::string& name, double translation_spe
     it->second["rotation_deadzone"] = float_to_string_decimal_point(rotation_deadzone);
     it->second["zoom_speed"] = float_to_string_decimal_point(zoom_speed);
     it->second["swap_yz"] = swap_yz ? "1" : "0";
+    it->second["lock_horizon"] = lock_horizon ? "1" : "0";
 }
 
 std::vector<std::string> AppConfig::get_mouse_device_names() const

--- a/src/libslic3r/AppConfig.hpp
+++ b/src/libslic3r/AppConfig.hpp
@@ -240,7 +240,7 @@ public:
     std::vector<std::string> get_recent_projects() const;
     void set_recent_projects(const std::vector<std::string>& recent_projects);
 
-	void set_mouse_device(const std::string& name, double translation_speed, double translation_deadzone, float rotation_speed, float rotation_deadzone, double zoom_speed, bool swap_yz);
+	void set_mouse_device(const std::string& name, double translation_speed, double translation_deadzone, float rotation_speed, float rotation_deadzone, double zoom_speed, bool swap_yz, bool lock_horizon);
 	std::vector<std::string> get_mouse_device_names() const;
 	bool get_mouse_device_translation_speed(const std::string& name, double& speed) const
 		{ return get_3dmouse_device_numeric_value(name, "translation_speed", speed); }
@@ -254,6 +254,8 @@ public:
 		{ return get_3dmouse_device_numeric_value(name, "zoom_speed", speed); }
 	bool get_mouse_device_swap_yz(const std::string& name, bool& swap) const
 		{ return get_3dmouse_device_numeric_value(name, "swap_yz", swap); }
+	bool get_mouse_device_lock_horizon(const std::string& name, bool& lock) const
+		{ return get_3dmouse_device_numeric_value(name, "lock_horizon", lock); }
 
 	static const std::string SECTION_FILAMENTS;
     static const std::string SECTION_MATERIALS;

--- a/src/slic3r/GUI/Mouse3DController.cpp
+++ b/src/slic3r/GUI/Mouse3DController.cpp
@@ -345,7 +345,11 @@ bool Mouse3DController::State::apply(const Mouse3DController::Params &params, Ca
             Vec3d rot = params.rotation.scale * input_queue_item.vector * (PI / 180.);
             if (params.swap_yz)
                 rot = Vec3d(rot.x(), -rot.z(), rot.y());
-            camera.rotate_local_around_target(Vec3d(rot.x(), - rot.z(), rot.y()));
+            // With the horizon locked, orbit on a sphere instead and drop the roll component.
+            if (params.lock_horizon)
+                camera.rotate_on_sphere(- rot.z(), rot.x(), true);
+            else
+                camera.rotate_local_around_target(Vec3d(rot.x(), - rot.z(), rot.y()));
 	    } else {
 	    	assert(input_queue_item.is_buttons());
 	        switch (input_queue_item.type_or_buttons) {
@@ -373,12 +377,14 @@ void Mouse3DController::load_config(const AppConfig &appconfig)
 	    float  rotation_deadzone 	= Params::DefaultRotationDeadzone;
 	    double zoom_speed 			= 2.0;
         bool   swap_yz              = false;
+        bool   lock_horizon         = false;
         appconfig.get_mouse_device_translation_speed(device_name, translation_speed);
 	    appconfig.get_mouse_device_translation_deadzone(device_name, translation_deadzone);
 	    appconfig.get_mouse_device_rotation_speed(device_name, rotation_speed);
 	    appconfig.get_mouse_device_rotation_deadzone(device_name, rotation_deadzone);
 	    appconfig.get_mouse_device_zoom_speed(device_name, zoom_speed);
         appconfig.get_mouse_device_swap_yz(device_name, swap_yz);
+        appconfig.get_mouse_device_lock_horizon(device_name, lock_horizon);
         // clamp to valid values
 	    Params params;
 	    params.translation.scale = Params::DefaultTranslationScale * std::clamp(translation_speed, Params::MinTranslationScale, Params::MaxTranslationScale);
@@ -387,6 +393,7 @@ void Mouse3DController::load_config(const AppConfig &appconfig)
 	    params.rotation.deadzone = std::clamp(rotation_deadzone, 0.0f, Params::MaxRotationDeadzone);
 	    params.zoom.scale = Params::DefaultZoomScale * std::clamp(zoom_speed, 0.1, 10.0);
         params.swap_yz = swap_yz;
+        params.lock_horizon = lock_horizon;
         m_params_by_device[device_name] = std::move(params);
 	}
 }
@@ -402,7 +409,7 @@ void Mouse3DController::save_config(AppConfig &appconfig) const
 		const Params      &params      = key_value_pair.second;
 	    // Store current device parameters into the config
         appconfig.set_mouse_device(device_name, params.translation.scale / Params::DefaultTranslationScale, params.translation.deadzone,
-            params.rotation.scale / Params::DefaultRotationScale, params.rotation.deadzone, params.zoom.scale / Params::DefaultZoomScale, params.swap_yz);
+            params.rotation.scale / Params::DefaultRotationScale, params.rotation.deadzone, params.zoom.scale / Params::DefaultZoomScale, params.swap_yz, params.lock_horizon);
     }
 }
 
@@ -586,6 +593,21 @@ void Mouse3DController::render_settings_dialog(GLCanvas3D& canvas) const
             if (imgui.bbl_checkbox(_L("Swap Y/Z axes"), swap_yz)) {
                 params_copy.swap_yz = swap_yz;
                 params_changed = true;
+            }
+
+            ImGui::SetCursorPosX(max_left_size + max_slider_txt_size - imgui.get_slider_icon_size().x + space_size);
+            bool lock_horizon = params_copy.lock_horizon;
+            if (imgui.bbl_checkbox(_L("Lock horizon"), lock_horizon)) {
+                params_copy.lock_horizon = lock_horizon;
+                params_changed = true;
+                if (lock_horizon) {
+                    // Level the view, or any roll already accumulated stays frozen in place.
+                    Plater *plater = wxGetApp().plater();
+                    if (plater != nullptr) {
+                        plater->get_camera().recover_from_free_camera();
+                        plater->set_current_canvas_as_dirty();
+                    }
+                }
             }
 
 #if ENABLE_3DCONNEXION_DEVICES_DEBUG_OUTPUT

--- a/src/slic3r/GUI/Mouse3DController.hpp
+++ b/src/slic3r/GUI/Mouse3DController.hpp
@@ -61,6 +61,8 @@ class Mouse3DController
         size_t 					 input_queue_max_size { 15 };
         // Whether to swap Y/Z axes or not.
         bool 					 swap_yz{ false };
+        // Whether to keep the horizon level while rotating or not.
+        bool 					 lock_horizon{ false };
     };
 
 	// Queue of the 3DConnexion input events (translations, rotations, button presses).


### PR DESCRIPTION
## What
Add a **Lock horizon** option to the 3Dconnexion settings dialog. When enabled, 3D mouse rotation orbits on a sphere about the target instead of rotating freely about the camera local axes, so the horizon stays level.

<img width="396" height="310" alt="BambuStudio SpaceMouse Lock Horizon" src="https://github.com/user-attachments/assets/f211cbc7-e06a-4a45-9004-711e7f8758d6" />

## Why
Rotation is applied with `rotate_local_around_target()`, which has no world-up constraint. Roll accumulates as the view is reoriented and never returns to level, leaving the scene progressively tilted. 3Dconnexion drivers offer this as "Lock Horizon" for NavLib applications, but Bambu Studio uses the legacy 3DconnexionClient path, so the driver shows no Navigation tab for it and the option cannot come from that side.

## Changes (4 files, +31/-4)
- `slic3r/GUI/Mouse3DController.{cpp,hpp}` — `lock_horizon` param, dialog checkbox, and the rotation branch: `rotate_on_sphere(-rot.z(), rot.x(), true)`, so azimut turns about the world Z axis and zenit about the camera right vector — what a mouse drag already does. The roll axis is dropped, having nowhere to go under a locked horizon.
- `libslic3r/AppConfig.{cpp,hpp}` — persist `lock_horizon` per device, alongside `swap_yz`.

Ticking the box also levels the current view through the existing `Camera::recover_from_free_camera()`. Orbiting on a sphere only stops roll from growing, so without this any roll already accumulated would be frozen in place as a permanently tilted horizon.

## Testing
Manual, macOS 26 / arm64, 3Dconnexion SpaceMouse Wireless BT: the horizon holds level through combined orbit/pan/zoom, levels correctly when enabled from an already-tilted view, and the setting survives a restart and opening other projects. Top view is unaffected — `recover_from_free_camera()` no-ops when the right vector is already horizontal.

## Scope
Defaults to off, so existing free rotation is unchanged for anyone who prefers it. Axis direction/inversion is a separate concern (#6220) and is not touched here.
