### PR TITLE
Read an SVG's styling and clip paths, and import outline art as colored parts

### DIFF
--- a/src/libslic3r/EmbossShape.hpp
+++ b/src/libslic3r/EmbossShape.hpp
@@ -124,6 +124,12 @@ struct ExPolygonsWithId
 
     // flag whether expolygons are fully healed(without duplication)
     bool is_healed = true;
+
+    // Color of the SVG path this shape came from, packed the way NanoSVG stores it
+    // (0xAABBGGRR). Zero means the path carried no plain color - it was a gradient,
+    // or the shape did not come from an SVG at all - and the shape is uncolored.
+    // Not serialized: it is derived from the SVG on import.
+    unsigned color = 0;
 };
 using ExPolygonsWithIds = std::vector<ExPolygonsWithId>;
 

--- a/src/libslic3r/NSVGUtils.cpp
+++ b/src/libslic3r/NSVGUtils.cpp
@@ -1,7 +1,12 @@
 #include "NSVGUtils.hpp"
+#include <algorithm>
+#include <sstream>
+#include <cstring>
+#include <map>
 #include <array>
 #include <charconv> // to_chars
 
+#include <boost/log/trivial.hpp>
 #include <boost/nowide/iostream.hpp>
 #include <boost/nowide/fstream.hpp>
 #include "ClipperUtils.hpp"
