### PR TITLE
ENH: send files to external storage by default when a USB stick is present

### DIFF
--- a/src/slic3r/GUI/Jobs/PrintJob.cpp
+++ b/src/slic3r/GUI/Jobs/PrintJob.cpp
@@ -273,7 +273,7 @@ void PrintJob::process()
     params.auto_offset_cali     = this->auto_offset_cali;
     params.extruder_cali_manual_mode = this->extruder_cali_manual_mode;
     params.task_ext_change_assist = this->task_ext_change_assist;
-    params.try_emmc_print         = this->could_emmc_print;
+    params.try_emmc_print         = this->could_emmc_print && this->use_emmc_storage;
 
     if (m_print_type == "from_sdcard_view") {
         params.dst_file = m_dst_path;

--- a/src/slic3r/GUI/Jobs/PrintJob.hpp
+++ b/src/slic3r/GUI/Jobs/PrintJob.hpp
@@ -85,6 +85,13 @@ public:
     bool        cloud_print_only { false };
     bool        has_sdcard { false };
     bool        could_emmc_print { false };
+    /* Where this job's file should be stored, for a printer that could do either.
+       ``could_emmc_print`` is a firmware capability bit and says only that the
+       internal cache is available; this says whether to use it. Defaults to true
+       so a caller that does not care keeps the historical behaviour of preferring
+       the cache whenever the printer supports it -- only the print dialog, which
+       knows whether a USB stick is in, sets it. (#10481) */
+    bool        use_emmc_storage { true };
     bool        task_use_ams { true };
     bool        task_ext_change_assist { false };
     bool        task_timelapse_use_internal { false };

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -3330,6 +3330,13 @@ void SelectMachineDialog::on_send_print()
 
     m_print_job->has_sdcard = obj_->GetStorage()->get_sdcard_state() == DevStorage::SdcardState::HAS_SDCARD_NORMAL;
     m_print_job->could_emmc_print = obj_->is_support_print_with_emmc;
+    /* Send to the USB stick when there is one, and to the internal cache only when
+       there is not. Until now the capability bit was forwarded as the destination,
+       so every printer that could use its cache always did -- a file that Bambu
+       Handy cannot list, that no FTP client on the network can read, and that the
+       printer's own screen will not offer for a reprint. The send dialog picks the
+       same way; see update_storage_list in SendToPrinter.cpp. (#10481) */
+    m_print_job->use_emmc_storage = !m_print_job->has_sdcard;
 
 
     bool timelapse_option = m_checkbox_list["timelapse"]->IsShown()?true:false;

--- a/src/slic3r/GUI/SendToPrinter.cpp
+++ b/src/slic3r/GUI/SendToPrinter.cpp
@@ -669,10 +669,27 @@ void SendToPrinterDialog::update_storage_list(const std::vector<std::string> &st
 
     if (m_storage_radioBox.size() > 0) {
         m_storage_sizer->Add(0, 0, 0, wxEXPAND, FromDIP(6));
-        auto radio = m_storage_radioBox.front();
-        radio->SetValue(true);
-        if (storages.size() > 0)
-           m_selected_storage = storages[0];
+
+        /* Preselect external storage whenever a USB stick is present, instead of
+           whichever entry the printer happened to list first. Firmware answers the
+           media ability query with "emmc" ahead of "udisk", so taking the head
+           always landed on Cache even with a stick in -- and a file in the cache
+           cannot be picked in Bambu Handy, is invisible to anything reading the
+           printer over FTP, and is not offered for a reprint on the printer's own
+           screen. With no stick in, the cache is the only place the file can go, so
+           it stays the default there. The print dialog picks the same way; see
+           SelectMachineDialog::on_send_print in SelectMachine.cpp. (#10481) */
+        const bool want_emmc = !m_if_has_sdcard;
+        size_t     preferred = 0;
+        for (size_t i = 0; i < storages.size(); i++) {
+            if ((storages[i] == "emmc") == want_emmc) {
+                preferred = i;
+                break;
+            }
+        }
+
+        m_storage_radioBox[preferred]->SetValue(true);
+        m_selected_storage = storages[preferred];
     }
 
     m_storage_panel->Layout();

--- a/src/slic3r/GUI/SendToPrinter.hpp
+++ b/src/slic3r/GUI/SendToPrinter.hpp
@@ -134,7 +134,7 @@ private:
     std::shared_ptr<int>                m_token = std::make_shared<int>(0);
     std::vector<RadioBox *>             m_storage_radioBox;
     std::string                         m_selected_storage;
-    bool                                m_if_has_sdcard;
+    bool                                m_if_has_sdcard{ false };
     bool                                m_waiting_support{ false };
     bool                                m_waiting_enable{ false };
     std::vector<std::string>            m_ability_list;


### PR DESCRIPTION
Addresses #10481.

## What happens today

A printer that can store a sliced file in its internal cache always does, whether
or not a USB stick is plugged in. Both dialogs decide this without asking, and
they get there by two different routes.

**Print dialog.** The firmware capability bit is forwarded straight through as
the destination: `could_emmc_print`, set from `is_support_print_with_emmc`,
becomes `params.try_emmc_print` unchanged. Nothing in the UI can alter it, so on
every printer that supports the cache, Print goes to the cache.

**Send dialog.** This one does offer a picker, but preselects the head of the
printer's media ability list. Firmware answers that query with `emmc` ahead of
`udisk`, so the head is always Cache -- even with a stick in, and even though the
dialog already knows there is one, having used exactly that two lines earlier to
decide whether the External radio should be enabled.

The consequence is the same either way: a file in the cache cannot be selected in
Bambu Handy, is not offered for a reprint on the printer's own screen, and is
invisible to anything reading the printer over FTP. The printer-side "Store sent
files on external storage" setting does not affect either path.

## The change

Both dialogs now prefer external storage when a stick is present, and fall back
to the cache when there is not -- which is the only place the file can go then.

The capability and the choice become separate things. `try_emmc_print` is now
`could_emmc_print && use_emmc_storage`. `could_emmc_print` keeps its other jobs
unchanged: the port 6000 access-code check and the two no-SD-card gates in
`PrintJob`, which are about what the printer can do rather than where this file
goes.

`use_emmc_storage` defaults to `true`, so any caller that does not set it behaves
exactly as before -- the calibration jobs in `CalibUtils` keep their current
routing, including on a printer with no external storage at all. Only the two
dialogs set it.

`m_if_has_sdcard` had no initialiser. It already gated the External radio's
enabled state; it now also picks the default, so it is initialised to `false`.

## Scope

The change is a no-op everywhere except the two cases it targets. With no stick
present, `use_emmc_storage` evaluates to `true` and `try_emmc_print` is
bit-for-bit what it was before; in the send dialog, `want_emmc` is then true and
the loop selects `emmc`, which firmware lists first, so it picks the same entry
`.front()` did. Printers without cache support are unaffected in both dialogs,
as are callers that never touch the new field.

## Testing

Built and run against an H2D:

- Stick present, Print: the file goes to external storage rather than the cache,
  and behaves as expected end to end.
- Stick present, Send: the picker opens on External instead of Cache.

The no-stick path is unchanged by construction rather than by measurement -- see
Scope above; the computed values are identical to the current ones.

Measured while investigating: H2C/H2D route sliced sends to `brtc://emmc/`, while
X1C uses `ftp://` and so was never affected in practice.

## Not included

The Print dialog still has no storage picker of its own -- it now chooses well by
default, but cannot be overridden the way the Send dialog can. Adding one would
follow the existing `show_timelapse_folder_popup` pattern in `SelectMachine.cpp`
(folder button, Internal/External radio popup, External disabled with fallback
when no card). Happy to do that as a follow-up if you would like it, but it is a
UI addition and seemed better kept out of a behaviour fix.