### PR TITLE
ENH: remember last-used process profile per printer

### DIFF
--- a/deps/OCCT/OCCT.cmake
+++ b/deps/OCCT/OCCT.cmake
@@ -16,6 +16,11 @@ bambustudio_add_cmake_project(OCCT
     #DEPENDS dep_FREETYPE
     CMAKE_ARGS
         -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        # OCCT 7.6 only sets -std=c++0x when the compiler id is "Clang"; Apple Xcode reports
+        # "AppleClang", so it falls through with no C++ standard and fails to parse nested
+        # template closes (>>). Force C++11 explicitly to match OCCT's intended standard.
+        -DCMAKE_CXX_STANDARD=11
+        -DCMAKE_CXX_STANDARD_REQUIRED=ON
         -DBUILD_LIBRARY_TYPE=${library_build_type}
         -DUSE_TK=OFF
         -DUSE_TBB=OFF

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -5617,7 +5617,7 @@ void PresetBundle::update_multi_material_filament_presets(size_t to_delete_filam
     }
 }
 
-void PresetBundle::update_compatible(PresetSelectCompatibleType select_other_print_if_incompatible, PresetSelectCompatibleType select_other_filament_if_incompatible)
+void PresetBundle::update_compatible(PresetSelectCompatibleType select_other_print_if_incompatible, PresetSelectCompatibleType select_other_filament_if_incompatible, const std::string &prefered_print_profile_override)
 {
     const Preset					&printer_preset					    = this->printers.get_edited_preset();
 	const PresetWithVendorProfile    printer_preset_with_vendor_profile = this->printers.get_preset_with_vendor_profile(printer_preset);
@@ -5738,8 +5738,13 @@ void PresetBundle::update_compatible(PresetSelectCompatibleType select_other_pri
 		assert(printer_preset.config.has("default_print_profile"));
 		assert(printer_preset.config.has("default_filament_profile"));
         const std::vector<std::string> &prefered_filament_profiles = printer_preset.config.option<ConfigOptionStrings>("default_filament_profile")->values;
+        // BBS: prefer the caller-supplied process profile (e.g. the last one used with this printer)
+        // over the printer's default_print_profile, so switching printers restores the remembered
+        // process instead of dropping to the system base.
+        const std::string prefered_print_profile = prefered_print_profile_override.empty() ?
+            printer_preset.config.opt_string("default_print_profile") : prefered_print_profile_override;
         this->prints.update_compatible(printer_preset_with_vendor_profile, nullptr, select_other_print_if_incompatible,
-            PreferedPrintProfileMatch(this->prints.get_selected_idx() == size_t(-1) ? nullptr : &this->prints.get_edited_preset(), printer_preset.config.opt_string("default_print_profile")));
+            PreferedPrintProfileMatch(this->prints.get_selected_idx() == size_t(-1) ? nullptr : &this->prints.get_edited_preset(), prefered_print_profile));
         const PresetWithVendorProfile   print_preset_with_vendor_profile = this->prints.get_edited_preset_with_vendor_profile();
         // Remember whether the filament profiles were compatible before updating the filament compatibility.
         std::vector<char> 				filament_preset_was_compatible(this->filament_presets.size(), false);

--- a/src/libslic3r/PresetBundle.hpp
+++ b/src/libslic3r/PresetBundle.hpp
@@ -392,7 +392,10 @@ public:
     // Also updates the is_visible flag of each preset.
     // If select_other_if_incompatible is true, then the print or filament preset is switched to some compatible
     // preset if the current print or filament preset is not compatible.
-    void                        update_compatible(PresetSelectCompatibleType select_other_print_if_incompatible, PresetSelectCompatibleType select_other_filament_if_incompatible);
+    // BBS: prefered_print_profile_override, when non-empty, takes precedence over the printer's
+    // default_print_profile when picking a compatible process profile (used to restore the
+    // last-used process for a printer instead of always falling back to the system base).
+    void                        update_compatible(PresetSelectCompatibleType select_other_print_if_incompatible, PresetSelectCompatibleType select_other_filament_if_incompatible, const std::string &prefered_print_profile_override = std::string());
     void                        update_compatible(PresetSelectCompatibleType select_other_if_incompatible) { this->update_compatible(select_other_if_incompatible, select_other_if_incompatible); }
 
     // Set the is_visible flag for printer vendors, printer models and printer variants

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -6825,10 +6825,16 @@ bool Tab::select_preset(
         	       on_page                                ? PresetSelectCompatibleType::Never  :
         	       show_incompatible_presets              ? PresetSelectCompatibleType::OnlyIfWasCompatible : PresetSelectCompatibleType::Always;
         };
+        // BBS: when switching printer (not deleting), prefer the process profile last used with the
+        // newly-selected printer over the system base, so the process isn't reset on every switch.
+        std::string prefered_process_override;
+        if (printer_tab && !delete_current)
+            prefered_process_override = app_config->get("last_process_per_printer", preset_name);
         if (current_dirty || delete_current || print_tab || printer_tab)
             m_preset_bundle->update_compatible(
             	update_compatible_type(technology_changed, print_tab,   (print_tab ? this : wxGetApp().get_tab(Preset::TYPE_PRINT))->m_show_incompatible_presets),
-            	update_compatible_type(technology_changed, false, 		wxGetApp().get_tab(Preset::TYPE_FILAMENT)->m_show_incompatible_presets));
+            	update_compatible_type(technology_changed, false, 		wxGetApp().get_tab(Preset::TYPE_FILAMENT)->m_show_incompatible_presets),
+            	prefered_process_override);
         // Initialize the UI from the current preset.
         if (printer_tab)
             static_cast<TabPrinter*>(this)->update_pages();
