### PR TITLE
fix(webview): log JS only when it runs; drop redundant post-wake Update()

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2805,7 +2805,6 @@ void GUI_App::MacPowerCallBack(void* refcon, io_service_t service, natural_t mes
             BOOST_LOG_TRIVIAL(info) << "MacPowerCallBack: re-laying out main frame after wake";
             mf->Layout();
             mf->Refresh();
-            mf->Update();
         });
     };
 }

--- a/src/slic3r/GUI/Widgets/WebView.cpp
+++ b/src/slic3r/GUI/Widgets/WebView.cpp
@@ -856,10 +856,6 @@ void WebView::LoadUrl(wxWebView * webView, wxString const &url)
 
 bool WebView::RunScript(wxWebView *webView, wxString const &javascript, bool force_execute)
 {
-    if (Slic3r::GUI::wxGetApp().app_config->get("internal_developer_mode") == "true"
-            && javascript.find("studio_userlogin") == wxString::npos)
-        wxLogMessage("Running JavaScript:\n%s\n", javascript);
-
     if (webView == nullptr)
         return false;
 
@@ -893,6 +889,12 @@ bool WebView::RunScript(wxWebView *webView, wxString const &javascript, bool for
     // 这边隐藏态直接拦截js消息引入了多个业务问题，先注释掉，等0908beta发版之后再考虑pr优化
     // if (!force_execute && !webView->IsShownOnScreen()) return true;
 #endif // __WXMAC__
+
+    // Logged after the early-outs above, so the message can never claim to be
+    // running JavaScript that was in fact skipped.
+    if (Slic3r::GUI::wxGetApp().app_config->get("internal_developer_mode") == "true"
+            && javascript.find("studio_userlogin") == wxString::npos)
+        wxLogMessage("Running JavaScript:\n%s\n", javascript);
 
     try {
 #ifdef __WIN32__


### PR DESCRIPTION
Two review points @tonghao-bbl raised on #10812 before it merged, addressed here.

### 1. `RunScript` logged JS it hadn't run

[Review comment](https://github.com/bambulab/BambuStudio/pull/10812#discussion_r3377584611):

> Is it better to move this check to the top of the function? otherwise we may get a message saying `Running JavaScript` but actually we wont running it. small issue:)

`WebView::RunScript` emitted `wxLogMessage("Running JavaScript: …")` as its very first statement, ahead of the `webView == nullptr` early-out. Every skipped call logged that it was running JavaScript that never ran. The log now sits below the early-outs, so it only fires for a call that actually reaches the platform backend.

Rather than hoist the guard block and its explanatory comment above the log, I moved the log down — same result, much smaller diff.

**Note on the current state of that code:** the `IsShownOnScreen()` guard is presently commented out ([`842e2b8a4a`](https://github.com/bambulab/BambuStudio/commit/842e2b8a4a72095dd5ef505cdd0d7df4a2fbd103), after [`2fc38113ba`](https://github.com/bambulab/BambuStudio/commit/2fc38113bab4ee8fe57e37dae8a5721d6b883623) added the `force_execute` bypass). So today this hunk only affects the null-`webView` path, which is a narrower win than when the point was first raised. The ordering is correct either way, and becomes fully relevant again if that guard is reinstated. Flagging it so the scope isn't overstated.

### 2. Redundant `Update()` in the post-wake handler

[Review comment](https://github.com/bambulab/BambuStudio/pull/10812#discussion_r3377594629):

> Is `mf->Update` necessary here? what about remove this and let it update on next time when the framework think its a good time.

`MacPowerCallBack`'s post-wake handler called `Layout()`, `Refresh()` and `Update()`. `Refresh()` already queues the repaint; `Update()` only forces it to happen synchronously, which the surrounding comment never asks for — it justifies "Layout()+Refresh()" and doesn't mention `Update()`. Dropping it lets the frame repaint on the framework's own schedule and leaves the code matching its stated rationale.

This half is independent of anything above and unaffected by the guard's current state.

### Testing

Builds clean on macOS arm64. No functional change beyond the two points above.
