### PR TITLE
ENH: cut gizmo - set the cut plane from a clicked triangular facet

### DIFF
--- a/bbl/i18n/BambuStudio.pot
+++ b/bbl/i18n/BambuStudio.pot
@@ -968,6 +968,15 @@ msgstr ""
 msgid "Flip cut plane"
 msgstr ""
 
+msgid "Pick face"
+msgstr ""
+
+msgid "Click a face of the model."
+msgstr ""
+
+msgid "Click a face of the model to set the cut plane. The plane lands flush with that face; use Movement to offset it."
+msgstr ""
+
 msgid "Planar"
 msgstr ""
 

--- a/bbl/i18n/BambuStudio.pot
+++ b/bbl/i18n/BambuStudio.pot
@@ -968,15 +968,6 @@ msgstr ""
 msgid "Flip cut plane"
 msgstr ""
 
-msgid "Pick face"
-msgstr ""
-
-msgid "Click a face of the model."
-msgstr ""
-
-msgid "Click a face of the model to set the cut plane. The plane lands flush with that face; use Movement to offset it."
-msgstr ""
-
 msgid "Planar"
 msgstr ""
 

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -138,6 +138,8 @@ set(SLIC3R_GUI_SOURCES
     GUI/Gizmos/GLGizmosManager.hpp
     GUI/Gizmos/GLGizmosCommon.cpp
     GUI/Gizmos/GLGizmosCommon.hpp
+    GUI/Gizmos/FacetPicker.cpp
+    GUI/Gizmos/FacetPicker.hpp
     GUI/Gizmos/GLGizmoBase.cpp
     GUI/Gizmos/GLGizmoBase.hpp
     GUI/Gizmos/GLGizmoMove.cpp

--- a/src/slic3r/GUI/Gizmos/FacetPicker.cpp
+++ b/src/slic3r/GUI/Gizmos/FacetPicker.cpp
@@ -1,0 +1,158 @@
+#include "FacetPicker.hpp"
+
+#include "GLGizmoBase.hpp"
+#include "GLGizmosCommon.hpp"
+#include "slic3r/GUI/Camera.hpp"
+#include "slic3r/GUI/GUI_App.hpp"
+#include "slic3r/GUI/Selection.hpp"
+#include "libslic3r/Model.hpp"
+
+#include <GL/glew.h>
+
+#include <limits>
+
+namespace Slic3r {
+namespace GUI {
+
+Vec3d FacetPicker::world_normal(const Transform3d &trafo, const Vec3f &mesh_normal)
+{
+    const Vec3d  n   = trafo.linear().inverse().transpose() * mesh_normal.cast<double>();
+    const double len = n.norm();
+    return (len < EPSILON) ? Vec3d::Zero() : Vec3d(n / len);
+}
+
+void FacetPicker::set_active(bool active)
+{
+    if (m_active == active)
+        return;
+    m_active = active;
+    if (!m_active)
+        reset();
+}
+
+void FacetPicker::reset()
+{
+    m_hit            = Hit();
+    m_rendered_facet = -1;
+    m_highlight.reset();
+}
+
+bool FacetPicker::update(const Vec2d &mouse_position, const CommonGizmosDataPool *pool, const Selection &selection, const Camera &camera)
+{
+    m_hit = Hit();
+
+    if (pool == nullptr || pool->raycaster() == nullptr || pool->selection_info() == nullptr)
+        return false;
+
+    const ModelObject *mo           = pool->selection_info()->model_object();
+    const int          instance_idx = selection.get_instance_idx();
+    if (mo == nullptr || instance_idx < 0 || instance_idx >= int(mo->instances.size()))
+        return false;
+
+    // Raycaster builds one MeshRaycaster per model-part volume, in mo->volumes order, so
+    // build the matching transform list the same way.
+    const ModelInstance *mi        = mo->instances[instance_idx];
+    const double         sla_shift = pool->selection_info()->get_sla_shift();
+
+    std::vector<Transform3d>         trafo_matrices;
+    std::vector<const ModelVolume *> part_volumes;
+    for (const ModelVolume *mv : mo->volumes) {
+        if (mv->is_model_part()) {
+            trafo_matrices.emplace_back(Geometry::translation_transform(sla_shift * Vec3d::UnitZ()) *
+                                        mi->get_transformation().get_matrix() * mv->get_matrix());
+            part_volumes.emplace_back(mv);
+        }
+    }
+
+    const std::vector<const MeshRaycaster *> raycasters = pool->raycaster()->raycasters();
+    if (raycasters.size() != trafo_matrices.size())
+        return false; // hollowed-mesh or stale-cache case; skip rather than mis-index
+
+    Vec3f  hit = Vec3f::Zero(), normal = Vec3f::Zero();
+    Vec3f  closest_hit = Vec3f::Zero(), closest_normal = Vec3f::Zero();
+    double closest_sq    = std::numeric_limits<double>::max();
+    int    closest_id    = -1;
+    size_t closest_facet = 0;
+
+    for (int mesh_id = 0; mesh_id < int(trafo_matrices.size()); ++mesh_id) {
+        size_t facet = 0;
+        if (raycasters[mesh_id]->unproject_on_mesh(mouse_position, trafo_matrices[mesh_id], camera, hit, normal, nullptr, &facet)) {
+            const double sq = (camera.get_position() - trafo_matrices[mesh_id] * hit.cast<double>()).squaredNorm();
+            if (sq < closest_sq) {
+                closest_sq     = sq;
+                closest_id     = mesh_id;
+                closest_hit    = hit;
+                closest_normal = normal;
+                // Captured inside the nearest-hit branch on purpose. The equivalent loop in
+                // GLGizmoFlatten::update_raycast_cache captures it after the loop, so on a
+                // multi-volume object it can index the last-tested volume's facet into the
+                // nearest volume's mesh.
+                closest_facet  = facet;
+            }
+        }
+    }
+
+    if (closest_id < 0)
+        return false;
+
+    const ModelVolume *mv = part_volumes[closest_id];
+    if (closest_facet >= mv->mesh().its.indices.size())
+        return false;
+
+    const Vec3d n = world_normal(trafo_matrices[closest_id], closest_normal);
+    if (n.isZero())
+        return false; // degenerate facet
+
+    m_hit.facet        = int(closest_facet);
+    m_hit.volume       = mv;
+    m_hit.trafo        = trafo_matrices[closest_id];
+    m_hit.world_pos    = trafo_matrices[closest_id] * closest_hit.cast<double>();
+    m_hit.world_normal = n;
+    return true;
+}
+
+void FacetPicker::render(const Camera &camera)
+{
+    if (!m_hit.valid())
+        return;
+
+    // Rebuild only when the hovered facet actually changes.
+    if (m_rendered_facet != m_hit.facet) {
+        m_rendered_facet = m_hit.facet;
+        m_highlight.reset();
+
+        const indexed_triangle_set &its = m_hit.volume->mesh().its;
+        const auto                 &tri = its.indices[m_hit.facet];
+        // Lift off the surface so the highlight wins the depth test against the model.
+        const Vec3d bias = m_hit.world_normal * 0.05;
+
+        indexed_triangle_set temp_its;
+        for (int i = 0; i < 3; ++i) {
+            const Vec3d v = m_hit.trafo * its.vertices[tri[i]].cast<double>() + bias;
+            temp_its.vertices.push_back(v.cast<float>());
+        }
+        temp_its.indices.push_back({0, 1, 2});
+        m_highlight.init_from(temp_its);
+    }
+
+    if (!m_highlight.is_initialized())
+        return;
+
+    const auto &p_flat_shader = wxGetApp().get_shader("flat");
+    if (!p_flat_shader)
+        return;
+
+    glsafe(::glEnable(GL_DEPTH_TEST));
+    glsafe(::glDisable(GL_CULL_FACE));
+    wxGetApp().bind_shader(p_flat_shader);
+    p_flat_shader->set_uniform("projection_matrix", camera.get_projection_matrix());
+    // Vertices are already in world space, so the model part of the matrix is identity.
+    p_flat_shader->set_uniform("view_model_matrix", camera.get_view_matrix());
+    m_highlight.set_color(GLGizmoBase::FLATTEN_HOVER_COLOR);
+    m_highlight.render_geometry();
+    wxGetApp().unbind_shader();
+    glsafe(::glEnable(GL_CULL_FACE));
+}
+
+} // namespace GUI
+} // namespace Slic3r

--- a/src/slic3r/GUI/Gizmos/FacetPicker.hpp
+++ b/src/slic3r/GUI/Gizmos/FacetPicker.hpp
@@ -1,0 +1,69 @@
+#ifndef slic3r_FacetPicker_hpp_
+#define slic3r_FacetPicker_hpp_
+
+#include "slic3r/GUI/GLModel.hpp"
+#include "libslic3r/Point.hpp"
+
+namespace Slic3r {
+class ModelVolume;
+
+namespace GUI {
+class CommonGizmosDataPool;
+class Selection;
+struct Camera; // declared as a struct in Camera.hpp; matching it avoids MSVC ABI linker errors
+
+// Picks a single triangular facet of the selected object under the mouse and draws it
+// highlighted.
+//
+// It deliberately knows nothing about what a picked facet is *for* - the caller decides
+// that - so it can serve any gizmo that needs "which triangle is under the cursor".
+// GLGizmoAdvancedCut uses it to place the cut plane; GLGizmoFlatten does the same job
+// inline today and could be moved onto this later.
+class FacetPicker
+{
+public:
+    struct Hit
+    {
+        int                facet        = -1;
+        const ModelVolume *volume       = nullptr;
+        Transform3d        trafo        = Transform3d::Identity(); // volume -> world
+        Vec3d              world_pos    = Vec3d::Zero();
+        Vec3d              world_normal = Vec3d::Zero();
+
+        bool valid() const { return facet >= 0 && volume != nullptr; }
+    };
+
+    bool is_active() const { return m_active; }
+    void set_active(bool active);
+
+    // Drops the cached hit and the highlight geometry.
+    void reset();
+
+    // Recomputes the cached hit from the mouse position. Returns true when the ray hits a
+    // model part; on a miss the cache is left invalid.
+    bool update(const Vec2d &mouse_position, const CommonGizmosDataPool *pool, const Selection &selection, const Camera &camera);
+
+    // Draws the cached facet. No-op when there is no valid hit.
+    void render(const Camera &camera);
+
+    const Hit &hit() const { return m_hit; }
+
+    // World-space unit normal of a facet whose mesh-local normal is mesh_normal, for a
+    // volume placed by trafo. Returns zero for a degenerate facet.
+    //
+    // Uses the inverse-transpose of the linear part, not the linear part itself: on a
+    // non-uniformly scaled instance the latter yields a normal that is visibly not
+    // perpendicular to the facet.
+    static Vec3d world_normal(const Transform3d &trafo, const Vec3f &mesh_normal);
+
+private:
+    bool    m_active{false};
+    Hit     m_hit;
+    int     m_rendered_facet{-1}; // so the highlight is rebuilt only when the facet changes
+    GLModel m_highlight;
+};
+
+} // namespace GUI
+} // namespace Slic3r
+
+#endif // slic3r_FacetPicker_hpp_

--- a/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp
@@ -105,17 +105,6 @@ static void rotate_z_3d(std::array<Vec3d, 4>& verts, float radian_angle)
 
 namespace {
 
-// The mesh normal returned by MeshRaycaster::unproject_on_mesh is in mesh-local
-// coordinates. Transforming it needs the inverse-transpose of the linear part,
-// not the linear part itself, or a non-uniformly scaled instance yields a normal
-// that is visibly not perpendicular to the facet.
-Vec3d facet_world_normal(const Transform3d &trafo, const Vec3f &mesh_normal)
-{
-    const Vec3d  n   = trafo.linear().inverse().transpose() * mesh_normal.cast<double>();
-    const double len = n.norm();
-    return (len < EPSILON) ? Vec3d::Zero() : Vec3d(n / len);
-}
-
 // Rotation taking +Z onto `normal`, which must be unit length. Eigen's
 // setFromTwoVectors handles the antipodal case (normal == -Z) by picking an
 // arbitrary perpendicular axis, which is what we want: the plane's X direction
@@ -171,14 +160,11 @@ bool GLGizmoAdvancedCut::gizmo_event(SLAGizmoEventType action, const Vec2d &mous
         // ignored on purpose: the wanted face is often behind the translucent plane, and
         // gating on m_hover_id made those faces unclickable. gizmo_event runs before the
         // manager's grabber handling, so returning true here suppresses the drag.
-        if (m_pick_face_mode && !m_connectors_editing) {
-            update_facet_pick_cache(mouse_position);
-            if (apply_picked_facet()) {
-                m_pick_face_mode = false; // one-shot: press the button again to pick another
-                clear_facet_pick_cache();
-                return true;
-            }
-            return true; // stay armed on a miss rather than starting a rotate/pan
+        if (m_facet_picker.is_active() && !m_connectors_editing) {
+            m_facet_picker.update(mouse_position, m_c, m_parent.get_selection(), wxGetApp().plater()->get_camera());
+            if (apply_picked_facet())
+                m_facet_picker.set_active(false); // one-shot: press the button again to pick another
+            return true; // on a miss, stay armed rather than starting a rotate/pan
         }
         if (m_hover_id == c_plate_move_id) {
             Vec3d pos;
@@ -390,143 +376,16 @@ bool GLGizmoAdvancedCut::unproject_on_cut_plane(const Vec2d &mouse_pos, Vec3d &p
     return true;
 }
 
-void GLGizmoAdvancedCut::clear_facet_pick_cache()
-{
-    m_hit_facet        = -1;
-    m_last_hit_facet   = -1;
-    m_hit_volume       = nullptr;
-    m_hit_world_normal = Vec3d::Zero();
-    m_hovered_tri.reset();
-}
-
-bool GLGizmoAdvancedCut::update_facet_pick_cache(const Vec2d &mouse_position)
-{
-    m_hit_facet = -1;
-
-    if (!m_c || !m_c->raycaster() || !m_c->selection_info())
-        return false;
-
-    const ModelObject *mo           = m_c->selection_info()->model_object();
-    const int          instance_idx = m_parent.get_selection().get_instance_idx();
-    if (!mo || instance_idx < 0 || instance_idx >= int(mo->instances.size()))
-        return false;
-
-    // Raycaster builds one MeshRaycaster per model-part volume, in mo->volumes
-    // order, so build the matching transform list the same way.
-    const ModelInstance *mi        = mo->instances[instance_idx];
-    const double         sla_shift = m_c->selection_info()->get_sla_shift();
-
-    std::vector<Transform3d>         trafo_matrices;
-    std::vector<const ModelVolume *> part_volumes;
-    for (const ModelVolume *mv : mo->volumes) {
-        if (mv->is_model_part()) {
-            trafo_matrices.emplace_back(Geometry::translation_transform(sla_shift * Vec3d::UnitZ()) *
-                                        mi->get_transformation().get_matrix() * mv->get_matrix());
-            part_volumes.emplace_back(mv);
-        }
-    }
-
-    const std::vector<const MeshRaycaster *> raycasters = m_c->raycaster()->raycasters();
-    if (raycasters.size() != trafo_matrices.size())
-        return false; // hollowed-mesh or stale-cache case; skip this frame rather than mis-index
-
-    const Camera &camera = wxGetApp().plater()->get_camera();
-
-    Vec3f  hit = Vec3f::Zero(), normal = Vec3f::Zero();
-    Vec3f  closest_hit = Vec3f::Zero(), closest_normal = Vec3f::Zero();
-    double closest_sq    = std::numeric_limits<double>::max();
-    int    closest_id    = -1;
-    size_t closest_facet = 0;
-
-    for (int mesh_id = 0; mesh_id < int(trafo_matrices.size()); ++mesh_id) {
-        size_t facet = 0;
-        if (raycasters[mesh_id]->unproject_on_mesh(mouse_position, trafo_matrices[mesh_id], camera, hit, normal, nullptr, &facet)) {
-            const double sq = (camera.get_position() - trafo_matrices[mesh_id] * hit.cast<double>()).squaredNorm();
-            if (sq < closest_sq) {
-                closest_sq     = sq;
-                closest_id     = mesh_id;
-                closest_hit    = hit;
-                closest_normal = normal;
-                // Captured inside the nearest-hit branch on purpose. GLGizmoFlatten
-                // captures it after the loop, so on a multi-volume object it can index
-                // the last-tested volume's facet into the nearest volume's mesh.
-                closest_facet  = facet;
-            }
-        }
-    }
-
-    if (closest_id < 0)
-        return false;
-
-    const ModelVolume *mv = part_volumes[closest_id];
-    if (closest_facet >= mv->mesh().its.indices.size())
-        return false;
-
-    const Vec3d world_normal = facet_world_normal(trafo_matrices[closest_id], closest_normal);
-    if (world_normal.isZero())
-        return false; // degenerate facet
-
-    m_hit_facet        = int(closest_facet);
-    m_hit_volume       = mv;
-    m_hit_trafo        = trafo_matrices[closest_id];
-    m_hit_world_pos    = trafo_matrices[closest_id] * closest_hit.cast<double>();
-    m_hit_world_normal = world_normal;
-    return true;
-}
-
-void GLGizmoAdvancedCut::render_hovered_facet()
-{
-    if (m_hit_facet < 0 || m_hit_volume == nullptr)
-        return;
-
-    // Rebuild only when the hovered facet actually changes.
-    if (m_last_hit_facet != m_hit_facet) {
-        m_last_hit_facet = m_hit_facet;
-        m_hovered_tri.reset();
-
-        const indexed_triangle_set &its = m_hit_volume->mesh().its;
-        const auto                 &tri = its.indices[m_hit_facet];
-        // Lift off the surface so the highlight wins the depth test against the model.
-        const Vec3d bias = m_hit_world_normal * 0.05;
-
-        indexed_triangle_set temp_its;
-        for (int i = 0; i < 3; ++i) {
-            const Vec3d v = m_hit_trafo * its.vertices[tri[i]].cast<double>() + bias;
-            temp_its.vertices.push_back(v.cast<float>());
-        }
-        temp_its.indices.push_back({0, 1, 2});
-        m_hovered_tri.init_from(temp_its);
-    }
-
-    if (!m_hovered_tri.is_initialized())
-        return;
-
-    const auto &p_flat_shader = wxGetApp().get_shader("flat");
-    if (!p_flat_shader)
-        return;
-
-    const Camera &camera = wxGetApp().plater()->get_camera();
-    glsafe(::glEnable(GL_DEPTH_TEST));
-    glsafe(::glDisable(GL_CULL_FACE));
-    wxGetApp().bind_shader(p_flat_shader);
-    p_flat_shader->set_uniform("projection_matrix", camera.get_projection_matrix());
-    // Vertices are already in world space, so the model part of the matrix is identity.
-    p_flat_shader->set_uniform("view_model_matrix", camera.get_view_matrix());
-    m_hovered_tri.set_color(GLGizmoBase::FLATTEN_HOVER_COLOR);
-    m_hovered_tri.render_geometry();
-    wxGetApp().unbind_shader();
-    glsafe(::glEnable(GL_CULL_FACE));
-}
-
 bool GLGizmoAdvancedCut::apply_picked_facet()
 {
-    if (m_hit_facet < 0 || m_hit_world_normal.isZero())
+    const FacetPicker::Hit &picked = m_facet_picker.hit();
+    if (!picked.valid() || picked.world_normal.isZero())
         return false;
 
-    const Transform3d m = rotation_from_plane_normal(m_hit_world_normal);
+    const Transform3d m = rotation_from_plane_normal(picked.world_normal);
 
     // Plane lands flush with the facet; the user offsets it afterwards with Movement.
-    const Vec3d new_plane_center = m_hit_world_pos;
+    const Vec3d new_plane_center = picked.world_pos;
 
     const auto new_tbb = transformed_bounding_box(new_plane_center, m);
 
@@ -794,8 +653,7 @@ void GLGizmoAdvancedCut::on_set_state()
         }
         m_hover_id           = -1;
         m_connectors_editing = false;
-        m_pick_face_mode     = false;
-        clear_facet_pick_cache();
+        m_facet_picker.set_active(false);
 
         update_bb();
         reset_cut_plane();//according to boundingbox
@@ -1030,8 +888,8 @@ void GLGizmoAdvancedCut::on_render()
     if (!m_connectors_editing) {
         render_cut_plane_and_grabbers();
     }
-    if (m_pick_face_mode && !m_connectors_editing)
-        render_hovered_facet();
+    if (m_facet_picker.is_active() && !m_connectors_editing)
+        m_facet_picker.render(wxGetApp().plater()->get_camera());
     // render_clipper_cut for get the cut plane result
     render_clipper_cut();
     // render a cut line on screen by shift key and mouse move
@@ -1045,13 +903,13 @@ void GLGizmoAdvancedCut::on_render()
 
 bool GLGizmoAdvancedCut::on_mouse(const wxMouseEvent &mouse_event)
 {
-    if (m_pick_face_mode && !m_connectors_editing) {
+    if (m_facet_picker.is_active() && !m_connectors_editing) {
         if (mouse_event.Moving() || mouse_event.Dragging()) {
-            if (!update_facet_pick_cache(Vec2d(mouse_event.GetX(), mouse_event.GetY())))
-                clear_facet_pick_cache();
+            m_facet_picker.update(Vec2d(mouse_event.GetX(), mouse_event.GetY()), m_c, m_parent.get_selection(),
+                                  wxGetApp().plater()->get_camera());
             m_parent.request_extra_frame();
         } else if (mouse_event.Leaving()) {
-            clear_facet_pick_cache();
+            m_facet_picker.reset();
         }
     }
 
@@ -2111,10 +1969,8 @@ void GLGizmoAdvancedCut::set_connectors_editing(bool connectors_editing)
         return;
 
     m_connectors_editing = connectors_editing;
-    if (m_connectors_editing) {
-        m_pick_face_mode = false;
-        clear_facet_pick_cache();
-    }
+    if (m_connectors_editing)
+        m_facet_picker.set_active(false);
     m_c->object_clipper()->set_behaviour(m_connectors_editing, m_connectors_editing, double(m_contour_width));
     m_parent.request_extra_frame();
     // todo: zhimin need a better method
@@ -2345,10 +2201,8 @@ void GLGizmoAdvancedCut::switch_to_mode(CutMode new_mode) {
     if (m_cut_mode == CutMode::cutTongueAndGroove) {
         m_cut_to_parts = false;//into Groove function,cancel m_cut_to_parts
     }
-    if (m_cut_mode != CutMode::cutPlanar) {
-        m_pick_face_mode = false;
-        clear_facet_pick_cache();
-    }
+    if (m_cut_mode != CutMode::cutPlanar)
+        m_facet_picker.set_active(false);
     apply_color_clip_plane_colors();
     if (auto oc = m_c->object_clipper()) {
         m_contour_width = m_cut_mode == CutMode::cutTongueAndGroove ? 0.f : 0.4f;
@@ -2767,19 +2621,17 @@ void GLGizmoAdvancedCut::render_cut_plane_input_window(float x, float y, float b
     m_imgui->disabled_begin(!pick_face_available);
     // Keep the button looking pressed while armed - it is a mode, and the only other
     // cue that it is on is the facet highlight, which needs the cursor over the model.
-    if (m_pick_face_mode)
+    const bool picking = m_facet_picker.is_active();
+    if (picking)
         ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetColorU32(ImGuiCol_ButtonActive));
-    if (m_imgui->button(_L("Pick face"))) {
-        m_pick_face_mode = !m_pick_face_mode;
-        if (!m_pick_face_mode)
-            clear_facet_pick_cache();
-    }
-    if (m_pick_face_mode)
+    if (m_imgui->button(_L("Pick face")))
+        m_facet_picker.set_active(!picking);
+    if (picking)
         ImGui::PopStyleColor();
     m_imgui->disabled_end();
     if (ImGui::IsItemHovered())
         m_imgui->tooltip(_L("Click a face of the model to set the cut plane. The plane lands flush with that face; use Movement to offset it."), ImGui::GetFontSize() * 20.0f);
-    if (m_pick_face_mode) {
+    if (m_facet_picker.is_active()) {
         ImGui::SameLine();
         m_imgui->text(_L("Click a face of the model."));
     }

--- a/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.cpp
@@ -103,6 +103,33 @@ static void rotate_z_3d(std::array<Vec3d, 4>& verts, float radian_angle)
         rotate_point_2d(verts[i](0), verts[i](1), c, s);
 }
 
+namespace {
+
+// The mesh normal returned by MeshRaycaster::unproject_on_mesh is in mesh-local
+// coordinates. Transforming it needs the inverse-transpose of the linear part,
+// not the linear part itself, or a non-uniformly scaled instance yields a normal
+// that is visibly not perpendicular to the facet.
+Vec3d facet_world_normal(const Transform3d &trafo, const Vec3f &mesh_normal)
+{
+    const Vec3d  n   = trafo.linear().inverse().transpose() * mesh_normal.cast<double>();
+    const double len = n.norm();
+    return (len < EPSILON) ? Vec3d::Zero() : Vec3d(n / len);
+}
+
+// Rotation taking +Z onto `normal`, which must be unit length. Eigen's
+// setFromTwoVectors handles the antipodal case (normal == -Z) by picking an
+// arbitrary perpendicular axis, which is what we want: the plane's X direction
+// is unconstrained here, exactly as in process_cut_line().
+Transform3d rotation_from_plane_normal(const Vec3d &normal)
+{
+    Eigen::Quaterniond q;
+    Transform3d        m = Transform3d::Identity();
+    m.matrix().block(0, 0, 3, 3) = q.setFromTwoVectors(Vec3d::UnitZ(), normal).toRotationMatrix();
+    return m;
+}
+
+} // namespace
+
 const double GLGizmoAdvancedCut::Offset = 20.0;
 const double GLGizmoAdvancedCut::Margin = 20.0;
 const std::array<float, 4> GLGizmoAdvancedCut::GrabberColor      = { 1.0, 1.0, 0.0, 1.0 };
@@ -139,6 +166,20 @@ bool GLGizmoAdvancedCut::gizmo_event(SLAGizmoEventType action, const Vec2d &mous
     }
 
     if (action == SLAGizmoEventType::LeftDown) {
+        // Pick-face mode is armed deliberately by the user, so while it is on, a click
+        // means "pick that facet" and nothing else. Grabbers and the cut plane itself are
+        // ignored on purpose: the wanted face is often behind the translucent plane, and
+        // gating on m_hover_id made those faces unclickable. gizmo_event runs before the
+        // manager's grabber handling, so returning true here suppresses the drag.
+        if (m_pick_face_mode && !m_connectors_editing) {
+            update_facet_pick_cache(mouse_position);
+            if (apply_picked_facet()) {
+                m_pick_face_mode = false; // one-shot: press the button again to pick another
+                clear_facet_pick_cache();
+                return true;
+            }
+            return true; // stay armed on a miss rather than starting a rotate/pan
+        }
         if (m_hover_id == c_plate_move_id) {
             Vec3d pos;
             Vec3d pos_world;
@@ -346,6 +387,185 @@ bool GLGizmoAdvancedCut::unproject_on_cut_plane(const Vec2d &mouse_pos, Vec3d &p
     pos       = hit_d;
     pos_world = hit;
 
+    return true;
+}
+
+void GLGizmoAdvancedCut::clear_facet_pick_cache()
+{
+    m_hit_facet        = -1;
+    m_last_hit_facet   = -1;
+    m_hit_volume       = nullptr;
+    m_hit_world_normal = Vec3d::Zero();
+    m_hovered_tri.reset();
+}
+
+bool GLGizmoAdvancedCut::update_facet_pick_cache(const Vec2d &mouse_position)
+{
+    m_hit_facet = -1;
+
+    if (!m_c || !m_c->raycaster() || !m_c->selection_info())
+        return false;
+
+    const ModelObject *mo           = m_c->selection_info()->model_object();
+    const int          instance_idx = m_parent.get_selection().get_instance_idx();
+    if (!mo || instance_idx < 0 || instance_idx >= int(mo->instances.size()))
+        return false;
+
+    // Raycaster builds one MeshRaycaster per model-part volume, in mo->volumes
+    // order, so build the matching transform list the same way.
+    const ModelInstance *mi        = mo->instances[instance_idx];
+    const double         sla_shift = m_c->selection_info()->get_sla_shift();
+
+    std::vector<Transform3d>         trafo_matrices;
+    std::vector<const ModelVolume *> part_volumes;
+    for (const ModelVolume *mv : mo->volumes) {
+        if (mv->is_model_part()) {
+            trafo_matrices.emplace_back(Geometry::translation_transform(sla_shift * Vec3d::UnitZ()) *
+                                        mi->get_transformation().get_matrix() * mv->get_matrix());
+            part_volumes.emplace_back(mv);
+        }
+    }
+
+    const std::vector<const MeshRaycaster *> raycasters = m_c->raycaster()->raycasters();
+    if (raycasters.size() != trafo_matrices.size())
+        return false; // hollowed-mesh or stale-cache case; skip this frame rather than mis-index
+
+    const Camera &camera = wxGetApp().plater()->get_camera();
+
+    Vec3f  hit = Vec3f::Zero(), normal = Vec3f::Zero();
+    Vec3f  closest_hit = Vec3f::Zero(), closest_normal = Vec3f::Zero();
+    double closest_sq    = std::numeric_limits<double>::max();
+    int    closest_id    = -1;
+    size_t closest_facet = 0;
+
+    for (int mesh_id = 0; mesh_id < int(trafo_matrices.size()); ++mesh_id) {
+        size_t facet = 0;
+        if (raycasters[mesh_id]->unproject_on_mesh(mouse_position, trafo_matrices[mesh_id], camera, hit, normal, nullptr, &facet)) {
+            const double sq = (camera.get_position() - trafo_matrices[mesh_id] * hit.cast<double>()).squaredNorm();
+            if (sq < closest_sq) {
+                closest_sq     = sq;
+                closest_id     = mesh_id;
+                closest_hit    = hit;
+                closest_normal = normal;
+                // Captured inside the nearest-hit branch on purpose. GLGizmoFlatten
+                // captures it after the loop, so on a multi-volume object it can index
+                // the last-tested volume's facet into the nearest volume's mesh.
+                closest_facet  = facet;
+            }
+        }
+    }
+
+    if (closest_id < 0)
+        return false;
+
+    const ModelVolume *mv = part_volumes[closest_id];
+    if (closest_facet >= mv->mesh().its.indices.size())
+        return false;
+
+    const Vec3d world_normal = facet_world_normal(trafo_matrices[closest_id], closest_normal);
+    if (world_normal.isZero())
+        return false; // degenerate facet
+
+    m_hit_facet        = int(closest_facet);
+    m_hit_volume       = mv;
+    m_hit_trafo        = trafo_matrices[closest_id];
+    m_hit_world_pos    = trafo_matrices[closest_id] * closest_hit.cast<double>();
+    m_hit_world_normal = world_normal;
+    return true;
+}
+
+void GLGizmoAdvancedCut::render_hovered_facet()
+{
+    if (m_hit_facet < 0 || m_hit_volume == nullptr)
+        return;
+
+    // Rebuild only when the hovered facet actually changes.
+    if (m_last_hit_facet != m_hit_facet) {
+        m_last_hit_facet = m_hit_facet;
+        m_hovered_tri.reset();
+
+        const indexed_triangle_set &its = m_hit_volume->mesh().its;
+        const auto                 &tri = its.indices[m_hit_facet];
+        // Lift off the surface so the highlight wins the depth test against the model.
+        const Vec3d bias = m_hit_world_normal * 0.05;
+
+        indexed_triangle_set temp_its;
+        for (int i = 0; i < 3; ++i) {
+            const Vec3d v = m_hit_trafo * its.vertices[tri[i]].cast<double>() + bias;
+            temp_its.vertices.push_back(v.cast<float>());
+        }
+        temp_its.indices.push_back({0, 1, 2});
+        m_hovered_tri.init_from(temp_its);
+    }
+
+    if (!m_hovered_tri.is_initialized())
+        return;
+
+    const auto &p_flat_shader = wxGetApp().get_shader("flat");
+    if (!p_flat_shader)
+        return;
+
+    const Camera &camera = wxGetApp().plater()->get_camera();
+    glsafe(::glEnable(GL_DEPTH_TEST));
+    glsafe(::glDisable(GL_CULL_FACE));
+    wxGetApp().bind_shader(p_flat_shader);
+    p_flat_shader->set_uniform("projection_matrix", camera.get_projection_matrix());
+    // Vertices are already in world space, so the model part of the matrix is identity.
+    p_flat_shader->set_uniform("view_model_matrix", camera.get_view_matrix());
+    m_hovered_tri.set_color(GLGizmoBase::FLATTEN_HOVER_COLOR);
+    m_hovered_tri.render_geometry();
+    wxGetApp().unbind_shader();
+    glsafe(::glEnable(GL_CULL_FACE));
+}
+
+bool GLGizmoAdvancedCut::apply_picked_facet()
+{
+    if (m_hit_facet < 0 || m_hit_world_normal.isZero())
+        return false;
+
+    const Transform3d m = rotation_from_plane_normal(m_hit_world_normal);
+
+    // Plane lands flush with the facet; the user offsets it afterwards with Movement.
+    const Vec3d new_plane_center = m_hit_world_pos;
+
+    const auto new_tbb = transformed_bounding_box(new_plane_center, m);
+
+    // transformed_bounding_box() maps a point to R^-1 * (p_world - plane_center), so new_tbb
+    // is the model's bounding box in the cut plane's own frame and the plane is z = 0 there.
+    // The pick is meaningful when the model actually spans that plane, which is exactly the
+    // test set_center_pos() applies before it will accept the new centre. Asking the same
+    // question here is the point: a guard that disagrees with the function it guards would
+    // either reject a good pick or apply the rotation while the position is silently refused.
+    //
+    // Do not reuse process_cut_line()'s containment check here. It tests
+    //   m.inverse() * (plane_center - instance_offset) + new_tbb.center()
+    // which is not the plane's position in this frame. The two terms cancel in X and Y
+    // because an instance origin sits at the model's bounding-box centre in those axes, but
+    // in Z the origin sits at the object's base, so the error is the object's half-height.
+    // process_cut_line() hides that by always cutting through m_bb_center, where the stale Z
+    // still lands inside a tall box. A plane placed flush with a facet - especially on a cut
+    // piece, whose geometry is offset from its instance origin - falls outside and the pick
+    // is silently dropped.
+    const double limit_val = 0.5;
+    if (!(new_tbb.max.z() > -limit_val && new_tbb.min.z() < limit_val))
+        return false;
+
+    Plater::TakeSnapshot snapshot(wxGetApp().plater(), "Cut plane from face");
+
+    m_transformed_bounding_box = new_tbb;
+    set_center(new_plane_center);
+    m_start_dragging_m = m_rotate_matrix = m;
+    m_plane_normal                       = m_rotate_matrix * Vec3d::UnitZ();
+    m_ar_plane_center                    = m_plane_center;
+
+    reset_cut_by_contours();
+
+    // Keep the Rotation / Movement boxes in step with the new plane.
+    m_movement = 0.0;
+    m_rotation = Geometry::extract_euler_angles(m_rotate_matrix);
+    update_buffer_data();
+
+    m_parent.request_extra_frame();
     return true;
 }
 
@@ -574,6 +794,8 @@ void GLGizmoAdvancedCut::on_set_state()
         }
         m_hover_id           = -1;
         m_connectors_editing = false;
+        m_pick_face_mode     = false;
+        clear_facet_pick_cache();
 
         update_bb();
         reset_cut_plane();//according to boundingbox
@@ -638,7 +860,8 @@ CommonGizmosDataID GLGizmoAdvancedCut::on_get_requirements() const
 {
     return CommonGizmosDataID(int(CommonGizmosDataID::SelectionInfo)
         | int(CommonGizmosDataID::InstancesHider)
-        | int(CommonGizmosDataID::ObjectClipper));
+        | int(CommonGizmosDataID::ObjectClipper)
+        | int(CommonGizmosDataID::Raycaster));
 }
 
 void GLGizmoAdvancedCut::on_start_dragging()
@@ -807,6 +1030,8 @@ void GLGizmoAdvancedCut::on_render()
     if (!m_connectors_editing) {
         render_cut_plane_and_grabbers();
     }
+    if (m_pick_face_mode && !m_connectors_editing)
+        render_hovered_facet();
     // render_clipper_cut for get the cut plane result
     render_clipper_cut();
     // render a cut line on screen by shift key and mouse move
@@ -820,6 +1045,16 @@ void GLGizmoAdvancedCut::on_render()
 
 bool GLGizmoAdvancedCut::on_mouse(const wxMouseEvent &mouse_event)
 {
+    if (m_pick_face_mode && !m_connectors_editing) {
+        if (mouse_event.Moving() || mouse_event.Dragging()) {
+            if (!update_facet_pick_cache(Vec2d(mouse_event.GetX(), mouse_event.GetY())))
+                clear_facet_pick_cache();
+            m_parent.request_extra_frame();
+        } else if (mouse_event.Leaving()) {
+            clear_facet_pick_cache();
+        }
+    }
+
     // If we are in connector mode and the mouse is hovering...
     if (m_connectors_editing && mouse_event.Moving()) {
         Vec3d pos;
@@ -1876,6 +2111,10 @@ void GLGizmoAdvancedCut::set_connectors_editing(bool connectors_editing)
         return;
 
     m_connectors_editing = connectors_editing;
+    if (m_connectors_editing) {
+        m_pick_face_mode = false;
+        clear_facet_pick_cache();
+    }
     m_c->object_clipper()->set_behaviour(m_connectors_editing, m_connectors_editing, double(m_contour_width));
     m_parent.request_extra_frame();
     // todo: zhimin need a better method
@@ -2105,6 +2344,10 @@ void GLGizmoAdvancedCut::switch_to_mode(CutMode new_mode) {
     m_cut_mode = new_mode;
     if (m_cut_mode == CutMode::cutTongueAndGroove) {
         m_cut_to_parts = false;//into Groove function,cancel m_cut_to_parts
+    }
+    if (m_cut_mode != CutMode::cutPlanar) {
+        m_pick_face_mode = false;
+        clear_facet_pick_cache();
     }
     apply_color_clip_plane_colors();
     if (auto oc = m_c->object_clipper()) {
@@ -2518,6 +2761,29 @@ void GLGizmoAdvancedCut::render_cut_plane_input_window(float x, float y, float b
     }
     ImGui::Separator();
     m_imgui->disabled_end();
+
+    // Pick-face mode is planar-cut only; the groove mode has its own plane state machine.
+    const bool pick_face_available = (m_cut_mode == CutMode::cutPlanar) && !m_connectors_editing;
+    m_imgui->disabled_begin(!pick_face_available);
+    // Keep the button looking pressed while armed - it is a mode, and the only other
+    // cue that it is on is the facet highlight, which needs the cursor over the model.
+    if (m_pick_face_mode)
+        ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetColorU32(ImGuiCol_ButtonActive));
+    if (m_imgui->button(_L("Pick face"))) {
+        m_pick_face_mode = !m_pick_face_mode;
+        if (!m_pick_face_mode)
+            clear_facet_pick_cache();
+    }
+    if (m_pick_face_mode)
+        ImGui::PopStyleColor();
+    m_imgui->disabled_end();
+    if (ImGui::IsItemHovered())
+        m_imgui->tooltip(_L("Click a face of the model to set the cut plane. The plane lands flush with that face; use Movement to offset it."), ImGui::GetFontSize() * 20.0f);
+    if (m_pick_face_mode) {
+        ImGui::SameLine();
+        m_imgui->text(_L("Click a face of the model."));
+    }
+    ImGui::Separator();
 
     ImGui::PushItemWidth(caption_size);
     ImGui::Dummy(ImVec2(caption_size, -1));

--- a/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.hpp
@@ -3,6 +3,7 @@
 
 #include "GLGizmoBase.hpp"
 #include "GLGizmoRotate.hpp"
+#include "FacetPicker.hpp"
 #include "libslic3r/Model.hpp"
 #include "libslic3r/CutUtils.hpp"
 
@@ -123,14 +124,7 @@ private:
     mutable Grabber m_move_x_grabber;
 
     // Pick-face mode: click a triangular facet of the model to set the cut plane.
-    bool               m_pick_face_mode{false};
-    int                m_hit_facet{-1};
-    int                m_last_hit_facet{-1};
-    const ModelVolume *m_hit_volume{nullptr};
-    Transform3d        m_hit_trafo{Transform3d::Identity()};
-    Vec3d              m_hit_world_pos{Vec3d::Zero()};
-    Vec3d              m_hit_world_normal{Vec3d::Zero()};
-    GLModel            m_hovered_tri;
+    FacetPicker m_facet_picker;
 
     bool m_connectors_editing{false};
     bool m_localized_cut_editing = true;
@@ -322,9 +316,6 @@ private:
     void render_clipper_cut();
     void render_cut_line();
     // pick-face mode
-    bool update_facet_pick_cache(const Vec2d &mouse_position);
-    void render_hovered_facet();
-    void clear_facet_pick_cache();
     bool apply_picked_facet();
 
     void clear_selection();

--- a/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAdvancedCut.hpp
@@ -122,6 +122,16 @@ private:
     mutable Grabber m_move_z_grabber;
     mutable Grabber m_move_x_grabber;
 
+    // Pick-face mode: click a triangular facet of the model to set the cut plane.
+    bool               m_pick_face_mode{false};
+    int                m_hit_facet{-1};
+    int                m_last_hit_facet{-1};
+    const ModelVolume *m_hit_volume{nullptr};
+    Transform3d        m_hit_trafo{Transform3d::Identity()};
+    Vec3d              m_hit_world_pos{Vec3d::Zero()};
+    Vec3d              m_hit_world_normal{Vec3d::Zero()};
+    GLModel            m_hovered_tri;
+
     bool m_connectors_editing{false};
     bool m_localized_cut_editing = true;
     Vec3d m_localized_cut_pos = Vec3d::Zero();
@@ -311,6 +321,11 @@ private:
     void render_localized_cut_shadow();
     void render_clipper_cut();
     void render_cut_line();
+    // pick-face mode
+    bool update_facet_pick_cache(const Vec2d &mouse_position);
+    void render_hovered_facet();
+    void clear_facet_pick_cache();
+    bool apply_picked_facet();
 
     void clear_selection();
     void init_connector_shapes();


### PR DESCRIPTION
![Pick face demo](https://raw.githubusercontent.com/MatRanc/BambuStudio/media/pickface.gif)

### Background

In #2249 the request was to align a model to the plate using an actual facet rather than a bounding-polyhedron face, and *Lay on Face* gained its **Triangular facet** mode as a result. In that thread @Haidiye00 wrote:

> You've given us a great idea, we'll consider it, thank you very much.

The Cut tool never received the equivalent, and it has the same problem — arguably a worse one, because a cut usually needs to be *precise*.

### Problem

The cut plane can only be positioned by dragging the grabbers or typing Euler angles into the Rotation fields. Neither is workable when the cut has to be taken relative to a specific surface of the model — a chamfer, an angled boss, a draft face. Today you either eyeball the rotation or realign the model in another tool first.

### What this adds

Press **Pick face** in the cut panel, then click a facet. The cut plane becomes coplanar with that facet, oriented along its normal.

The plane lands *flush* with the face, so the cut is degenerate at that instant — that is intended. The existing **Movement** field then supplies a real offset, which is what makes this useful for precise work: "3 mm in from this face". Orientation-only placement would throw away the positional reference that motivates the feature.

Everything downstream — clipper, connectors, the Rotation/Movement fields, undo — derives from `m_plane_center` and `m_rotate_matrix` and needed no changes.

### Implementation notes

- The rotation is built the same way `process_cut_line()` builds it, with the normal coming from a facet instead of a screen-space line.

- **The validity check is deliberately not `process_cut_line()`'s containment guard.** That one tests `m.inverse() * (plane_center - instance_offset) + new_tbb.center()`, which is not the plane's position in that frame — `transformed_bounding_box()` maps a point to `R⁻¹·(p_world − plane_center)`, so the plane sits at the origin. The terms cancel in X and Y because an instance origin sits at the model's bounding-box centre in those axes, but in Z it sits at the object's base, leaving the object's half-height as error. `process_cut_line()` hides this by always cutting through `m_bb_center`. A plane flush with a facet does not, so reusing that guard silently dropped clicks on cut pieces. This uses the test `set_center_pos()` itself applies, so the guard and the function it guards ask the same question. Flagging it in case the same latent issue matters elsewhere.

- `on_get_requirements()` now also requests `CommonGizmosDataID::Raycaster`.

- `MeshRaycaster::unproject_on_mesh` returns the hit normal in **mesh-local** coordinates while the cut gizmo works in world space, so the normal is transformed with the inverse-transpose of the linear part. Using the linear part directly leaves the plane visibly non-perpendicular to the picked facet on a non-uniformly scaled instance.

- The facet index is captured **inside** the nearest-hit branch. The equivalent loop in `GLGizmoFlatten::update_raycast_cache` captures it *after* the loop, so on a multi-volume object it can index the last-tested volume's facet into the nearest volume's mesh. I have left `GLGizmoFlatten` untouched to keep this PR scoped to the cut gizmo — happy to send that as a separate fix if you'd like.

- Clicks are deliberately **not** gated on `m_hover_id`. The cut plane is a large translucent quad and the wanted face is usually behind it; gating on hover made exactly those faces unclickable. Since the mode is armed by an explicit button press, a click while armed can only mean "pick that facet". `gizmo_event` runs before the manager's grabber handling, so returning `true` suppresses the drag rather than racing it.

### Scope

Planar cut mode only. The button is disabled in Dovetail / tongue-and-groove mode, which has its own plane-editing state machine and would need separate reasoning.

Three files changed: `GLGizmoAdvancedCut.{cpp,hpp}` plus two new strings in `bbl/i18n/BambuStudio.pot`. No changes to `GLGizmoFlatten`, `GLGizmosManager`, or the build system.

### Known limitations

- **Mesh quality.** Cutting exactly along a facet plane can leave slivers or non-manifold edges where the plane is coplanar with, or grazes, existing geometry. This is inherent to cutting triangle meshes and affects the existing drag-the-plane cut equally — aiming at real geometry just makes it easier to land on such a plane. No change to the cutting algorithm itself is included here.
- **One facet, no coplanar snapping.** Picking uses the single triangle under the cursor. On a flat face that is exact; on a curved or finely tessellated surface you get that one triangle's plane, which may not be what you want.
- **One-shot by design.** The mode disarms after a successful pick; press the button again to pick another face.

### Testing

Built and manually tested by the author. The `Build all` run on this PR is sitting at `action_required` pending maintainer approval, as fork PRs do — happy to act on whatever it reports once someone kicks it off.

| | |
|---|---|
| Base | `926a719` (`02.08.02.61`) |
| OS | macOS 26.5.2 (build 25F84) |
| Toolchain | Xcode 26.5 (17F42), CMake 3.31.12 |
| Target | arm64, `Release`, Xcode generator via `BuildMac.sh` |

Cases exercised:

- Cube, top face — plane lands flush, Rotation reads `0, 0, 0`, **Movement** offsets into the body and the preview cuts correctly.
- Wedge, 45° face — Rotation reads the true facet angle rather than a bounding-box angle.
- **Non-uniformly scaled instance** (Z scaled to 200%) — plane stays perpendicular to the highlighted facet. This is the case that catches the normal-transform error described above.
- **Rotated instance** (30° about Z) — plane matches the face in world space.
- **Cut pieces** — repeatedly picking faces on the bodies produced by a previous cut. This is what surfaced the containment-guard problem above; it was diagnosed from a trace of a failing pick and fixed before submitting.
- Picking a face *behind* the translucent cut plane.
- Undo/redo — one `Cmd+Z` restores the previous plane exactly; redo reapplies.
- Connectors — with connectors placed, picking a new face moves them onto the new plane.
- Clicking empty space while armed changes nothing and pushes no undo step.

Not exercised: the multi-volume case, and Windows/Linux builds — the change is platform-independent but I only have a Mac to verify on.