@@ -6854,6 +6860,15 @@ bool Tab::select_preset(
         apply_config_from_cache();
 
         load_current_preset();
+
+        // BBS: remember the process profile chosen for the currently-active printer, so switching
+        // back to this printer later restores it instead of resetting to the system base.
+        if (m_type == Preset::TYPE_PRINT) {
+            const std::string cur_printer = m_preset_bundle->printers.get_selected_preset_name();
+            const std::string cur_process = m_preset_bundle->prints.get_selected_preset_name();
+            if (!cur_printer.empty() && !cur_process.empty())
+                app_config->set("last_process_per_printer", cur_printer, cur_process);
+        }
 
         if (delete_third_printer) {
             wxGetApp().CallAfter([filament_presets, process_presets]() {


### PR DESCRIPTION
## What
When switching printers, restore the process (print) profile you last used with the newly-selected printer, instead of always falling back to the printer's `default_print_profile` / the system `-- default --` base.

## Why

Today, switching printers re-runs compatibility checks and, when the current process isn't compatible with the new printer, drops the selection to the system base. Users who keep a preferred process per machine have to re-select it every single time they switch. This makes the process selection "sticky" per printer with no new UI and no manual configuration - it just learns what you last used.

## How

Reuses the existing "preferred profile" matching machinery rather than adding a parallel code path:

- **Record** — `Tab::select_preset` writes the chosen process into AppConfig under a new `last_process_per_printer` section, keyed by printer preset name, whenever a process preset is selected for the active printer.
- **Restore** — on a printer switch, `Tab::select_preset` looks up that printer's remembered process and passes it to `PresetBundle::update_compatible` as a preferred-profile override. `update_compatible` gains an optional  `prefered_print_profile_override` argument that takes precedence over the printer's `default_print_profile` when picking a compatible process.

The existing match-quality ranking already scores a name match above a generic compatible preset, so the remembered profile wins automatically - provided it's compatible with the new printer.

## Behavior / safety

- Falls back to today's behavior if the printer has no remembered process, or the remembered profile is incompatible / has been deleted. No crash paths.
- The "keep current profile if it shares an alias" fast-path is unchanged.
- Printer-switch auto-selection does not pollute the memory - only explicit user process selections are recorded.
- Storage is local to the device (AppConfig), not synced to the account.

## Files

- `src/libslic3r/PresetBundle.hpp` — optional `prefered_print_profile_override` param
- `src/libslic3r/PresetBundle.cpp` — prefer the override over `default_print_profile`
- `src/slic3r/GUI/Tab.cpp` — record on process select, restore on printer switch

## Testing

- Set process A on printer X → switch to printer Y → switch back to X → process A is restored (previously reset to system base).
- New/never-used printer → unchanged fallback behavior.
- Remembered profile made incompatible → graceful fallback, no error.