### PR TITLE
Text tool: multi-line text with Enter and a Line Gap control

### DIFF
--- a/src/libslic3r/Emboss.cpp
+++ b/src/libslic3r/Emboss.cpp
@@ -1475,7 +1475,8 @@ void Slic3r::Emboss::text2vshapes(EmbossShape &                emboss_shape,
             text_scales.emplace_back(real_scale);
         }
         cur_x = cursor.x() * standard_scale;
-        text_cursors.emplace_back(cur_x - last_x);
+        // '\n' resets cursor to line start, it is not an advance
+        text_cursors.emplace_back(letter == '\n' ? 0.f : cur_x - last_x);
         text_absolute_cursors.emplace_back(cur_x);
         last_x = cur_x;
     }
@@ -1508,6 +1509,12 @@ void Slic3r::Emboss::text2vshapes(EmbossShape &                emboss_shape,
     }
     emboss_shape.shapes_with_ids = result;
     emboss_shape.align_type      = std::pair<int, int>((int) font_prop.align.first, (int) font_prop.align.second);
+    // line layout of multi line text (line Y offsets are already baked in shapes)
+    unsigned count_lines             = get_count_lines(text);
+    emboss_shape.line_height         = static_cast<float>(get_line_height(font, font_prop) * standard_scale);
+    emboss_shape.first_line_offset_y = (count_lines > 1) ?
+        static_cast<float>(get_align_y_offset_in_mm(font_prop.align.second, count_lines, font, font_prop) -
+                           get_align_y_offset_in_mm(font_prop.align.second, 1, font, font_prop)) : 0.f;
 }
 
 #include <boost/range/adaptor/reversed.hpp>
@@ -1551,6 +1558,20 @@ unsigned Emboss::get_count_lines(const ExPolygonsWithIds &shapes) {
     for (const ExPolygonsWithId &shape_id : shapes)
         if (shape_id.id == ENTER_UNICODE)
             ++result;
+    return result;
+}
+
+Emboss::LineRanges Emboss::get_line_ranges(const ExPolygonsWithIds &shapes)
+{
+    LineRanges result;
+    size_t     first = 0;
+    for (size_t i = 0; i < shapes.size(); ++i) {
+        if (shapes[i].id != ENTER_UNICODE)
+            continue;
+        result.emplace_back(first, i);
+        first = i + 1;
+    }
+    result.emplace_back(first, shapes.size());
     return result;
 }
 
