### PR TITLE
fix: apply mixed-filament gradient ratios across model height

### DIFF
--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -2177,14 +2177,6 @@ void ToolOrdering::resolve_mixed_filaments(const PrintConfig &config)
             continue;
         slots[i].ratios = parse_mixed_ratios(
             i < ratio_strs.size() ? ratio_strs[i] : "", slots[i].components.size());
-        if (!sublayer_enabled) {
-            for (double &r : slots[i].ratios)
-                r = snap_to_simple_fraction(r);
-            double sum = 0;
-            for (double r : slots[i].ratios) sum += r;
-            if (sum > 0)
-                for (double &r : slots[i].ratios) r /= sum;
-        }
         slots[i].accum.assign(slots[i].components.size(), 0LL);
     }
 
@@ -2216,6 +2208,23 @@ void ToolOrdering::resolve_mixed_filaments(const PrintConfig &config)
         }
         if (i < gradient_curve_strs.size() && !gradient_curve_strs[i].empty())
             gradient_info[i].curve = parse_gradient_curve(gradient_curve_strs[i]);
+    }
+
+    // A valid two-component gradient always needs sublayer resolution so its
+    // height-dependent ratios can be represented, even when the independent
+    // mixed-color sublayer option is disabled. Non-gradient slots retain the
+    // deficit round-robin normalization in that configuration.
+    std::vector<bool> use_sublayers(slots.size(), sublayer_enabled);
+    for (size_t i = 0; i < slots.size(); ++i) {
+        use_sublayers[i] = use_sublayers[i] || is_gradient[i];
+        if (slots[i].components.empty() || use_sublayers[i])
+            continue;
+        for (double &r : slots[i].ratios)
+            r = snap_to_simple_fraction(r);
+        double sum = 0;
+        for (double r : slots[i].ratios) sum += r;
+        if (sum > 0)
+            for (double &r : slots[i].ratios) r /= sum;
     }
 
     // Pass 1: identify continuous runs for each gradient slot (Per-Run).
@@ -2418,7 +2427,7 @@ void ToolOrdering::resolve_mixed_filaments(const PrintConfig &config)
             auto &s = slots[ext];
 
             // Skip sublayer splitting for the first layer to preserve bed adhesion.
