### PR TITLE
fix: Restore layer Z after spiral-vase raft tool changes

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7722,11 +7722,11 @@ std::string GCode::travel_to(const Point &point, ExtrusionRole role, std::string
 
         if (m_spiral_vase) {
             // No lazy z lift for spiral vase mode
+            for (size_t i = 1; i < travel.size(); ++i)
+                gcode += m_writer.travel_to_xy(this->point_to_gcode(travel.points[i]), comment, use_short_travel_accel);
             const double target_z = z == DBL_MAX ? m_nominal_z : z;
             if (std::abs(m_writer.get_position().z() - target_z) > EPSILON)
                 gcode += m_writer.travel_to_z(target_z, "restore spiral vase layer Z");
-            for (size_t i = 1; i < travel.size(); ++i)
-                gcode += m_writer.travel_to_xy(this->point_to_gcode(travel.points[i]), comment, use_short_travel_accel);
         } else {
             if (travel.size() == 2) {
                 // No extra movements emitted by avoid_crossing_perimeters, simply move to the end point with z change

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7722,6 +7722,9 @@ std::string GCode::travel_to(const Point &point, ExtrusionRole role, std::string
 
         if (m_spiral_vase) {
             // No lazy z lift for spiral vase mode
+            const double target_z = z == DBL_MAX ? m_nominal_z : z;
+            if (std::abs(m_writer.get_position().z() - target_z) > EPSILON)
+                gcode += m_writer.travel_to_z(target_z, "restore spiral vase layer Z");
             for (size_t i = 1; i < travel.size(); ++i)
                 gcode += m_writer.travel_to_xy(this->point_to_gcode(travel.points[i]), comment, use_short_travel_accel);
         } else {

--- a/tests/fff_print/test_printgcode.cpp
+++ b/tests/fff_print/test_printgcode.cpp
@@ -15,6 +15,79 @@ boost::regex perimeters_regex("G1 X[-0-9.]* Y[-0-9.]* E[-0-9.]* ; perimeter");
 boost::regex infill_regex("G1 X[-0-9.]* Y[-0-9.]* E[-0-9.]* ; infill");
 boost::regex skirt_regex("G1 X[-0-9.]* Y[-0-9.]* E[-0-9.]* ; skirt");
 
+namespace {
+
+struct SpiralRaftGCodeResult
+{
+    double first_model_extrusion_z { -1. };
+    double highest_z_before_model  { 0. };
+    double nominal_model_layer_z   { 0. };
+    size_t layer_z_restores        { 0 };
+    bool   model_z_is_continuous   { true };
+};
+
+SpiralRaftGCodeResult spiral_raft_gcode_result(const std::string &change_filament_gcode)
+{
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_num_extruders(2);
+    config.set_deserialize_strict({
+        { "spiral_mode",                       true },
+        { "wall_loops",                        1 },
+        { "top_shell_layers",                  0 },
+        { "bottom_shell_layers",               1 },
+        { "sparse_infill_density",             "0%" },
+        { "raft_layers",                       2 },
+        { "support_material_extruder",         2 },
+        { "support_material_interface_extruder", 2 },
+        { "perimeter_extruder",                1 },
+        { "infill_extruder",                   1 },
+        { "solid_infill_extruder",             1 },
+        { "retraction_length",                 0 },
+        { "skirts",                            0 },
+        { "gcode_comments",                    true },
+        { "start_gcode",                       "T[initial_tool]\n" },
+        { "change_filament_gcode",             change_filament_gcode }
+    });
+
+    Slic3r::Print print;
+    Slic3r::Model model;
+    Slic3r::Test::init_print({ TestMesh::cube_20x20x20 }, print, model, config);
+    std::string gcode = Slic3r::Test::gcode(print);
+
+    SpiralRaftGCodeResult result;
+    result.nominal_model_layer_z = print.objects().front()->layers().front()->print_z;
+    int                   current_tool = -1;
+    bool                  raft_tool_seen = false;
+    double                last_model_extrusion_z = -1.;
+    GCodeReader           reader;
+    reader.apply_config(config);
+    reader.parse_buffer(gcode, [&result, &current_tool, &raft_tool_seen, &last_model_extrusion_z](GCodeReader &self, const GCodeReader::GCodeLine &line) {
+        if (line.cmd().size() > 1 && line.cmd().front() == 'T') {
+            current_tool = atoi(line.cmd().data() + 1);
+            raft_tool_seen |= current_tool == 1;
+        }
+
+        if (result.first_model_extrusion_z < 0.) {
+            result.highest_z_before_model = std::max(result.highest_z_before_model, static_cast<double>(self.z()));
+            if (line.comment().find("restore spiral vase layer Z") != std::string_view::npos)
+                ++result.layer_z_restores;
+            if (raft_tool_seen && current_tool == 0 && line.extruding(self) && line.dist_XY(self) > 0.)
+                result.first_model_extrusion_z = self.z();
+        }
+
+        if (raft_tool_seen && current_tool == 0 && line.extruding(self) && line.dist_XY(self) > 0.) {
+            if (last_model_extrusion_z >= 0.) {
+                double z_step = self.z() - last_model_extrusion_z;
+                result.model_z_is_continuous &= z_step >= -EPSILON && z_step <= 0.21;
+            }
+            last_model_extrusion_z = self.z();
+        }
+    });
+    return result;
+}
+
+} // namespace
+
 SCENARIO( "PrintGCode basic functionality", "[PrintGCode]") {
     GIVEN("A default configuration and a print test object") {
         WHEN("the output is executed with no support material") {
@@ -267,5 +340,32 @@ SCENARIO( "PrintGCode basic functionality", "[PrintGCode]") {
 				REQUIRE(z == Approx(20.));
 			}
         }
+    }
+}
+
+TEST_CASE("Spiral vase restores object layer Z after a raft tool change", "[PrintGCode][SpiralVase]")
+{
+    SECTION("tool change ends at an elevated clearance Z") {
+        SpiralRaftGCodeResult result = spiral_raft_gcode_result("G1 X5 F12000\nG1 Z{max_layer_z + 3.0} F1200\nT[next_extruder]\n");
+
+        REQUIRE(result.first_model_extrusion_z == Approx(result.nominal_model_layer_z));
+        REQUIRE(result.highest_z_before_model >= result.nominal_model_layer_z + 2.);
+        REQUIRE(result.layer_z_restores == 1);
+    }
+
+    SECTION("tool change does not alter Z") {
+        SpiralRaftGCodeResult result = spiral_raft_gcode_result("T[next_extruder]\n");
+
+        REQUIRE(result.first_model_extrusion_z == Approx(result.nominal_model_layer_z));
+        REQUIRE(result.layer_z_restores == 0);
+        REQUIRE(result.model_z_is_continuous);
+    }
+
+    SECTION("tool change leaves the XY position unknown at clearance Z") {
+        SpiralRaftGCodeResult result = spiral_raft_gcode_result("G1 Z{max_layer_z + 3.0} F1200\nT[next_extruder]\n");
+
+        REQUIRE(result.first_model_extrusion_z == Approx(result.nominal_model_layer_z));
+        REQUIRE(result.highest_z_before_model >= result.nominal_model_layer_z + 2.);
+        REQUIRE(result.layer_z_restores == 1);
     }
 }


### PR DESCRIPTION
## Summary

Update the spiral-vase path in `GCode::travel_to` to restore the writer to the requested/nominal layer Z when an earlier tool change or injected G-code left it at a different height, then retain the existing XY-only travel behavior once Z is correct. Base the decision on the generator's tracked position and the travel's target Z rather than on X2D-specific commands, raft counts, or a hard-coded clearance value, so other custom tool-change sequences receive the same correction. Preserve the no-extra-Z-move behavior for ordinary spiral layers where the tracked and nominal heights already agree, avoiding changes to seam blending and spiral interpolation.

## Test plan

- Happy path: slice a hollow single-object spiral-vase print with two raft layers on filament 2 and the model on filament 1, with tool-change G-code ending at `max_layer_z + 3`; verify the first model extrusion after the raft is at the nominal first-object-layer Z.
- Edge case: slice the same spiral-vase/raft geometry without a Z-changing tool change; verify no redundant layer-height correction is introduced and the existing spiralized Z progression remains continuous.
- Error path: use custom tool-change G-code that moves to a clearance Z and leaves the current XY position unknown; verify the generated travel safely restores Z before any model extrusion and does not emit extrusion at the clearance height.

## Why

On an X2D print that uses an auxiliary filament for a two-layer raft and the main filament for a spiral-vase object, the first object extrusion is emitted roughly ten layers above its intended position. The raft-to-object filament change runs custom machine G-code that may finish at a clearance Z such as `max_layer_z + 3`, and the generator records that external Z position. The spiral-vase branch of `GCode::travel_to` then emits only an XY travel, unlike the normal branch that travels in XYZ, so it does not restore the nominal object-layer Z before extrusion. The issue is limited to the interaction between raft-driven tool changes, externally moved Z, and spiral-vase travel behavior; ordinary spiral interpolation and the X2D profile template should remain unchanged.

Closes #11961
