### PR TITLE
ENH: text tool accepts emoji and other characters above U+FFFF

### DIFF
--- a/src/imgui/imconfig.h
+++ b/src/imgui/imconfig.h
@@ -53,7 +53,10 @@
 //#define IMGUI_USE_BGRA_PACKED_COLOR
 
 //---- Use 32-bit for ImWchar (default is 16-bit) to support unicode planes 1-16. (e.g. point beyond 0xFFFF like emoticons, dingbats, symbols, shapes, ancient languages, etc...)
-//#define IMGUI_USE_WCHAR32
+// Needed by the text tool. With a 16-bit ImWchar every code point above U+FFFF
+// (emoji live in plane 1) is replaced by IM_UNICODE_CODEPOINT_INVALID on the way into
+// InputText, so the character is destroyed before it ever reaches the emboss pipeline.
+#define IMGUI_USE_WCHAR32
 
 //---- Avoid multiple STB libraries implementations, or redefine path/filenames to prioritize another version
 // By default the embedded implementations are declared static and not available outside of Dear ImGui sources files.

--- a/src/libslic3r/Emboss.cpp
+++ b/src/libslic3r/Emboss.cpp
@@ -4,6 +4,8 @@
 #include <numeric>
 #include <cstdlib>
 #include <boost/nowide/convert.hpp>
+#include <boost/nowide/cstdio.hpp>
+#include <boost/locale/encoding_utf.hpp>
 #include <boost/log/trivial.hpp>
 #include <ClipperUtils.hpp> // union_ex + for boldness(polygon extend(offset))
 #include "IntersectionPoints.hpp"
