### PR TITLE
perf: avoid copying rvalue meshes when adding model volumes

### DIFF
--- a/src/libslic3r/Model.hpp
+++ b/src/libslic3r/Model.hpp
@@ -1243,6 +1243,12 @@ private:
         if (mesh.facets_count() > 1)
             calculate_convex_hull();
     }
+	ModelVolume(ModelObject *object, TriangleMesh &&mesh, ModelVolumeType type = ModelVolumeType::MODEL_PART) :
+		ModelVolume(object, std::make_shared<const TriangleMesh>(std::move(mesh)), type)
+	{
+		if (m_mesh->facets_count() > 1)
+			calculate_convex_hull();
+	}
     ModelVolume(ModelObject *object, const std::shared_ptr<const TriangleMesh> &mesh, ModelVolumeType type = ModelVolumeType::MODEL_PART) : m_mesh(mesh), m_type(type), object(object)
     {
 		assert(this->id().valid());

--- a/tests/fff_print/test_model.cpp
+++ b/tests/fff_print/test_model.cpp
@@ -7,6 +7,8 @@
 #include <boost/nowide/cstdio.hpp>
 #include <boost/filesystem.hpp>
 
+#include <utility>
+
 #include "test_data.hpp"
 
 using namespace Slic3r;
@@ -58,4 +60,20 @@ SCENARIO("Model construction", "[Model]") {
 			}
         }
     }
+}
+
+TEST_CASE("ModelObject moves rvalue mesh storage into a volume", "[Model]")
+{
+    Model model;
+    ModelObject *object = model.add_object();
+    TriangleMesh mesh = make_cube(20, 20, 20);
+
+    const Vec3f *vertices = mesh.its.vertices.data();
+    const Vec3i *indices  = mesh.its.indices.data();
+
+    const ModelVolume *volume = object->add_volume(std::move(mesh), ModelVolumeType::MODEL_PART, false);
+
+    REQUIRE(volume->mesh().its.vertices.data() == vertices);
+    REQUIRE(volume->mesh().its.indices.data() == indices);
+    REQUIRE(!volume->get_convex_hull().empty());
 }


### PR DESCRIPTION
## Summary
- avoid deep-copying `TriangleMesh` when `ModelObject::add_volume` receives an rvalue
- preserve convex-hull initialization after the mesh is moved into the volume
- add a regression test that verifies the vertex and index buffers are transferred

## Validation
- `cmake --build build/arm64 --target libslic3r --parallel 8`
- focused `fff_print_tests` regression: `ModelObject moves rvalue mesh storage into a volume`
- `git diff --check`

The full `fff_print_tests` target is currently blocked by pre-existing test sources that use an older `GCodeWriter` API (`set_extruder`, `lift`, and `retract_lift`); those failures are unrelated to this change.
