### PR TITLE
FIX: Linux startup crash when using Japanese or Korean

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -1458,9 +1458,6 @@ GUI_App::GUI_App()
 
 	//app config initializes early becasuse it is used in instance checking in BambuStudio.cpp
     this->init_app_config();
-    if (app_config) {
-        ::Label::initSysFont(app_config->get_language_code(), false);
-    }
     this->init_download_path();
 
 #if defined(__WXOSX__)
@@ -3127,6 +3124,9 @@ bool GUI_App::on_init_inner()
     init_live_view_track_context(app_config);
 
 // initialize label colors and fonts
+    if (app_config) {
+        ::Label::initSysFont(app_config->get_language_code(), false);
+    }
     init_label_colours();
     init_fonts();
     wxGetApp().Update_dark_mode_flag();

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -449,7 +449,7 @@ wxBoxSizer *PreferencesDialog::create_item_language_combobox(
                 Close();
                 // Reparent(nullptr);
                 GetParent()->RemoveChild(this);
-                Label::initSysFont(app_config->get_language_code());
+                Label::initSysFont(app_config->get_language_code(), false);
                 wxGetApp().recreate_GUI(_L("Changing application language"));
             }
         }

--- a/src/slic3r/GUI/Widgets/Label.cpp
+++ b/src/slic3r/GUI/Widgets/Label.cpp
@@ -71,6 +71,18 @@ void Label::initSysFont(std::string lang_code, bool load_font_resource)
         font_path = wxString::FromUTF8(resource_path+"/fonts/HarmonyOS_Sans_SC_Regular.ttf");
         result = wxFont::AddPrivateFont(font_path);
         BOOST_LOG_TRIVIAL(info) << boost::format("add font of HarmonyOS_Sans_SC_Regular returns %1%")%result;
+        font_path = wxString::FromUTF8(resource_path + "/fonts/SourceHanSansJP-Normal.otf");
+        result    = wxFont::AddPrivateFont(font_path);
+        BOOST_LOG_TRIVIAL(info) << boost::format("add font of SourceHanSansJP-Normal returns %1%")%result;
+        font_path = wxString::FromUTF8(resource_path + "/fonts/SourceHanSansJP-Bold.otf");
+        result    = wxFont::AddPrivateFont(font_path);
+        BOOST_LOG_TRIVIAL(info) << boost::format("add font of SourceHanSansJP-Bold returns %1%")%result;
+        font_path = wxString::FromUTF8(resource_path + "/fonts/NanumGothic-Regular.ttf");
+        result    = wxFont::AddPrivateFont(font_path);
+        BOOST_LOG_TRIVIAL(info) << boost::format("add font of NanumGothic-Regular returns %1%")%result;
+        font_path = wxString::FromUTF8(resource_path + "/fonts/NanumGothic-Bold.ttf");
+        result    = wxFont::AddPrivateFont(font_path);
+        BOOST_LOG_TRIVIAL(info) << boost::format("add font of NanumGothic-Bold returns %1%")%result;
     }
 #endif
     Head_48 = Label::sysFont(48, true, lang_code);


### PR DESCRIPTION
## Summary

  Fix a Linux startup crash when Bambu Studio is configured to use Japanese or Korean.

  - Closes  #8861
  - Closes #10633

  ## Root cause

  `GUI_App` is constructed before `wxEntry()` initializes wxGTK.

  The constructor previously called the language-specific `Label::initSysFont()`. On Linux, only the HarmonyOS fonts were registered as private fonts. When Japanese or Korean was selected, the requested font could be unavailable, causing
  `Label::sysFont()` to fall back to `wxSystemSettings::GetFont()`.

  This fallback may access `GtkSettings` before GTK initialization, resulting in GLib/GTK critical errors and a startup crash.

  ## Changes

  - Register the bundled `Source Han Sans JP` and `NanumGothic` fonts with `wxFont::AddPrivateFont()` on Linux, alongside the existing HarmonyOS fonts.
  - Defer language-specific `Label` font initialization from the `GUI_App` constructor to `on_init_inner()`, after `wxEntry()` has initialized wxGTK.
  - Avoid re-registering private fonts when changing the language in Preferences. The fonts are already registered during startup, so only the language-specific `Label` fonts need to be recreated.
