### PR TITLE
fix: update FFmpeg on Linux to avoid GStreamer ABI conflict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -802,32 +802,32 @@ function(bambustudio_copy_sos target config postfix output_sos)
     else()
         file(COPY ${CMAKE_PREFIX_PATH}/lib/libavcodec.so
                   ${CMAKE_PREFIX_PATH}/lib/libavcodec.so.61
-                  ${CMAKE_PREFIX_PATH}/lib/libavcodec.so.61.3.100
+                  ${CMAKE_PREFIX_PATH}/lib/libavcodec.so.61.19.101
                   ${CMAKE_PREFIX_PATH}/lib/libavutil.so
                   ${CMAKE_PREFIX_PATH}/lib/libavutil.so.59
-                  ${CMAKE_PREFIX_PATH}/lib/libavutil.so.59.8.100
+                  ${CMAKE_PREFIX_PATH}/lib/libavutil.so.59.39.100
                   ${CMAKE_PREFIX_PATH}/lib/libswscale.so
                   ${CMAKE_PREFIX_PATH}/lib/libswscale.so.8
-                  ${CMAKE_PREFIX_PATH}/lib/libswscale.so.8.1.100
+                  ${CMAKE_PREFIX_PATH}/lib/libswscale.so.8.3.100
                   ${CMAKE_PREFIX_PATH}/lib/libswresample.so
                   ${CMAKE_PREFIX_PATH}/lib/libswresample.so.5
-                  ${CMAKE_PREFIX_PATH}/lib/libswresample.so.5.1.100
+                  ${CMAKE_PREFIX_PATH}/lib/libswresample.so.5.3.100
              DESTINATION ${_out_dir})
     endif()
 
     set(${output_dlls}
         ${_out_dir}/libavcodec.so
         ${_out_dir}/libavcodec.so.61
-        ${_out_dir}/libavcodec.so.61.3.100
+        ${_out_dir}/libavcodec.so.61.19.101
         ${_out_dir}/libavutil.so
         ${_out_dir}/libavutil.so.59
-        ${_out_dir}/libavutil.so.59.8.100
+        ${_out_dir}/libavutil.so.59.39.100
         ${_out_dir}/libswscale.so
         ${_out_dir}/libswscale.so.8
-        ${_out_dir}/libswscale.so.8.1.100
+        ${_out_dir}/libswscale.so.8.3.100
         ${_out_dir}/libswresample.so
         ${_out_dir}/libswresample.so.5
-        ${_out_dir}/libswresample.so.5.1.100
+        ${_out_dir}/libswresample.so.5.3.100
         PARENT_SCOPE
     )
 endfunction()
@@ -889,13 +889,13 @@ endif ()
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT FLATPAK)
     set(LIBRARY_FILES
     ${LIBDIR_BIN}/libavcodec.so.61
-    ${LIBDIR_BIN}/libavcodec.so.61.3.100
+    ${LIBDIR_BIN}/libavcodec.so.61.19.101
     ${LIBDIR_BIN}/libavutil.so.59
-    ${LIBDIR_BIN}/libavutil.so.59.8.100
+    ${LIBDIR_BIN}/libavutil.so.59.39.100
     ${LIBDIR_BIN}/libswresample.so.5
-    ${LIBDIR_BIN}/libswresample.so.5.1.100
+    ${LIBDIR_BIN}/libswresample.so.5.3.100
     ${LIBDIR_BIN}/libswscale.so.8
-    ${LIBDIR_BIN}/libswscale.so.8.1.100
+    ${LIBDIR_BIN}/libswscale.so.8.3.100
     )
     install(FILES ${LIBRARY_FILES} DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 endif ()

--- a/deps/FFMPEG/FFMPEG.cmake
+++ b/deps/FFMPEG/FFMPEG.cmake
@@ -19,6 +19,14 @@ if (MSVC)
     )
 
 else ()
