### PR TITLE
FIX: keep gizmo screen size constant under a perspective camera

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -2807,6 +2807,9 @@ void GLCanvas3D::render(bool only_init)
     camera.apply_projection(_max_bounding_box(true, true, true,is_volumes_limit_to_expand_plate()));
     camera.update_frustum();
 
+    //BBS update gizmo camera scaling (inv_zoom + perspective depth correction)
+    GLGizmoBase::update_camera_scaling(camera, m_selection);
+
     m_frame_callback_list.clear();
 
     const std::array<int, 4>& viewport = camera.get_viewport();
@@ -9428,8 +9431,6 @@ void GLCanvas3D::_render_volumes_for_picking() const
 
 void GLCanvas3D::_render_current_gizmo() const
 {
-    //BBS update inv_zoom
-    GLGizmoBase::INV_ZOOM = (float)get_active_camera().get_inv_zoom();
     m_gizmos.render_current_gizmo();
 }
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoBase.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBase.cpp
@@ -5,6 +5,7 @@
 #include <GL/glew.h>
 #include <algorithm>
 
+#include "slic3r/GUI/Camera.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
 #include "slic3r/GUI/GUI_Colors.hpp"
 #include "slic3r/GUI/OpenGLManager.hpp"
@@ -15,6 +16,7 @@ namespace Slic3r {
 namespace GUI {
 
 float GLGizmoBase::INV_ZOOM = 1.0f;
+float GLGizmoBase::DEPTH_CORRECTION = 1.0f;
 
 
 const float GLGizmoBase::Grabber::SizeFactor = 0.05f;
@@ -324,11 +326,51 @@ void GLGizmoBase::render_lines(const std::vector<Vec3d> &points)
     wxGetApp().unbind_shader();
 }
 
+void GLGizmoBase::update_camera_scaling(const Camera& camera, const Selection& selection)
+{
+    INV_ZOOM = (float)camera.get_inv_zoom();
+    DEPTH_CORRECTION = 1.0f;
+
+    if (camera.get_type() != Camera::EType::Perspective)
+        return;
+
+    // Left untouched on purpose: with the flag off the gizmo geometry is anchored to the object
+    // bounding box in world space and only the grabber cubes follow 1/zoom, so that path was never
+    // screen size stable to begin with. Reworking it is out of scope here.
+    const auto& ogl_manager = wxGetApp().get_opengl_manager();
+    if (!ogl_manager || !ogl_manager->is_gizmo_keep_screen_size_enabled())
+        return;
+
+    if (selection.is_empty())
+        return;
+
+    const BoundingBoxf3& box = selection.get_bounding_box();
+    if (!box.defined)
+        return;
+
+    const double near_z    = camera.get_near_z();
+    const double gui_scale = camera.get_gui_scale(); // == near_z / orbit_distance under perspective
+    if (near_z <= EPSILON || gui_scale <= EPSILON)
+        return;
+
+    // Scaling a world space length by 1/zoom keeps it constant on screen only under an orthographic
+    // projection. Under perspective the projected size also scales with orbit_distance / depth, so a
+    // gizmo anchored away from the orbit plane grows or shrinks on its own. Cancel that term here.
+    const double depth = -(camera.get_view_matrix() * box.center()).z(); // eye space depth, positive in front of the camera
+    if (depth <= near_z) // anchor is in front of the near plane, nothing is drawn there anyway
+        return;
+
+    // Clamped on both ends: a large factor inflates the gizmo AABB which feeds back into
+    // Camera::apply_projection, a tiny one makes the grabber model matrix degenerate.
+    const double orbit_distance = near_z / gui_scale;
+    DEPTH_CORRECTION = (float)std::clamp(depth / orbit_distance, 0.1, 8.0);
+}
+
 float GLGizmoBase::get_grabber_size()
 {
     float grabber_size = 8.0f;
     if (GLGizmoBase::INV_ZOOM > 0) {
-        grabber_size = GLGizmoBase::Grabber::FixedGrabberSize * GLGizmoBase::Grabber::GrabberSizeFactor * GLGizmoBase::INV_ZOOM;
+        grabber_size = GLGizmoBase::Grabber::FixedGrabberSize * GLGizmoBase::Grabber::GrabberSizeFactor * GLGizmoBase::INV_ZOOM * GLGizmoBase::DEPTH_CORRECTION;
     }
     return grabber_size;
 }
@@ -688,7 +730,7 @@ void GLGizmoBase::modify_radius(float& radius) const
             uint32_t t_height = 0;
             ogl_manager->get_viewport_size(t_width, t_height);
             radius = 0.2f * std::min(t_width, t_height);
-            radius *= GLGizmoBase::INV_ZOOM;
+            radius *= GLGizmoBase::INV_ZOOM * GLGizmoBase::DEPTH_CORRECTION;
         }
     }
 }