@@ -22,13 +27,34 @@ HealedExPolygons stroke_to_expolygons(const LinesPath &lines_path, const NSVGsha
 
 namespace Slic3r {
 
-ExPolygonsWithIds create_shape_with_ids(const NSVGimage &image, const NSVGLineParams &param)
+// Mark written onto elements a clip path applies to. The parser keeps an element's id and
+// hands it down to the shapes of a group, so a marked group passes it to all it contains.
+static const char *CLIP_MARK     = "p7clip";
+// Mark on the copies of the clip shapes themselves, so they can be gathered and then
+// left out of the model.
+static const char *CLIP_DEF_MARK = "p7cdef";
+
+// Trim a shape to the clip path marked on it. Returns false when nothing of it survives.
+static bool trim_to_clip(const NSVGshape &shape, const std::vector<ExPolygons> *clips, ExPolygons &area)
+{
+    if (clips == nullptr || strncmp(shape.id, CLIP_MARK, strlen(CLIP_MARK)) != 0)
+        return true;
+    const int index = atoi(shape.id + strlen(CLIP_MARK));
+    if (index < 0 || index >= int(clips->size()) || (*clips)[index].empty())
+        return true;
+    area = intersection_ex(area, (*clips)[index]);
+    return !area.empty();
+}
+
+ExPolygonsWithIds create_shape_with_ids(const NSVGimage &image, const NSVGLineParams &param,
+                                        const std::vector<ExPolygons> *clips)
 {
     ExPolygonsWithIds result;
     size_t shape_id = 0;
     for (NSVGshape *shape_ptr = image.shapes; shape_ptr != NULL; shape_ptr = shape_ptr->next, ++shape_id) {
         const NSVGshape &shape = *shape_ptr;
-        if (!(shape.flags & NSVG_FLAGS_VISIBLE))
+        if (!(shape.flags & NSVG_FLAGS_VISIBLE) ||
+            strncmp(shape.id, CLIP_DEF_MARK, strlen(CLIP_DEF_MARK)) == 0)
             continue;
 
         bool is_fill_used = shape.fill.type != NSVG_PAINT_NONE;
@@ -41,22 +67,338 @@ ExPolygonsWithIds create_shape_with_ids(const NSVGimage &image, const NSVGLinePa
 
         const LinesPath lines_path = linearize_path(shape.paths, param);
 
+        // Keep the path's color with its shape. Only a plain color is meaningful
+        // here; a gradient has no single value, so it is left uncolored.
+        auto plain_color = [](const NSVGpaint &paint) -> unsigned {
+            return paint.type == NSVG_PAINT_COLOR ? paint.color : 0u;
+        };
+
         if (is_fill_used) {
             unsigned unique_id = static_cast<unsigned>(2 * shape_id);
             HealedExPolygons expoly = fill_to_expolygons(lines_path, shape, param);
-            result.push_back({unique_id, expoly.expolygons, expoly.is_healed});
+            if (trim_to_clip(shape, clips, expoly.expolygons))
+                result.push_back({unique_id, expoly.expolygons, expoly.is_healed, plain_color(shape.fill)});
         }
         if (is_stroke_used) {
             unsigned unique_id = static_cast<unsigned>(2 * shape_id + 1);
             HealedExPolygons expoly = stroke_to_expolygons(lines_path, shape, param);
-            result.push_back({unique_id, expoly.expolygons, expoly.is_healed});
+            if (trim_to_clip(shape, clips, expoly.expolygons))
+                result.push_back({unique_id, expoly.expolygons, expoly.is_healed, plain_color(shape.stroke)});
         }
+    }
+
+    // Report the colors the SVG carried, so an import can be checked against the
+    // artwork without stepping through it. NanoSVG packs the color as 0xAABBGGRR.
+    {
+        std::vector<unsigned> distinct;
+        for (const ExPolygonsWithId &shape : result)
+            if (shape.color != 0 && std::find(distinct.begin(), distinct.end(), shape.color) == distinct.end())
+                distinct.push_back(shape.color);
+        std::string colors;
+        for (unsigned c : distinct) {
+            char buf[16];
+            snprintf(buf, sizeof(buf), " #%02X%02X%02X", c & 0xFF, (c >> 8) & 0xFF, (c >> 16) & 0xFF);
+            colors += buf;
+        }
+        BOOST_LOG_TRIVIAL(info) << "SVG import: " << result.size() << " shapes, "
+                                << distinct.size() << " distinct colors:" << colors;
     }
 
     // SVG is used as centered
     // Do not disturb user by settings of pivot position
     center(result);
     return result;
+}
+
+namespace {
+
+// Whitespace as CSS and XML count it.
+static const char *WS = " \t\r\n";
+
+// Value of one declaration, matched as a whole word so that asking for "fill" is not
+// answered with "fill-rule".
+static std::string css_value(const std::string &declarations, const std::string &property)
+{
+    for (size_t at = declarations.find(property); at != std::string::npos;
+         at = declarations.find(property, at + property.size())) {
+        if (at > 0 && (isalnum((unsigned char) declarations[at - 1]) || declarations[at - 1] == '-'))
+            continue;
+        const size_t colon = declarations.find_first_not_of(WS, at + property.size());
+        if (colon == std::string::npos || declarations[colon] != ':')
+            continue;
+        const size_t from = declarations.find_first_not_of(WS, colon + 1);
+        if (from == std::string::npos)
+            break;
+        const size_t to    = declarations.find_first_of(";}\r\n", from);
+        std::string  value = declarations.substr(from, (to == std::string::npos ? declarations.size() : to) - from);
+        while (!value.empty() && isspace((unsigned char) value.back()))
+            value.pop_back();
+        return value;
+    }
+    return {};
+}
+
+// Declarations of every class rule in the document's <style> blocks, by class name.
+static std::map<std::string, std::string> css_rules(const std::string &svg)
+{
+    std::map<std::string, std::string> rules;
+    for (size_t at = svg.find("<style"); at != std::string::npos; at = svg.find("<style", at)) {
+        const size_t open = svg.find('>', at);
+        const size_t end  = svg.find("</style", open == std::string::npos ? at : open);
+        if (open == std::string::npos || end == std::string::npos)
+            break;
+        const std::string css = svg.substr(open + 1, end - open - 1);
+        for (size_t rule = css.find('.'); rule != std::string::npos; rule = css.find('.', rule)) {
+            const size_t body_open  = css.find('{', rule);
+            const size_t body_close = css.find('}', body_open == std::string::npos ? rule : body_open);
+            if (body_open == std::string::npos || body_close == std::string::npos)
+                break;
+            std::string name = css.substr(rule + 1, body_open - rule - 1);
+            while (!name.empty() && isspace((unsigned char) name.back()))
+                name.pop_back();
+            if (!name.empty() && name.find_first_of(" \t\r\n.#,>") == std::string::npos)
+                rules[name] = css.substr(body_open + 1, body_close - body_open - 1);
+            rule = body_close + 1;
+        }
+        at = end + 1;
+    }
+    return rules;
+}
+
+// Value of an attribute on one element, empty when the element does not carry it.
+static std::string attribute(const std::string &element, const std::string &name)
+{
+    const std::string key = name + "=\"";
+    const size_t      at  = element.find(key);
+    if (at == std::string::npos)
+        return {};
+    const size_t end = element.find('"', at + key.size());
+    return end == std::string::npos ? std::string() : element.substr(at + key.size(), end - at - key.size());
+}
+
+// The clip a class or an element names, empty when it names none.
+static std::string clip_reference(const std::string &declarations)
+{
+    const std::string url = css_value(declarations, "clip-path");
+    const size_t      at  = url.find("url(#");
+    if (at == std::string::npos)
+        return {};
+    const size_t end = url.find(')', at);
+    return end == std::string::npos ? std::string() : url.substr(at + 5, end - at - 5);
+}
+
+// Add attributes to an element, after the ones it already carries so they take precedence.
+static void append_attributes(std::string &element, const std::string &attributes)
+{
+    size_t at = element.size() - 1;              // the closing '>'
+    if (at > 0 && element[at - 1] == '/')
+        --at;                                    // an element closed as <tag ... />
+    element.insert(at, attributes);
+}
+
+} // namespace
+
+std::string prepare_svg(const std::string &svg)
+{
+    // The clip paths, by id.
+    std::map<std::string, std::string> clip_body;
+    for (size_t at = svg.find("<clipPath"); at != std::string::npos; at = svg.find("<clipPath", at)) {
+        const size_t open  = svg.find('>', at);
+        const size_t close = svg.find("</clipPath", open == std::string::npos ? at : open);
+        if (open == std::string::npos || close == std::string::npos)
+            break;
+        const std::string id = attribute(svg.substr(at, open - at + 1), "id");
+        if (!id.empty())
+            clip_body[id] = svg.substr(open + 1, close - open - 1);
+        at = close + 1;
+    }
+
+    const std::map<std::string, std::string> rules = css_rules(svg);
+    if (rules.empty() && clip_body.empty())
+        return svg;
+
+    // Walk the document once, giving each element the colors its classes carry and marking
+    // the ones a clip path applies to.
+    std::map<std::string, int> clip_index;
+    std::string                out;
+    out.reserve(svg.size() + svg.size() / 8);
+    size_t copied = 0;
+    for (size_t tag = svg.find('<'); tag != std::string::npos; tag = svg.find('<', tag)) {
+        const size_t tag_end = svg.find('>', tag);
+        if (tag_end == std::string::npos)
+            break;
+        std::string element = svg.substr(tag, tag_end - tag + 1);
+        std::string added;
+
+        // An element may carry several classes; the later ones win, as in CSS. Only what the
+        // element does not state itself is added, so its own attributes still take precedence.
+        std::string fill, stroke, clip = clip_reference(element);
+        const std::string classes = attribute(element, "class");
+        for (size_t at = 0; at < classes.size();) {
+            const size_t end  = classes.find_first_of(WS, at);
+            const auto   rule = rules.find(classes.substr(at, end == std::string::npos ? end : end - at));
+            if (rule != rules.end()) {
+                const std::string rule_fill   = css_value(rule->second, "fill");
+                const std::string rule_stroke = css_value(rule->second, "stroke");
+                const std::string rule_clip   = clip_reference(rule->second);
+                if (!rule_fill.empty())   fill   = rule_fill;
+                if (!rule_stroke.empty()) stroke = rule_stroke;
+                if (!rule_clip.empty())   clip   = rule_clip;
+            }
+            if (end == std::string::npos)
+                break;
+            at = classes.find_first_not_of(WS, end);
+            if (at == std::string::npos)
+                break;
+        }
+        if (!fill.empty() && attribute(element, "fill").empty())
+            added += " fill=\"" + fill + "\"";
+        if (!stroke.empty() && attribute(element, "stroke").empty())
+            added += " stroke=\"" + stroke + "\"";
+
+        // The parser keeps an element's id and hands a group's id down to the shapes inside
+        // it, which is how a clipped group is recognised again once the document is parsed.
+        // Any id the element already carries is written over: nothing here reads it.
+        if (!clip.empty() && clip_body.count(clip) != 0) {
+            auto known = clip_index.find(clip);
+            if (known == clip_index.end())
+                known = clip_index.emplace(clip, int(clip_index.size())).first;
+            added += " id=\"" + std::string(CLIP_MARK) + std::to_string(known->second) + "\"";
+        }
+
+        if (!added.empty()) {
+            append_attributes(element, added);
+            out.append(svg, copied, tag - copied);
+            out.append(element);
+            copied = tag_end + 1;
+        }
+        tag = tag_end + 1;
+    }
+    out.append(svg, copied, std::string::npos);
+
+    if (clip_index.empty())
+        return out;
+
+    // Copy the clip shapes into the drawing, marked so they can be gathered again and then
+    // left out of it. They have to be read alongside the artwork: the parser sizes a document
+    // from what it contains, so a clip path read on its own is measured against its own bounds
+    // and no longer lines up with what it trims.
+    std::string clip_shapes;
+    for (const auto &entry : clip_index) {
+        std::string body = clip_body[entry.first];
+        for (size_t at = body.find('<'); at != std::string::npos; at = body.find('<', at)) {
+            const size_t end = body.find('>', at);
+            if (end == std::string::npos)
+                break;
+            if (body.compare(at, 2, "</") != 0) {
+                std::string element = body.substr(at, end - at + 1);
+                // A clip shape is normally drawn as nothing; give it a fill so it reads as an area.
+                append_attributes(element, " fill=\"#000000\" id=\"" + std::string(CLIP_DEF_MARK) +
+                                               std::to_string(entry.second) + "\"");
+                body.replace(at, end - at + 1, element);
+                at = at + element.size();
+                continue;
+            }
+            at = end + 1;
+        }
+        clip_shapes += body;
+    }
+    const size_t root_close = out.rfind("</svg");
+    if (root_close != std::string::npos)
+        out.insert(root_close, clip_shapes);
+
+    // Drop the definitions now their shapes are part of the drawing.
+    for (size_t at = out.find("<clipPath"); at != std::string::npos; at = out.find("<clipPath", at)) {
+        const size_t close = out.find("</clipPath", at);
+        const size_t end   = close == std::string::npos ? std::string::npos : out.find('>', close);
+        if (end == std::string::npos)
+            break;
+        out.erase(at, end - at + 1);
+    }
+    return out;
+}
+
+std::vector<ExPolygons> collect_clip_regions(const NSVGimage &image, const NSVGLineParams &param)
+{
+    std::vector<ExPolygons> clips;
+    for (NSVGshape *shape = image.shapes; shape != NULL; shape = shape->next) {
+        if (strncmp(shape->id, CLIP_DEF_MARK, strlen(CLIP_DEF_MARK)) != 0)
+            continue;
+        const int index = atoi(shape->id + strlen(CLIP_DEF_MARK));
+        if (index < 0)
+            continue;
+        if (int(clips.size()) <= index)
+            clips.resize(index + 1);
+        append(clips[index], fill_to_expolygons(linearize_path(shape->paths, param), *shape, param).expolygons);
+    }
+    for (ExPolygons &clip : clips)
+        clip = union_ex(clip);
+    return clips;
+}
+
+SvgColorRegions create_color_regions(const NSVGimage &image, const NSVGLineParams &param,
+                                    const std::vector<ExPolygons> *clips)
+{
+    // Every closed path, as the area it encloses plus the color it was drawn in. The
+    // path's own stroke color is what the artist chose, so it wins over any fill.
+    struct Loop {
+        ExPolygons area;
+        unsigned   color = 0;
+    };
+    std::vector<Loop> loops;
+    for (NSVGshape *shape_ptr = image.shapes; shape_ptr != NULL; shape_ptr = shape_ptr->next) {
+        const NSVGshape &shape = *shape_ptr;
+        if (!(shape.flags & NSVG_FLAGS_VISIBLE) ||
+            strncmp(shape.id, CLIP_DEF_MARK, strlen(CLIP_DEF_MARK)) == 0)
+            continue;
+        unsigned color = shape.stroke.type == NSVG_PAINT_COLOR ? shape.stroke.color :
+                        (shape.fill.type   == NSVG_PAINT_COLOR ? shape.fill.color   : 0u);
+        if (color == 0)
+            continue; // gradient or no plain color: nothing to fill with
+
+        // The enclosed area is wanted whether or not the path is filled in the file,
+        // so the path is closed and healed exactly as a fill would be.
+        const LinesPath lines_path = linearize_path(shape.paths, param);
+        HealedExPolygons filled = fill_to_expolygons(lines_path, shape, param);
+        if (filled.expolygons.empty())
+            continue;
+
+        Loop loop;
+        loop.color = color;
+        loop.area  = std::move(filled.expolygons);
+        if (!trim_to_clip(shape, clips, loop.area))
+            continue;
+        double area = 0.;
+        for (const ExPolygon &e : loop.area)
+            area += e.area();
+        if (area > 0.)
+            loops.push_back(std::move(loop));
+    }
+    if (loops.empty())
+        return {};
+
+    // Later shapes are painted over earlier ones, so working back to front each shape is cut
+    // against the union of everything above it. Subtracting only nested shapes would not do:
+    // artwork overlaps freely, and an overlap claimed twice leaves two solids in one place.
+    std::vector<ExPolygons> visible(loops.size());
+    ExPolygons              covered;
+    for (size_t i = loops.size(); i-- > 0;) {
+        visible[i] = covered.empty() ? loops[i].area : diff_ex(loops[i].area, covered);
+        if (i > 0) {
+            append(covered, loops[i].area);
+            covered = union_ex(covered);
+        }
+    }
+
+    SvgColorRegions regions;
+    regions.reserve(loops.size());
+    for (size_t i = 0; i < loops.size(); ++i)
+        if (!visible[i].empty())
+            regions.push_back({std::move(visible[i]), loops[i].color});
+
+    BOOST_LOG_TRIVIAL(info) << "SVG color regions: " << loops.size() << " closed loops -> "
+                            << regions.size() << " regions";
+    return regions;
 }
 
 Polygons to_polygons(const NSVGimage &image, const NSVGLineParams &param)

--- a/src/libslic3r/NSVGUtils.hpp
+++ b/src/libslic3r/NSVGUtils.hpp
@@ -53,7 +53,34 @@ struct NSVGLineParams
 /// <param name="scale">Multiplicator of point coors
 /// NOTE: Every point coor from image(float) is multiplied by scale and rounded to integer</param>
 /// <returns>Shapes from svg image - fill + stroke</returns>
-ExPolygonsWithIds create_shape_with_ids(const NSVGimage &image, const NSVGLineParams &param);
+// Fold what the parser cannot read into the elements themselves: <style> class rules become
+// fill and stroke attributes, and clip paths are marked and their shapes copied into the
+// drawing for collect_clip_regions() to pick up. Returns the document unchanged when it
+// carries neither.
+std::string prepare_svg(const std::string &svg);
+
+// Clip regions of a document prepared by prepare_svg, indexed as its marks refer to them.
+std::vector<ExPolygons> collect_clip_regions(const NSVGimage &image, const NSVGLineParams &param);
+
+// clips, when given, trims the shapes a clip path applies to.
+ExPolygonsWithIds create_shape_with_ids(const NSVGimage &image, const NSVGLineParams &param,
+                                        const std::vector<ExPolygons> *clips = nullptr);
+
+// One planar region of an SVG import, and the color that region should print in.
+// Color is packed the way NanoSVG stores it (0xAABBGGRR).
+struct SvgColorRegion
+{
+    ExPolygons expoly;
+    unsigned   color = 0;
+};
+using SvgColorRegions = std::vector<SvgColorRegion>;
+
+// Partition the artwork into the colored regions it is drawn as, resolving overlaps the way
+// the drawing does: a shape keeps only what nothing painted after it covers, so the regions
+// never overlap. Unlike plain import, which draws the lines themselves, this takes the areas
+// those lines enclose - which is what outline artwork means but never states.
+SvgColorRegions create_color_regions(const NSVGimage &image, const NSVGLineParams &param,
+                                     const std::vector<ExPolygons> *clips = nullptr);
 
 // help functions - prepare to be tested
 /// <param name="is_y_negative">Flag is y negative, when true than y coor is multiplied by -1</param>

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -43,6 +43,8 @@
 #include "Gizmos/GLGizmoScale.hpp"
 #include "Gizmos/GLGizmoMeshBoolean.hpp"
 #include "libslic3r/TriangleMeshDeal.hpp"
+#include "libslic3r/NSVGUtils.hpp"
+#include "libslic3r/Emboss.hpp"
 namespace Slic3r
 {
 namespace GUI
@@ -2716,6 +2718,211 @@ void ObjectList::load_mesh_object(const TriangleMesh &mesh, const wxString &name
 #ifdef _DEBUG
     check_model_ids_validity(model);
 #endif /* _DEBUG */
+}
+
+void ObjectList::load_svg_color_regions(const std::string &svg_path)
+{
+    // Plain SVG import builds the lines the file draws; this builds the areas they enclose,
+    // each as its own part so it can print in its own filament.
+    std::unique_ptr<std::string> file_data = read_from_disk(svg_path);
+    if (file_data == nullptr) {
+        show_error(nullptr, format_wxstr(_L("File does NOT exist (%1%)."), svg_path));
+        return;
+    }
+
+    // Same 0.1 mm chord error the SVG gizmo flattens curves to, so circles stay round.
+    const double            tolerance_mm = 0.1;
+    NSVGLineParams          params{ (tolerance_mm * tolerance_mm) / (SCALING_FACTOR * SCALING_FACTOR) };
+    const std::string document = prepare_svg(*file_data);
+    NSVGimage_ptr     image    = nsvgParse(document, "mm", 96.0f);
+    if (image == nullptr) {
+        show_error(nullptr, format_wxstr(_L("Nano SVG parser can't load from file (%1%)."), svg_path));
+        return;
+    }
+    const std::vector<ExPolygons> clips = collect_clip_regions(*image, params);
+
+    SvgColorRegions regions = create_color_regions(*image, params, &clips);
+    if (regions.empty()) {
+        show_error(nullptr, _L("No closed, colored outlines were found in this SVG."));
+        return;
+    }
+
+    // 10 mm tall, measured in the scaled units the shapes are already in.
+    const double     depth = 10. / SCALING_FACTOR;
+    Emboss::ProjectZ projection(depth);
+
+    // Match each region to the loaded filament closest to the color it was drawn in,
+    // so the artwork arrives wearing the colors the artist chose rather than whatever
+    // order the regions happened to come out in.
+    // NOTE: the config key is spelled "filament_colour" upstream (inherited from
+    // PrusaSlicer) even though the UI text is American. Do not "correct" it.
+    auto load_filament_rgb = []() {
+        std::vector<std::array<int, 3>> rgbs;
+        if (auto *colors = wxGetApp().preset_bundle->project_config.option<ConfigOptionStrings>("filament_colour"))
+            for (const std::string &hex : colors->values) {
+                std::array<int, 3> rgb{ 0, 0, 0 };
+                if (hex.size() >= 7 && hex[0] == '#')
+                    for (int c = 0; c < 3; ++c)
+                        rgb[c] = std::stoi(hex.substr(1 + 2 * c, 2), nullptr, 16);
+                rgbs.push_back(rgb);
+            }
+        return rgbs;
+    };
+    // NanoSVG packs color as 0xAABBGGRR.
+    auto svg_rgb = [](unsigned packed) {
+        return std::array<int, 3>{ int(packed & 0xFF), int((packed >> 8) & 0xFF), int((packed >> 16) & 0xFF) };
+    };
+    auto distance2 = [](const std::array<int, 3> &a, const std::array<int, 3> &b) {
+        const int dr = a[0] - b[0], dg = a[1] - b[1], db = a[2] - b[2];
+        return dr * dr + dg * dg + db * db;
+    };
+
+    std::vector<std::array<int, 3>> filament_rgb = load_filament_rgb();
+
+    // The colors the artwork is actually drawn in, in the order they first appear.
+    std::vector<std::array<int, 3>> svg_colors;
+    for (const SvgColorRegion &region : regions) {
+        const std::array<int, 3> rgb = svg_rgb(region.color);
+        if (std::none_of(svg_colors.begin(), svg_colors.end(),
+                         [&](const std::array<int, 3> &c) { return c == rgb; }))
+            svg_colors.push_back(rgb);
+    }
+
+    // Which of them no loaded filament is close to. Squared distance in RGB; 40 per channel
+    // is about as far apart as two colors can be while still reading as the same one.
+    const int    same_color2 = 3 * 40 * 40;
+    const size_t room        = size_t(EnforcerBlockerType::ExtruderMax) - filament_rgb.size();
+    std::vector<std::array<int, 3>> missing;
+    for (const std::array<int, 3> &c : svg_colors) {
+        const bool matched = std::any_of(filament_rgb.begin(), filament_rgb.end(),
+                                         [&](const std::array<int, 3> &f) { return distance2(c, f) <= same_color2; });
+        if (!matched && missing.size() < room)
+            missing.push_back(c);
+    }
+
+    // Artwork drawn in colors the project does not have would otherwise all collapse onto
+    // the nearest loaded filament - with one filament loaded, onto that single filament.
+    // Adding them is the default; matching what is already loaded stays available.
+    if (!missing.empty()) {
+        InfoDialog dialog(wxGetApp().plater(), _L("Import SVG as color regions"),
+                          format_wxstr(_L("This SVG is drawn in %1% colors and the project has %2% "
+                                          "filaments.\n\n"
+                                          "The %3% missing colors can be added to the project, or every "
+                                          "region can be matched to the filaments already loaded."),
+                                       svg_colors.size(), filament_rgb.size(), missing.size()),
+                          false, wxYES_NO | wxCANCEL | wxCANCEL_DEFAULT | wxICON_INFORMATION);
+        dialog.SetButtonLabel(wxID_YES, format_wxstr(_L("Add %1% colors"), missing.size()), true);
+        dialog.SetButtonLabel(wxID_NO, _L("Match loaded filaments"));
+        const int answer = dialog.ShowModal();
+        if (answer == wxID_CANCEL)
+            return;
+        if (answer == wxID_YES) {
+            for (const std::array<int, 3> &c : missing)
+                wxGetApp().plater()->sidebar().add_custom_filament(wxColour(c[0], c[1], c[2]));
+            filament_rgb = load_filament_rgb();   // re-read: the additions changed the list
+        }
+    }
+
+    auto nearest_filament = [&filament_rgb, &svg_rgb, &distance2](unsigned packed) {
+        const std::array<int, 3> rgb = svg_rgb(packed);
+        int best = 1, best_d = std::numeric_limits<int>::max();
+        for (size_t i = 0; i < filament_rgb.size(); ++i) {
+            const int d = distance2(rgb, filament_rgb[i]);
+            if (d < best_d) { best_d = d; best = static_cast<int>(i) + 1; }
+        }
+        return best;
+    };
+    // Settled before anything is built, so the layout can be offered in terms of it.
+    std::vector<int> region_filament(regions.size());
+    for (size_t i = 0; i < regions.size(); ++i)
+        region_filament[i] = nearest_filament(regions[i].color);
+    std::vector<int> distinct = region_filament;
+    std::sort(distinct.begin(), distinct.end());
+    distinct.erase(std::unique(distinct.begin(), distinct.end()), distinct.end());
+
+    // Far fewer colors than regions, so one part per color is much easier to handle -
+    // recoloring is then a click per color. Nothing is lost: the regions of a color stay
+    // separate bodies, so Split to objects recovers them.
+    bool group_by_filament = false;
+    if (distinct.size() < regions.size()) {
+        InfoDialog dialog(wxGetApp().plater(), _L("Import SVG as color regions"),
+                          format_wxstr(_L("This SVG is drawn as %1% regions in %2% colors.\n\n"
+                                          "They can be imported as one part per color, or kept as "
+                                          "one part per region."),
+                                       regions.size(), distinct.size()),
+                          false, wxYES_NO | wxCANCEL | wxCANCEL_DEFAULT | wxICON_INFORMATION);
+        dialog.SetButtonLabel(wxID_YES, _L("One part per color"));
+        dialog.SetButtonLabel(wxID_NO, _L("One part per region"));
+        const int answer = dialog.ShowModal();
+        if (answer == wxID_CANCEL)
+            return;
+        group_by_filament = answer == wxID_YES;
+    }
+
+    Model       &model      = wxGetApp().plater()->model();
+    ModelObject *new_object = model.add_object();
+    std::string object_name = svg_path;
+    if (size_t slash = object_name.find_last_of("/\\"); slash != std::string::npos)
+        object_name = object_name.substr(slash + 1);
+    if (size_t dot = object_name.find_last_of('.'); dot != std::string::npos)
+        object_name = object_name.substr(0, dot);
+    new_object->name = object_name;
+    new_object->add_instance();
+    new_object->config.set_key_value("extruder", new ConfigOptionInt(1));
+
+    auto region_mesh = [&projection](const SvgColorRegion &region) {
+        indexed_triangle_set its = Emboss::polygons2model(region.expoly, projection);
+        // polygons2model works in the shapes' own scaled units; bring it back to mm.
+        for (Vec3f &v : its.vertices)
+            v *= static_cast<float>(SCALING_FACTOR);
+        return its;
+    };
+
+    if (group_by_filament) {
+        // The regions printing in one filament are disjoint islands, so a color's part is
+        // simply their meshes concatenated - none of them overlap, nothing has to be resolved.
+        for (int filament : distinct) {
+            indexed_triangle_set merged;
+            for (size_t i = 0; i < regions.size(); ++i)
+                if (region_filament[i] == filament)
+                    its_merge(merged, region_mesh(regions[i]));
+            if (merged.indices.empty())
+                continue;
+            ModelVolume *volume = new_object->add_volume(TriangleMesh(std::move(merged)));
+            volume->name = "color " + std::to_string(filament);
+            volume->config.set_key_value("extruder", new ConfigOptionInt(filament));
+        }
+    } else {
+        for (size_t i = 0; i < regions.size(); ++i) {
+            indexed_triangle_set its = region_mesh(regions[i]);
+            if (its.indices.empty())
+                continue;
+            ModelVolume *volume = new_object->add_volume(TriangleMesh(std::move(its)));
+            volume->name = "region " + std::to_string(i + 1);
+            volume->config.set_key_value("extruder", new ConfigOptionInt(region_filament[i]));
+        }
+    }
+    if (new_object->volumes.empty()) {
+        model.delete_object(model.objects.size() - 1);
+        show_error(nullptr, _L("The outlines in this SVG did not enclose any printable area."));
+        return;
+    }
+
+    new_object->sort_volumes(true);
+    new_object->invalidate_bounding_box();
+    new_object->center_around_origin();
+
+    // Drop it in the middle of the plate being worked on. Artwork is imported at the size
+    // the file states, which for a large drawing can be far bigger than the plate, and
+    // leaving it at the origin would put most of it off the front left corner.
+    const BoundingBoxf3 plate = wxGetApp().plater()->get_partplate_list().get_curr_plate()->get_build_volume();
+    new_object->instances[0]->set_offset(Vec3d(plate.center().x(), plate.center().y(), 0.));
+    new_object->ensure_on_bed();
+    new_object->get_model()->set_assembly_pos(new_object);
+    wxGetApp().plater()->ensure_model_object_volume_assemble_initialized(new_object);
+
+    std::vector<size_t> object_idxs{ model.objects.size() - 1 };
+    paste_objects_into_list(object_idxs);
 }
 
 int ObjectList::load_mesh_part(const TriangleMesh &mesh, const wxString &name, const TextInfo &text_info, bool is_temp)

--- a/src/slic3r/GUI/GUI_ObjectList.hpp
+++ b/src/slic3r/GUI/GUI_ObjectList.hpp
@@ -312,6 +312,9 @@ public:
     void                add_new_model_object_from_old_object();
     void                load_shape_object(const std::string &type_name);
     void                load_mesh_object(const TriangleMesh &mesh, const wxString &name, bool center = true);
+    // Import outline artwork: every area enclosed by the SVG's closed paths becomes its
+    // own part, printed in the filament nearest the color that area was drawn in.
+    void                load_svg_color_regions(const std::string &svg_path);
     // BBS
     void                switch_to_object_process();
     int                 load_mesh_part(const TriangleMesh &mesh, const wxString &name, const TextInfo &text_info, bool is_temp);

--- a/src/slic3r/GUI/Gizmos/GLGizmoSVG.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSVG.cpp
@@ -154,14 +154,25 @@ EmbossShape select_shape(std::string_view filepath, double tesselation_tolerance
         return {};
     }
 
+    // Set default and unchanging scale
+    NSVGLineParams params{tesselation_tolerance};
+
+    // The parser reads neither <style> rules nor clip paths, so a file that keeps its colors
+    // in a style block would lose them and clipped artwork would arrive whole.
+    std::unique_ptr<std::string> file_data = read_from_disk(svg.path);
+    if (file_data == nullptr) {
+        show_error(nullptr, GUI::format(_u8L("File does NOT exist (%1%)."), svg.path));
+        return {};
+    }
+    svg.file_data = std::make_unique<std::string>(prepare_svg(*file_data));
+
     if (init_image(svg) == nullptr) {
         show_error(nullptr, GUI::format(_u8L("Nano SVG parser can't load from file (%1%)."), svg.path));
         return {};
     }
 
-    // Set default and unchanging scale
-    NSVGLineParams params{tesselation_tolerance};
-    shape.shapes_with_ids = create_shape_with_ids(*svg.image, params);
+    const std::vector<ExPolygons> clips = collect_clip_regions(*svg.image, params);
+    shape.shapes_with_ids = create_shape_with_ids(*svg.image, params, &clips);
 
     // Must contain some shapes !!!
     if (shape.shapes_with_ids.empty()) {

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -3009,6 +3009,19 @@ void MainFrame::init_menubar_as_editor()
             [this](wxCommandEvent&) { load_config_file(); }, "menu_import", nullptr,
             [this](){return true; }, this);
 
+        append_menu_item(import_menu, wxID_ANY, _L("Import SVG as color regions") + dots,
+            _L("Build a part for every area enclosed by the SVG's colored outlines"),
+            [this](wxCommandEvent&) {
+                if (m_plater == nullptr)
+                    return;
+                wxFileDialog dialog(this, _L("Choose an SVG file:"), from_u8(wxGetApp().app_config->get_last_dir()),
+                                    wxEmptyString, "SVG files (*.svg)|*.svg;*.SVG", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+                if (dialog.ShowModal() != wxID_OK)
+                    return;
+                wxGetApp().obj_list()->load_svg_color_regions(into_u8(dialog.GetPath()));
+            }, "menu_import", nullptr,
+            [this](){return can_add_models(); }, this);
+
         append_submenu(fileMenu, import_menu, wxID_ANY, _L("Import"), "");
 
 


### PR DESCRIPTION
Closes #8044.

Two related changes to SVG import: the parser is taught to read styling and clip paths it currently ignores, and on top of that a new import builds a part for every color an outline drawing is made of.

The first half is a fix to SVG import as it stands today. The second is additive and can be dropped if it is not wanted.

### Reading what the file says

NanoSVG reads only presentation attributes. It sees neither the styling a drawing program keeps in a `<style>` block nor the clip paths that trim the artwork, and it has no notion of `<clipPath>` at all, so it draws the clip shapes as though they were part of the drawing.

For a file exported with "style elements" - the default in common drawing programs - the result is that every shape arrives the same default color, clipped artwork arrives whole and spills past the edge it was meant to stop at, and the clip shapes appear in the model as stray geometry.

`prepare_svg()` folds both into the elements before parsing:

- class rules become plain `fill` and `stroke` attributes, leaving alone anything the element already states itself. Several classes on one element are applied in order, the later winning, as CSS does.
- the elements a clip applies to - named directly or through a class - are marked, so their shapes can be recognised once parsed. The parser keeps an element's id and hands a group's id down to the shapes inside it, which is what makes a clipped group recognisable.
- the clip shapes are copied into the drawing rather than read on their own. This matters: the parser sizes a document from the bounds of what it contains, so a clip path read separately is measured against itself and no longer lines up with what it trims.

`collect_clip_regions()` gathers the clip regions once the document is parsed, and `create_shape_with_ids()` trims the shapes each clip applies to. Both are shared, so importing an SVG through the existing gizmo now keeps the colors the file gives it, honours its clip paths, and no longer draws the clip shapes.

Nothing about sizing changes, and a file that carries neither a `<style>` block nor a clip path is returned untouched.

**Before** - the same file on current master. Every shape arrives one color, the clip is ignored, and the clip circles are drawn as artwork:

<img width="1752" height="930" alt="svg stock import" src="https://github.com/user-attachments/assets/ede8bdde-8b8f-499a-9b94-6b3fd5a8c14b" />

**After:**

<img width="1752" height="930" alt="svg Fixed import" src="https://github.com/user-attachments/assets/4f145ed9-0390-4791-897d-128d71b8de22" />

### Importing outline art as colored parts

**File > Import > Import SVG as color regions**

Outline art carries its meaning in the areas its lines enclose, which the file never states - only the lines are drawn. Plain import draws what the file says to draw, so such a file arrives as a set of thin ribbons rather than the shapes a reader sees.

This takes each closed path's enclosed area instead, and:

- resolves overlaps the way the drawing itself does - a shape keeps only what nothing painted after it covers - so the regions do not overlap and cannot fight over the same space
- extrudes each region separately, since a single merged outline would be triangulated without regard to where one color meets the next, leaving facets straddling two regions
- gives each region a filament matching the color it was drawn in, adding the colors the project does not have when asked to
- centres the object on the plate being worked on

#### Colors the project does not have

Matching regions to whatever filaments happen to be loaded falls apart when there are not enough of them: a three-color drawing imported into a project with one filament would arrive as a single part in that color, with nothing on screen to say why. That is the situation #8044 describes, so the import compares the colors the artwork is drawn in against the loaded filaments and offers to add the ones that are missing:

> This SVG is drawn in 3 colors and the project has 1 filament.
>
> The 2 missing colors can be added to the project, or every region can be matched to the filaments already loaded.

Adding goes through `Sidebar::add_custom_filament()`, the same path as the **+** button in the filament panel, so they are ordinary project filaments carrying the SVG's own RGB. Matching what is already loaded stays available, and the question is skipped when every color the drawing uses is already there - so a project set up with the right filaments imports without being asked anything.

Artwork resolves to only as many colors as there are filaments to print it in, which for a drawing of any size is far fewer than it has regions - the logo below is 136 regions in 3 colors. Since handling 136 parts to change 3 colors is nobody's idea of convenient, the import asks:

> This SVG is drawn as 136 regions in 3 colors.
> They can be imported as one part per color, or kept as one part per region.

One part per color merges the regions printing in each filament, so recoloring is a click per color. The regions of a color are disjoint islands, so this is only their meshes concatenated - nothing overlaps and no geometry has to be resolved - and Split to objects brings the individual regions back. The question is skipped when every region is already its own color, there being nothing to choose.

One part per color - the logo arrives as three parts, one per filament:

<img width="1752" height="930" alt="svg Color import grouped" src="https://github.com/user-attachments/assets/ffb48ac9-c24f-465a-a6d1-f7075833c689" />

One part per region - the same import keeping all 136:

<img width="1752" height="930" alt="svg Color import regions" src="https://github.com/user-attachments/assets/4b654fef-e6d6-4f91-ad64-e46811c5cb4c" />

Split to objects, recovering the individual regions from a merged color:

<img width="1752" height="930" alt="split to objects" src="https://github.com/user-attachments/assets/76850dc9-e15d-43f4-9f6e-a82d5f63d4fb" />


It is a separate action rather than a change to SVG import, because the two produce different things: the gizmo makes one editable volume, this makes a part per color. Anyone importing an SVG today gets exactly what they got before.

### Testing

Built on Windows and exercised on real artwork - a logo of 211 shapes using CSS classes, two clip paths on groups, and overlapping fills throughout. Results were checked by reading the per-triangle data back out of the saved 3MF rather than by eye:

| File | Result |
|---|---|
| Logo with CSS classes + 2 clip paths | 196 closed paths resolve to 136 non-overlapping regions, split 66 / 69 / 1 across the three colors it is drawn in; clip regions measure exactly the radii the file gives them |
| Same logo, one part per color | 3 parts on filaments 1 / 2 / 3, the artwork unchanged |
| Same logo, one filament loaded | offered the 2 missing colors; added them and the artwork arrives on its own three filaments rather than collapsed onto one |
| Same file through the existing SVG gizmo | colors and clipping now honoured; clip shapes no longer drawn |
| Outline art, colors declared per path | 18 regions, 4 and 14 across two filaments |
| Same art drawn entirely in black | 18 regions, one filament |
| Nested loops, four colors | 4 concentric regions, each matched to its nearest filament |

Plain outline artwork, where the drawing states only the lines and not the areas they enclose:

<img width="1752" height="930" alt="svg outline import" src="https://github.com/user-attachments/assets/ae97fed1-90fc-4841-a39f-5bfe10276f95" />

Sliced, showing the regions resolve to the right filaments:

<img width="1400" height="743" alt="Slice After Import (small)" src="https://github.com/user-attachments/assets/2cbeaaea-8bef-47b0-abbe-854ed57c53cb" />


### Notes

Curves are flattened to the same 0.1 mm chord tolerance the SVG gizmo already uses.

Not handled, and left for later: `clipPathUnits="objectBoundingBox"`, a transform on a clipped group, and CSS selectors other than class rules. Gradients have no single color to print and are skipped, as before.