+    set(_ffmpeg_version "7.0.2")
+    set(_ffmpeg_sha256 "5EB46D18D664A0CCADF7B0ADEE03BD3B7FA72893D667F36C69E202A807E6D533")
+
+    if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        set(_ffmpeg_version "7.1.5")
+        set(_ffmpeg_sha256 "e3963a50831c985933e1a625ed566ec4c7adb5c012c34fa9f84438e1d61bdacc")
+    endif()
+
     set(_extra_cmd "--pkg-config-flags=\"--static\"")
     string(APPEND _extra_cmd "--extra-cflags=\"-I ${DESTDIR}/usr/local/include\"")
     string(APPEND _extra_cmd "--extra-ldflags=\"-I ${DESTDIR}/usr/local/lib\"")
@@ -52,8 +60,8 @@ else ()
     endif()
 
     ExternalProject_Add(dep_FFMPEG
-        URL https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n7.0.2.tar.gz
-        URL_HASH SHA256=5EB46D18D664A0CCADF7B0ADEE03BD3B7FA72893D667F36C69E202A807E6D533
+        URL https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n${_ffmpeg_version}.tar.gz
+        URL_HASH SHA256=${_ffmpeg_sha256}
         DOWNLOAD_DIR ${DEP_DOWNLOAD_DIR}/FFMPEG
         CONFIGURE_COMMAND ${_conf_cmd}
             ${_cross_cmd}


### PR DESCRIPTION
## Summary

Update the bundled FFmpeg dependency from 7.0.2 to 7.1.5 on Linux to avoid an ABI conflict with newer system GStreamer `libav` plugins.

macOS remains on FFmpeg 7.0.2 and the MSVC/Windows dependency is unchanged.

Fixes #12074

## Problem

The generated Linux launcher exposes BambuStudio's bundled libraries through:

~~~bash
export LD_LIBRARY_PATH="$DIR/bin"
~~~

BambuStudio currently bundles FFmpeg 7.0.2, including:

~~~text
libavcodec.so.61
libavutil.so.59
libswresample.so.5
libswscale.so.8
~~~

On Debian 13, the system GStreamer `libav` plugin is built against FFmpeg 7.1.5.

Both FFmpeg versions expose the same `libavutil.so.59` SONAME, but the bundled FFmpeg 7.0.2 library does not provide:

~~~text
av_mastering_display_metadata_alloc_size
~~~

The system GStreamer plugin requires that symbol.

This causes `gst-plugin-scanner` to fail with:

~~~text
libavformat.so.61:
undefined symbol: av_mastering_display_metadata_alloc_size,
version LIBAVUTIL_59
~~~

## Fix

Use FFmpeg 7.1.5 for Linux builds while keeping the existing FFmpeg 7.0.2 dependency for macOS.

The MSVC dependency is not modified.

The Linux FFmpeg source archive is updated to:

~~~text
n7.1.5
SHA256=e3963a50831c985933e1a625ed566ec4c7adb5c012c34fa9f84438e1d61bdacc
~~~

FFmpeg 7.1.5 retains the same relevant major library versions while providing the symbol required by newer GStreamer builds.

## Validation

Before changing the dependency, the issue was reproduced using the packaged Linux build with the normal BambuStudio launcher.

With bundled FFmpeg 7.0.2:

~~~text
gst-plugin-scanner:
Failed to load plugin ... libgstlibav.so

undefined symbol:
av_mastering_display_metadata_alloc_size
version LIBAVUTIL_59
~~~

As an A/B runtime test, the FFmpeg 7.0.2 libraries in an isolated copy of the package were replaced with the installed Debian 13 FFmpeg 7.1.5 libraries while keeping the original BambuStudio launcher and its `LD_LIBRARY_PATH`.

Results:

~~~text
SYSTEM_LIBRARIES=OK
REPLACEMENT=OK
LIBRARIES=OK
av_mastering_display_metadata_alloc_size@@LIBAVUTIL_59
GSTREAMER_FFMPEG_FIX=PASS
~~~

BambuStudio started normally through the original launcher and the GStreamer/FFmpeg undefined-symbol warning disappeared.

Existing unrelated GTK warnings such as:

~~~text
gtk_window_resize: assertion 'width > 0' failed
~~~

are unaffected and are not part of this fix.

## Scope

Only:

~~~text
deps/FFMPEG/FFMPEG.cmake
~~~

is changed.

The actual dependency change still needs to be validated by CI by building the Linux package with FFmpeg 7.1.5 and then testing that generated artifact through the normal launcher.
