### PR TITLE
ENH: write cumulative per-layer filament usage into slice_info.config

### DIFF
--- a/src/libslic3r/Format/bbs_3mf.cpp
+++ b/src/libslic3r/Format/bbs_3mf.cpp
@@ -230,6 +230,9 @@ static constexpr const char *FILAMENT_USED_FOR_OBJECT      = "used_for_object";
 static constexpr const char *FILAMENT_TOTAL_LOAD_TIME_TAG   = "total_load_time";
 static constexpr const char *FILAMENT_TOTAL_UNLOAD_TIME_TAG = "total_unload_time";
 static constexpr const char *FILAMENT_TRAY_INFO_ID_TAG     = "tray_info_idx";
+static constexpr const char *FILAMENT_LAYER_USAGE_TAG        = "filament_layer_usage";
+static constexpr const char *FILAMENT_LAYER_USAGE_UNIT_TAG   = "unit";
+static constexpr const char *FILAMENT_LAYER_USAGE_VALUES_TAG = "values";
 static constexpr const char *LAYER_FILAMENT_LISTS_TAG      = "layer_filament_lists";
 static constexpr const char *LAYER_FILAMENT_LIST_TAG       = "layer_filament_list";
 static constexpr const char *FILAMENT_NOZZLE_GROUP_ID_TAG    = "group_id";
@@ -572,6 +575,39 @@ std::string join_int_list_comma(const std::vector<int>& values)
     return stream.str();
 }
 
+std::vector<float> parse_float_list(const std::string& value)
+{
+    std::vector<float> out;
+    if (value.empty())
+        return out;
+
+    std::vector<std::string> tokens;
+    boost::split(tokens, value, boost::is_any_of(" ,"), boost::token_compress_on);
+    out.reserve(tokens.size());
+    for (const auto& t : tokens) {
+        if (t.empty())
+            continue;
+        try {
+            out.push_back(static_cast<float>(Slic3r::string_to_double_decimal_point(t)));
+        } catch (...) {
+            // ignore malformed entries
+        }
+    }
+    return out;
+}
+
+std::string join_float_list_comma(const std::vector<float>& values, int precision)
+{
+    std::stringstream stream;
+    stream << std::fixed << std::setprecision(precision);
+    for (size_t i = 0; i < values.size(); ++i) {
+        stream << values[i];
+        if (i + 1 < values.size())
+            stream << ",";
+    }
+    return stream.str();
+}
+
 Slic3r::Vec3f get_vec3_from_string(const std::string &pos_str)
 {
     Slic3r::Vec3f pos(0, 0, 0);
@@ -722,6 +758,12 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
         info.id = it->first;
         info.used_g = used_filament_g;
         info.used_m = used_filament_m;
+        auto layers_it = ps.layer_volumes_per_extruder.find(it->first);
+        if (layers_it != ps.layer_volumes_per_extruder.end()) {
+            info.layer_used_g.reserve(layers_it->second.size());
+            for (double layer_volume : layers_it->second)
+                info.layer_used_g.push_back(get_used_filament_from_volume(layer_volume, it->first).second);
+        }
         {
             auto load_it = ps.load_time_per_filament.find(it->first);
             if (load_it != ps.load_time_per_filament.end())
@@ -1373,6 +1415,7 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
 
         bool _handle_start_config_filament(const char** attributes, unsigned int num_attributes);
         bool _handle_end_config_filament();
+        bool _handle_start_config_filament_layer_usage(const char** attributes, unsigned int num_attributes);
 
         bool _handle_start_config_pause(const char** attributes, unsigned int num_attributes);
 
@@ -3689,6 +3732,8 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
             res = _handle_start_config_plater_instance(attributes, num_attributes);
         else if (::strcmp(FILAMENT_TAG, name) == 0)
             res = _handle_start_config_filament(attributes, num_attributes);
+        else if (::strcmp(FILAMENT_LAYER_USAGE_TAG, name) == 0)
+            res = _handle_start_config_filament_layer_usage(attributes, num_attributes);
         else if (::strcmp(PAUSE_TAG, name) == 0)
             res = _handle_start_config_pause(attributes, num_attributes);
         else if (::strcmp(MIXED_FILAMENT_TAG, name) == 0)
@@ -4834,6 +4879,22 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
     bool _BBS_3MF_Importer::_handle_end_config_metadata()
     {
         // do nothing
+        return true;
+    }
+
+    bool _BBS_3MF_Importer::_handle_start_config_filament_layer_usage(const char** attributes, unsigned int num_attributes)
+    {
+        if (m_curr_plater) {
+            std::string id = bbs_get_attribute_value_string(attributes, num_attributes, FILAMENT_ID_TAG);
+            std::string values = bbs_get_attribute_value_string(attributes, num_attributes, FILAMENT_LAYER_USAGE_VALUES_TAG);
+            int filament_id = atoi(id.c_str()) - 1;
+            for (FilamentInfo& filament_info : m_curr_plater->slice_filaments_info) {
+                if (filament_info.id == filament_id) {
+                    filament_info.layer_used_g = parse_float_list(values);
+                    break;
+                }
+            }
+        }
         return true;
     }
 
@@ -8778,6 +8839,18 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
                            << FILAMENT_USED_FOR_SUPPORT << "=\"" << it->used_for_support << "\" "
                            << FILAMENT_TOTAL_LOAD_TIME_TAG << "=\"" << it->total_load_time << "\" "
                            << FILAMENT_TOTAL_UNLOAD_TIME_TAG << "=\"" << it->total_unload_time << "\"/>\n";
+                }
+
+                // Cumulative usage per layer, so a consumer that knows the layer a print stopped
+                // at can tell how much of each filament had been extruded by then. Entry 0 is
+                // what was extruded before the first layer; the last entry equals used_g.
+                for (auto it = plate_data->slice_filaments_info.begin(); it != plate_data->slice_filaments_info.end(); it++)
+                {
+                    if (it->layer_used_g.empty())
+                        continue;
+                    stream << "    <" << FILAMENT_LAYER_USAGE_TAG << " " << FILAMENT_ID_TAG << "=\"" << std::to_string(it->id + 1) << "\" "
+                           << FILAMENT_LAYER_USAGE_UNIT_TAG << "=\"g\" "
+                           << FILAMENT_LAYER_USAGE_VALUES_TAG << "=\"" << join_float_list_comma(it->layer_used_g, 2) << "\"/>\n";
                 }
 
                 // Mixed (virtual) filaments used by this plate. These are resolved to physical

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -1375,6 +1375,9 @@ void GCodeProcessor::UsedFilaments::reset()
 
     total_volume_cache = 0.0f;
     total_volumes_per_filament.clear();
+
+    layer_volumes_per_filament.clear();
+    layers_recorded = 0;
 }
 
 void GCodeProcessor::UsedFilaments::increase_support_caches(double extruded_volume)
