### PR TITLE
ENH: per-filament control of purifying the chamber air at print end

### DIFF
--- a/resources/profiles/BBL/machine/Bambu Lab X2D 0.4 nozzle.json
+++ b/resources/profiles/BBL/machine/Bambu Lab X2D 0.4 nozzle.json
@@ -190,6 +190,7 @@
         "20"
     ],
     "support_chamber_temp_control": "1",
+    "support_purify_air_at_print_end": "1",
     "upward_compatible_machine": [
         "Bambu Lab A1 0.4 nozzle",
         "Bambu Lab P2S 0.4 nozzle",

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1113,6 +1113,7 @@ static std::vector<std::string> s_Preset_filament_options {/*"filament_colour", 
     "filament_start_gcode", "filament_end_gcode",
     //exhaust fan control
     "activate_air_filtration","during_print_exhaust_fan_speed","complete_print_exhaust_fan_speed",
+    "purify_air_at_print_end",
     // Retract overrides
     "filament_retraction_length", "filament_z_hop", "filament_z_hop_types", "filament_retraction_speed", "filament_deretraction_speed", "filament_retract_length_nc", "filament_retract_restart_extra", "filament_retraction_minimum_travel",
     "filament_retract_when_changing_layer", "filament_wipe", "filament_retract_before_wipe",
@@ -1172,7 +1173,7 @@ static std::vector<std::string> s_Preset_printer_options {
     "scan_first_layer", "wrapping_detection_layers", "wrapping_exclude_area", "machine_load_filament_time", "machine_unload_filament_time",
     "ams_filament_load_time_ams", "ams_filament_load_time_ams_lite", "ams_filament_load_time_n3f_s",
     "ams_filament_unload_time_ams", "ams_filament_unload_time_ams_lite", "ams_filament_unload_time_n3f_s", "default_ams_type", "machine_pause_gcode", "template_custom_gcode","machine_hotend_change_time",
-    "nozzle_type","auxiliary_fan", "fan_direction", "nozzle_volume","upward_compatible_machine", "z_hop_types","support_chamber_temp_control","support_air_filtration","support_cooling_filter","cooling_filter_enabled","printer_structure","farthest_point_timelapse","thumbnail_size",
+    "nozzle_type","auxiliary_fan", "fan_direction", "nozzle_volume","upward_compatible_machine", "z_hop_types","support_chamber_temp_control","support_air_filtration","support_purify_air_at_print_end","support_cooling_filter","cooling_filter_enabled","printer_structure","farthest_point_timelapse","thumbnail_size",
     "best_object_pos", "head_wrap_detect_zone","printer_notes","print_in_clockwise",
     "enable_long_retraction_when_cut","long_retractions_when_cut","retraction_distances_when_cut",
     //OrcaSlicer

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -207,6 +207,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "activate_air_filtration",
         "during_print_exhaust_fan_speed",
         "complete_print_exhaust_fan_speed",
+        "purify_air_at_print_end",
         "use_firmware_retraction",
         "enable_long_retraction_when_cut",
         "long_retractions_when_cut",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -544,6 +544,14 @@ static const t_config_enum_values s_keys_map_FilamentMetalStickiness = {
 };
 CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(FilamentMetalStickiness)
 
+static const t_config_enum_values s_keys_map_PurifyAirAtPrintEnd = {
+    { "follow_printer", paeFollowPrinter },
+    { "off",            paeOff },
+    { "internal",       paeInternal },
+    { "external",       paeExternal }
+};
+CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(PurifyAirAtPrintEnd)
+
 static const t_config_enum_values s_keys_map_CounterboreHoleBridgingOption{
     { "none", chbNone },
     { "partiallybridge", chbBridges },
@@ -1972,6 +1980,28 @@ void PrintConfigDef::init_fff_params()
     def->max=100;
     def->mode = comSimple;
     def->set_default_value(new ConfigOptionInts{80});
+
+    def = this->add("purify_air_at_print_end", coEnums);
+    def->label = L("Purify air at print end");
+    def->tooltip = L("Ask the printer to purify the chamber air once a print using this filament finishes. "
+                     "\"Follow printer setting\" leaves the printer's own setting alone. "
+                     "Set this to \"Off\" for filaments that do not need it, such as PLA or PETG, and to "
+                     "\"Internal Circulation\" or \"Exhaust\" for filaments that do, such as ABS or ASA. "
+                     "Only printers that support purifying the chamber air are affected.");
+    def->enum_keys_map = &ConfigOptionEnum<PurifyAirAtPrintEnd>::get_enum_values();
+    def->enum_values.push_back("follow_printer");
+    def->enum_values.push_back("off");
+    def->enum_values.push_back("internal");
+    def->enum_values.push_back("external");
+    // Same wording the device's own print options dialog uses for these two modes
+    def->enum_labels.push_back(L("Follow printer setting"));
+    def->enum_labels.push_back(L("Off"));
+    def->enum_labels.push_back(L("Internal Circulation"));
+    def->enum_labels.push_back(L("Exhaust"));
+    def->mode = comSimple;
+    // A choice field is def_width_wider() by default, too narrow for these labels
+    def->width = 18;
+    def->set_default_value(new ConfigOptionEnumsGeneric{paeFollowPrinter});
 
     def = this->add("close_additional_fan_first_x_layers", coInts);
     def->label = L("For the first");
@@ -3772,6 +3802,12 @@ void PrintConfigDef::init_fff_params()
     def->label=L("Air filtration enhancement");
     def->tooltip=L("Enable this if printer support air filtration enhancement.");
     def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
+
+    def = this->add("support_purify_air_at_print_end", coBool);
+    def->label = L("Support purifying air at print end");
+    def->tooltip = L("This option is enabled if the machine can purify the chamber air after a print finishes.");
+    def->mode = comDevelop;
     def->set_default_value(new ConfigOptionBool(false));
 
     def = this->add("support_cooling_filter", coBool);

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -394,6 +394,16 @@ enum FilamentMetalStickiness {
     fmsHigh         // High metal stickiness (e.g. PETG) - retraction should not be skipped
 };
 
+// BBS: per-filament request for the printer to purify the chamber air once the print finishes.
+// "Follow printer setting" leaves whatever the user configured on the device untouched, so the
+// default value changes nothing for filaments that never opt in.
+enum PurifyAirAtPrintEnd {
+    paeFollowPrinter = 0,   // Do not touch the printer's own setting
+    paeOff,                 // Ask the printer not to purify after this print
+    paeInternal,            // Purify through internal circulation
+    paeExternal             // Purify by exhausting outside
+};
+
 inline bool is_auto_filament_map_mode(FilamentMapMode mode) {
     return mode == fmmAutoForFlush || mode == fmmAutoForMatch || mode == fmmAutoForQuality;
 }
@@ -556,6 +566,7 @@ CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(PerimeterGeneratorType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(TopOneWallType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(ReduceInfillRetractionMode)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(FilamentMetalStickiness)
+CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(PurifyAirAtPrintEnd)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(CounterboreHoleBridgingOption)
 #undef CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS
 
@@ -1370,6 +1381,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionEnum<FanDirection>,fan_direction))
     ((ConfigOptionBool,                support_chamber_temp_control))
     ((ConfigOptionBool,                support_air_filtration))
+    ((ConfigOptionBool,                support_purify_air_at_print_end))
     ((ConfigOptionBool,                support_cooling_filter))
     ((ConfigOptionBool,                cooling_filter_enabled))
     ((ConfigOptionIntsNullable,        extruder_max_nozzle_count))
@@ -1460,6 +1472,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionFloatsNullable,     inner_wall_acceleration))
     ((ConfigOptionFloatsOrPercentsNullable,   sparse_infill_acceleration))
     ((ConfigOptionBools,              activate_air_filtration))
+    ((ConfigOptionEnumsGeneric,       purify_air_at_print_end))
     ((ConfigOptionInts,               during_print_exhaust_fan_speed))
     ((ConfigOptionInts,               complete_print_exhaust_fan_speed))
     ((ConfigOptionInts,               close_additional_fan_first_x_layers))

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -30,6 +30,7 @@
 #include "DeviceCore/DevExtruderSystem.h"
 #include "DeviceCore/DevConfigUtil.h"
 #include "DeviceCore/DevFilaBlackList.h"
+#include "DeviceCore/DevFan.h"
 #include "DeviceCore/DevFilaSystem.h"
 #include "DeviceCore/DevFilaSwitch.h"
 #include "DeviceCore/DevInfo.h"
@@ -3409,8 +3410,59 @@ void SelectMachineDialog::on_send_print()
         agent->track_update_property(dev_ota_str, obj_->get_ota_version());
     }
 
+    apply_purify_air_at_print_end(obj_);
+
     m_print_job->start();
     BOOST_LOG_TRIVIAL(info) << "print_job: start print job";
+}
+
+// Push the printer's "purify air at print end" setting from the filaments on the plate, so that a
+// PLA job does not sit through a purification cycle that only ABS-like filaments need. Filaments
+// left on the default "Follow printer setting" say nothing, and when every filament says nothing
+// the printer keeps whatever the user configured under Device -> Print options.
+void SelectMachineDialog::apply_purify_air_at_print_end(MachineObject *obj_)
+{
+    if (!obj_ || m_print_type != PrintFromType::FROM_NORMAL) return;
+
+    DevPrintOptions *print_options = obj_->GetPrintOptions();
+    if (!print_options) return;
+
+    const PrintOptionData *option = print_options->GetDetectionOption(PrintOptionEnum::Purify_Air_At_Print_End);
+    if (!option || !option->is_support_detect) return;
+
+    const DynamicPrintConfig &full_config = wxGetApp().preset_bundle->full_config();
+    const ConfigOptionEnumsGeneric *purify_opt = full_config.option<ConfigOptionEnumsGeneric>("purify_air_at_print_end");
+    if (!purify_opt) return;
+
+    // The most demanding request among the filaments on the plate wins: Exhaust over Internal
+    // Circulation over Off. A filament that wants purification is never overruled by one that
+    // does not.
+    int resolved = paeFollowPrinter;
+    for (const FilamentInfo &filament : m_ams_mapping_result) {
+        if (filament.id < 0 || filament.id >= (int) purify_opt->values.size()) continue;
+
+        const int requested = purify_opt->values[filament.id];
+        if (requested == paeFollowPrinter) continue;
+        if (resolved == paeFollowPrinter || requested > resolved) resolved = requested;
+    }
+
+    if (resolved == paeFollowPrinter) return;
+
+    DevPrintOptions::PurifyAirAtPrintEndState state = DevPrintOptions::PurifyAirAtPrintEndState::PurifyAirDisable;
+    if (resolved == paeExternal) {
+        // Exhausting needs the chamber exhaust duct; fall back to internal circulation rather
+        // than silently leaving the air unpurified.
+        state = obj_->GetFan() && obj_->GetFan()->GetAirDuctData().IsExaustFanExit() ?
+                    DevPrintOptions::PurifyAirAtPrintEndState::PurifyAirByOutside :
+                    DevPrintOptions::PurifyAirAtPrintEndState::PurifyAirByInside;
+    } else if (resolved == paeInternal) {
+        state = DevPrintOptions::PurifyAirAtPrintEndState::PurifyAirByInside;
+    }
+
+    if (option->current_detect_value == (int) state) return;
+
+    BOOST_LOG_TRIVIAL(info) << "print_job: purify air at print end set to " << (int) state << " from filament settings";
+    print_options->command_xcam_control_purify_air_at_print_end((int) state);
 }
 
 void SelectMachineDialog::clear_ip_address_config(wxCommandEvent& e)

--- a/src/slic3r/GUI/SelectMachine.hpp
+++ b/src/slic3r/GUI/SelectMachine.hpp
@@ -524,6 +524,7 @@ public:
     void on_reselect_dialog_btn_clicked(wxMouseEvent&);
     void Enable_Auto_Refill(bool enable);
     void on_send_print();
+    void apply_purify_air_at_print_end(MachineObject *obj_);
     void clear_ip_address_config(wxCommandEvent& e);
     void on_refresh(wxCommandEvent& event);
     void on_set_finish_mapping(wxCommandEvent& evt);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -4819,6 +4819,10 @@ void TabFilament::build()
         line = {L("Complete print"), ""};
         line.append_option(optgroup->get_option("complete_print_exhaust_fan_speed"));
         optgroup->append_line(line);
+
+        optgroup = page->new_optgroup(L("Air purification"), L"param_cooling_fan");
+
+        optgroup->append_single_option_line("purify_air_at_print_end");
         //BBS
         add_filament_overrides_page();
 #if 0
@@ -4963,6 +4967,11 @@ void TabFilament::toggle_options()
 
         for (auto elem : { "during_print_exhaust_fan_speed","complete_print_exhaust_fan_speed" })
             toggle_line(elem, m_config->opt_bool("activate_air_filtration",0)&&support_air_filtration);
+
+        // Purifying the chamber air at the end of a print is a separate printer capability from the
+        // exhaust fan above: the X2D has it while support_air_filtration stays off for that machine.
+        bool support_purify_air = m_preset_bundle->printers.get_edited_preset().config.opt_bool("support_purify_air_at_print_end");
+        toggle_line("purify_air_at_print_end", is_BBL_printer && support_purify_air);
 
     }
     if (m_active_page->title() == "Filament")


### PR DESCRIPTION
**Closes #11276** — [Add support to purify air at end only for specific materials](https://github.com/bambulab/BambuStudio/issues/11276)

### The problem

"Purify air at print end" is a single printer-wide toggle under **Device → Print options**. It is worth the extra time for ABS or ASA and wasted on PLA or PETG, but it is not per-job, and the control is disabled while a job is running. So the only way to skip it for a PLA print is to cancel the job, change the setting, and start over. That is what the issue reports.

### The change

A per-filament option under **Filament → Cooling → Air purification**:

| Value | Effect when this filament is on the plate |
|---|---|
| **Follow printer setting** (default) | Studio does not touch the printer's setting |
| Off | Ask the printer not to purify after this print |
| Internal Circulation | Purify through internal circulation |
| Exhaust | Purify by exhausting |

![Per-filament purify air at print end](https://raw.githubusercontent.com/jeremykenedy/BambuStudio/assets/purify-air/purify-air-per-filament.gif)

Because the default is *Follow printer setting*, nothing changes for anyone who never opens the option. When at least one filament on the plate does name a value, `SelectMachineDialog::on_send_print` resolves it and pushes it to the printer with the existing `print_option` / `air_purification` command before the job starts. The most demanding request wins — Exhaust over Internal Circulation over Off — so a filament that wants purification is never overruled by one that does not. Exhaust falls back to internal circulation on a machine with no chamber exhaust duct.

The two mode names are the strings the device's own print options dialog already uses.

### Capability gating

`support_air_filtration` is **0** on the X2D — it gates the during-print exhaust fan, which is a different feature. Gating on it would have hidden this option on exactly the machine the issue is about. So this adds `support_purify_air_at_print_end`, set on the X2D profile, and the group is hidden on machines without it. Other models can be opted in by adding the flag to their profile.

Changing the option does not invalidate any slicing step — it is listed with the other options that have no influence on the generated G-code.

### What I verified

- Builds clean on macOS arm64.
- The option appears on an X2D profile and is hidden on P1S/P2S, which do not carry the new flag.
- Round-trip: setting it and saving writes `"purify_air_at_print_end": ["external"]` to the user preset; after a full restart the preset loads back showing **Exhaust**.

### What I could not verify

I do not have an X2D, so the send-time half — the printer actually receiving the `print_option` command and honouring it — is **not** verified against hardware. The command itself is the existing one used by the Print options dialog; what is new is the call site and the resolution logic. Worth a check on a real machine before this lands.

Happy to rework the shape of this — in particular, whether the setting should be per-filament at all versus a new per-job field, and whether writing a persistent device setting from the send path is acceptable. The current design leans on the default value being a no-op so that nothing is written unless a user explicitly opts a filament in.