-            if (sublayer_enabled && layer_idx > 0) {
+            if (use_sublayers[ext] && layer_idx > 0) {
                 double lh = calc_slot_lh(ext, lt.print_z);
                 size_t n = s.components.size();
 

--- a/tests/fff_print/test_printgcode.cpp
+++ b/tests/fff_print/test_printgcode.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch.hpp>
 
 #include "libslic3r/libslic3r.h"
+#include "libslic3r/GCode/ToolOrdering.hpp"
 #include "libslic3r/GCodeReader.hpp"
 
 #include "test_data.hpp"
@@ -14,6 +15,34 @@ using namespace Slic3r::Test;
 boost::regex perimeters_regex("G1 X[-0-9.]* Y[-0-9.]* E[-0-9.]* ; perimeter");
 boost::regex infill_regex("G1 X[-0-9.]* Y[-0-9.]* E[-0-9.]* ; infill");
 boost::regex skirt_regex("G1 X[-0-9.]* Y[-0-9.]* E[-0-9.]* ; skirt");
+
+namespace {
+
+DynamicPrintConfig mixed_filament_config(bool gradient_enabled)
+{
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_num_filaments(3);
+    config.option<ConfigOptionBools>("filament_is_mixed")->values[2] = true;
+    config.option<ConfigOptionStrings>("filament_mixed_components")->values[2] = "1,2";
+    config.option<ConfigOptionStrings>("filament_mixed_sublayer_ratios")->values[2] = "0.5,0.5";
+    config.option<ConfigOptionBools>("filament_mixed_gradient")->values[2] = gradient_enabled;
+    config.option<ConfigOptionStrings>("filament_mixed_gradient_range")->values[2] = "0.10,0.90";
+    config.set_key_value("enable_mixed_color_sublayer", new ConfigOptionBool(false));
+    config.set_key_value("wall_filament", new ConfigOptionInt(3));
+    config.set_key_value("sparse_infill_filament", new ConfigOptionInt(3));
+    config.set_key_value("solid_infill_filament", new ConfigOptionInt(3));
+    config.set_key_value("layer_height", new ConfigOptionFloat(0.2));
+    config.set_key_value("initial_layer_print_height", new ConfigOptionFloat(0.2));
+    return config;
+}
+
+void init_mixed_filament_print(Print &print, Model &model, bool gradient_enabled)
+{
+    init_print({make_cube(10., 10., 4.)}, print, model, mixed_filament_config(gradient_enabled));
+    print.process();
+}
+
+} // namespace
 
 SCENARIO( "PrintGCode basic functionality", "[PrintGCode]") {
     GIVEN("A default configuration and a print test object") {
@@ -268,4 +297,56 @@ SCENARIO( "PrintGCode basic functionality", "[PrintGCode]") {
 			}
         }
     }
+}
+
+TEST_CASE("mixed filament gradient enables sublayer resolution", "[PrintGCode][MixedFilament]")
+{
+    Print print;
+    Model model;
+    init_mixed_filament_print(print, model, true);
+    ToolOrdering ordering(print, unsigned(-1));
+    ordering.sort_and_build_data(print, unsigned(-1));
+    const std::vector<LayerTools> &layers = ordering.layer_tools();
+
+    REQUIRE(layers.size() > 3);
+    CHECK(layers.front().mixed_sub_layer_groups.empty());
+    REQUIRE(layers.front().mixed_filament_resolution.count(2) == 1);
+
+    std::vector<const LayerTools::MixedSubLayerGroup *> gradient_groups;
+    for (const LayerTools &layer : layers) {
+        for (const LayerTools::MixedSubLayerGroup &group : layer.mixed_sub_layer_groups) {
+            REQUIRE(group.mixed_slot_0based == 2);
+            REQUIRE(group.is_gradient);
+            REQUIRE((group.components_0based == std::vector<unsigned int>{0, 1}));
+            REQUIRE(group.sub_heights.size() == 2);
+            CHECK(group.sub_heights[0] >= 0.);
+            CHECK(group.sub_heights[1] >= 0.);
+            CHECK(group.sub_heights[0] <= group.layer_height);
+            CHECK(group.sub_heights[1] <= group.layer_height);
+            CHECK(group.sub_heights[0] + group.sub_heights[1] == Approx(group.layer_height));
+            gradient_groups.push_back(&group);
+        }
+    }
+
+    REQUIRE(gradient_groups.size() > 1);
+    CHECK(gradient_groups.front()->sub_heights[0] < gradient_groups.back()->sub_heights[0]);
+}
+
+TEST_CASE("non-gradient mixed filament keeps per-layer resolution", "[PrintGCode][MixedFilament]")
+{
+    Print print;
+    Model model;
+    init_mixed_filament_print(print, model, false);
+    ToolOrdering ordering(print, unsigned(-1));
+    ordering.sort_and_build_data(print, unsigned(-1));
+
+    std::set<unsigned int> resolved_components;
+    for (const LayerTools &layer : ordering.layer_tools()) {
+        CHECK(layer.mixed_sub_layer_groups.empty());
+        REQUIRE(layer.mixed_filament_resolution.count(2) == 1);
+        const unsigned int component = layer.mixed_filament_resolution.at(2);
+        CHECK((component == 0 || component == 1));
+        resolved_components.insert(component);
+    }
+    CHECK((resolved_components == std::set<unsigned int>{0, 1}));
 }


### PR DESCRIPTION
## Summary

In `src/libslic3r/GCode/ToolOrdering.cpp`, derive the effective sublayer-resolution mode from either the existing mixed-color sublayer print option or the presence of an enabled, valid two-component gradient slot. This makes Gradient Effect honor its height-dependent range or custom curve even when the independent mixed-color sublayer setting remains at its default, and it covers newly created as well as loaded project configurations without coupling slicer correctness to a GUI side effect. Keep non-gradient mixed filaments on the current deficit round-robin path when the print option is off, and retain the existing first-layer adhesion behavior and component-order handling.

## Test plan

- Configure a two-component mixed slot with Gradient Effect enabled, a bottom-to-top ratio curve, and `enable_mixed_color_sublayer=false`; after slicing/tool ordering, layers above the first contain mixed sublayer groups whose component heights change from the lower layers to the upper layers according to the gradient direction.
- Configure the same two-component mixed slot with Gradient Effect disabled and `enable_mixed_color_sublayer=false`; each layer continues to resolve to one physical component through deficit round-robin and does not gain a mixed sublayer group.
- Verify the first layer retains the existing no-split adhesion behavior while subsequent gradient layers use both physical components, and ensure the resolved sublayer heights remain bounded by and sum to the source layer height.

## Why

Mixed filaments with Gradient Effect enabled are sliced using an approximately constant alternating-layer mix instead of following the configured ratio curve from the bottom to the top of the model. The report provides concrete reproduction steps, and three additional users confirm the behavior on current Bambu Studio versions across macOS and Windows. In `ToolOrdering::resolve_mixed_filaments`, gradient metadata is parsed regardless of the print setting, but gradient ratios are used only inside the `enable_mixed_color_sublayer` branch; that setting defaults to false, leaving the fixed-layer deficit round-robin path to use the static mix ratios. The issue has no assignee, claim, competing PR, or prior closed PR attempt in the supplied bundle.

Closes #11851
