### PR TITLE
fix(emboss): crash in slicing prep after embossing all-space text

### DIFF
--- a/src/slic3r/GUI/Jobs/EmbossJob.cpp
+++ b/src/slic3r/GUI/Jobs/EmbossJob.cpp
@@ -1401,8 +1401,11 @@ void GenerateTextJob::process(Ctl &ctl)
     m_input.m_text_align_offsets    = m_input.m_text_shape.text_align_offsets;
     m_input.m_align_type = m_input.m_text_shape.align_type;
 
+    // Must fail the job, not return successfully: finalize() bails only on
+    // canceled/eptr, so a silent return here commits m_final_text_mesh while
+    // it is still empty.
     if (m_input.m_chars_mesh_result.empty()) {
-        return;
+        throw JobException(_u8L("Font doesn't have any shape for given text.").c_str());
     }
     if (!update_text_positions(m_input)) {
         throw JobException("update_text_positions fail.");
@@ -1933,12 +1936,12 @@ void  GenerateTextJob::generate_mesh_according_points(InputInfo &input_info)
         size_t                     count_lines = 1; // input1.text_lines.size();
         bbs = create_line_bounds(es.shapes_with_ids, count_lines);
         if (bbs.empty()) {
-            return;
+            throw JobException(_u8L("Font doesn't have any shape for given text.").c_str());
         }
         SurfaceVolumeData::ModelSource ms;
         ms.mesh = std::make_shared<const TriangleMesh> (input_info.slice_mesh);
         if (ms.mesh->empty()) {
-            return;
+            throw JobException(_u8L("There is no valid surface for text projection.").c_str());
         }
         ms_es.push_back(ms);
         input_db.is_outside = input_info.is_outside;


### PR DESCRIPTION
### What breaks

Embossing text that contains only spaces commits a `ModelVolume` holding an empty mesh. The next background slicing prep then dereferences a null vector data pointer inside `Print::apply`, taking the application down.

### Root cause

`GenerateTextJob::process` has three early-exit paths that `return` normally while leaving `m_input.m_final_text_mesh` empty. `finalize()` cannot tell that apart from success, so it commits the empty mesh.

Line numbers are against `master` at [`66e405477`](https://github.com/bambulab/BambuStudio/commit/66e405477604cf9346ea7aa9e439a7854a01029b).

| site | condition | function |
|---|---|---|
| `EmbossJob.cpp:1404` | `m_chars_mesh_result.empty()` | `GenerateTextJob::process` |
| `EmbossJob.cpp:1935` | `bbs.empty()` | `generate_mesh_according_points` |
| `EmbossJob.cpp:1940` | `ms.mesh->empty()` | `generate_mesh_according_points` |

Three things make this fatal rather than merely a no-op:

1. `generate_mesh_according_points` calls `mesh.clear()` on `input_info.m_final_text_mesh` at `EmbossJob.cpp:1922` **before** either of its two early exits, so both leave the mesh empty rather than untouched.
2. `GenerateTextJob::finalize` tests only `canceled || eptr` (`EmbossJob.cpp:1423-1425`). It has no emptiness check, so a normal return from `process()` reads as success and the mesh is committed through `create_text_volume()` / `recreate_model_volume()`.
3. `Print::apply` → `update_volume_bboxes` → `transformed_its_bbox2d` then evaluates `its.vertices[its.indices.front()(0)]` (`PrintApply.cpp:587`). The guarding `assert(! its.indices.empty())` one line above is compiled out in release, so `front()` reads through a null data pointer.

### Trigger

All-space text. `create_all_char_mesh` clears its out-parameter at `EmbossJob.cpp:1284` and only afterwards tests for all-space input, at `EmbossJob.cpp:1291-1293`:

```cpp
wxRegEx re("^ +$");
bool    is_all_space = re.Matches(input_text);
if (is_all_space) { return; }
```

Because the clear precedes the early return, `m_chars_mesh_result` comes back empty rather than unmodified. `m_final_text_mesh` is then still default-constructed — `InputInfo` is a stack local (`GLGizmoText.cpp:3336`) and `generate_mesh_according_points` is its only writer — so the volume that reaches slicing prep has an empty `indexed_triangle_set`.

### The fix

The three sites now `throw JobException` instead of returning. That is what every other failure path in these two functions already does — `EmbossJob.cpp:1408`, `1411`, `1415`, `1932`, and `1964`. The last of those is especially relevant: it throws on exactly this condition (`mesh.its.empty()`) at the end of `generate_mesh_according_points`. The three sites being changed are the outliers, not a new convention.

No signature changes, no new translatable strings. Both messages already exist in this file for these conditions — *"Font doesn't have any shape for given text."* at `EmbossJob.cpp:1415` and `1932`, and *"There is no valid surface for text projection."* at `EmbossJob.cpp:1004` and `1024`.

This is the same shape and scope as [`ef96c2001`](https://github.com/bambulab/BambuStudio/commit/ef96c2001f3b4823942567a0cd8bf466c4d196fc) (*"FIX:A special font does not generate x characters, causing software crashes"*), which fixed the neighbouring instance of this bug class in this file.

### Why the sibling job doesn't have this bug

`CreateObjectTextJob::process` has the identical bare return at `EmbossJob.cpp:1978`, but it is safe: its `finalize()` guards `m_input.m_position_points.empty()` before building any geometry (`EmbossJob.cpp:1990-1992`). That is the contract `GenerateTextJob::finalize` is missing, and throwing restores it without touching either signature.

### Deliberately out of scope

Two adjacent problems are left alone, because bundling either would make this change much harder to reason about:

**Hardening `update_volume_bboxes` against an empty `indexed_triangle_set`.** That would defend against *any* source of an empty volume, not just this one, and it is worth doing. But it is shared slicing-core code, and the obvious implementation — dropping empty volumes from the vector it walks — is unsafe: `update_volume_bboxes` is the sole writer of `PrintObjectRegions::cached_volume_ids` (`PrintApply.cpp:955-959`), and the consumer at `PrintApply.cpp:687-690` indexes that vector in a loop whose condition has no bounds check. Removing volumes from the walk desynchronises the two and turns a deterministic fault into an out-of-bounds read. Doing it properly needs its own change.

**Error reporting for these jobs.** This stops the crash but does not tell the user anything. `GenerateTextJob::finalize` and `CreateObjectTextJob::finalize` are the only two of seven `finalize()` methods in this file that don't route through `_finalize()`; the other five (`EmbossJob.cpp:350`, `373`, `456`, `535`, `552`) call `if (!_finalize(canceled, eptr, *m_input.base)) return;`, which hands the exception to `exception_process()` and shows the user a message. These two test `canceled || eptr` and discard `eptr`, which is also why the five `JobException`s already present in `GenerateTextJob::process` are silent today. Rewiring them changes user-visible error reporting and belongs in its own change.