@@ -1622,6 +1643,8 @@ std::string Slic3r::Emboss::create_range_text(std::string &text, std::vector<std
     *exist_unknown                              = false;
     bool                     temp_exist_unknown = false;
     std::wstring             not_dup_text       = remove_duplicates(boost::nowide::widen(text));
+    // white spaces are no glyphs, the single font range skips them too
+    not_dup_text.erase(std::remove_if(not_dup_text.begin(), not_dup_text.end(), [](wchar_t wc) { return wc == L'\n' || wc == L'\r' || wc == L'\t'; }), not_dup_text.end());
     std::sort(not_dup_text.begin(), not_dup_text.end());
     std::vector<std::string> results;
     results.reserve(fonts.size());
@@ -2194,7 +2217,7 @@ void align_shape(ExPolygonsWithIds &shapes, std::vector<Point> &offset_xy, const
     // Speed up for left aligned text
     if (prop.align.first == FontProp::HorizontalAlign::left){
         // already horizontaly aligned
-        offset_xy.emplace_back(Point(0, y_offset));
+        offset_xy.assign(shapes.size(), Point(0, y_offset));
         for (ExPolygonsWithId& shape : shapes)
             for (ExPolygon &s : shape.expoly)
                 s.translate(Point(0, y_offset));
@@ -2219,6 +2242,8 @@ void align_shape(ExPolygonsWithIds &shapes, std::vector<Point> &offset_xy, const
     for (size_t i = 0; i < shapes.size(); ++i) {
         wchar_t letter = text[i];
         if (letter == '\n'){
+            // keep offsets aligned with shapes
+            offset_xy.emplace_back(offset);
             offset.x() = get_align_x_offset(prop.align.first, shape_bb, get_line_bb(i + 1));
             continue;
         }
@@ -2275,6 +2300,7 @@ void align_shape(ExPolygonsWithIds &            shapes,
     for (size_t i = 0; i < shapes.size(); ++i) {
         wchar_t letter = text[i];
         if (letter == '\n') {//Enter the next line of text
+            offset_xy.emplace_back(main_offset); // keep offsets aligned with shapes
             main_offset.x() = get_align_x_offset(prop.align.first, shape_bb, get_line_bb(i + 1));
             continue;
         }

--- a/src/libslic3r/Emboss.hpp
+++ b/src/libslic3r/Emboss.hpp
@@ -2,6 +2,7 @@
 #define slic3r_Emboss_hpp_
 
 #include <vector>
+#include <utility>
 #include <set>
 #include <optional>
 #include <memory>
@@ -98,6 +99,10 @@ namespace Emboss
     unsigned get_count_lines(const std::wstring &ws);
     unsigned get_count_lines(const std::string &text);
     unsigned get_count_lines(const ExPolygonsWithIds &shape);
+
+    /// Glyph index ranges [first, last) of each text line, '\n' glyphs are not part of any range
+    using LineRanges = std::vector<std::pair<size_t, size_t>>;
+    LineRanges get_line_ranges(const ExPolygonsWithIds &shapes);
 
     /// <summary>
     /// Fix duplicit points and self intersections in polygons.

--- a/src/libslic3r/EmbossShape.hpp
+++ b/src/libslic3r/EmbossShape.hpp
@@ -192,6 +192,10 @@ struct EmbossShape
     std::vector<float>     text_absolute_cursors;
     std::vector<Vec2f>     text_align_offsets;
     std::pair<int, int>    align_type;
+    // [mm] distance between base lines of neighbour text lines
+    float line_height = 0.f;
+    // [mm] base line offset of the first text line against single line text (vertical align of whole text)
+    float first_line_offset_y = 0.f;
     // undo / redo stack recovery
     template<class Archive> void save(Archive &ar) const
     {

--- a/src/libslic3r/Format/bbs_3mf.cpp
+++ b/src/libslic3r/Format/bbs_3mf.cpp
@@ -5114,6 +5114,7 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
         text_info.m_embeded_depth = bbs_get_attribute_value_float(attributes, num_attributes, EMBEDED_DEPTH_ATTR);
         text_info.m_rotate_angle  = bbs_get_attribute_value_float(attributes, num_attributes, ROTATE_ANGLE_ATTR);
         text_info.m_text_gap      = bbs_get_attribute_value_float(attributes, num_attributes, TEXT_GAP_ATTR);
+        text_info.m_line_gap      = bbs_get_attribute_value_float(attributes, num_attributes, LINE_GAP_ATTR);
 
         text_info.m_bold      = bbs_get_attribute_value_int(attributes, num_attributes, BOLD_ATTR);
         text_info.m_italic    = bbs_get_attribute_value_int(attributes, num_attributes, ITALIC_ATTR);
@@ -8145,7 +8146,7 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
     void _add_text_info_to_archive(std::stringstream& stream, const TextInfo& text_info) {
         stream << "      <" << TEXT_INFO_TAG << " ";
 
-        stream << TEXT_ATTR << "=\"" << xml_escape(text_info.m_text) << "\" ";
+        stream << TEXT_ATTR << "=\"" << xml_escape_double_quotes_attribute_value(text_info.m_text) << "\" ";
         stream << FONT_NAME_ATTR << "=\"" << xml_escape(text_info.m_font_name) << "\" ";
         stream << FONT_VERSION_ATTR << "=\"" << text_info.m_font_version << "\" ";
         stream << STYLE_NAME_ATTR << "=\"" << xml_escape_double_quotes_attribute_value(text_info.text_configuration.style.name) << "\" ";
@@ -8159,6 +8160,7 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
         stream << EMBEDED_DEPTH_ATTR << "=\"" << text_info.m_embeded_depth << "\" ";
         stream << ROTATE_ANGLE_ATTR << "=\"" << text_info.m_rotate_angle << "\" ";
         stream << TEXT_GAP_ATTR << "=\"" << text_info.m_text_gap << "\" ";
+        stream << LINE_GAP_ATTR << "=\"" << text_info.m_line_gap << "\" ";
 
         stream << BOLD_ATTR << "=\"" << (text_info.m_bold ? 1 : 0) << "\" ";
         stream << ITALIC_ATTR << "=\"" << (text_info.m_italic ? 1 : 0) << "\" ";

--- a/src/libslic3r/Model.hpp
+++ b/src/libslic3r/Model.hpp
@@ -867,6 +867,7 @@ struct TextInfo
     float       m_embeded_depth = 0.f;
     float       m_rotate_angle    = 0;
     float       m_text_gap        = 0.f;
+    float       m_line_gap        = 0.f; // [mm] extra space between text lines
     bool        m_is_surface_text = false;//for old
     bool        m_keep_horizontal = false;//for old
     enum TextType {
@@ -880,7 +881,7 @@ struct TextInfo
 
     RaycastResult m_rr;
     template<typename Archive> void serialize(Archive &ar) {
-        ar(m_font_name, m_font_version, m_font_size, m_curr_font_idx, m_bold, m_italic, m_thickness, m_embeded_depth, m_rotate_angle, m_text_gap, m_surface_type, m_text,
+        ar(m_font_name, m_font_version, m_font_size, m_curr_font_idx, m_bold, m_italic, m_thickness, m_embeded_depth, m_rotate_angle, m_text_gap, m_line_gap, m_surface_type, m_text,
            m_rr,text_configuration);
     }
     TextConfiguration text_configuration;

--- a/src/slic3r/GUI/Gizmos/GLGizmoText.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoText.cpp
@@ -1,5 +1,7 @@
 // Include GLGizmoBase.hpp before I18N.hpp as it includes some libigl code, which overrides our localization "L" macro.
 #include "GLGizmoText.hpp"
+#include <algorithm>
+#include <cmath>
 #include "libslic3r/ClipperUtils.hpp"
 #include "slic3r/GUI/GLCanvas3D.hpp"
 #include "slic3r/GUI/Gizmos/GLGizmosCommon.hpp"
@@ -1327,6 +1329,75 @@ void GLGizmoText::draw_rotation(int caption_size, int slider_width, int drag_lef
     }*/
 }
 
+// Line gap is edited in mm, font property stores it in font points
+static int line_gap_mm_to_font_points(float line_gap_mm, const FontProp &fp, const FontFile &ff)
+{
+    if (fp.size_in_mm <= 0.f)
+        return 0;
+    const FontFile::Info &info = Slic3r::Emboss::get_font_info(ff, fp);
+    return static_cast<int>(std::lround(line_gap_mm * info.unit_per_em / fp.size_in_mm));
+}
+
+static float line_gap_font_points_to_mm(const FontProp &fp, const FontFile &ff)
+{
+    if (!fp.line_gap.has_value())
+        return 0.f;
+    const FontFile::Info &info = Slic3r::Emboss::get_font_info(ff, fp);
+    return static_cast<float>(*fp.line_gap) * fp.size_in_mm / static_cast<float>(info.unit_per_em);
+}
+
+// Distance between base lines of the active font and size, without the user line gap
+static float font_line_height_mm(const FontProp &fp, const FontFile &ff)
+{
+    const FontFile::Info &info = Slic3r::Emboss::get_font_info(ff, fp);
+    if (info.unit_per_em <= 0)
+        return 0.f;
+    return static_cast<float>(info.ascent - info.descent + info.linegap) * fp.size_in_mm / static_cast<float>(info.unit_per_em);
+}
+
+// Line gap range in mm for the active style. The lower bound keeps the resulting line height
+// positive, a bigger negative gap would stack the text lines in reverse order.
+// Returns false when there is no active font to measure.
+static bool get_style_line_gap_range(StyleManager &style_manager, float &min_gap, float &max_gap)
+{
+    if (!style_manager.is_active_font())
+        return false;
+    const FontFileWithCache &ff = style_manager.get_font_file_with_cache();
+    if (!ff.has_value())
+        return false;
+    const float line_height = font_line_height_mm(style_manager.get_font_prop(), *ff.font_file);
+    if (line_height <= 0.f)
+        return false;
+    min_gap = -0.9f * line_height;
+    max_gap = std::max(10.f, 2.f * line_height);
+    return true;
+}
+
+static void set_style_line_gap(StyleManager &style_manager, float line_gap_mm)
+{
+    if (!style_manager.is_active_font())
+        return;
+    const FontFileWithCache &ff = style_manager.get_font_file_with_cache();
+    if (!ff.has_value())
+        return;
+    FontProp &fp       = style_manager.get_font_prop();
+    int       line_gap = line_gap_mm_to_font_points(line_gap_mm, fp, *ff.font_file);
+    if (line_gap == 0)
+        fp.line_gap.reset();
+    else
+        fp.line_gap = line_gap;
+}
+
+static float get_style_line_gap_mm(StyleManager &style_manager)
+{
+    if (!style_manager.is_active_font())
+        return 0.f;
+    const FontFileWithCache &ff = style_manager.get_font_file_with_cache();
+    if (!ff.has_value())
+        return 0.f;
+    return line_gap_font_points_to_mm(style_manager.get_font_prop(), *ff.font_file);
+}
+
 std::unique_ptr<Emboss::DataBase> GLGizmoText::create_emboss_data_base(
     const std::string &text, Emboss::StyleManager &style_manager, const Selection &selection, ModelVolumeType type, std::shared_ptr<std::atomic<bool>> &cancel)
 {
@@ -1362,6 +1433,7 @@ std::unique_ptr<Emboss::DataBase> GLGizmoText::create_emboss_data_base(
     DataBase base(volume_name, cancel);
     style.projection.depth = m_thickness; // BBS add
     style.projection.embeded_depth = m_embeded_depth; // BBS add
+    set_style_line_gap(style_manager, m_line_gap); // BBS add: line gap is edited in mm
     base.is_outside   = is_outside;
    // base.text_lines   = text_lines.get_lines();
     base.from_surface = style.distance;
@@ -1686,6 +1758,7 @@ void GLGizmoText::load_init_text(bool first_open_text)
                     }
                     // Re-apply authoritative 3mf fields after any preset load (load_style may reset face/size).
                     m_style_manager.get_font_prop().size_in_mm = m_font_size;
+                    set_style_line_gap(m_style_manager, m_line_gap);
                     if (!m_font_name.empty())
                         select_facename(wxString::FromUTF8(m_font_name.c_str()), false);
                 }
@@ -2418,6 +2491,32 @@ void GLGizmoText::on_render_input_window(float x, float y, float bottom_limit)
         }
     }
 
+    ImGui::AlignTextToFramePadding();
+    m_imgui->text(_L("Line Gap"));
+    ImGui::SameLine(caption_size);
+    ImGui::PushItemWidth(slider_width);
+    // Slider and input share one range, it follows the font so the gap can not cancel the line height.
+    float      line_gap_min = -10.f, line_gap_max = 10.f;
+    const bool has_line_gap_range = get_style_line_gap_range(m_style_manager, line_gap_min, line_gap_max);
+    bool       line_gap_changed   = false;
+    // The stored value is never rewritten from the range: the size field applies every keystroke,
+    // so a transient size would clamp the gap away for good. The range only bounds what the slider
+    // and the input let the user pick, a value from an older file is left alone.
+    if (m_imgui->bbl_slider_float_style("##line_gap", &m_line_gap, line_gap_min, line_gap_max, "%.2f", 1.0f, true))
+        line_gap_changed = true;
+
+    ImGui::SameLine(drag_left_width);
+    ImGui::PushItemWidth(1.5 * slider_icon_width);
+    if (ImGui::BBLDragFloat("##line_gap_input", &m_line_gap, 0.05f, line_gap_min, line_gap_max, "%.2f"))
+        line_gap_changed = true;
+    if (line_gap_changed) {
+        if (has_line_gap_range)
+            m_line_gap = std::clamp(m_line_gap, line_gap_min, line_gap_max);
+        set_style_line_gap(m_style_manager, m_line_gap);
+        m_style_manager.clear_imgui_font(); // preview in text input uses the line gap too
+        m_need_update_text = true;
+    }
+
     draw_rotation(caption_size, slider_width, drag_left_width, slider_icon_width);
 #if BBL_RELEASE_TO_PUBLIC
     if (GUI::wxGetApp().app_config->get("enable_text_styles") == "true") {
@@ -2635,7 +2734,8 @@ void GLGizmoText::draw_text_input(int caption_width)
     // ranges can't be extend during font is activ(pushed)
     std::string               range_text;
     ImVec2                    input_size(2 * m_gui_cfg->input_width, m_gui_cfg->text_size.y); // 2 * m_gui_cfg->input_width - caption_width
-    const ImGuiInputTextFlags flags = ImGuiInputTextFlags_AllowTabInput;// | ImGuiInputTextFlags_AutoSelectAll
+    // Multiline must be passed explicitly (see ImGui::InputTextMultiline). Enter inserts a line break, Ctrl+Enter (Cmd+Enter on macOS) leaves the field.
+    const ImGuiInputTextFlags flags = ImGuiInputTextFlags_AllowTabInput | ImGuiInputTextFlags_Multiline;// | ImGuiInputTextFlags_AutoSelectAll
     if (ImGui::InputTextMultiline("##Text", &m_text, input_size, flags)) {
         if (m_style_manager.get_font_prop().per_glyph) {
             unsigned count_lines = get_count_lines(m_text);
@@ -3094,6 +3194,7 @@ void GLGizmoText::reset_text_info()
     m_embeded_depth = m_style_manager.get_style().projection.embeded_depth;
     m_rotate_angle    = get_angle_from_current_style();
     m_text_gap        = m_style_manager.get_style().prop.char_gap.value_or(0);
+    m_line_gap        = get_style_line_gap_mm(m_style_manager);
     m_surface_type    = TextInfo::TextType::SURFACE;
     m_rr              = RaycastResult();
     m_last_text_mv = nullptr;
@@ -3444,6 +3545,7 @@ TextInfo GLGizmoText::get_text_info()
     text_info.m_rr.mesh_id    = m_rr.mesh_id;
     text_info.m_rotate_angle  = m_rotate_angle;
     text_info.m_text_gap      = m_text_gap;
+    text_info.m_line_gap      = m_line_gap;
     text_info.m_surface_type  = m_surface_type;
     text_info.text_configuration = m_ui_text_configuration;
     text_info.m_font_version     = CUR_FONT_VERSION;
@@ -3469,6 +3571,7 @@ void GLGizmoText::load_from_text_info(const TextInfo &text_info)
     m_rotate_angle = (float) Geometry::rad2deg(limit_angle);
 
     m_text_gap      = text_info.m_text_gap;
+    m_line_gap      = text_info.m_line_gap;
     m_surface_type  = (TextInfo::TextType) text_info.m_surface_type;
 
     if (is_old_text_info(text_info)) { // compatible with older versions

--- a/src/slic3r/GUI/Gizmos/GLGizmoText.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoText.hpp
@@ -56,6 +56,7 @@ private:
     const float  m_embeded_depth_max = 1000.f;
     float m_rotate_angle = 0;
     float m_text_gap = 0.f;
+    float m_line_gap = 0.f; // [mm] extra space between text lines
     TextConfiguration  m_ui_text_configuration;
     TextInfo::TextType m_surface_type{TextInfo::TextType ::SURFACE};
     bool m_really_use_surface_calc = false;

--- a/src/slic3r/GUI/Jobs/EmbossJob.cpp
+++ b/src/slic3r/GUI/Jobs/EmbossJob.cpp
@@ -1,5 +1,6 @@
 #include "EmbossJob.hpp"
 #include <stdexcept>
+#include <algorithm>
 #include <type_traits>
 #include <boost/log/trivial.hpp>
 //
@@ -1296,7 +1297,8 @@ void create_all_char_mesh(DataBase &input, std::vector<TriangleMesh> &result, st
     }
     for (int i = 0; i < shape.shapes_with_ids.size(); i++) {
         auto &temp_shape = shape.shapes_with_ids[i];
-        if (input_text[i] == ' ') {
+        if (input_text[i] == ' ' || temp_shape.id == ENTER_UNICODE) {
+            // empty mesh keeps index aligned with text cursors
             result.emplace_back(TriangleMesh());
             continue;
         }
@@ -1389,6 +1391,21 @@ void calc_position_points(std::vector<Vec3d> &position_points, std::vector<doubl
     }
 }
 
+// Every text line is laid out separately and centered on the text origin along pos_dir.
+// Line Y offsets are baked in glyph shapes by text2vshapes, '\n' glyphs stay at origin (empty mesh).
+void calc_position_points_by_lines(std::vector<Vec3d> &position_points, const std::vector<double> &text_lengths, const LineRanges &lines, float text_gap, const Vec3d &pos_dir)
+{
+    position_points.assign(text_lengths.size(), Vec3d::Zero());
+    for (const auto &[first, last] : lines) {
+        if (first >= last || last > text_lengths.size())
+            continue;
+        std::vector<double> line_lengths(text_lengths.begin() + first, text_lengths.begin() + last);
+        std::vector<Vec3d>  line_points;
+        calc_position_points(line_points, line_lengths, text_gap, pos_dir);
+        std::copy(line_points.begin(), line_points.end(), position_points.begin() + first);
+    }
+}
+
 GenerateTextJob::GenerateTextJob(InputInfo &&input) : m_input(std::move(input)) {}
 std::vector<Vec3d> GenerateTextJob::debug_cut_points_in_world;
 void GenerateTextJob::process(Ctl &ctl)
@@ -1476,11 +1493,8 @@ bool GenerateTextJob::update_text_positions(InputInfo &input_info)
         auto  mouse_normal_local = inv_ * mouse_normal_world;
         mouse_normal_local.normalize();
 
-        calc_position_points(input_info.m_position_points, text_lengths, input_info.m_text_gap, pos_dir);
-
-        for (int i = 0; i < text_num; ++i) {
-            input_info.m_normal_points[i] = mouse_normal_local;
-        }
+        calc_position_points_by_lines(input_info.m_position_points, text_lengths, get_line_ranges(input_info.m_text_shape.shapes_with_ids), input_info.m_text_gap, pos_dir);
+        input_info.m_normal_points.assign(input_info.m_position_points.size(), mouse_normal_local);
         return true;
     }
     input_info.m_surface_type = GenerateTextJob::SurfaceType::Surface;
@@ -1500,7 +1514,6 @@ bool GenerateTextJob::generate_text_points(InputInfo &input_info)
     auto &m_cut_points_in_world  = input_info.m_cut_points_in_world;
     std::vector<Vec3d> m_cut_points_in_local;
     auto &m_text_cs_to_world_tran   = input_info.m_text_tran_in_world.get_matrix();
-    auto &m_chars_mesh_result       = input_info.m_chars_mesh_result;
     auto &m_text_position_in_world  = input_info.m_text_position_in_world;
     auto &m_text_normal_in_world    = input_info.m_text_normal_in_world;
     auto &m_text_gap                = input_info.m_text_gap;
@@ -1533,162 +1546,43 @@ bool GenerateTextJob::generate_text_points(InputInfo &input_info)
     slicing_params.trafo       = cut_tran.inverse();
     // for debug
     // its_write_obj(slice_meshs.its, "D:/debug_files/mesh.obj");
-    // generate polygons
-    const Polygons temp_polys = slice_mesh(slice_meshs.its, 0, slicing_params);
-    Vec3d          scale_click_pt(scale_(0), scale_(0), 0);
-    // for debug
-    // export_regions_to_svg(Point(scale_pt.x(), scale_pt.y()), temp_polys);
-    Polygons polys = union_(temp_polys);
-
+    auto world_tran = m_model_object_in_world_tran * text_tran_in_object;
     auto point_in_line_rectange = [](const Line &line, const Point &point, double &distance) {
         distance = line.distance_to(point);
         return distance < line.length() / 2;
     };
-
-    int     index        = 0;
-    double  min_distance = 1e12;
-    Polygon hit_ploy;
-    for (const Polygon poly : polys) {
-        if (poly.points.size() == 0)
-            continue;
-        Lines lines = poly.lines();
-        for (int i = 0; i < lines.size(); ++i) {
-            Line   line     = lines[i];
-            double distance = min_distance;
-            if (point_in_line_rectange(line, Point(scale_click_pt.x(), scale_click_pt.y()), distance)) {
-                if (distance < min_distance) {
-                    min_distance = distance;
-                    index        = i;
-                    hit_ploy     = poly;
-                }
-            }
-        }
-    }
-
-    if (hit_ploy.points.size() == 0) {
-        BOOST_LOG_TRIVIAL(info) << boost::format("Text: the hit polygon is null,") << "x:" << m_text_position_in_world.x() << ",y:" << m_text_position_in_world.y()
-                                << ",z:" << m_text_position_in_world.z();
-        throw JobException("The hit polygon is null,please try to regenerate after adjusting text position.");
-        return false;
-    }
-    int text_num = m_chars_mesh_result.size();
-
-    auto world_tran = m_model_object_in_world_tran * text_tran_in_object;
-    m_cut_points_in_world.clear();
-    m_cut_points_in_world.reserve(hit_ploy.points.size());
-    m_cut_points_in_local.clear();
-    m_cut_points_in_local.reserve(hit_ploy.points.size());
-    for (int i = 0; i < hit_ploy.points.size(); ++i) {
-        m_cut_points_in_local.emplace_back(rotate_tran * Vec3d(unscale_(hit_ploy.points[i].x()), unscale_(hit_ploy.points[i].y()), 0)); // m_text_cs_to_world_tran *
-        m_cut_points_in_world.emplace_back(world_tran.get_matrix() * m_cut_points_in_local.back());
-    }
-
-    Slic3r::Polygon_3D new_polygon(m_cut_points_in_local);
-    m_position_points.resize(text_num);
-    if (text_num % 2 == 1) {
-        m_position_points[text_num / 2] = Vec3d::Zero();
-        std::vector<Line_3D> lines = new_polygon.get_lines();
-        Line_3D              line  = lines[index];
-        auto                 min_dist   = 1e6;
-        {// Find the nearest tangent point
-            for (int i = 0; i < lines.size(); i++) {
-                Line_3D temp_line = lines[i];
-                Vec3d   intersection_pt;
-                float   proj_length;
-                auto    pt = Vec3d::Zero();
-                Linef3::get_point_projection_to_line(pt, temp_line.a, temp_line.vector(), intersection_pt, proj_length);
-                auto dist = (intersection_pt - pt).norm();
-                if (min_dist > dist) {
-                    min_dist = dist;
-                    m_position_points[text_num / 2] = intersection_pt;
-                }
-            }
-        }
-        {
-            int    index1      = index;
-            double left_length = (Vec3d::Zero() - line.a).cast<double>().norm();
-            int    left_num    = text_num / 2;
-            while (left_num > 0) {
-                double gap_length = (text_lengths[left_num] + m_text_gap + text_lengths[left_num - 1]);
-                if (gap_length < 0)
-                    gap_length = 0;
-
-                while (gap_length > left_length) {
-                    gap_length -= left_length;
-                    if (index1 == 0)
-                        index1 = lines.size() - 1;
-                    else
-                        --index1;
-                    left_length = lines[index1].length();
-                }
-
-                Vec3d direction = lines[index1].vector();
-                direction.normalize();
-                double  distance_to_a = (left_length - gap_length);
-                Line_3D new_line      = lines[index1];
-
-                double norm_value = direction.cast<double>().norm();
-                double deta_x     = distance_to_a * direction.x() / norm_value;
-                double deta_y     = distance_to_a * direction.y() / norm_value;
-                double deta_z     = distance_to_a * direction.z() / norm_value;
-                Vec3d  new_pos    = new_line.a + Vec3d(deta_x, deta_y, deta_z);
-                left_num--;
-                m_position_points[left_num] = new_pos;
-                left_length                 = distance_to_a;
-            }
-        }
-
-        {
-            int    index2       = index;
-            double right_length = (line.b - Vec3d::Zero()).cast<double>().norm();
-            int    right_num    = text_num / 2;
-            while (right_num > 0) {
-                double gap_length = (text_lengths[text_num - right_num] + m_text_gap + text_lengths[text_num - right_num - 1]);
-                if (gap_length < 0)
-                    gap_length = 0;
-
-                while (gap_length > right_length) {
-                    gap_length -= right_length;
-                    if (index2 == lines.size() - 1)
-                        index2 = 0;
-                    else
-                        ++index2;
-                    right_length = lines[index2].length();
-                }
-
-                Line_3D line2 = lines[index2];
-                line2.reverse();
-                Vec3d direction = line2.vector();
-                direction.normalize();
-                double  distance_to_b = (right_length - gap_length);
-                Line_3D new_line      = lines[index2];
-
-                double norm_value                       = direction.cast<double>().norm();
-                double deta_x                           = distance_to_b * direction.x() / norm_value;
-                double deta_y                           = distance_to_b * direction.y() / norm_value;
-                double deta_z                           = distance_to_b * direction.z() / norm_value;
-                Vec3d  new_pos                          = new_line.b + Vec3d(deta_x, deta_y, deta_z);
-                m_position_points[text_num - right_num] = new_pos;
-                right_length                            = distance_to_b;
-                right_num--;
-            }
-        }
-    } else {
-        for (int i = 0; i < text_num / 2; ++i) {
+    // Place glyphs of one text line along the slice polygon: middle glyph on the tangent point
+    // nearest to the text origin, the others by their lengths and gap to both sides.
+    auto place_line_on_polygon = [&](Slic3r::Polygon_3D &new_polygon, int index, std::vector<double> &text_lengths, std::vector<Vec3d> &m_position_points) {
+        int text_num = static_cast<int>(text_lengths.size());
+        m_position_points.resize(text_num);
+        if (text_num % 2 == 1) {
+            m_position_points[text_num / 2] = Vec3d::Zero();
             std::vector<Line_3D> lines = new_polygon.get_lines();
             Line_3D              line  = lines[index];
+            auto                 min_dist   = 1e6;
+            {// Find the nearest tangent point
+                for (int i = 0; i < lines.size(); i++) {
+                    Line_3D temp_line = lines[i];
+                    Vec3d   intersection_pt;
+                    float   proj_length;
+                    auto    pt = Vec3d::Zero();
+                    Linef3::get_point_projection_to_line(pt, temp_line.a, temp_line.vector(), intersection_pt, proj_length);
+                    auto dist = (intersection_pt - pt).norm();
+                    if (min_dist > dist) {
+                        min_dist = dist;
+                        m_position_points[text_num / 2] = intersection_pt;
+                    }
+                }
+            }
             {
                 int    index1      = index;
                 double left_length = (Vec3d::Zero() - line.a).cast<double>().norm();
                 int    left_num    = text_num / 2;
-                for (int i = 0; i < text_num / 2; ++i) {
-                    double gap_length = 0;
-                    if (i == 0) {
-                        gap_length = m_text_gap / 2 + text_lengths[text_num / 2 - 1 - i];
-                    } else {
-                        gap_length = text_lengths[text_num / 2 - i] + m_text_gap + text_lengths[text_num / 2 - 1 - i];
-                    }
-                    if (gap_length < 0) gap_length = 0;
+                while (left_num > 0) {
+                    double gap_length = (text_lengths[left_num] + m_text_gap + text_lengths[left_num - 1]);
+                    if (gap_length < 0)
+                        gap_length = 0;
 
                     while (gap_length > left_length) {
                         gap_length -= left_length;
@@ -1709,9 +1603,9 @@ bool GenerateTextJob::generate_text_points(InputInfo &input_info)
                     double deta_y     = distance_to_a * direction.y() / norm_value;
                     double deta_z     = distance_to_a * direction.z() / norm_value;
                     Vec3d  new_pos    = new_line.a + Vec3d(deta_x, deta_y, deta_z);
-
-                    m_position_points[text_num / 2 - 1 - i] = new_pos;
-                    left_length                             = distance_to_a;
+                    left_num--;
+                    m_position_points[left_num] = new_pos;
+                    left_length                 = distance_to_a;
                 }
             }
 
@@ -1719,15 +1613,10 @@ bool GenerateTextJob::generate_text_points(InputInfo &input_info)
                 int    index2       = index;
                 double right_length = (line.b - Vec3d::Zero()).cast<double>().norm();
                 int    right_num    = text_num / 2;
-                double gap_length   = 0;
-                for (int i = 0; i < text_num / 2; ++i) {
-                    double gap_length = 0;
-                    if (i == 0) {
-                        gap_length = m_text_gap / 2 + text_lengths[text_num / 2 + i];
-                    } else {
-                        gap_length = text_lengths[text_num / 2 + i] + m_text_gap + text_lengths[text_num / 2 + i - 1];
-                    }
-                    if (gap_length < 0) gap_length = 0;
+                while (right_num > 0) {
+                    double gap_length = (text_lengths[text_num - right_num] + m_text_gap + text_lengths[text_num - right_num - 1]);
+                    if (gap_length < 0)
+                        gap_length = 0;
 
                     while (gap_length > right_length) {
                         gap_length -= right_length;
@@ -1745,16 +1634,226 @@ bool GenerateTextJob::generate_text_points(InputInfo &input_info)
                     double  distance_to_b = (right_length - gap_length);
                     Line_3D new_line      = lines[index2];
 
-                    double norm_value                   = direction.cast<double>().norm();
-                    double deta_x                       = distance_to_b * direction.x() / norm_value;
-                    double deta_y                       = distance_to_b * direction.y() / norm_value;
-                    double deta_z                       = distance_to_b * direction.z() / norm_value;
-                    Vec3d  new_pos                      = new_line.b + Vec3d(deta_x, deta_y, deta_z);
-                    m_position_points[text_num / 2 + i] = new_pos;
-                    right_length                        = distance_to_b;
+                    double norm_value                       = direction.cast<double>().norm();
+                    double deta_x                           = distance_to_b * direction.x() / norm_value;
+                    double deta_y                           = distance_to_b * direction.y() / norm_value;
+                    double deta_z                           = distance_to_b * direction.z() / norm_value;
+                    Vec3d  new_pos                          = new_line.b + Vec3d(deta_x, deta_y, deta_z);
+                    m_position_points[text_num - right_num] = new_pos;
+                    right_length                            = distance_to_b;
+                    right_num--;
+                }
+            }
+        } else {
+            for (int i = 0; i < text_num / 2; ++i) {
+                std::vector<Line_3D> lines = new_polygon.get_lines();
+                Line_3D              line  = lines[index];
+                {
+                    int    index1      = index;
+                    double left_length = (Vec3d::Zero() - line.a).cast<double>().norm();
+                    int    left_num    = text_num / 2;
+                    for (int i = 0; i < text_num / 2; ++i) {
+                        double gap_length = 0;
+                        if (i == 0) {
+                            gap_length = m_text_gap / 2 + text_lengths[text_num / 2 - 1 - i];
+                        } else {
+                            gap_length = text_lengths[text_num / 2 - i] + m_text_gap + text_lengths[text_num / 2 - 1 - i];
+                        }
+                        if (gap_length < 0) gap_length = 0;
+
+                        while (gap_length > left_length) {
+                            gap_length -= left_length;
+                            if (index1 == 0)
+                                index1 = lines.size() - 1;
+                            else
+                                --index1;
+                            left_length = lines[index1].length();
+                        }
+
+                        Vec3d direction = lines[index1].vector();
+                        direction.normalize();
+                        double  distance_to_a = (left_length - gap_length);
+                        Line_3D new_line      = lines[index1];
+
+                        double norm_value = direction.cast<double>().norm();
+                        double deta_x     = distance_to_a * direction.x() / norm_value;
+                        double deta_y     = distance_to_a * direction.y() / norm_value;
+                        double deta_z     = distance_to_a * direction.z() / norm_value;
+                        Vec3d  new_pos    = new_line.a + Vec3d(deta_x, deta_y, deta_z);
+
+                        m_position_points[text_num / 2 - 1 - i] = new_pos;
+                        left_length                             = distance_to_a;
+                    }
+                }
+
+                {
+                    int    index2       = index;
+                    double right_length = (line.b - Vec3d::Zero()).cast<double>().norm();
+                    int    right_num    = text_num / 2;
+                    double gap_length   = 0;
+                    for (int i = 0; i < text_num / 2; ++i) {
+                        double gap_length = 0;
+                        if (i == 0) {
+                            gap_length = m_text_gap / 2 + text_lengths[text_num / 2 + i];
+                        } else {
+                            gap_length = text_lengths[text_num / 2 + i] + m_text_gap + text_lengths[text_num / 2 + i - 1];
+                        }
+                        if (gap_length < 0) gap_length = 0;
+
+                        while (gap_length > right_length) {
+                            gap_length -= right_length;
+                            if (index2 == lines.size() - 1)
+                                index2 = 0;
+                            else
+                                ++index2;
+                            right_length = lines[index2].length();
+                        }
+
+                        Line_3D line2 = lines[index2];
+                        line2.reverse();
+                        Vec3d direction = line2.vector();
+                        direction.normalize();
+                        double  distance_to_b = (right_length - gap_length);
+                        Line_3D new_line      = lines[index2];
+
+                        double norm_value                   = direction.cast<double>().norm();
+                        double deta_x                       = distance_to_b * direction.x() / norm_value;
+                        double deta_y                       = distance_to_b * direction.y() / norm_value;
+                        double deta_z                       = distance_to_b * direction.z() / norm_value;
+                        Vec3d  new_pos                      = new_line.b + Vec3d(deta_x, deta_y, deta_z);
+                        m_position_points[text_num / 2 + i] = new_pos;
+                        right_length                        = distance_to_b;
+                    }
                 }
             }
         }
+
+    };
+
+    // Every text line lies on its own curve: the object is sliced by the plane of the line base line.
+    // Base line offset is text CS Y, which rotate_tran maps to slicing Z. Line offsets baked in
+    // glyph shapes are removed later by calc_mesh_offset (see m_text_line_y).
+    const EmbossShape &shape       = input_info.m_text_shape;
+    const LineRanges   line_ranges = get_line_ranges(shape.shapes_with_ids);
+    m_position_points.assign(text_lengths.size(), Vec3d::Zero());
+    input_info.m_text_line_y.assign(text_lengths.size(), 0.f);
+    m_cut_points_in_world.clear();
+    m_cut_points_in_local.clear();
+
+    // A line gap can push a base line above or below the mesh, then the object is not sliced there.
+    // Cut every base line first, so such a line can borrow the nearest one that did cross the object
+    // instead of dropping the whole text. Only text that misses the object completely is an error.
+    struct LineCut
+    {
+        bool    used = false;
+        bool    hit  = false;
+        Polygon poly;
+        int     index  = 0;
+        float   line_y = 0.f;
+    };
+    std::vector<LineCut> line_cuts(line_ranges.size());
+    bool                 any_hit = false;
+    // Slice the object by the plane of one base line and keep the polygon nearest to the anchor.
+    auto cut_base_line = [&](LineCut &cut) {
+        const Polygons temp_polys = slice_mesh(slice_meshs.its, cut.line_y, slicing_params);
+        Vec3d          scale_click_pt(scale_(0), scale_(0), 0);
+        Polygons       polys = union_(temp_polys);
+
+        double min_distance = 1e12;
+        for (const Polygon poly : polys) {
+            if (poly.points.size() == 0)
+                continue;
+            Lines lines = poly.lines();
+            for (int i = 0; i < lines.size(); ++i) {
+                Line   line     = lines[i];
+                double distance = min_distance;
+                if (point_in_line_rectange(line, Point(scale_click_pt.x(), scale_click_pt.y()), distance)) {
+                    if (distance < min_distance) {
+                        min_distance = distance;
+                        cut.index    = i;
+                        cut.poly     = poly;
+                    }
+                }
+            }
+        }
+        cut.hit = cut.poly.points.size() > 0;
+    };
+    {
+        BoundingBoxf3 dbgbb;
+        for (const stl_vertex &v : slice_meshs.its.vertices)
+            dbgbb.merge(Vec3d(slicing_params.trafo * Vec3d(v.x(), v.y(), v.z())));
+    }
+    for (size_t line_i = 0; line_i < line_ranges.size(); ++line_i) {
+        const size_t first = line_ranges[line_i].first;
+        const size_t last  = line_ranges[line_i].second;
+        if (first >= last || last > text_lengths.size())
+            continue;
+        LineCut &cut = line_cuts[line_i];
+        cut.used     = true;
+        cut.line_y   = shape.first_line_offset_y - static_cast<float>(line_i) * shape.line_height;
+        cut_base_line(cut);
+        any_hit = any_hit || cut.hit;
+    }
+
+    LineCut anchor_cut;
+    bool    use_anchor = false;
+    if (!any_hit) {
+        // No base line crossed the object, the text as a whole sits past an edge. The anchor the
+        // user picked is on the surface, so cut there and keep every line on that curve.
+        anchor_cut.used   = true;
+        anchor_cut.line_y = 0.f;
+        cut_base_line(anchor_cut);
+        if (!anchor_cut.hit) {
+            BOOST_LOG_TRIVIAL(info) << boost::format("Text: the hit polygon is null,") << "x:" << m_text_position_in_world.x() << ",y:" << m_text_position_in_world.y()
+                                    << ",z:" << m_text_position_in_world.z();
+            throw JobException("The hit polygon is null,please try to regenerate after adjusting text position.");
+            return false;
+        }
+        BOOST_LOG_TRIVIAL(info) << "Text: no base line crosses the object, every line placed on the text anchor.";
+        use_anchor = true;
+    }
+
+    for (size_t line_i = 0; line_i < line_ranges.size(); ++line_i) {
+        if (!line_cuts[line_i].used)
+            continue;
+        const size_t first = line_ranges[line_i].first;
+        const size_t last  = line_ranges[line_i].second;
+        // Offset baked into the glyph shapes of this line, calc_mesh_offset removes exactly this,
+        // so it stays the nominal value even when the line is placed on a borrowed base line.
+        const float nominal_line_y = line_cuts[line_i].line_y;
+
+        LineCut cut = use_anchor ? anchor_cut : line_cuts[line_i];
+        if (!cut.hit) { // borrow the nearest base line that crossed the object
+            size_t nearest      = line_cuts.size();
+            size_t nearest_dist = 0;
+            for (size_t j = 0; j < line_cuts.size(); ++j) {
+                if (!line_cuts[j].used || !line_cuts[j].hit)
+                    continue;
+                const size_t dist = (j > line_i) ? (j - line_i) : (line_i - j);
+                if (nearest == line_cuts.size() || dist < nearest_dist) {
+                    nearest      = j;
+                    nearest_dist = dist;
+                }
+            }
+            BOOST_LOG_TRIVIAL(info) << boost::format("Text: base line of line %1% misses the object, placed on the base line of line %2%.") % line_i % nearest;
+            cut = line_cuts[nearest];
+        }
+        for (size_t i = first; i < last; ++i)
+            input_info.m_text_line_y[i] = nominal_line_y;
+
+        std::vector<Vec3d> cut_points_in_local;
+        cut_points_in_local.reserve(cut.poly.points.size());
+        for (int i = 0; i < cut.poly.points.size(); ++i) {
+            cut_points_in_local.emplace_back(rotate_tran * Vec3d(unscale_(cut.poly.points[i].x()), unscale_(cut.poly.points[i].y()), cut.line_y));
+            m_cut_points_in_local.emplace_back(cut_points_in_local.back());
+            m_cut_points_in_world.emplace_back(world_tran.get_matrix() * cut_points_in_local.back());
+        }
+
+        Slic3r::Polygon_3D  new_polygon(cut_points_in_local);
+        std::vector<double> line_lengths(text_lengths.begin() + first, text_lengths.begin() + last);
+        std::vector<Vec3d>  line_points;
+        place_line_on_polygon(new_polygon, cut.index, line_lengths, line_points);
+        std::copy(line_points.begin(), line_points.end(), m_position_points.begin() + first);
     }
 
     std::vector<double> mesh_values(m_position_points.size(), 1e9);
@@ -1856,7 +1955,6 @@ void GenerateTextJob::get_text_mesh(TriangleMesh &result_mesh, std::vector<Trian
 
 void GenerateTextJob::get_text_mesh(TriangleMesh &            result_mesh,
                                     EmbossShape &             text_shape,
-                                    BoundingBoxes &           line_bbs,
                                     SurfaceVolumeData::ModelSources &input_ms_es,
                                     DataBase &                       input_db,
                                     int                       i,
@@ -1867,7 +1965,6 @@ void GenerateTextJob::get_text_mesh(TriangleMesh &            result_mesh,
 {
     float              text_scale  = input_db.shape.scale;
     ExPolygons glyph_shape = text_shape.shapes_with_ids[i].expoly;
-    const BoundingBox &glyph_bb    = line_bbs[i];
     Point   offset(mesh_offset[0] / text_scale, mesh_offset[1] / text_scale);
     for (ExPolygon &s : glyph_shape) {
         s.translate(offset);
@@ -1894,14 +1991,18 @@ Vec2f GenerateTextJob::calc_mesh_offset(const std::pair<int, int> &align_type,
                                         const std::vector<float> & text_cursors,
                                         const std::vector<float> &text_absolute_cursors,
                                         const std::vector<Vec2f> &text_align_offsets,
-                                        int                       i)
+                                        int                       i,
+                                        float                     line_y)
 {
     Vec2f mesh_offset(Vec2f::Zero());
-    if (i < text_absolute_cursors.size()) {
+    if (i < text_absolute_cursors.size() && i < text_align_offsets.size()) {
         if (align_type.first == (int) Slic3r::FontProp::HorizontalAlign::center) {
-            mesh_offset[0] = -text_absolute_cursors[i] - text_align_offsets[0][0] + text_cursors[i] / 2.f;
+            // horizontal align offset differs per text line
+            mesh_offset[0] = -text_absolute_cursors[i] - text_align_offsets[i][0] + text_cursors[i] / 2.f;
         } // else todo
     }
+    // surface text: glyph is placed on the curve of its own line, remove line offset baked in shape
+    mesh_offset[1] = -line_y;
     return mesh_offset;
 }
 
@@ -1922,19 +2023,12 @@ void  GenerateTextJob::generate_mesh_according_points(InputInfo &input_info)
     auto inv_text_cs_in_object_no_offset = (m_model_object_in_world_tran.get_matrix_no_offset() * text_tran_in_object.get_matrix_no_offset()).inverse();
 
     ExPolygons ex_polygons;
-    std::vector<BoundingBoxes> bbs;
-    int                        line_idx = 0;
     SurfaceVolumeData::ModelSources ms_es;
     DataBase                        input_db("", std::make_shared<std::atomic<bool>>(false));
     if (input_info.use_surface) {
         EmbossShape &es = input_info.m_text_shape;
         if (es.shapes_with_ids.empty())
             throw JobException(_u8L("Font doesn't have any shape for given text.").c_str());
-        size_t                     count_lines = 1; // input1.text_lines.size();
-        bbs = create_line_bounds(es.shapes_with_ids, count_lines);
-        if (bbs.empty()) {
-            return;
-        }
         SurfaceVolumeData::ModelSource ms;
         ms.mesh = std::make_shared<const TriangleMesh> (input_info.slice_mesh);
         if (ms.mesh->empty()) {
@@ -1951,9 +2045,10 @@ void  GenerateTextJob::generate_mesh_according_points(InputInfo &input_info)
         auto         normal        = m_normal_points[i];
         TriangleMesh sub_mesh;
         auto         local_tran = get_sub_mesh_tran(position, normal, cut_plane_dir, m_embeded_depth);
-        Vec2f mesh_offset = calc_mesh_offset(input_info.m_align_type, input_info.m_text_cursors, input_info.m_text_absolute_cursors, input_info.m_text_align_offsets, i);
+        float line_y      = i < input_info.m_text_line_y.size() ? input_info.m_text_line_y[i] : 0.f;
+        Vec2f mesh_offset = calc_mesh_offset(input_info.m_align_type, input_info.m_text_cursors, input_info.m_text_absolute_cursors, input_info.m_text_align_offsets, i, line_y);
         if (input_info.use_surface) {
-            get_text_mesh(sub_mesh, input_info.m_text_shape, bbs[line_idx], ms_es, input_db, i, mesh_offset, text_tran_in_object, local_tran, input_info.slice_mesh);
+            get_text_mesh(sub_mesh, input_info.m_text_shape, ms_es, input_db, i, mesh_offset, text_tran_in_object, local_tran, input_info.slice_mesh);
         }
         else {
             get_text_mesh(sub_mesh, m_chars_mesh_result, i, mesh_offset, local_tran);
@@ -1980,7 +2075,7 @@ void CreateObjectTextJob::process(Ctl &ctl) {
     }
     std::vector<double> text_lengths;
     calc_text_lengths(text_lengths, m_input.m_text_cursors);
-    calc_position_points(m_input.m_position_points, text_lengths, m_input.text_info.m_text_gap, Vec3d(1, 0, 0));
+    calc_position_points_by_lines(m_input.m_position_points, text_lengths, get_line_ranges(m_input.m_text_shape.shapes_with_ids), m_input.text_info.m_text_gap, Vec3d(1, 0, 0));
 }
 
 void CreateObjectTextJob::finalize(bool canceled, std::exception_ptr &eptr) {

--- a/src/slic3r/GUI/Jobs/EmbossJob.hpp
+++ b/src/slic3r/GUI/Jobs/EmbossJob.hpp
@@ -365,6 +365,7 @@ public:
         Vec3f                     m_text_normal_in_world;
         float                     m_text_gap;
         std::vector<double>       text_lengths;
+        std::vector<float>        m_text_line_y; // [mm] per glyph: base line offset of its text line (surface text only)
 
         Vec3d       m_cut_plane_dir_in_world;
         float       m_thickness     = 2.f;
@@ -392,7 +393,6 @@ public:
     static void get_text_mesh(TriangleMesh &result_mesh, std::vector<TriangleMesh> &chars_mesh, int i, const Vec2f &mesh_offset, Geometry::Transformation &local_tran);
     static void                     get_text_mesh(TriangleMesh &            result_mesh,
                                                   EmbossShape &             text_shape,
-                                                  BoundingBoxes &           line_bbs,
                                                   SurfaceVolumeData::ModelSources& input_ms_es,
                                                   DataBase &input_db,
                                                   int                       i,
@@ -404,7 +404,8 @@ public:
                                                      const std::vector<float> & text_cursors,
                                                      const std::vector<float> & text_absolute_cursors,
                                                      const std::vector<Vec2f> & text_align_offsets,
-                                                     int                        i);
+                                                     int                        i,
+                                                     float                      line_y = 0.f);
     static void generate_mesh_according_points(InputInfo& input_info);
     static std::vector<Vec3d>       debug_cut_points_in_world;
 

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(${_TEST_NAME}_tests
     test_timeutils.cpp
     test_indexed_triangle_set.cpp
     test_debounce.cpp
+    test_emboss.cpp
     ../libnest2d/printer_parts.cpp
 	)
 

--- a/tests/libslic3r/test_emboss.cpp
+++ b/tests/libslic3r/test_emboss.cpp
@@ -1,0 +1,142 @@
+#include <catch2/catch.hpp>
+
+#include <boost/filesystem.hpp>
+
+#include <libslic3r/Emboss.hpp>
+#include <libslic3r/EmbossShape.hpp>
+#include <libslic3r/TextConfiguration.hpp>
+
+using namespace Slic3r;
+using namespace Slic3r::Emboss;
+
+namespace {
+
+// font present on a developer machine, empty when none is found
+std::string get_font_filepath()
+{
+    const char *candidates[] = {
+#ifdef _WIN32
+        "C:/Windows/Fonts/arial.ttf",
+#elif defined(__APPLE__)
+        "/System/Library/Fonts/Supplemental/Arial.ttf",
+        "/System/Library/Fonts/Helvetica.ttc",
+#else
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/TTF/DejaVuSans.ttf",
+        "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+#endif
+    };
+    for (const char *path : candidates)
+        if (boost::filesystem::exists(path))
+            return path;
+    return {};
+}
+
+ExPolygonsWithIds ids_to_shapes(const std::vector<unsigned> &ids)
+{
+    ExPolygonsWithIds shapes;
+    for (unsigned id : ids) {
+        ExPolygonsWithId shape;
+        shape.id = id;
+        shapes.push_back(shape);
+    }
+    return shapes;
+}
+
+} // namespace
+
+TEST_CASE("Line ranges split glyph indices by new line", "[Emboss]")
+{
+    CHECK(get_line_ranges(ids_to_shapes({'A', 'B'})) == LineRanges{{0, 2}});
+    CHECK(get_line_ranges(ids_to_shapes({'A', 'B', '\n', 'C'})) == LineRanges{{0, 2}, {3, 4}});
+    CHECK(get_line_ranges(ids_to_shapes({'\n', 'A', '\n', '\n', 'B', 'C', '\n'})) == LineRanges{{0, 0}, {1, 2}, {3, 3}, {4, 6}, {7, 7}});
+    CHECK(get_line_ranges({}) == LineRanges{{0, 0}});
+    CHECK(get_count_lines(ids_to_shapes({'A', '\n', 'B'})) == 2);
+}
+
+TEST_CASE("Multi line text shapes keep per glyph data aligned", "[Emboss]")
+{
+    std::string font_path = get_font_filepath();
+    if (font_path.empty()) {
+        WARN("No font file found on this machine, test skipped");
+        return;
+    }
+    std::unique_ptr<FontFile> font_file = create_font_file(font_path.c_str());
+    REQUIRE(font_file != nullptr);
+    FontFileWithCache font(std::move(font_file));
+    const FontFile &  ff = *font.font_file;
+
+    FontProp fp(10.f);
+    double   scale = get_text_shape_scale(fp, ff);
+
+    // H sits on the base line, so the base line distance can be measured on glyph bounds
+    const std::wstring text = L"HE\nH";
+    EmbossShape        shape;
+    text2vshapes(shape, font, text, fp, scale);
+
+    REQUIRE(shape.shapes_with_ids.size() == text.size());
+    CHECK(shape.text_cursors.size() == text.size());
+    CHECK(shape.text_absolute_cursors.size() == text.size());
+    CHECK(shape.text_align_offsets.size() == text.size());
+    CHECK(shape.shapes_with_ids[2].id == ENTER_UNICODE);
+    CHECK(shape.shapes_with_ids[2].expoly.empty());
+    CHECK(shape.text_cursors[2] == 0.f);
+    CHECK(get_line_ranges(shape.shapes_with_ids) == LineRanges{{0, 2}, {3, 4}});
+
+    // second line is one line height below the first one
+    double line_height_mm = get_line_height(ff, fp) * scale;
+    CHECK(shape.line_height == Approx(line_height_mm));
+    BoundingBox first_h  = get_extents(shape.shapes_with_ids[0].expoly);
+    BoundingBox second_h = get_extents(shape.shapes_with_ids[3].expoly);
+    CHECK((first_h.min.y() - second_h.min.y()) * scale == Approx(line_height_mm).epsilon(0.01));
+    CHECK(second_h.max.y() < first_h.min.y());
+    // whole text is vertically centered, so the first line moves up by half of the line height
+    CHECK(shape.first_line_offset_y == Approx(line_height_mm / 2.).epsilon(0.01));
+
+    // single line text has no line offset
+    EmbossShape single;
+    text2vshapes(single, font, L"HE", fp, scale);
+    CHECK(single.first_line_offset_y == 0.f);
+    CHECK(single.text_align_offsets.size() == 2);
+
+    // left aligned text has an offset for every glyph too
+    FontProp fp_left(10.f);
+    fp_left.align.first = FontProp::HorizontalAlign::left;
+    EmbossShape left;
+    text2vshapes(left, font, text, fp_left, scale);
+    CHECK(left.text_align_offsets.size() == text.size());
+}
+
+TEST_CASE("Line gap changes distance between text lines", "[Emboss]")
+{
+    std::string font_path = get_font_filepath();
+    if (font_path.empty()) {
+        WARN("No font file found on this machine, test skipped");
+        return;
+    }
+    std::unique_ptr<FontFile> font_file = create_font_file(font_path.c_str());
+    REQUIRE(font_file != nullptr);
+    FontFileWithCache font(std::move(font_file));
+    const FontFile &  ff = *font.font_file;
+
+    FontProp    fp(10.f);
+    double      scale = get_text_shape_scale(fp, ff);
+    EmbossShape shape;
+    text2vshapes(shape, font, L"H\nH", fp, scale);
+
+    FontProp fp_gap(10.f);
+    fp_gap.line_gap = 500; // font points
+    EmbossShape shape_gap;
+    text2vshapes(shape_gap, font, L"H\nH", fp_gap, scale);
+
+    // line gap is in font points, one em is size_in_mm
+    double expected_delta = 500. * fp.size_in_mm / get_font_info(ff, fp).unit_per_em;
+    CHECK(shape_gap.line_height - shape.line_height == Approx(expected_delta).epsilon(0.01));
+    BoundingBox h0       = get_extents(shape.shapes_with_ids[0].expoly);
+    BoundingBox h2       = get_extents(shape.shapes_with_ids[2].expoly);
+    BoundingBox g0       = get_extents(shape_gap.shapes_with_ids[0].expoly);
+    BoundingBox g2       = get_extents(shape_gap.shapes_with_ids[2].expoly);
+    double      dist     = (h0.min.y() - h2.min.y()) * scale;
+    double      dist_gap = (g0.min.y() - g2.min.y()) * scale;
+    CHECK(dist_gap - dist == Approx(expected_delta).epsilon(0.01));
+}


### PR DESCRIPTION
## What

- Text tool input: **Enter inserts a line break**, like a normal text editor. Ctrl+Enter (Cmd+Enter on macOS) leaves the field.
- Multi-line text is generated correctly for flat text and for the three surface modes (Surround surface, Horizontal, Per character).
- New **Line Gap** slider/input under Text Gap (mm, default 0, negative allowed) to adjust the spacing between lines. Its range follows the active font, the negative end stops before the gap cancels the line height.
- Multi-line text and line gap survive project save/load.

## Demo

Flat text: Enter adds a second line, then the Line Gap slider changes the spacing between the lines.

![two line text](https://raw.githubusercontent.com/jeremykenedy/BambuStudio/assets/pr-12176/text-multiline-flat.gif)

Surface text on a cube (Surround surface mode), same steps:

![two line surface text](https://raw.githubusercontent.com/jeremykenedy/BambuStudio/assets/pr-12176/text-multiline-surface.gif)

## Why

Since 86641262a `ImGui::InputTextMultiline` no longer sets `ImGuiInputTextFlags_Multiline` itself and the text gizmo did not pass it, so Enter only unfocused the field and there was no way to type a second line. Even with a `\n` in the text, `GenerateTextJob` laid all glyphs out on one line and lost index alignment on the `\n` entry: `align_shape` skipped it in `offset_xy`, `create_all_char_mesh` dropped it from the mesh list, and positions/normals ended up with different sizes, which read out of bounds.

## How

- Text input: the gizmo passes `ImGuiInputTextFlags_Multiline`, so Enter inserts `\n` and Ctrl+Enter unfocuses (stock ImGui behaviour, `io.KeyCtrl` comes from `wxGetKeyState(WXK_CONTROL)` so it is Cmd+Enter on macOS). No change to `src/imgui`.
- Emboss: `\n` keeps its entry in every per-glyph array (align offsets, cursors), its cursor advance is 0, `EmbossShape` carries `line_height` and `first_line_offset_y` in mm, new `get_line_ranges()`. The backup-font `create_range_text` no longer counts white space as unknown glyphs, which used to flag every multi-line text with the "unsupported characters" tooltip.
- GenerateTextJob: `\n` gets an empty mesh placeholder so mesh, cursor and position arrays stay aligned. Flat text lays every line out separately (`calc_position_points_by_lines`), line Y offsets come from the glyph shapes. Surface text slices the object once per line at the line's base line and places each line on its own curve; the line offset baked in the shape is removed in `calc_mesh_offset`, which now uses the glyph's own align offset instead of glyph 0's.
- Line Gap: `m_line_gap` (mm) maps to `FontProp::line_gap` (font points), so it drives `get_line_height()` and the input preview. Stored in `TextInfo::m_line_gap`, 3mf attribute `line_gap` (0 for older files), undo/redo serialization.
- Line Gap range: slider and number input share one range derived from the active font, min `-0.9 * (ascent - descent + linegap)` in mm and max `max(10, 2x)` that. `get_line_height()` adds `line_gap` straight onto the font metrics, so without the lower bound a big negative gap drives the line height to zero or below and stacks the lines in reverse order. The stored value is only clamped when the user moves one of the two controls, never on its own: the Size field applies every keystroke, so clamping against a transient size would throw the gap away, and rewriting it while drawing would regenerate the volume and push an undo snapshot nobody asked for.
- Surface text is now robust to a base line that does not cross the object, which happens when the text sits near an edge or the gap is large. Every base line is cut first; a line whose own plane misses is placed on the nearest one that did, or on the text anchor when none did, since the anchor is on the surface by construction. `m_text_line_y` keeps the nominal per-line offset in that case, because `calc_mesh_offset` removes exactly the offset baked into that line's glyph shapes. The existing `JobException` is only raised when even the anchor misses, which is the pre-existing "text is off the object" case.
- 3mf: the `text` attribute is written with `xml_escape_double_quotes_attribute_value`, so a line break is stored as `&#xA;` instead of being normalized to a space by the XML parser on load.

## Tests

- New `tests/libslic3r/test_emboss.cpp`: line ranges, per-glyph array alignment for multi-line text, line gap effect on line distance. 3 test cases, 24 assertions, pass on macOS arm64. (`test_aabbindirect.cpp` and `test_3mf.cpp` in that directory do not compile on master, they are untouched.)
- Manual, macOS 26.5 / arm64 build, Bambu Lab P2S profile:
  - Flat text "Text" + Enter + "Line2": two lines, size Y 9.57 mm -> 22.57 mm at Line Gap 0, 29.61 mm at Line Gap 7.04. Cmd+Enter leaves the field.
  - Surface text (Surround surface) on a 60x40x40 box: two lines on the face, block centered on the anchor, height 22.57 mm -> 28.23 mm after Line Gap +5.67.
  - Surface text on a 25.6 mm cube with the anchor near the top edge, 8 mm font, three lines, Line Gap dragged to the low end: lines land on the part, the slider stops at -7.20 (0.9 x the 8 mm line height) and nothing is dropped. Before the base line handling above, adding the second line alone raised "The hit polygon is null" because re-centering the block pushed the only line's plane past the top of the cube.
  - Save/reopen: `text="Text&#xA;Line2" line_gap="5.67"` in `model_settings.config`, text comes back with the line break.
