### PR TITLE
fix(webview): stop the 2s login poll while the home panel is hidden

### DIFF
--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -66,6 +66,10 @@ namespace GUI {
 
     #define LOGIN_INFO_UPDATE_TIMER_ID 10002
 
+    // Poll interval for the login/print-task refresh. Only runs while the panel
+    // is on screen; see the wxEVT_SHOW handler in the constructor.
+    static constexpr int LOGIN_INFO_UPDATE_INTERVAL_MS = 2000;
+
     namespace {
     bool IsBlankWebUrl(const wxString &url)
     {
@@ -416,6 +420,31 @@ WebViewPanel::WebViewPanel(wxWindow *parent)
         if (e.IsShown() && m_has_pending_staff_pick) {
             SendDesignStaffpick(true);
         }
+
+        // Suspend the login/print-task poll while this panel is off screen.
+        //
+        // RefreshLoginStatus() pushes JS into m_browser / m_browserMW on every
+        // tick (ShowUserPrintTask, and the Makerworld/Makerlab updates on a
+        // status change) and additionally calls get_login_info(). On macOS each
+        // evaluateJavaScript on a hidden WKWebView cancels that WebContent
+        // process's ProcessThrottler suspension, so a 2 s poll against a panel
+        // nobody is looking at keeps the WebContent, GPU and Networking helper
+        // processes awake for the whole life of the application, with the
+        // associated GPU priority churn. Nothing it computes is observable while
+        // hidden, so there is no reason to run it.
+        //
+        // Refresh once immediately on becoming visible, otherwise the panel
+        // could show login/task state up to one interval stale — previously the
+        // poll had already run while hidden, so the state was warm on show.
+        if (m_LoginUpdateTimer != nullptr) {
+            if (e.IsShown()) {
+                if (!m_LoginUpdateTimer->IsRunning())
+                    m_LoginUpdateTimer->Start(LOGIN_INFO_UPDATE_INTERVAL_MS);
+                RefreshLoginStatus();
+            } else {
+                m_LoginUpdateTimer->Stop();
+            }
+        }
     });
  }
 
@@ -711,6 +740,14 @@ void WebViewPanel::OnClose(wxCloseEvent& evt)
 }
 
 void WebViewPanel::OnFreshLoginStatus(wxTimerEvent &event)
+{
+    RefreshLoginStatus();
+}
+
+// Body of the former OnFreshLoginStatus, unchanged. Split out so the wxEVT_SHOW
+// handler can refresh once on becoming visible without synthesising a
+// wxTimerEvent; the timer event argument was never used.
+void WebViewPanel::RefreshLoginStatus()
 {
     //wxString mwnow = m_browserMW->GetCurrentURL();
 
@@ -1870,7 +1907,11 @@ void WebViewPanel::OnScriptMessage(wxWebViewEvent& evt)
     if (m_LoginUpdateTimer == nullptr) {
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " Create Timer";
         m_LoginUpdateTimer = new wxTimer(this, LOGIN_INFO_UPDATE_TIMER_ID);
-        m_LoginUpdateTimer->Start(2000);
+        // Only start polling if the panel is actually visible; if a script
+        // message arrives while it is hidden, the wxEVT_SHOW handler starts the
+        // timer when it next becomes visible.
+        if (IsShownOnScreen())
+            m_LoginUpdateTimer->Start(LOGIN_INFO_UPDATE_INTERVAL_MS);
     }
 
     if (wxGetApp().get_mode() == comDevelop)

--- a/src/slic3r/GUI/WebViewDialog.hpp
+++ b/src/slic3r/GUI/WebViewDialog.hpp
@@ -99,6 +99,9 @@ public:
 
     wxTimer * m_LoginUpdateTimer{nullptr};
     void OnFreshLoginStatus(wxTimerEvent &event);
+    // Same work as OnFreshLoginStatus, callable without a timer event so the
+    // wxEVT_SHOW handler can refresh once when the panel becomes visible.
+    void RefreshLoginStatus();
 
 public:
     void ResetWholePage();


### PR DESCRIPTION
### What this does

`WebViewPanel` polls login and print-task state every 2 s via `m_LoginUpdateTimer`. The timer starts on the first script message and runs until the panel is destroyed, whether or not the panel is on screen. This gates it on visibility.

### Why

Each tick pushes JS into `m_browser` / `m_browserMW` (`ShowUserPrintTask`, plus the Makerworld/Makerlab updates on a status change) and calls `get_login_info()`. On macOS every `evaluateJavaScript` against a hidden `WKWebView` cancels that WebContent process's `ProcessThrottler` suspension — so polling a panel nobody is looking at keeps the WebContent, GPU and Networking helper processes awake for the entire life of the application.

A user posted measurements of this on #10812, from an idle app with the home panel off screen for ~3 hours:

| Event | per 300 s |
|---|---|
| `WebPage::runJavaScriptInFrameInScriptWorld` | 300 |
| `WebProcess::prepareToSuspend` | 300 |
| `Set Darwin GPU` transitions (GPU / WebContent / Networking) | 900 |

The suspends never complete — WebKit's `markLayersVolatile` retry backoff is longer than the effective wakeup interval, so `still processing request to suspend=N` climbs monotonically (89 → 1,471 → 3,283 → 5,098 over about three hours). RunningBoard promotes the GPU helper to `UserInteractives` and back to `Denys` once per second throughout, on an idle hidden view.

Nothing the poll computes is observable while the panel is hidden.

### How

- The `wxEVT_SHOW` handler that already exists for the pending staff-pick replay now also stops the timer when the panel is hidden and restarts it when shown.
- On becoming visible it refreshes **once immediately**. Without that, login/task state could be up to one interval stale on show — the previous behaviour polled while hidden, so the state was always warm by the time you saw it.
- `OnScriptMessage` starts a newly created timer only if the panel is already visible, since that first script message can arrive while it is hidden.
- `RefreshLoginStatus()` is the former body of `OnFreshLoginStatus`, split out **unchanged**, so the show handler can call it without synthesising a `wxTimerEvent`. The timer event argument was never used.
- The repeated literal `2000` is now `LOGIN_INFO_UPDATE_INTERVAL_MS`.

### Scope

`WebView::RunScript` is deliberately untouched. That function has 116 call sites across 14 files, most of them dialogs that are visible whenever they run JS. This change is scoped to one timer on one panel, so it cannot affect any other call site.

That's a deliberate contrast with [`a9814fe291`](https://github.com/bambulab/BambuStudio/commit/a9814fe2914eb1bf7cd93e415e62619c01322538) (#10812), which addressed the same class of problem at the shared chokepoint and had to be walked back — [`2fc38113ba`](https://github.com/bambulab/BambuStudio/commit/2fc38113bab4ee8fe57e37dae8a5721d6b883623) added a `force_execute` bypass for the network-plugin tip, then [`842e2b8a4a`](https://github.com/bambulab/BambuStudio/commit/842e2b8a4a72095dd5ef505cdd0d7df4a2fbd103) commented the guard out entirely after testing found three affected scenarios. **This PR does not restore that guard and does not depend on it**; it works identically whether the guard stays commented out or is later reinstated.

### Known limitation

If the whole window is minimised, rather than the panel being switched away from, `wxEVT_SHOW` may not fire for the panel and the poll continues. That is not a regression, but it means this addresses the off-screen-panel case and not the minimised-application case.

### Testing

Builds clean on macOS arm64. I have not independently measured the wakeup-rate change — that needs the instrumentation methodology used in the #10812 report, and I would rather have the numbers confirmed by someone other than the author than assert them myself.
