### PR TITLE
FIX: validate cut connector volume_id and type from cut_information.xml

### DIFF
--- a/src/libslic3r/Format/bbs_3mf.cpp
+++ b/src/libslic3r/Format/bbs_3mf.cpp
@@ -2301,8 +2301,19 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
             if (cut_object_info != m_cut_object_infos.end()) {
                 model_object->cut_id = cut_object_info->second.id;
 
-                for (auto connector : cut_object_info->second.connectors) {
-                    assert(0 <= connector.volume_id && connector.volume_id <= int(model_object->volumes.size()));
+                for (const auto &connector : cut_object_info->second.connectors) {
+                    // volume_id and type come straight out of Metadata/cut_information.xml, i.e. from
+                    // untrusted file content. They must be range-checked before use: assert() is compiled
+                    // out in release builds, so a crafted or corrupted 3MF would index ModelObject::volumes
+                    // out of bounds and write a CutInfo through the resulting garbage pointer.
+                    if (connector.volume_id < 0 || connector.volume_id >= int(model_object->volumes.size())) {
+                        add_error("Invalid cut connector volume_id " + std::to_string(connector.volume_id));
+                        continue;
+                    }
+                    if (connector.type < 0 || connector.type > int(CutConnectorType::Undef)) {
+                        add_error("Invalid cut connector type " + std::to_string(connector.type));
+                        continue;
+                    }
                     model_object->volumes[connector.volume_id]->cut_info =
                         ModelVolume::CutInfo(CutConnectorType(connector.type), connector.radius, connector.height, connector.r_tolerance, connector.h_tolerance, true);
                 }


### PR DESCRIPTION
### Problem

`_BBS_3MF_Importer` reads the cut-connector `volume_id` and `type` verbatim out of `Metadata/cut_information.xml` (`_extract_cut_information_from_archive`). Both are later used without validation — the only guard is an `assert()`:

```cpp
assert(0 <= connector.volume_id && connector.volume_id <= int(model_object->volumes.size()));
model_object->volumes[connector.volume_id]->cut_info =
    ModelVolume::CutInfo(CutConnectorType(connector.type), ...);
```

`assert()` is compiled out under `NDEBUG`, which is what the Release configurations in `CMakePresets.json` build with. In shipping builds there is therefore no bounds check: a `volume_id` taken from the file indexes `ModelObject::volumes` (a `std::vector<ModelVolume*>`) directly, and a `CutInfo` is written through the pointer that comes back. A 3MF carrying a `volume_id` outside the object's volume range reads and writes out of bounds.

`type` has the same problem on a smaller scale: an arbitrary `int` is cast into the scoped enum `CutConnectorType`, which is undefined behaviour for out-of-range values.

The assert is also off by one — it accepts `volume_id == volumes.size()`.

### Fix

Replace the assert with runtime range checks on both fields. A rejected connector is skipped and reported via `add_error()` rather than failing the whole load, matching how the rest of this importer handles malformed data — one bad entry should not make a project file unopenable.

### Notes

- No behaviour change for well-formed files.
- The other two `assert`-guarded indexing sites in this importer (`custom_supports` / `mmu_segmentation`) are **not** affected: those arrays are filled in lockstep with `geometry.triangles`, and `first_triangle_id` / `last_triangle_id` are already range-checked before use. Left alone deliberately.
