### PR TITLE
FIX: filament vendor submenu never opens when each group has one preset

### DIFF
--- a/src/slic3r/GUI/Widgets/DropDown.cpp
+++ b/src/slic3r/GUI/Widgets/DropDown.cpp
@@ -466,7 +466,9 @@ int DropDown::selectedItem()
 {
     if (selection < 0)
         return -1;
-    if (count == items.size())
+    // Same caveat as hoverIndex(): equal counts do not imply "no grouping",
+    // because single-member groups make them coincide. See messureSize().
+    if (count == items.size() && !has_groups)
         return selection;
     auto & sel = items[selection];
     if (group.IsEmpty() ? !sel.group.IsEmpty() : sel.group != group)
@@ -587,6 +589,7 @@ void DropDown::messureSize()
     // Gtk has a wrapper window for popup widget
     gtk_window_resize (GTK_WINDOW (m_widget), szContent.x, szContent.y);
 #endif
+    has_groups = !groups.empty();
     if (!groups.empty() && subDropDown == nullptr) {
         subDropDown = new DropDown(items);
         subDropDown->mainDropDown = this;
@@ -764,7 +767,7 @@ void DropDown::mouseMove(wxMouseEvent &event)
         if (hover == hover_item) return;
         hover_item = hover;
         int index  = hoverIndex();
-        if (index < -1) {
+        if (index < -1 && subDropDown) {
             auto & drop = *subDropDown;
             drop.group  = items[-index - 2].group;
             drop.need_sync = true;

--- a/src/slic3r/GUI/Widgets/DropDown.hpp
+++ b/src/slic3r/GUI/Widgets/DropDown.hpp
@@ -37,6 +37,7 @@ public:
 private:
     std::vector<Item> &items;
     size_t             count = 0;
+    bool               has_groups = false; // set by messureSize()
     wxString           group;
     bool               need_sync  = false;
     int                selection  = -1;


### PR DESCRIPTION
Hovering a category row (Custom, Bambu, Generic, ...) in the Project Filaments dropdown is supposed to open a submenu listing that vendor's presets. Often it does nothing at all.

`DropDown::hoverIndex()` short-circuits on `count == items.size()` and returns the row index unchanged, assuming equal counts mean nothing is grouped. That does not hold when every group contains exactly one item: each group still collapses to a single row, so the counts match while grouping is present. The `-i-2` group-row encoding is then never produced and `mouseMove()` cannot open the submenu.

This is why it looks intermittent. It depends only on the preset list: as soon as one vendor has two or more compatible presets the counts differ, the shortcut is skipped, and every submenu works again.

Track `has_groups` in `messureSize()` next to count and require it to be false before taking the shortcut. `selectedItem()` had the same flaw, mispositioning the check mark in the affected lists. Also guard the `subDropDown` dereference in `mouseMove()`, which this makes reachable.