@@ -1070,7 +1072,7 @@ std::unique_ptr<FontFile> Emboss::create_font_file(
 
 std::unique_ptr<FontFile> Emboss::create_font_file(const char *file_path)
 {
-    FILE *file = std::fopen(file_path, "rb");
+    FILE *file = boost::nowide::fopen(file_path, "rb");
     if (file == nullptr) {
         assert(false);
         BOOST_LOG_TRIVIAL(error) << "Couldn't open " << file_path << " for reading.";
@@ -1192,7 +1194,7 @@ int Emboss::get_line_height(const FontFile &font, const FontProp &prop) {
 }
 
 namespace {
-ExPolygons letter2shapes(wchar_t letter, Point &cursor, FontFileWithCache &font_with_cache, const FontProp &font_prop, fontinfo_opt &font_info_cache)
+ExPolygons letter2shapes(char32_t letter, Point &cursor, FontFileWithCache &font_with_cache, const FontProp &font_prop, fontinfo_opt &font_info_cache)
 {
     assert(font_with_cache.has_value());
     if (!font_with_cache.has_value())
@@ -1216,7 +1218,7 @@ ExPolygons letter2shapes(wchar_t letter, Point &cursor, FontFileWithCache &font_
         cursor.x() += count_spaces * space->advance_width;
         return {};
     }
-    if (letter == '\r')
+    if (letter == '\r' || is_zero_width_mark(letter))
         return {};
 
     int unicode = static_cast<int>(letter);
@@ -1239,7 +1241,7 @@ void letter2shapes(ExPolygons &       result,
                    float              cur_scale,
                    FontFileWithCache &real_use_font,
                    float &            real_scale,
-                   wchar_t            letter,
+                   char32_t           letter,
                    Point &            cursor,
                    FontFileWithCache &font_with_cache,
                    const FontProp &   font_prop,
@@ -1267,7 +1269,7 @@ void letter2shapes(ExPolygons &       result,
         cursor.x() += count_spaces * space->advance_width;
         return;
     }
-    if (letter == '\r')
+    if (letter == '\r' || is_zero_width_mark(letter))
         return;
 
     int  unicode = static_cast<int>(letter);
@@ -1293,6 +1295,9 @@ void letter2shapes(ExPolygons &       result,
                 // Create glyph from font file and cache it
                 fontinfo_opt cur_font_info_cache;
                 glyph_ptr = get_glyph(unicode, cur_font, temp_font_prop, cur_cache, cur_font_info_cache);
+                // a code point mapped to an empty outline (bitmap fonts) does not end the search
+                if (glyph_ptr != nullptr && glyph_ptr->shape.empty())
+                    glyph_ptr = nullptr;
                 if (glyph_ptr) {
                     real_use_font          = temp_font;
                     real_scale             = new_scale;
@@ -1399,13 +1404,13 @@ namespace {
 /// <param name="text">To detect end of lines - to be able horizontal center the line</param>
 /// <param name="prop">Containe Horizontal and vertical alignment</param>
 /// <param name="font">Needed for scale and font size</param>
-void align_shape(ExPolygonsWithIds &shapes, std::vector<Point> &offset_xy, const std::wstring &text, const FontProp &prop, const FontFile &font);
+void align_shape(ExPolygonsWithIds &shapes, std::vector<Point> &offset_xy, const std::u32string &text, const FontProp &prop, const FontFile &font);
 void align_shape(ExPolygonsWithIds & shapes,
                  std::vector<Point> &offset_xy,
                  std::vector<float>& text_scales,
                  float                          standard_scale,
                  std::vector<FontFileWithCache> real_fonts,
-                 const std::wstring &           text,
+                 const std::u32string &         text,
                  const FontProp &               prop,
                  const FontFile &               font);
 }
@@ -1418,7 +1423,7 @@ HealedExPolygons Slic3r::Emboss::text2shapes(EmbossShape &                emboss
                                              const std::function<bool()> &was_canceled,
                                              BackFontCacheFn              bfc_fn)
 {//for CreateFontImageJob
-    std::wstring      text_w  = boost::nowide::widen(text);
+    std::u32string    text_w  = to_utf32(text);
     text2vshapes(emboss_shape, font_with_cache, text_w, font_prop, standard_scale, was_canceled, bfc_fn); // ExPolygonsWithIds vshapes =
     auto &vshapes = emboss_shape.shapes_with_ids;
     float delta   = static_cast<float>(1. / SHAPE_SCALE);
@@ -1427,7 +1432,7 @@ HealedExPolygons Slic3r::Emboss::text2shapes(EmbossShape &                emboss
 
 void Slic3r::Emboss::text2vshapes(EmbossShape &                emboss_shape,
                                   FontFileWithCache &          font_with_cache,
-                                  const std::wstring &         text,
+                                  const std::u32string &       text,
                                   const FontProp &             font_prop,
                                   double                       standard_scale,
                                   const std::function<bool()> &was_canceled,
@@ -1452,14 +1457,14 @@ void Slic3r::Emboss::text2vshapes(EmbossShape &                emboss_shape,
     std::vector<FontFileWithCache> text_map_font;
     text_map_font.reserve(text.size());
 
-    for (wchar_t letter : text) {
+    for (char32_t letter : text) {
         if (++counter == CANCEL_CHECK) {
             counter = 0;
             if (was_canceled())
                 return;
         }
-        if (letter == wchar_t(' ')) {
-            letter = 'i';
+        if (letter == U' ') {
+            letter = U'i';
         }
         unsigned id = static_cast<unsigned>(letter);
         float    real_scale = -1.f;
@@ -1495,14 +1500,14 @@ void Slic3r::Emboss::text2vshapes(EmbossShape &                emboss_shape,
     }
     emboss_shape.text_align_offsets    = text_align_offsets;
     std::vector<float> no_use_text_scales;
-    for (wchar_t letter : text) {
+    for (char32_t letter : text) {
         no_use_text_scales.emplace_back(-1);
     }
     emboss_shape.text_scales           = no_use_text_scales;
     emboss_shape.text_cursors    = text_cursors;
     emboss_shape.text_absolute_cursors = text_absolute_cursors;
     for (int i = 0; i < result.size(); i++) {
-        if (text[i] == wchar_t(' ')) {
+        if (text[i] == U' ') {
             result[i].expoly.clear();
         }
     }
@@ -1510,14 +1515,24 @@ void Slic3r::Emboss::text2vshapes(EmbossShape &                emboss_shape,
     emboss_shape.align_type      = std::pair<int, int>((int) font_prop.align.first, (int) font_prop.align.second);
 }
 
+std::u32string Emboss::to_utf32(const std::string &text)
+{
+    return boost::locale::conv::utf_to_utf<char32_t>(text);
+}
+
+std::string Emboss::to_utf8(const std::u32string &text)
+{
+    return boost::locale::conv::utf_to_utf<char>(text);
+}
+
 #include <boost/range/adaptor/reversed.hpp>
-unsigned Emboss::get_count_lines(const std::wstring& ws)
+unsigned Emboss::get_count_lines(const std::u32string& ws)
 {
     if (ws.empty())
         return 0;
 
     unsigned count = 1;
-    for (wchar_t wc : ws)
+    for (char32_t wc : ws)
         if (wc == '\n')
             ++count;
     return count;
@@ -1540,8 +1555,7 @@ unsigned Emboss::get_count_lines(const std::wstring& ws)
 
 unsigned Emboss::get_count_lines(const std::string &text)
 {
-    std::wstring ws = boost::nowide::widen(text.c_str());
-    return get_count_lines(ws);
+    return get_count_lines(to_utf32(text));
 }
 
 unsigned Emboss::get_count_lines(const ExPolygonsWithIds &shapes) {
@@ -1603,11 +1617,11 @@ bool Emboss::is_italic(const FontFile &font, unsigned int font_index)
     return false;
 }
 
-std::wstring remove_duplicates(const std::wstring &input)
+std::u32string remove_duplicates(const std::u32string &input)
 {
-    std::set<wchar_t> seen;
-    std::wstring      result;
-    for (wchar_t c : input) {
+    std::set<char32_t> seen;
+    std::u32string     result;
+    for (char32_t c : input) {
         if (seen.find(c) == seen.end()) {
             seen.insert(c);
             result += c;
@@ -1619,37 +1633,32 @@ std::wstring remove_duplicates(const std::wstring &input)
 std::string Slic3r::Emboss::create_range_text(std::string &text, std::vector<std::shared_ptr<const FontFile>> fonts, unsigned int font_index, bool *exist_unknown)
 {
     if (fonts.empty()) { return ""; }
-    *exist_unknown                              = false;
-    bool                     temp_exist_unknown = false;
-    std::wstring             not_dup_text       = remove_duplicates(boost::nowide::widen(text));
-    std::sort(not_dup_text.begin(), not_dup_text.end());
-    std::vector<std::string> results;
-    results.reserve(fonts.size());
-    for (int i = 0; i < fonts.size(); i++) {
-        auto temp_text = create_range_text(text, *fonts[i], font_index, &temp_exist_unknown);
-        results.emplace_back(temp_text);
-        auto valid_text = boost::nowide::widen(temp_text);
-        if (valid_text.size() == not_dup_text.size()) {
-            if (i > 0) {
-                *exist_unknown = true;
-            }
-            return results.back();
-        }
-    }
+    *exist_unknown = false;
+    // code points that need a glyph, the single font version skips the same ones
+    std::u32string wanted = remove_duplicates(to_utf32(text));
+    wanted.erase(std::remove_if(wanted.begin(), wanted.end(), [](char32_t c) { return c == U'\n' || c == U'\r' || c == U'\t' || is_zero_width_mark(c); }), wanted.end());
+
+    bool        temp_exist_unknown = false;
+    std::string primary            = create_range_text(text, *fonts[0], font_index, &temp_exist_unknown);
+    if (to_utf32(primary).size() == wanted.size())
+        return primary;
+
+    // the first font does not cover the text, the atlas needs what every backup font adds
     *exist_unknown = true;
-    for (int i = 0; i < results.size(); i++) {
-        if (boost::nowide::widen(results[i]).size() == not_dup_text.size()) {
-            return results[i];
-        }
-    }
-    return results[0];
+    std::set<char32_t> covered;
+    for (char32_t c : to_utf32(primary))
+        covered.insert(c);
+    for (size_t i = 1; i < fonts.size(); ++i)
+        for (char32_t c : to_utf32(create_range_text(text, *fonts[i], font_index, &temp_exist_unknown)))
+            covered.insert(c);
+    return to_utf8(std::u32string(covered.begin(), covered.end()));
 }
 
 std::string Emboss::create_range_text(const std::string &text, const FontFile &font, unsigned int font_index,bool *exist_unknown)
 {
     if (!is_valid(font, font_index)) return {};
 
-    std::wstring ws = boost::nowide::widen(text);
+    std::u32string ws = to_utf32(text);
 
     // need remove symbols not contained in font
     std::sort(ws.begin(), ws.end());
@@ -1663,13 +1672,14 @@ std::string Emboss::create_range_text(const std::string &text, const FontFile &f
         *exist_unknown = false;
     int prev_unicode = -1;
     ws.erase(std::remove_if(ws.begin(), ws.end(),
-        [&prev_unicode, font_info, exist_unknown](wchar_t wc) -> bool {
+        [&prev_unicode, font_info, exist_unknown](char32_t wc) -> bool {
             int unicode = static_cast<int>(wc);
 
-            // skip white spaces
+            // skip white spaces and marks without a glyph
             if (unicode == '\n' ||
                 unicode == '\r' ||
-                unicode == '\t') return true;
+                unicode == '\t' ||
+                is_zero_width_mark(wc)) return true;
 
             // is duplicit?
             if (prev_unicode == unicode) return true;
@@ -1682,7 +1692,7 @@ std::string Emboss::create_range_text(const std::string &text, const FontFile &f
             return is_unknown;
         }), ws.end());
 
-    return boost::nowide::narrow(ws);
+    return to_utf8(ws);
 }
 
 double Emboss::get_text_shape_scale(const FontProp &fp, const FontFile &ff)
@@ -2183,7 +2193,7 @@ int32_t get_align_x_offset(FontProp::HorizontalAlign align, const BoundingBox &s
     return 0;
 }
 
-void align_shape(ExPolygonsWithIds &shapes, std::vector<Point> &offset_xy, const std::wstring &text, const FontProp &prop, const FontFile &font)
+void align_shape(ExPolygonsWithIds &shapes, std::vector<Point> &offset_xy, const std::u32string &text, const FontProp &prop, const FontFile &font)
 {
     // Shapes have to match letters in text
     assert(shapes.size() == text.length());
@@ -2217,7 +2227,7 @@ void align_shape(ExPolygonsWithIds &shapes, std::vector<Point> &offset_xy, const
         get_align_x_offset(prop.align.first, shape_bb, get_line_bb(0)),
         y_offset);
     for (size_t i = 0; i < shapes.size(); ++i) {
-        wchar_t letter = text[i];
+        char32_t letter = text[i];
         if (letter == '\n'){
             offset.x() = get_align_x_offset(prop.align.first, shape_bb, get_line_bb(i + 1));
             continue;
@@ -2234,7 +2244,7 @@ void align_shape(ExPolygonsWithIds &            shapes,
                  std::vector<float> &           text_scales,
                  float                          standard_scale,
                  std::vector<FontFileWithCache> real_fonts,
-                 const std::wstring &text, const FontProp &prop, const FontFile &font)
+                 const std::u32string &text, const FontProp &prop, const FontFile &font)
 { // Shapes have to match letters in text
     assert(shapes.size() == text.length());
 
@@ -2248,8 +2258,10 @@ void align_shape(ExPolygonsWithIds &            shapes,
         for (ExPolygonsWithId &shape : shapes) {
             int temp_y_offset = main_y_offset;
             if (real_fonts[index].has_value()) {
+                // the backup glyph was scaled into the main font units, its offset must follow
                 const FontFile &temp_font = *real_fonts[index].font_file;
-                temp_y_offset             = get_align_y_offset(prop.align.second, count_lines, temp_font, prop);
+                double          ratio     = text_scales[index] / standard_scale;
+                temp_y_offset = static_cast<int>(std::round(get_align_y_offset(prop.align.second, count_lines, temp_font, prop) * ratio));
             }
             offset_xy.emplace_back(Point(0, temp_y_offset));
             for (ExPolygon &s : shape.expoly) {
@@ -2273,7 +2285,7 @@ void align_shape(ExPolygonsWithIds &            shapes,
     // Align x line by line
     Point main_offset(get_align_x_offset(prop.align.first, shape_bb, get_line_bb(0)), main_y_offset);
     for (size_t i = 0; i < shapes.size(); ++i) {
-        wchar_t letter = text[i];
+        char32_t letter = text[i];
         if (letter == '\n') {//Enter the next line of text
             main_offset.x() = get_align_x_offset(prop.align.first, shape_bb, get_line_bb(i + 1));
             continue;
@@ -2281,11 +2293,11 @@ void align_shape(ExPolygonsWithIds &            shapes,
         ExPolygons &shape = shapes[i].expoly;
         auto       temp_offset = main_offset;
         if (real_fonts[i].has_value()) {
+            // the backup glyph was scaled into the main font units, its offset must follow
             const FontFile &temp_font = *real_fonts[i].font_file;
-            int temp_y_offset         = get_align_y_offset(prop.align.second, count_lines, temp_font, prop);
-            int ratio = int(text_scales[i] / standard_scale);
-            Point           new_offset(main_offset.x(), temp_y_offset * ratio);
-            temp_offset = new_offset;
+            double          ratio     = text_scales[i] / standard_scale;
+            int             temp_y_offset = static_cast<int>(std::round(get_align_y_offset(prop.align.second, count_lines, temp_font, prop) * ratio));
+            temp_offset = Point(main_offset.x(), temp_y_offset);
         }
         offset_xy.emplace_back(temp_offset);
         for (ExPolygon &s : shape) {

--- a/src/libslic3r/Emboss.hpp
+++ b/src/libslic3r/Emboss.hpp
@@ -86,16 +86,41 @@ namespace Emboss
     void text2vshapes(
         EmbossShape &                emboss_shape,
         FontFileWithCache &          font_with_cache,
-        const std::wstring &         text,
+        const std::u32string &       text,
         const FontProp &             font_prop,
         double                       standard_scale,
         const std::function<bool()> &was_canceled = []() { return false; },
         BackFontCacheFn              bfc_fn       = nullptr);
     HealedExPolygons union_with_delta(ExPolygons expoly, float delta, unsigned max_heal_iteration);
 
+    /// <summary>
+    /// Decode UTF-8 into one element per Unicode code point.
+    /// std::wstring is not usable here: wchar_t is 16 bit on Windows, so anything above
+    /// U+FFFF (emoji, plane 1 symbols) would be split into an unusable surrogate pair.
+    /// </summary>
+    /// <param name="text">UTF-8 text</param>
+    /// <returns>One char32_t per code point</returns>
+    std::u32string to_utf32(const std::string &text);
+
+    /// <summary>
+    /// Encode code points back to UTF-8, inverse of to_utf32()
+    /// </summary>
+    /// <param name="text">One char32_t per code point</param>
+    /// <returns>UTF-8 text</returns>
+    std::string to_utf8(const std::u32string &text);
+
+    /// <summary>
+    /// Variation selectors and joiners (U+FE00..U+FE0F, U+200C, U+200D) have no glyph of their own.
+    /// Emoji pickers append them to many symbols and without a shaping engine they could only
+    /// show up as a missing glyph, so the text pipeline skips them.
+    /// </summary>
+    /// <param name="c">Unicode code point</param>
+    /// <returns>True for a code point that must not produce a glyph</returns>
+    inline bool is_zero_width_mark(char32_t c) { return (c >= 0xFE00 && c <= 0xFE0F) || c == 0x200C || c == 0x200D; }
+
     const unsigned ENTER_UNICODE = static_cast<unsigned>('\n');
     /// Sum of character '\n'
-    unsigned get_count_lines(const std::wstring &ws);
+    unsigned get_count_lines(const std::u32string &ws);
     unsigned get_count_lines(const std::string &text);
     unsigned get_count_lines(const ExPolygonsWithIds &shape);
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoText.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoText.cpp
@@ -3123,10 +3123,10 @@ bool GLGizmoText::filter_model_volume(ModelVolume *mv) {
 
 float GLGizmoText::get_text_height(const std::string &text)//todo
 {
-    std::wstring             ws = boost::nowide::widen(text);
+    std::u32string           ws = to_utf32(text);
     std::vector<std::string> alphas;
     for (auto w : ws) {
-        alphas.push_back(boost::nowide::narrow(std::wstring(1, w)));
+        alphas.push_back(to_utf8(std::u32string(1, w)));
     }
     auto  texts  = alphas ;
     float max_height = 0.f;
@@ -3941,7 +3941,7 @@ EmbossShape &TextDataBase::create_shape()
         return shape;
     // create shape by configuration
     const char *    text         = m_text_configuration.text.c_str();
-    std::wstring    text_w       = boost::nowide::widen(text);
+    std::u32string  text_w       = to_utf32(text);
     const FontProp &fp           = m_text_configuration.style.prop;
     auto            was_canceled = [&c = cancel]() { return c->load(); };
     auto ft_fn        = [](){
@@ -3955,9 +3955,9 @@ EmbossShape &TextDataBase::create_shape()
     }
     if (shape.shapes_with_ids.size() == 1 && shape.shapes_with_ids[0].expoly.empty()) {//empty deal
         if (support_backup_fonts) {
-            text2vshapes(shape, m_font_file, L"?", fp, shape.scale, was_canceled, ft_fn);
+            text2vshapes(shape, m_font_file, U"?", fp, shape.scale, was_canceled, ft_fn);
         } else {
-            text2vshapes(shape, m_font_file, L"?", fp, shape.scale, was_canceled);
+            text2vshapes(shape, m_font_file, U"?", fp, shape.scale, was_canceled);
         }
     }
     return shape;

--- a/src/slic3r/GUI/GuiTextShape.cpp
+++ b/src/slic3r/GUI/GuiTextShape.cpp
@@ -4,7 +4,7 @@
 namespace Slic3r {
     using namespace Emboss;
     namespace GUI {
-    ExPolygons GuiTextShape::letter2shapes(wchar_t letter, Point &cursor, FontFileWithCache &font_with_cache, const FontProp &font_prop, fontinfo_opt &font_info_cache)
+    ExPolygons GuiTextShape::letter2shapes(char32_t letter, Point &cursor, FontFileWithCache &font_with_cache, const FontProp &font_prop, fontinfo_opt &font_info_cache)
     {
     assert(font_with_cache.has_value());
     if (!font_with_cache.has_value()) return {};
@@ -26,7 +26,7 @@ namespace Slic3r {
         cursor.x() += count_spaces * space->advance_width;
         return {};
     }
-    if (letter == '\r') return {};
+    if (letter == '\r' || is_zero_width_mark(letter)) return {};
 
     int  unicode = static_cast<int>(letter);
     auto it      = cache.find(unicode);

--- a/src/slic3r/GUI/GuiTextShape.hpp
+++ b/src/slic3r/GUI/GuiTextShape.hpp
@@ -11,7 +11,7 @@ namespace Slic3r {
 	class GuiTextShape
 	{
 	public:
-        static ExPolygons letter2shapes(wchar_t letter, Point &cursor, FontFileWithCache &font_with_cache, const FontProp &font_prop, fontinfo_opt &font_info_cache);
+        static ExPolygons letter2shapes(char32_t letter, Point &cursor, FontFileWithCache &font_with_cache, const FontProp &font_prop, fontinfo_opt &font_info_cache);
 
 	private:
 	};

--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -511,7 +511,12 @@ bool ImGuiWrapper::update_key_data(wxKeyEvent &evt)
         // Char event
         const auto key = evt.GetUnicodeKey();
         if (key != 0) {
-            io.AddInputCharacter(key);
+            // Where wxChar is UTF-16 (Windows) a code point above U+FFFF arrives as two
+            // events carrying a surrogate pair; ImGui joins them back into one code point.
+            if constexpr (sizeof(wxChar) == 2)
+                io.AddInputCharacterUTF16(static_cast<ImWchar16>(key));
+            else
+                io.AddInputCharacter(static_cast<unsigned>(key));
         }
     } else {
         // Key up/down event

--- a/src/slic3r/GUI/Jobs/CreateFontNameImageJob.cpp
+++ b/src/slic3r/GUI/Jobs/CreateFontNameImageJob.cpp
@@ -2,6 +2,7 @@
 
 // rasterization of ExPoly
 #include "libslic3r/SLA/AGGRaster.hpp"
+#include "libslic3r/Utils.hpp" // resources_dir
 
 #include "slic3r/Utils/WxFontUtils.hpp"
 #include "slic3r/GUI/3DScene.hpp" // ::glsafe
@@ -201,7 +202,22 @@ void Slic3r::GUI::BackupFonts::generate_backup_fonts() {
          for (int i = 0; i < font_names.size(); i++) {
              backup_fonts.emplace_back(gener_font_with_cache(font_names[i], wxFontEncoding::wxFONTENCODING_SYSTEM));
          }
+         // emoji outlines, last so the fonts above keep priority (OS emoji fonts are bitmap/COLR, nothing to extrude)
+         backup_fonts.emplace_back(gener_font_with_cache_from_file(Slic3r::resources_dir() + "/fonts/Symbola.ttf"));
     }
+}
+
+Slic3r::Emboss::FontFileWithCache Slic3r::GUI::BackupFonts::gener_font_with_cache_from_file(const std::string &font_path)
+{
+    Emboss::FontFileWithCache font_file_with_cache;
+    std::unique_ptr<Emboss::FontFile> font_file = Emboss::create_font_file(font_path.c_str());
+    if (font_file == nullptr) {
+        BOOST_LOG_TRIVIAL(warning) << "Backup font could not be loaded: " << font_path;
+        return font_file_with_cache;
+    }
+
+    font_file_with_cache = Emboss::FontFileWithCache(std::move(font_file));
+    return font_file_with_cache;
 }
 
 Slic3r::Emboss::FontFileWithCache Slic3r::GUI::BackupFonts::gener_font_with_cache(const wxString &font_name, const wxFontEncoding &encoding)

--- a/src/slic3r/GUI/Jobs/CreateFontNameImageJob.hpp
+++ b/src/slic3r/GUI/Jobs/CreateFontNameImageJob.hpp
@@ -51,6 +51,8 @@ class BackupFonts
 public:
     static void generate_backup_fonts();
     static Slic3r::Emboss::FontFileWithCache              gener_font_with_cache(const wxString &font_name, const wxFontEncoding& encoding);
+    // Load a backup font packed with the application instead of one installed in the OS.
+    static Slic3r::Emboss::FontFileWithCache              gener_font_with_cache_from_file(const std::string &font_path);
     static std::vector<Slic3r::Emboss::FontFileWithCache> backup_fonts;
 };
 

--- a/src/slic3r/GUI/Jobs/EmbossJob.cpp
+++ b/src/slic3r/GUI/Jobs/EmbossJob.cpp
@@ -27,7 +27,6 @@
 //#include "slic3r/GUI/3DScene.hpp"
 #include "slic3r/GUI/Jobs/Worker.hpp"
 #include "slic3r/Utils/UndoRedo.hpp"
-#include <wx/regex.h>
 // #define EXECUTE_UPDATE_ON_MAIN_THREAD // debug execution on main thread
 using namespace Slic3r::Emboss;
 namespace Slic3r {
@@ -1286,22 +1285,20 @@ void create_all_char_mesh(DataBase &input, std::vector<TriangleMesh> &result, st
 
     TextConfiguration text_configuration = input.get_text_configuration();
     bool              support_backup_fonts = std::any_of(shape.text_scales.begin(), shape.text_scales.end(), [](float x) { return x > 0; });
-    const char *text     = input.get_text_configuration().text.c_str();
-    wxString          input_text           = wxString::FromUTF8(input.get_text_configuration().text);
-    wxRegEx           re("^ +$");
-    bool              is_all_space = re.Matches(input_text);
+    // one entry per code point, decoded the same way the shapes were
+    const std::u32string input_text = Slic3r::Emboss::to_utf32(input.get_text_configuration().text);
+    bool is_all_space = std::all_of(input_text.begin(), input_text.end(), [](char32_t c) { return c == U' '; });
     if (is_all_space) { return; }
     if (input_text.size() != shape.shapes_with_ids.size()) {
         BOOST_LOG_TRIVIAL(info) <<__FUNCTION__<< "error: input_text.size() != shape.shapes_with_ids.size()";
     }
     for (int i = 0; i < shape.shapes_with_ids.size(); i++) {
         auto &temp_shape = shape.shapes_with_ids[i];
-        if (input_text[i] == ' ') {
+        // one mesh per glyph, empty or not, so the cursor arrays stay aligned with the meshes
+        if ((i < input_text.size() && input_text[i] == U' ') || temp_shape.expoly.empty()) {
             result.emplace_back(TriangleMesh());
             continue;
         }
-        if (temp_shape.expoly.empty())
-            continue;
         if (support_backup_fonts) {
             if (i < shape.text_scales.size() && shape.text_scales[i] > 0) {
                 auto temp_scale = shape.text_scales[i];

--- a/src/slic3r/Utils/EmbossStyleManager.cpp
+++ b/src/slic3r/Utils/EmbossStyleManager.cpp
@@ -69,10 +69,17 @@ bool font_has_any_glyph_in_ranges(const FontFile &font, const ImVector<ImWchar> 
     if (stbtt_InitFont(&font_info, font.data->data(), font_offset) == 0)
         return false;
 
+    // A mapped code point is not enough: bitmap emoji fonts map every emoji to an
+    // outline without a usable contour, which the atlas would rasterize as nothing.
+    const float flatness = 1.f;
     for (const ImWchar *range = ranges.Data; range[0] && range[1]; range += 2)
-        for (unsigned int codepoint = range[0]; codepoint <= range[1]; ++codepoint)
-            if (stbtt_FindGlyphIndex(&font_info, codepoint) != 0)
+        for (unsigned int codepoint = range[0]; codepoint <= range[1]; ++codepoint) {
+            if (stbtt_FindGlyphIndex(&font_info, codepoint) == 0)
+                continue;
+            std::optional<Glyph> glyph = letter2glyph(font, 0, static_cast<int>(codepoint), flatness);
+            if (glyph.has_value() && !glyph->shape.empty())
                 return true;
+        }
 
     return false;
 }
@@ -510,13 +517,22 @@ ImFont *StyleManager::create_imgui_font(const std::string &text, double scale, b
     ImFont *font{nullptr};
     const FontFile *base_font_file = &font_file;
     int base_backup_index = -1;
-    if (!font_has_any_glyph_in_ranges(font_file, m_style_cache.ranges) && support_backup_fonts) {
+    // judge the fonts by the text itself, the language range alone lets a bitmap emoji
+    // font pass on the few keycap digits it draws with an outline
+    ImVector<ImWchar> text_ranges;
+    if (!text.empty()) {
+        ImFontGlyphRangesBuilder text_builder;
+        text_builder.AddText(text.c_str());
+        text_builder.BuildRanges(&text_ranges);
+    }
+    const ImVector<ImWchar> &judged_ranges = text_ranges.empty() ? m_style_cache.ranges : text_ranges;
+    if (!font_has_any_glyph_in_ranges(font_file, judged_ranges) && support_backup_fonts) {
         for (int i = 0; i < Slic3r::GUI::BackupFonts::backup_fonts.size(); i++) {
             if (!Slic3r::GUI::BackupFonts::backup_fonts[i].has_value())
                 continue;
 
             const FontFile &temp_font_file = *Slic3r::GUI::BackupFonts::backup_fonts[i].font_file;
-            if (!font_has_any_glyph_in_ranges(temp_font_file, m_style_cache.ranges))
+            if (!font_has_any_glyph_in_ranges(temp_font_file, judged_ranges))
                 continue;
 
             base_font_file = &temp_font_file;
@@ -539,6 +555,14 @@ ImFont *StyleManager::create_imgui_font(const std::string &text, double scale, b
                 font = m_style_cache.atlas.AddFontFromMemoryTTF((void *) temp_buffer.data(), temp_buffer.size(), font_size, &font_config, m_style_cache.ranges.Data);
             }
         }
+    }
+
+    // zero width marks draw nothing instead of the missing glyph box
+    if (font != nullptr) {
+        for (ImWchar c = 0xFE00; c <= 0xFE0F; ++c)
+            m_style_cache.atlas.AddCustomRectFontGlyph(font, c, 1, 1, 0.f);
+        m_style_cache.atlas.AddCustomRectFontGlyph(font, 0x200C, 1, 1, 0.f);
+        m_style_cache.atlas.AddCustomRectFontGlyph(font, 0x200D, 1, 1, 0.f);
     }
 
     unsigned char *pixels;

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(${_TEST_NAME}_tests
     test_timeutils.cpp
     test_indexed_triangle_set.cpp
     test_debounce.cpp
+    test_emboss.cpp
     ../libnest2d/printer_parts.cpp
 	)
 

--- a/tests/libslic3r/test_emboss.cpp
+++ b/tests/libslic3r/test_emboss.cpp
@@ -1,0 +1,209 @@
+#include <catch2/catch.hpp>
+
+#include <boost/filesystem.hpp>
+
+#include <libslic3r/Emboss.hpp>
+#include <libslic3r/EmbossShape.hpp>
+#include <libslic3r/TextConfiguration.hpp>
+
+using namespace Slic3r;
+using namespace Slic3r::Emboss;
+
+namespace {
+
+const char32_t ROCKET = U'\U0001F680'; // outside the Basic Multilingual Plane
+
+// fonts packed with the application, resolved from this source file
+std::string packed_font(const char *file_name)
+{
+    boost::filesystem::path path = boost::filesystem::path(__FILE__).parent_path().parent_path().parent_path() / "resources" / "fonts" / file_name;
+    return boost::filesystem::exists(path) ? path.string() : std::string();
+}
+
+FontFileWithCache load_font(const std::string &path)
+{
+    std::unique_ptr<FontFile> font_file = create_font_file(path.c_str());
+    REQUIRE(font_file != nullptr);
+    return FontFileWithCache(std::move(font_file));
+}
+
+} // namespace
+
+TEST_CASE("UTF-8 conversion keeps code points above U+FFFF", "[Emboss]")
+{
+    const std::string utf8 = "A\xF0\x9F\x9A\x80" "b"; // "A🚀b"
+    std::u32string    utf32 = to_utf32(utf8);
+    REQUIRE(utf32.size() == 3);
+    CHECK(utf32[0] == U'A');
+    CHECK(utf32[1] == ROCKET);
+    CHECK(utf32[2] == U'b');
+    CHECK(to_utf8(utf32) == utf8);
+
+    CHECK(get_count_lines(std::string("a\nb\xF0\x9F\x9A\x80")) == 2);
+    CHECK(get_count_lines(std::u32string(U"\U0001F680")) == 1);
+    CHECK(get_count_lines(std::string()) == 0);
+}
+
+TEST_CASE("Range text keeps an emoji only when the font has a glyph for it", "[Emboss]")
+{
+    std::string symbola = packed_font("Symbola.ttf");
+    std::string latin   = packed_font("HarmonyOS_Sans_SC_Regular.ttf");
+    if (symbola.empty() || latin.empty()) {
+        WARN("Packed fonts not found, test skipped");
+        return;
+    }
+    const std::string text = "A\xF0\x9F\x9A\x80"; // "A🚀"
+
+    bool        unknown = true;
+    std::string range   = create_range_text(text, *load_font(symbola).font_file, 0, &unknown);
+    CHECK(!unknown);
+    CHECK(to_utf32(range).find(ROCKET) != std::u32string::npos);
+
+    unknown = false;
+    range   = create_range_text(text, *load_font(latin).font_file, 0, &unknown);
+    CHECK(unknown);
+    CHECK(to_utf32(range).find(ROCKET) == std::u32string::npos);
+    CHECK(to_utf32(range).find(U'A') != std::u32string::npos);
+}
+
+TEST_CASE("Backup font supplies the outline of an emoji", "[Emboss]")
+{
+    std::string symbola = packed_font("Symbola.ttf");
+    std::string latin   = packed_font("HarmonyOS_Sans_SC_Regular.ttf");
+    if (symbola.empty() || latin.empty()) {
+        WARN("Packed fonts not found, test skipped");
+        return;
+    }
+    FontFileWithCache primary = load_font(latin);
+    FontFileWithCache backup  = load_font(symbola);
+
+    FontProp fp(10.f);
+    double   scale = get_text_shape_scale(fp, *primary.font_file);
+    const std::u32string text = U"A\U0001F680";
+
+    // the primary font has no rocket, without a backup font the glyph stays empty
+    EmbossShape alone;
+    text2vshapes(alone, primary, text, fp, scale);
+    REQUIRE(alone.shapes_with_ids.size() == 2);
+    CHECK(alone.shapes_with_ids[0].id == U'A');
+    CHECK(!alone.shapes_with_ids[0].expoly.empty());
+    CHECK(alone.shapes_with_ids[1].id == static_cast<unsigned>(ROCKET));
+    CHECK(alone.shapes_with_ids[1].expoly.empty());
+
+    // with Symbola as backup the rocket gets an outline and the glyph arrays stay aligned
+    EmbossShape shape;
+    text2vshapes(shape, primary, text, fp, scale, []() { return false; }, [&backup]() { return std::vector<FontFileWithCache>{backup}; });
+    REQUIRE(shape.shapes_with_ids.size() == 2);
+    CHECK(shape.shapes_with_ids[0].id == U'A');
+    CHECK(shape.shapes_with_ids[1].id == static_cast<unsigned>(ROCKET));
+    CHECK(!shape.shapes_with_ids[0].expoly.empty());
+    CHECK(!shape.shapes_with_ids[1].expoly.empty());
+    CHECK(shape.text_cursors.size() == 2);
+    CHECK(shape.text_align_offsets.size() == 2);
+    BoundingBox a      = get_extents(shape.shapes_with_ids[0].expoly);
+    BoundingBox rocket = get_extents(shape.shapes_with_ids[1].expoly);
+    CHECK(rocket.min.x() > a.min.x()); // the rocket follows the A on the line
+}
+
+TEST_CASE("Range text merges the glyphs of every font when the first one does not cover the text", "[Emboss]")
+{
+    std::string symbola = packed_font("Symbola.ttf");
+    std::string latin   = packed_font("HarmonyOS_Sans_SC_Regular.ttf");
+    if (symbola.empty() || latin.empty()) {
+        WARN("Packed fonts not found, test skipped");
+        return;
+    }
+    std::shared_ptr<const FontFile> primary = create_font_file(latin.c_str());
+    std::shared_ptr<const FontFile> backup  = create_font_file(symbola.c_str());
+    REQUIRE(primary != nullptr);
+    REQUIRE(backup != nullptr);
+    std::vector<std::shared_ptr<const FontFile>> fonts{primary, backup};
+
+    // "A你🚀": the first font draws A and 你, only the backup has the rocket
+    std::string    text    = "A\xE4\xBD\xA0\xF0\x9F\x9A\x80";
+    bool           unknown = false;
+    std::u32string range   = to_utf32(create_range_text(text, fonts, 0, &unknown));
+    CHECK(unknown);
+    CHECK(range.find(U'A') != std::u32string::npos);
+    CHECK(range.find(U'你') != std::u32string::npos);
+    CHECK(range.find(ROCKET) != std::u32string::npos);
+
+    // covered by the first font alone: no fallback is reported
+    text  = "A\xE4\xBD\xA0";
+    range = to_utf32(create_range_text(text, fonts, 0, &unknown));
+    CHECK(!unknown);
+    CHECK(range.size() == 2);
+
+    // white space and zero width marks are not missing glyphs
+    text  = "A\n\t\xEF\xB8\x8F"; // "A", new line, tab, U+FE0F
+    range = to_utf32(create_range_text(text, fonts, 0, &unknown));
+    CHECK(!unknown);
+    CHECK(range == U"A");
+}
+
+TEST_CASE("Zero width marks produce no glyph and no advance", "[Emboss]")
+{
+    std::string symbola = packed_font("Symbola.ttf");
+    if (symbola.empty()) {
+        WARN("Packed font not found, test skipped");
+        return;
+    }
+    CHECK(is_zero_width_mark(U'️'));
+    CHECK(is_zero_width_mark(U'‍'));
+    CHECK(!is_zero_width_mark(U'A'));
+    CHECK(!is_zero_width_mark(ROCKET));
+
+    FontFileWithCache font = load_font(symbola);
+    FontProp          fp(10.f);
+    double            scale = get_text_shape_scale(fp, *font.font_file);
+
+    EmbossShape plain, marked;
+    text2vshapes(plain, font, U"AB", fp, scale);
+    text2vshapes(marked, font, U"A️" "B", fp, scale); // A, VS16, B
+    REQUIRE(plain.shapes_with_ids.size() == 2);
+    REQUIRE(marked.shapes_with_ids.size() == 3);
+    CHECK(marked.shapes_with_ids[1].expoly.empty());
+    // B lands where it does without the mark
+    CHECK(get_extents(marked.shapes_with_ids[2].expoly).min.x() == get_extents(plain.shapes_with_ids[1].expoly).min.x());
+
+    // the mark is not reported as an unknown glyph
+    bool        unknown = true;
+    std::string text    = "A\xEF\xB8\x8F";
+    create_range_text(text, *font.font_file, 0, &unknown);
+    CHECK(!unknown);
+}
+
+TEST_CASE("Backup glyph keeps its vertical position when the fonts differ in units per em", "[Emboss]")
+{
+    // Symbola has 2048 units per em, HarmonyOS Sans 1000
+    std::string symbola = packed_font("Symbola.ttf");
+    std::string latin   = packed_font("HarmonyOS_Sans_SC_Regular.ttf");
+    if (symbola.empty() || latin.empty()) {
+        WARN("Packed fonts not found, test skipped");
+        return;
+    }
+    FontFileWithCache primary = load_font(latin);
+    FontFileWithCache backup  = load_font(symbola);
+    FontProp          fp(10.f);
+
+    // rocket drawn by Symbola as the main font
+    EmbossShape direct;
+    double      direct_scale = get_text_shape_scale(fp, *backup.font_file);
+    text2vshapes(direct, backup, U"\U0001F680", fp, direct_scale);
+
+    // rocket drawn by Symbola as the backup of HarmonyOS
+    EmbossShape fallback;
+    double      fallback_scale = get_text_shape_scale(fp, *primary.font_file);
+    text2vshapes(fallback, primary, U"\U0001F680", fp, fallback_scale, []() { return false; }, [&backup]() { return std::vector<FontFileWithCache>{backup}; });
+
+    REQUIRE(direct.shapes_with_ids.size() == 1);
+    REQUIRE(fallback.shapes_with_ids.size() == 1);
+    REQUIRE(!direct.shapes_with_ids[0].expoly.empty());
+    REQUIRE(!fallback.shapes_with_ids[0].expoly.empty());
+    BoundingBox d = get_extents(direct.shapes_with_ids[0].expoly);
+    BoundingBox f = get_extents(fallback.shapes_with_ids[0].expoly);
+    // same place and size in millimeters either way
+    CHECK(d.min.y() * direct_scale == Approx(f.min.y() * fallback_scale).margin(0.05));
+    CHECK(d.max.y() * direct_scale == Approx(f.max.y() * fallback_scale).margin(0.05));
+    CHECK(d.size().x() * direct_scale == Approx(f.size().x() * fallback_scale).epsilon(0.02));
+}


### PR DESCRIPTION
Fixes #12144 (Support Emojis in Text-Editor).

This solves that issue: an emoji typed or pasted into the Text tool no longer turns into `?`. It shows in the input box and is generated as a real 3D shape, with any font, and with an installed emoji font such as Noto Emoji selected directly, which is the exact case from the report.

## What

- Emoji (and anything else above U+FFFF) can be typed or pasted into the text tool and come out as a real 3D shape, flat or on a surface.
- Works with any font: when the selected font has no outline for the character, the glyph comes from Symbola (already shipped in `resources/fonts`).
- An installed outline emoji font such as Noto Emoji can be selected directly, as in the report. A bitmap emoji font (Apple Color Emoji, Noto Color Emoji) can be selected too, the outlines then come from the backup fonts.
- The input box, the font list previews and the generated mesh all show the glyph. Variation selectors that emoji pickers append (`❤️` is `U+2764 U+FE0F`) no longer show up as `?`.

## Demo

Flat text, default font: the emoji come from the Symbola fallback. Then the font is switched to Noto Emoji.

![emoji text](https://raw.githubusercontent.com/jeremykenedy/BambuStudio/assets/text-emoji/text-emoji-flat.gif)

Surface text on a cube (Surround surface):

![emoji surface text](https://raw.githubusercontent.com/jeremykenedy/BambuStudio/assets/text-emoji/text-emoji-surface.gif)

## Why

Several places dropped any character outside the Basic Multilingual Plane, each one on its own enough to turn an emoji into `?`:

1. ImGui was built with a 16-bit `ImWchar`, so its input queue replaced every code point above U+FFFF with U+FFFD before `InputText` saw it. No font in the atlas has that glyph, so the box draws ImGui's fallback `?`, and the gizmo shapes a `?` for text it cannot draw.
2. On Windows `wxChar` is UTF-16, so a single emoji arrives as two `wxEVT_CHAR` events carrying a surrogate pair, and each half was pushed to ImGui as its own (invalid) character.
3. `Emboss` converted the UTF-8 text to `std::wstring`, which is 16 bit on Windows, so the same split happened again right in front of the glyph lookup. `EmbossJob::create_all_char_mesh` indexed the text as a `wxString` for the same reason.
4. Most fonts have no emoji glyph at all, and the emoji fonts that ship with the OS (Apple Color Emoji, Segoe UI Emoji, Noto Color Emoji) are bitmap or COLR fonts, so there is no outline to extrude even when the code point survives.

## How

- `src/imgui/imconfig.h`: `IMGUI_USE_WCHAR32`. Nothing else in `src/imgui` changes; the codebase already uses `ImWchar` generically everywhere.
- `ImGuiWrapper::update_key_data`: where `sizeof(wxChar) == 2` the char event goes through `io.AddInputCharacterUTF16`, which ImGui already provides for exactly this; other platforms keep `AddInputCharacter`.
- `Emboss`: `text2vshapes`, `align_shape`, `letter2shapes`, `get_count_lines` and `remove_duplicates` work on `std::u32string` / `char32_t` instead of `std::wstring` / `wchar_t`; `create_range_text` decodes the same way. New `Emboss::to_utf32()` / `to_utf8()` (`boost::locale::conv::utf_to_utf`, header only, already used in `src/slic3r`). `EmbossJob::create_all_char_mesh` uses the same decoding and keeps one mesh per glyph (empty or not) so the cursor arrays stay aligned with the meshes.
- `BackupFonts::generate_backup_fonts`: appends `resources/fonts/Symbola.ttf` (loaded from file, new `gener_font_with_cache_from_file`) after the OS fonts, so the existing CJK/Arabic fallbacks keep priority and Symbola only answers for what they do not cover. The backup loop in `letter2shapes` skips a font whose glyph has no outline instead of stopping there, and the base font of the input box is chosen the same way, judged on the text's own characters (`font_has_any_glyph_in_ranges` looks for an outline, not just a mapped code point), so selecting a bitmap emoji font still gives a readable input box.
- `align_shape` (backup font overload): the vertical offset of a backup glyph was multiplied by `int(text_scale / standard_scale)`, which is 0 for every main font with 1000 units per em (Symbola has 2048), pushing the glyph off the base line. It uses the real ratio now, on the left aligned path too.
- `create_range_text` (multi font): the glyph range for the input box is the union of what all fonts cover instead of one font's set, so text that needs both a CJK backup and Symbola shows every glyph; white space is not counted as an unknown glyph.
- Zero width marks (`U+FE00..FE0F`, `U+200C`, `U+200D`): `is_zero_width_mark()`, skipped in `letter2shapes` (no shape, no advance) and in `create_range_text`, and given an empty custom glyph in the text tool atlas so the input box draws nothing for them.
- `Emboss::create_font_file(const char*)` opens the file with `boost::nowide::fopen` so the UTF-8 resources path works on Windows.

## Tests

`tests/libslic3r/test_emboss.cpp` (new): UTF-8/UTF-32 round trip above U+FFFF, `create_range_text` with and without the glyph (single font and multi font union, white space and zero width marks), backup font supplying the emoji outline with aligned per-glyph arrays, zero width marks producing no advance, and a backup glyph keeping its position in mm between a 1000 and a 2048 units-per-em font. 8 test cases pass on macOS arm64. (`libslic3r_tests` as a whole does not link on master, the new file was linked and run on its own.)

Manual, macOS 26.5 / arm64 build:

- Flat text and surface text (Surround surface) on a cube with `Hi 😀🚀`, `🎉`, `👍`, `❤`, `🚀`: input box shows the glyph, mesh is generated, no mesh warnings.
- Noto Emoji (monochrome, from google/fonts) installed and selected in the font list: `🦄Hi 😀🚀` renders in Noto's outlines, no warnings. Font list previews show the emoji for every font.
- Apple Color Emoji selected: `Hi🚀` shows in the input box (outlines from the backup fonts) and on the plate.
- Helvetica Neue (1000 units per em): `Ag🚀` sits on one base line. Helvetica with `你好🚀`: CJK and emoji both visible in the input box. `Hi ❤️🚀` (heart with U+FE0F): no `?` in the box.
- Paste (Cmd+V) and typing through the emoji picker path both work on macOS.

Builds: the branch was built with this repository's `build_all.yml` on my fork for ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, windows-latest, macos-15-intel, macos-15 and macos-26, all green: https://github.com/jeremykenedy/BambuStudio/actions/runs/34491495362. The Windows-only paths (surrogate pairs, 16-bit `wchar_t`) are the reason for the `u32string` change; runtime testing was done on macOS only.

## Known limits

- Symbola 9 covers emoji up to about Unicode 9; newer ones (🥺, 🫠, 🧑) need a selected font that has them, otherwise they show as `?` like any other unknown glyph.
- Skin tone modifiers and ZWJ sequences render as their separate glyphs, there is no shaping engine.
- Symbola's own unicorn (`U+1F984`) outline produces a "reversed faces" mesh warning; every other emoji tried is clean, and the same character from Noto Emoji is clean.