@@ -1420,6 +1423,21 @@ void GCodeProcessor::UsedFilaments::process_total_volume_cache(GCodeProcessor* p
         }
         total_volume_cache = 0.0f;
     }
+}
+
+void GCodeProcessor::UsedFilaments::record_layer(GCodeProcessor* processor)
+{
+    // Commit what the active filament has extruded so far, then snapshot every filament's total.
+    // Called at each layer change and once at the end, so entry 0 is what was extruded before the
+    // first layer (purge line, priming) and the last entry is the plate total.
+    process_total_volume_cache(processor);
+    for (const auto& [filament_id, volume] : total_volumes_per_filament) {
+        std::vector<double>& layers = layer_volumes_per_filament[filament_id];
+        // A filament first used after some layers were already recorded extruded nothing until now.
+        layers.resize(layers_recorded, 0.0);
+        layers.push_back(volume);
+    }
+    ++layers_recorded;
 }
 
 void GCodeProcessor::UsedFilaments::process_model_cache(GCodeProcessor* processor)
@@ -2738,6 +2756,8 @@ void GCodeProcessor::finalize(bool post_process)
     }
 
     m_used_filaments.process_caches(this);
+    // the last layer has no layer-change tag after it
+    m_used_filaments.record_layer(this);
 
     update_estimated_times_stats();
     auto time_mode = m_result.print_statistics.modes[static_cast<size_t>(PrintEstimatedStatistics::ETimeMode::Normal)];