--- a/src/slic3r/GUI/Gizmos/GLGizmoBase.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBase.hpp
@@ -32,6 +32,7 @@ namespace GUI {
 
 class ImGuiWrapper;
 class GLCanvas3D;
+struct Camera;
 enum class CommonGizmosDataID;
 class CommonGizmosDataPool;
 class Selection;
@@ -44,6 +45,16 @@ public:
     static const unsigned int BASE_ID = 255 * 255 * 254;
 
     static float INV_ZOOM;
+    // Cancels the perspective foreshortening for screen-space-sized gizmos, stays 1.0 under an orthographic camera.
+    static float DEPTH_CORRECTION;
+
+    // Refreshes INV_ZOOM and DEPTH_CORRECTION for the given camera. The selection provides the anchor the
+    // gizmo is drawn around; DEPTH_CORRECTION falls back to 1.0 with an orthographic camera, with nothing
+    // selected, or when the screen size mode is off.
+    // Call once per frame, after Camera::apply_projection(), which is what fills in near_z and gui_scale.
+    // Single anchor per frame: grabbers offset from the selection center (Scale corners, the Cut plane,
+    // the Text/SVG cube) keep a residual error proportional to their own depth offset.
+    static void update_camera_scaling(const Camera& camera, const Selection& selection);
 
     //BBS colors
     static std::array<float, 4> DEFAULT_BASE_COLOR;

--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -2872,9 +2872,11 @@ Transform3d get_screen_scalling_matrix()
     if (p_ogl_manager) {
         if (p_ogl_manager->is_gizmo_keep_screen_size_enabled()) {
             const auto& t_zoom = camera.get_zoom();
-            screen_scalling_matrix.data()[0 * 4 + 0] = 5.0f / t_zoom;
-            screen_scalling_matrix.data()[1 * 4 + 1] = 5.0f / t_zoom;
-            screen_scalling_matrix.data()[2 * 4 + 2] = 5.0f / t_zoom;
+            // Same perspective correction the gizmos get, so the hints stay the same length as the gizmo arrows.
+            const double t_scale = 5.0 * (double)GLGizmoBase::DEPTH_CORRECTION / t_zoom;
+            screen_scalling_matrix.data()[0 * 4 + 0] = t_scale;
+            screen_scalling_matrix.data()[1 * 4 + 1] = t_scale;
+            screen_scalling_matrix.data()[2 * 4 + 2] = t_scale;
         }
     }
     return screen_scalling_matrix;


### PR DESCRIPTION
## The problem

With default settings the gizmos (move / rotate / scale) do not keep a constant size on screen. Their size depends on where the selected object is relative to the point the camera orbits around. In a project with many plates, the gizmo of an object on a far plate becomes tiny, and it becomes huge when the object is closer to the camera than the orbit point. It also changes while panning the view, without touching the zoom.

Default settings here means `gizmo_keep_screen_size = true` and the perspective camera, both are defaults (`AppConfig.cpp` sets `gizmo_keep_screen_size` to true, `Camera.hpp` has `EType m_type{ EType::Perspective }`).

Reports that look like this problem: #5845, #3753, #6806, #5035, #11785.

## Where it comes from

Gizmos compute a world size and cancel the zoom with `INV_ZOOM = 1 / camera.get_zoom()`:

```cpp
// GLGizmoBase.cpp, get_grabber_size()
grabber_size = Grabber::FixedGrabberSize * Grabber::GrabberSizeFactor * INV_ZOOM;

// GLGizmoBase.cpp, modify_radius()
radius  = 0.2f * std::min(t_width, t_height);
radius *= GLGizmoBase::INV_ZOOM;
```

This cancels the projection only when the projection is orthographic. In `Camera::apply_projection()` the perspective branch does:

```cpp
// scale near plane to keep w and h constant on the plane at z = m_distance
const double scale = m_frustrum_zs.first / m_distance;
w *= scale;
h *= scale;
```

If you expand the resulting frustum matrix, `near_z` cancels out and the projected size of a world space object becomes

```
screen_px = world_size * zoom * (m_distance / depth)
```

`zoom` is cancelled by `INV_ZOOM`, but `m_distance / depth` is not cancelled by anything. `m_distance` is the distance from the camera to its orbit target, `depth` is the eye space depth of the object. They are equal only for an object sitting exactly on the orbit plane, and the camera orbits the center of the plate, not the selection. So the further the selected object is from that plane, the more wrong the size is.

Two more things make it move on its own:

- panning changes the target (`camera.set_target(...)` in `GLCanvas3D.cpp`), and with `zoom_to_mouse` the wheel calls `camera.translate(displacement)`, so `depth` changes on almost every navigation action;
- `Camera::calc_tight_frustrum_zs_around()` calls `set_distance(m_distance + delta)` when the near plane hits `FrustrumMinNearZ`, so `m_distance` itself changes depending on what is inside the frustum.

## Numbers

This does not need a build. The script below builds the same `glOrtho` / `glFrustum` matrices from the values used in `apply_projection()`, and projects the gizmo radius produced by `modify_radius()`:

<details>
<summary>proof.py</summary>

```python
#!/usr/bin/env python3
# Reproduces Camera::apply_projection() + GLGizmoBase::modify_radius() with plain arithmetic.
# No OpenGL and no build needed: it only builds the same glOrtho / glFrustum terms the code builds.

VP, ORBIT = (2560, 1440), 1000.0      # viewport in px, Camera::DefaultDistance in mm


def ring_px(depth, perspective, zoom=3.0):
    inv_zoom = 1.0 / zoom
    radius = 0.2 * min(VP) * inv_zoom                  # GLGizmoBase::modify_radius()
    w = 0.5 * VP[0] * inv_zoom                         # Camera::apply_projection()
    near = max(depth - 60.0, 100.0)                    # tight frustum, FrustrumMinNearZ = 100
    if perspective:
        w *= near / ORBIT                              # "scale near plane to keep w and h constant"
        clip_x, clip_w = near * radius / w, depth      # glFrustum
    else:
        clip_x, clip_w = radius / w, 1.0               # glOrtho
    return clip_x / clip_w * 0.5 * VP[0]


print("gizmo ring, expected constant %d px
" % (0.2 * min(VP)))
print("depth mm |    ortho | perspective")
for depth in (250, 500, 1000, 2000, 3000, 4000):
    ortho, persp = ring_px(depth, False), ring_px(depth, True)
    print("%8d | %6.1f px | %7.1f px  (%.2fx)" % (depth, ortho, persp, persp / ortho))

print("
same object at depth 3000, user zooms in and out:")
for zoom in (1.0, 2.0, 4.0, 8.0):
    print("  zoom %4.1f -> %5.1f px" % (zoom, ring_px(3000, True, zoom)))
```

</details>

Output:

```
gizmo ring, expected constant 288 px

depth mm |    ortho | perspective
     250 |  288.0 px |  1152.0 px  (4.00x)
     500 |  288.0 px |   576.0 px  (2.00x)
    1000 |  288.0 px |   288.0 px  (1.00x)
    2000 |  288.0 px |   144.0 px  (0.50x)
    3000 |  288.0 px |    96.0 px  (0.33x)
    4000 |  288.0 px |    72.0 px  (0.25x)

same object at depth 3000, user zooms in and out:
  zoom  1.0 ->  96.0 px
  zoom  2.0 ->  96.0 px
  zoom  4.0 ->  96.0 px
  zoom  8.0 ->  96.0 px
```

The orthographic column is exactly `0.2 * min(viewport)` at any depth, which is what the code intends. The perspective column is off by exactly `orbit_distance / depth`, from 4x too big to 4x too small in one scene. The second block changes the zoom by 8x and the size does not move at all, which shows `INV_ZOOM` compensates the zoom and only the zoom.

## Steps to reproduce in the app

1. View -> Use Perspective View (default).
2. Put the same object on plate 1 and on a far plate, say plate 10.
3. Select the one on plate 1, press R, look at the ring. Then select the one on the far plate, press R again.
4. The ring is much smaller on the far plate, and the arrow heads too.
5. Now View -> Use Orthogonal View and repeat: both rings are the same size.

Step 5 is the check that this is the projection and not something else, because the sizing code is the same in both cases.

## The fix

Cancel the missing term: multiply the screen space sizes by `depth / orbit_distance`, where `depth` is the eye space depth of the selection center.

`Camera::get_distance()` and `Camera::get_target()` are not const, so they cannot be called from the const render path. But the perspective branch already stores `m_gui_scale = near_z / m_distance`, so the orbit distance is `get_near_z() / get_gui_scale()`, and both getters are const.

The correction only applies when it is needed, and stays `1.0f` otherwise:

- orthographic camera: nothing to cancel, the old math is already exact;
- `gizmo_keep_screen_size == false`: that path is left bit identical, see the known limits below;
- nothing selected, or the anchor is in front of the near plane.

The factor is clamped to `[0.1, 8.0]`. The lower end keeps the grabber model matrix from becoming degenerate (`normal_matrix` takes an inverse of it), the upper end keeps the gizmo AABB from inflating too much, because it is merged into `_max_bounding_box()` and ends up in `apply_projection()` again.

`Selection::get_screen_scalling_matrix()` gets the same factor. It sizes the sidebar position and rotation hints under the same flag, from the same anchor, and they are drawn one line before the gizmo in the same frame, so leaving it out would make the hint arrows and the gizmo arrows differ in length by the same factor.

Because of that the update moved from `_render_current_gizmo()` up into `render()`, right after `apply_projection()` fills in `near_z` and `gui_scale`. Both consumers now read the value of the current frame. `_render_current_gizmo()` is the only call site of the old assignment, so nothing else loses the refresh.

Existing preferences keep their meaning, `grabber_size_factor` still scales the same way.

## Known limits of this patch

- The correction uses one anchor per frame, the selection center. Grabbers that sit away from it, the Scale corners, the Cut plane grabber, the Text/SVG cube, keep a residual error proportional to their own depth offset. One anchor keeps the parts of a gizmo proportional to each other, which looked more important than making each grabber exact.
- With `gizmo_keep_screen_size` off nothing changes at all. That path is also foreshortened, but there the grabber size and the arrow offset both scale as `1/zoom` and stay consistent with each other, so correcting only one of them would make it worse.
- The gizmo geometry used by the picking pass is still built in `on_render()`, which runs after `_picking_pass()`, so hit boxes lag one frame as before. Both passes use the same world sizes, so this patch does not change that, but it may be part of why grabbers are hard to hit while the camera moves (#6806).