@@ -3520,6 +3540,7 @@ void GCodeProcessor::process_tags(const std::string_view comment, bool producers
 
     // layer change tag
     if (comment == reserved_tag(ETags::Layer_Change)) {
+        m_used_filaments.record_layer(this);
         ++m_layer_id;
         if (m_detect_layer_based_on_tag) {
             if (m_result.moves.empty() || m_result.spiral_vase_layers.empty())
@@ -6345,6 +6366,7 @@ void GCodeProcessor::update_estimated_times_stats()
     m_result.print_statistics.flush_per_filament      = m_used_filaments.flush_per_filament;
     m_result.print_statistics.used_filaments_per_role   = m_used_filaments.filaments_per_role;
     m_result.print_statistics.total_volumes_per_extruder = m_used_filaments.total_volumes_per_filament;
+    m_result.print_statistics.layer_volumes_per_extruder = m_used_filaments.layer_volumes_per_filament;
 }
 
 //BBS: ugly code...

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -93,6 +93,9 @@ namespace Slic3r {
         std::map<size_t, double>                            wipe_tower_volumes_per_extruder;
         std::map<size_t, double>                            support_volumes_per_extruder;
         std::map<size_t, double>                            total_volumes_per_extruder;
+        // cumulative extruded volume per filament at the end of each layer; entry 0 is what was
+        // extruded before the first layer, the last entry equals total_volumes_per_extruder
+        std::map<size_t, std::vector<double>>               layer_volumes_per_extruder;
         //BBS: the flush amount of every filament
         std::map<size_t, double>                            flush_per_filament;
         std::map<ExtrusionRole, std::pair<double, double>>  used_filaments_per_role;
@@ -115,6 +118,7 @@ namespace Slic3r {
             model_volumes_per_extruder.clear();
             support_volumes_per_extruder.clear();
             total_volumes_per_extruder.clear();
+            layer_volumes_per_extruder.clear();
             flush_per_filament.clear();
             used_filaments_per_role.clear();
             load_time_per_filament.clear();
@@ -743,6 +747,10 @@ namespace Slic3r {
             double total_volume_cache;
             std::map<size_t, double>total_volumes_per_filament;
 
+            // cumulative total per filament recorded at each layer change and at the end
+            std::map<size_t, std::vector<double>> layer_volumes_per_filament;
+            size_t layers_recorded{0};
+
             double role_cache;
             std::map<ExtrusionRole, std::pair<double, double>> filaments_per_role;
 
@@ -757,6 +765,7 @@ namespace Slic3r {
             void process_wipe_tower_cache(GCodeProcessor* processor);
             void process_support_cache(GCodeProcessor* processor);
             void process_total_volume_cache(GCodeProcessor* processor);
+            void record_layer(GCodeProcessor* processor);
 
             void update_flush_per_filament(size_t extrude_id, float flush_length);
             void process_role_cache(GCodeProcessor* processor);

--- a/src/libslic3r/ProjectTask.hpp
+++ b/src/libslic3r/ProjectTask.hpp
@@ -46,6 +46,7 @@ struct FilamentInfo
     std::string brand;
     float       used_m{0.f};
     float       used_g{0.f};
+    std::vector<float> layer_used_g; // cumulative grams at the end of each layer, entry 0 = before the first layer
     int         tray_id{0}; // start with 0
     float       distance{0.f};
     int         remain{-1};    // filament remain on the mapped tray: 0~100, -1 = unknown / not reported by the printer


### PR DESCRIPTION
Implements #12145.

`slice_info.config` carries each filament's plate total (`used_g`), and the printer reports `layer_num` while it prints, so anyone estimating how much filament an interrupted print used has to scale the total linearly by layers. On real plates that is wrong by a wide margin, because the bottom layers are solid and the infill layers are light: measured on seven A1 plates in the issue, the linear estimate is off by up to 36 % of the plate on a 293-layer part and 70 % on a 26-layer one.

This writes, per filament, the cumulative usage at the end of each layer:

```xml
<filament id="4" tray_info_idx="GFG99" type="PETG" color="#FFFFFF" used_m="36.94" used_g="112.83" .../>
<filament_layer_usage id="4" unit="g" values="0.19,6.81,13.94,21.40,...,112.83"/>
```

Entry 0 is what was extruded before the first layer (purge line, priming); the last entry equals `used_g`; `layer_num` from the printer indexes the list directly. The values are an attribute rather than text content so the element is read and written like every other element in the file.

## Changes

- `GCodeProcessor`: `UsedFilaments::record_layer` commits the active filament's cache and snapshots every filament's cumulative total. It runs at each `; CHANGE_LAYER` tag, before `m_layer_id` is bumped, and once in `finalize` after `process_caches`, so the series has *total layer number + 1* entries. A filament first used later in the print is padded with zeros for the layers before it. The series travels in `PrintEstimatedStatistics::layer_volumes_per_extruder` next to `total_volumes_per_extruder`.
- `PlateData::parse_filament_info` converts the volumes to grams with the same density and diameter it uses for `used_g`, into `FilamentInfo::layer_used_g`.
- `_add_slice_info_config_file_to_archive` writes the element after the `<filament>` elements; `_handle_start_config_filament_layer_usage` reads it back when a sliced project is opened.

Size: about six bytes per layer per filament; a 1000-layer, four-filament plate adds roughly 25 KB to `slice_info.config`. `used_g`, `used_m` and every existing element are unchanged, and a reader that does not know the new element is unaffected.

## Verification

Built on Ubuntu 22.04 with `BuildLinux.sh -s` on top of the `docker/BuildDepsDockerfile` image, then sliced a test part from the CLI with the A1 0.4 mm nozzle system presets (0.20 mm Standard, Generic PETG, textured PEI plate): a 60 × 60 × 3 mm base with a 12 × 12 × 30 mm pillar, 165 layers.

- `slice_info.config` gets `<filament_layer_usage id="1" unit="g" values="0.09,0.96,1.83,2.70,...,10.85"/>`: 166 entries for 165 layers, last entry equal to `used_g` (10.85).
- Summing the relative `E` moves of the exported `plate_1.gcode` between `; CHANGE_LAYER` markers and converting with the header's density and diameter reproduces the series to within 0.05 g at every entry. That residue is constant along the series and is the same difference that sum shows against `used_g` itself.
- The shape is the reason for the change: after layer 15, the end of the base, the part has used 8.57 g of 10.85 g; the linear estimate for that layer is 0.99 g.

Not covered here: multi-filament plates (the zero padding for a filament first used after the first layers is written but was not exercised), and the importer side. `_handle_start_config_filament_layer_usage` mirrors `_handle_start_config_filament`, but a CLI `--export-3mf` without slicing drops the sliced plate data, so there is no command-line round trip to observe it with.
